### PR TITLE
Obtain GOPATH and GOROOT from go if they are not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Go parameters
-GOCMD=go
+GOPATH?=	$(shell go env GOPATH)
+GOROOT?=	$(shell go env GOROOT)
 
 ifneq ($(OS),Windows_NT)
 	ifndef $(shell command -v go 2> /dev/null)


### PR DESCRIPTION
If the user has not explicitely set GOPATH or GOROOT, we extract the implicit values from the go binary in the user's path.  When running in `state activate` this is not an issue, since the state tool is setting these values for us, but there's a bootstrapping problem for a user trying to build the tool without having the tool in an environment where GOPATH and GOROOT are not explicitly set.