### PR TITLE
installer: Only verify checksum if the downloaded file exists.

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -69,19 +69,19 @@ if [ ! -f $statepkg -a ! -f $stateexe ]; then
   $fetch $statepkg ${STATEURL}${version}/${statepkg} || exit 1
 fi
 
-# Verify checksum.
-echo "Verifying checksum..."
-shasum=`wget -q -O - $STATEURL$statejson | grep -m 1 '"Sha256":' | awk '{print $2}' | tr -d '",'`
-if [ "`sha256sum -b $statepkg | cut -d ' ' -f1`" != "$shasum" ]; then
-  echo "SHA256 sum did not match:"
-  echo "Expected: $shasum"
-  echo "Received: `sha256sum -b $statepkg | cut -d ' ' -f1`"
-  echo "Aborting installation."
-  exit 1
-fi
-
-# Extract the State binary.
+# Extract the State binary after verifying its checksum.
 if [ -f $statepkg ]; then
+  # Verify checksum.
+  echo "Verifying checksum..."
+  shasum=`wget -q -O - $STATEURL$statejson | grep -m 1 '"Sha256":' | awk '{print $2}' | tr -d '",'`
+  if [ "`sha256sum -b $statepkg | cut -d ' ' -f1`" != "$shasum" ]; then
+    echo "SHA256 sum did not match:"
+    echo "Expected: $shasum"
+    echo "Received: `sha256sum -b $statepkg | cut -d ' ' -f1`"
+    echo "Aborting installation."
+    exit 1
+  fi
+
   echo "Extracting $statepkg..."
   gunzip $statepkg || exit 1
   chmod +x $stateexe


### PR DESCRIPTION
After the download is gunzipped, the original file no longer exists.