### PR TITLE
Constrain cmds when running `state run blah`.

### DIFF
--- a/state/run/run.go
+++ b/state/run/run.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ActiveState/cli/internal/virtualenvironment"
 	"github.com/ActiveState/cli/pkg/cmdlets/commands"
 	"github.com/ActiveState/cli/pkg/project"
-	"github.com/ActiveState/cli/pkg/projectfile"
 	"github.com/spf13/cobra"
 )
 
@@ -71,13 +70,13 @@ func Execute(cmd *cobra.Command, args []string) {
 	}
 
 	// Determine which project command to run based on the given command name.
-	project := projectfile.Get()
+	prj := project.Get()
 	var command string
 	var standalone bool
-	for _, cmd := range project.Commands {
-		if cmd.Name == Args.Name {
-			command = cmd.Value
-			standalone = cmd.Standalone
+	for _, cmd := range prj.Commands() {
+		if cmd.Name() == Args.Name {
+			command = cmd.Value()
+			standalone = cmd.Standalone()
 			break
 		}
 	}


### PR DESCRIPTION
If i had two commands of the same name in a yaml, `state run --lists` would only show one if the other cmd was constrained to NOT run on the current system.  If I `state ran cmdname` though it would run the first command it found, even if it was constrained.