### PR TITLE
Print the relative path to a file when reporting what files need form…

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -35,7 +35,7 @@ unformatted=$(gofmt -l $gofiles)
 
 echo >&2 "Go files must be formatted with gofmt. Please run:"
 for fn in $unformatted; do
-	echo >&2 "  gofmt -w $PWD/$fn"
+	echo >&2 "  gofmt -w $fn"
 done
 
 exit 1


### PR DESCRIPTION
…atting.  Can't run commands on Windows when abspath.