### PR TITLE
correct log about when to write message about manual activation

### DIFF
--- a/public/install.ps1
+++ b/public/install.ps1
@@ -359,7 +359,7 @@ function install()
     Write-Host "To start using the State tool right away update your current PATH by running 'set PATH=%PATH%;$installDir'`n" -ForegroundColor Yellow
 
     # Print a warning that we cannot automatically activate a requested project.
-    if ( "$script:ACTIVATE" -eq "" ) {
+    if ( "$script:ACTIVATE" -ne "" ) {
         Write-Host "`nCannot activate project $script:ACTIVATE yet." -ForegroundColor Yellow
         Write-Host "In order to activate a project, the state tool needs to be installed in your PATH first."
         Write-Host "To manually activate the project run 'state activate $script:ACTIVATE' once 'state' is on your PATH"


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2203557/stories/168714530

The solution is to invert (correct) the logic for when the message is printed.  It needs to be printed, when provides the '-Activate' flag.
