### PR TITLE
Fix runtime using wrong identifier to store cache

### DIFF
--- a/pkg/platform/api/headchef/mock/mock.go
+++ b/pkg/platform/api/headchef/mock/mock.go
@@ -73,14 +73,19 @@ func (r *HeadchefRequesterMock) simulateCompleteBuild() {
 		if r.option(InvalidURL) {
 			u = strfmt.URI("htps;/not-a-url/" + filename)
 		}
+
+		id := strfmt.UUID("00010001-0001-0001-0001-000100010001")
 		artifacts = append(artifacts, &headchef_models.BuildCompletedArtifactsItems0{
-			URI: &u,
+			ArtifactID: &id,
+			URI:        &u,
 		})
 
 		// Also include a legacy python, which can be used to mock an artifact with no metadata
+		id2 := strfmt.UUID("00020002-0002-0002-0002-000200020002")
 		u2 := strfmt.URI("http://test.tld/legacy-python" + ext)
 		artifacts = append(artifacts, &headchef_models.BuildCompletedArtifactsItems0{
-			URI: &u2,
+			ArtifactID: &id2,
+			URI:        &u2,
 		})
 	}
 	r.buildCompleted(headchef_models.BuildCompleted{

--- a/pkg/platform/runtime/download_test.go
+++ b/pkg/platform/runtime/download_test.go
@@ -80,23 +80,23 @@ func (suite *RuntimeDLTestSuite) AfterTest(suiteName, testName string) {
 
 func (suite *RuntimeDLTestSuite) TestGetRuntimeDL() {
 	r := runtime.NewDownload(suite.project, suite.dir, suite.hcMock.Requester(hcMock.NoOptions))
-	urls, fail := r.FetchArtifactURLs()
+	artfs, fail := r.FetchArtifacts()
 	suite.Require().NoError(fail.ToError())
-	filenames, fail := r.Download(urls)
+	files, fail := r.Download(artfs)
 	suite.Require().NoError(fail.ToError())
 
 	suite.Implements((*runtime.Downloader)(nil), r)
-	suite.Contains(filenames, "python"+runtime.InstallerExtension)
-	suite.Contains(filenames, "legacy-python"+runtime.InstallerExtension)
+	suite.Contains(files, filepath.Join(suite.dir, "python"+runtime.InstallerExtension))
+	suite.Contains(files, filepath.Join(suite.dir, "legacy-python"+runtime.InstallerExtension))
 
-	for _, filename := range filenames {
-		suite.FileExists(filepath.Join(suite.dir, filename))
+	for file, _ := range files {
+		suite.FileExists(file)
 	}
 }
 
 func (suite *RuntimeDLTestSuite) TestGetRuntimeDLNoArtifacts() {
 	r := runtime.NewDownload(suite.project, suite.dir, suite.hcMock.Requester(hcMock.NoArtifacts))
-	_, fail := r.FetchArtifactURLs()
+	_, fail := r.FetchArtifacts()
 	suite.Require().Error(fail.ToError())
 
 	suite.Equal(runtime.FailNoArtifacts.Name, fail.Type.Name)
@@ -104,7 +104,7 @@ func (suite *RuntimeDLTestSuite) TestGetRuntimeDLNoArtifacts() {
 
 func (suite *RuntimeDLTestSuite) TestGetRuntimeDLInvalidArtifact() {
 	r := runtime.NewDownload(suite.project, suite.dir, suite.hcMock.Requester(hcMock.InvalidArtifact))
-	_, fail := r.FetchArtifactURLs()
+	_, fail := r.FetchArtifacts()
 	suite.Require().Error(fail.ToError())
 
 	suite.Equal(runtime.FailNoValidArtifact.Name, fail.Type.Name)
@@ -112,9 +112,9 @@ func (suite *RuntimeDLTestSuite) TestGetRuntimeDLInvalidArtifact() {
 
 func (suite *RuntimeDLTestSuite) TestGetRuntimeDLInvalidURL() {
 	r := runtime.NewDownload(suite.project, suite.dir, suite.hcMock.Requester(hcMock.InvalidURL))
-	urls, fail := r.FetchArtifactURLs()
+	files, fail := r.FetchArtifacts()
 	suite.Require().NoError(fail.ToError())
-	_, fail = r.Download(urls)
+	_, fail = r.Download(files)
 	suite.Require().Error(fail.ToError())
 
 	suite.Equal(model.FailSignS3URL.Name, fail.Type.Name)
@@ -122,7 +122,7 @@ func (suite *RuntimeDLTestSuite) TestGetRuntimeDLInvalidURL() {
 
 func (suite *RuntimeDLTestSuite) TestGetRuntimeDLBuildFailure() {
 	r := runtime.NewDownload(suite.project, suite.dir, suite.hcMock.Requester(hcMock.BuildFailure))
-	_, fail := r.FetchArtifactURLs()
+	_, fail := r.FetchArtifacts()
 	suite.Require().Error(fail.ToError())
 
 	suite.Equal(runtime.FailBuild.Name, fail.Type.Name)
@@ -130,7 +130,7 @@ func (suite *RuntimeDLTestSuite) TestGetRuntimeDLBuildFailure() {
 
 func (suite *RuntimeDLTestSuite) TestGetRuntimeDLFailure() {
 	r := runtime.NewDownload(suite.project, suite.dir, suite.hcMock.Requester(hcMock.RegularFailure))
-	_, fail := r.FetchArtifactURLs()
+	_, fail := r.FetchArtifacts()
 	suite.Require().Error(fail.ToError())
 
 	suite.Equal(failures.FailDeveloper.Name, fail.Type.Name)

--- a/pkg/platform/runtime/installer_lin_test.go
+++ b/pkg/platform/runtime/installer_lin_test.go
@@ -77,7 +77,7 @@ func (suite *InstallerLinuxTestSuite) AfterTest(suiteName, testName string) {
 }
 
 func (suite *InstallerLinuxTestSuite) TestInstall_ArchiveDoesNotExist() {
-	fail := suite.installer.InstallFromArchives([]string{"/no/such/archive.tar.gz"})
+	fail := suite.installer.InstallFromArchives(headchefArtifact("/no/such/archive.tar.gz"))
 	suite.Require().Error(fail.ToError())
 	suite.Equal(runtime.FailArchiveInvalid, fail.Type)
 	suite.Equal(locale.Tr("installer_err_archive_notfound", "/no/such/archive.tar.gz"), fail.Error())
@@ -90,14 +90,14 @@ func (suite *InstallerLinuxTestSuite) TestInstall_ArchiveNotTarGz() {
 	suite.Require().NoError(fail.ToError())
 	suite.Require().NoError(file.Close())
 
-	fail = suite.installer.InstallFromArchives([]string{invalidArchive})
+	fail = suite.installer.InstallFromArchives(headchefArtifact(invalidArchive))
 	suite.Require().Error(fail.ToError())
 	suite.Equal(runtime.FailArchiveInvalid, fail.Type)
 	suite.Equal(locale.Tr("installer_err_archive_badext", invalidArchive), fail.Error())
 }
 
 func (suite *InstallerLinuxTestSuite) TestInstall_BadArchive() {
-	fail := suite.installer.InstallFromArchives([]string{path.Join(suite.dataDir, "badarchive.tar.gz")})
+	fail := suite.installer.InstallFromArchives(headchefArtifact(path.Join(suite.dataDir, "badarchive.tar.gz")))
 	suite.Require().Error(fail.ToError())
 	suite.Equal(runtime.FailArchiveInvalid, fail.Type)
 	suite.Contains(fail.Error(), "EOF")
@@ -105,27 +105,27 @@ func (suite *InstallerLinuxTestSuite) TestInstall_BadArchive() {
 
 func (suite *InstallerLinuxTestSuite) TestInstall_ArchiveHasNoInstallDir_ForTarGz() {
 	archivePath := path.Join(suite.dataDir, "empty.tar.gz")
-	fail := suite.installer.InstallFromArchives([]string{archivePath})
+	fail := suite.installer.InstallFromArchives(headchefArtifact(archivePath))
 	suite.Require().Error(fail.ToError())
 	suite.Equal(runtime.FailArchiveNoInstallDir, fail.Type)
 }
 
 func (suite *InstallerLinuxTestSuite) TestInstall_RuntimeMissingPythonExecutable() {
 	archivePath := path.Join(suite.dataDir, "python-missing-python-binary.tar.gz")
-	fail := suite.installer.InstallFromArchives([]string{archivePath})
+	fail := suite.installer.InstallFromArchives(headchefArtifact(archivePath))
 	suite.Require().Error(fail.ToError())
 	suite.Equal(runtime.FailMetaDataNotDetected, fail.Type)
 }
 
 func (suite *InstallerLinuxTestSuite) TestInstall_PythonFoundButNotExecutable() {
 	archivePath := path.Join(suite.dataDir, "python-noexec-python.tar.gz")
-	fail := suite.installer.InstallFromArchives([]string{archivePath})
+	fail := suite.installer.InstallFromArchives(headchefArtifact(archivePath))
 	suite.Require().Error(fail.ToError())
 	suite.Equal(runtime.FailRuntimeNotExecutable, fail.Type)
 }
 
 func (suite *InstallerLinuxTestSuite) TestInstall_InstallerFailsToGetPrefixes() {
-	fail := suite.installer.InstallFromArchives([]string{path.Join(suite.dataDir, "python-fail-prefixes.tar.gz")})
+	fail := suite.installer.InstallFromArchives(headchefArtifact(path.Join(suite.dataDir, "python-fail-prefixes.tar.gz")))
 	suite.Require().Error(fail.ToError())
 	suite.Equal(runtime.FailRuntimeNoPrefixes, fail.Type)
 }

--- a/pkg/platform/runtime/runtime_test.go
+++ b/pkg/platform/runtime/runtime_test.go
@@ -1,0 +1,20 @@
+package runtime_test
+
+import (
+	"path"
+
+	"github.com/go-openapi/strfmt"
+
+	"github.com/ActiveState/cli/pkg/platform/runtime"
+)
+
+func headchefArtifact(artifactPath string) map[string]*runtime.HeadChefArtifact {
+	artifactID := strfmt.UUID("00010001-0001-0001-0001-000100010001")
+	uri := strfmt.URI("https://test.tld/" + path.Join(artifactPath))
+	result := map[string]*runtime.HeadChefArtifact{}
+	result[artifactPath] = &runtime.HeadChefArtifact{
+		ArtifactID: &artifactID,
+		URI:        &uri,
+	}
+	return result
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167500747

Not a simple fix because I had to get the identifier from the artifact metadata instead, which we weren't passing around.