### PR TITLE
logging: Truncate log files on open before writing.

### DIFF
--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -23,7 +23,7 @@ func (l *fileHandler) Emit(ctx *MessageContext, message string, args ...interfac
 	filename := filepath.Join(datadir, "log.txt")
 
 	if l.file == nil {
-		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`tail -F logfile` is still the best solution for monitoring logfiles over multiple sessions. The Go docs say O_TRUNC may not work on all platforms.