### PR TITLE
Initializes secretsapi client prior to generating new keypair

### DIFF
--- a/state/auth/login.go
+++ b/state/auth/login.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ActiveState/cli/internal/failures"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/print"
+	secretsapi "github.com/ActiveState/cli/internal/secrets-api"
 	"github.com/ActiveState/cli/internal/surveyor"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 )
@@ -22,6 +23,7 @@ func plainAuth() {
 	doPlainAuth(credentials)
 
 	if api.Auth != nil {
+		secretsapi.InitializeClient()
 		ensureUserKeypair(credentials.Password)
 	}
 }


### PR DESCRIPTION
This change fixes a bug that prevented a keypair from getting generated
just after a user authenticated with the platform.