### PR TITLE
Add support for tcsh for `state activate`

### DIFF
--- a/assets/shells/tcsh.sh
+++ b/assets/shells/tcsh.sh
@@ -1,0 +1,13 @@
+# We don't need to source the rcfile here (like the other shells do)  because
+# the mechanism we are using to spawn the subshell is already loading it.
+#
+# Also, it's ineffectual to attempt setting a prompt in this script since those
+# `set` variables are not inherited when we spawn the sub shell via exec.  Only
+# `setenv` values are inherited.
+
+{{range $K, $V := .Env}}
+setenv {{$K}} "{{$V}}"
+{{end}}
+cd "{{.WD}}"
+
+{{.UserScripts}}

--- a/internal/subshell/subshell.go
+++ b/internal/subshell/subshell.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/subshell/bash"
 	"github.com/ActiveState/cli/internal/subshell/cmd"
+	"github.com/ActiveState/cli/internal/subshell/tcsh"
 	"github.com/ActiveState/cli/internal/subshell/zsh"
 	"github.com/ActiveState/cli/internal/virtualenvironment"
 	"github.com/ActiveState/cli/pkg/project"
@@ -145,6 +146,8 @@ func Get() (SubShell, error) {
 		subs = &bash.SubShell{}
 	case "zsh":
 		subs = &zsh.SubShell{}
+	case "tcsh":
+		subs = &tcsh.SubShell{}
 	case "cmd.exe":
 		subs = &cmd.SubShell{}
 	default:

--- a/internal/subshell/tcsh/tcsh.go
+++ b/internal/subshell/tcsh/tcsh.go
@@ -1,0 +1,125 @@
+package tcsh
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/ActiveState/cli/internal/failures"
+)
+
+// SubShell covers the subshell.SubShell interface, reference that for documentation
+type SubShell struct {
+	binary string
+	rcFile *os.File
+	cmd    *exec.Cmd
+	wg     *sync.WaitGroup
+}
+
+// Shell - see subshell.SubShell
+func (v *SubShell) Shell() string {
+	return "tcsh"
+}
+
+// Binary - see subshell.SubShell
+func (v *SubShell) Binary() string {
+	return v.binary
+}
+
+// SetBinary - see subshell.SubShell
+func (v *SubShell) SetBinary(binary string) {
+	v.binary = binary
+}
+
+// RcFile - see subshell.SubShell
+func (v *SubShell) RcFile() *os.File {
+	return v.rcFile
+}
+
+// SetRcFile - see subshell.SubShell
+func (v *SubShell) SetRcFile(rcFile *os.File) {
+	v.rcFile = rcFile
+}
+
+// RcFileExt - see subshell.SubShell
+func (v *SubShell) RcFileExt() string {
+	return ""
+}
+
+// RcFileTemplate - see subshell.SubShell
+func (v *SubShell) RcFileTemplate() string {
+	return "tcsh.sh"
+}
+
+// Activate - see subshell.SubShell
+func (v *SubShell) Activate(wg *sync.WaitGroup) error {
+	v.wg = wg
+	wg.Add(1)
+
+	// This is horrible but it works.  tcsh doesn't offer a way to override the rc file and
+	// doesn't let us run a script and then drop to interactive mode.  So we source the
+	// state rc file and then chain an exec which inherits the environment we just set up.
+	// It seems to work fine except we don't have a way to override the shell prompt.
+	//
+	// The exec'd shell does not inherit 'prompt' from the calling terminal since
+	// tcsh does not export prompt.  This may be intractable.  I couldn't figure out a
+	// hack to make it work.
+	shellArgs := []string{"-c", "source " + v.rcFile.Name() + " ; exec " + v.Binary()}
+	cmd := exec.Command(v.Binary(), shellArgs...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	cmd.Start()
+
+	v.cmd = cmd
+
+	var err error
+	go func() {
+		err = cmd.Wait()
+		v.wg.Done()
+	}()
+
+	return err
+}
+
+// Deactivate - see subshell.SubShell
+func (v *SubShell) Deactivate() error {
+	if !v.IsActive() {
+		return nil
+	}
+
+	var err error
+	func() {
+		// Go's Process.Kill is not very safe to use, it throws a panic if the process no longer exists
+		defer failures.Recover()
+		err = v.cmd.Process.Kill()
+	}()
+
+	if err == nil {
+		v.cmd = nil
+	}
+	return err
+}
+
+// Run - see subshell.SubShell
+func (v *SubShell) Run(script string) error {
+	tmpfile, err := ioutil.TempFile("", "tcsh-script")
+	if err != nil {
+		return err
+	}
+
+	tmpfile.WriteString("#!/usr/bin/env tcsh\n")
+	tmpfile.WriteString(script)
+	tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+	os.Chmod(tmpfile.Name(), 0755)
+
+	runCmd := exec.Command(tmpfile.Name())
+	runCmd.Stdin, runCmd.Stdout, runCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	return runCmd.Run()
+}
+
+// IsActive - see subshell.SubShell
+func (v *SubShell) IsActive() bool {
+	return v.cmd != nil && (v.cmd.ProcessState == nil || !v.cmd.ProcessState.Exited())
+}

--- a/internal/subshell/tcsh/tcsh_test.go
+++ b/internal/subshell/tcsh/tcsh_test.go
@@ -1,0 +1,3 @@
+package tcsh
+
+// Tested in ../subshell_test.go


### PR DESCRIPTION
This commit adds support for tcsh developers using the cli tool.  This allows `activate` to launch a tcsh subshell.  Dissapointingly, due to limitations in `tcsh` it does not appear like it is possible for us to
override the user's prompt in the subshell, though.