### PR TITLE
Add SetWd() method to integration test suite

### DIFF
--- a/internal/testhelpers/integration/integration.go
+++ b/internal/testhelpers/integration/integration.go
@@ -33,6 +33,7 @@ type Suite struct {
 	cmd        *exec.Cmd
 	env        []string
 	logFile    *os.File
+	wd         *string
 }
 
 // SetupTest sets up an integration test suite for testing the state tool executable
@@ -92,6 +93,13 @@ func (s *Suite) AppendEnv(env []string) {
 	s.env = append(s.env, env...)
 }
 
+// SetWd specifies a working directory for the spawned processes
+// Use this method if you rely on running the test executable in a clean directory
+// By default all tests are run in `os.TempDir()`
+func (s *Suite) SetWd(dir string) {
+	s.wd = &dir
+}
+
 // Spawn executes the state tool executable under test in a pseudo-terminal
 func (s *Suite) Spawn(args ...string) {
 	s.SpawnCustom(s.executable, args...)
@@ -99,7 +107,12 @@ func (s *Suite) Spawn(args ...string) {
 
 // SpawnCustom executes an executable in a pseudo-terminal for integration tests
 func (s *Suite) SpawnCustom(executable string, args ...string) {
-	wd, _ := os.Getwd()
+	var wd string
+	if s.wd == nil {
+		wd, _ = os.Getwd()
+	} else {
+		wd = *s.wd
+	}
 	s.cmd = exec.Command(executable, args...)
 	s.cmd.Dir = wd
 	s.cmd.Env = s.env

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -27,6 +27,7 @@ func (suite *ActivateIntegrationTestSuite) prepareTempDirectory(prefix string) (
 	suite.Require().NoError(err)
 	err = os.Chdir(tempDir)
 	suite.Require().NoError(err)
+	suite.SetWd(tempDir)
 
 	return tempDir, func() {
 		os.Chdir(os.TempDir())
@@ -44,12 +45,6 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePython2() {
 }
 
 func (suite *ActivateIntegrationTestSuite) TestActivateWithoutRuntime() {
-
-	/*
-		if runtime.GOOS == "windows" {
-			suite.T().Skip("State activate currently always activates into a bash shell, but we expect cmd.exe")
-		}
-	*/
 
 	tempDir, cb := suite.prepareTempDirectory("activate_test_no_runtime")
 	defer cb()

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -47,7 +47,9 @@ func (suite *UpdateIntegrationTestSuite) TestLocked() {
 	// We need a projectfile to be able to version lock
 	dir, err := ioutil.TempDir("", "")
 	suite.Require().NoError(err)
-	os.Chdir(dir)
+	err = os.Chdir(dir)
+	suite.Require().NoError(err)
+	suite.SetWd(dir)
 	projectURL := fmt.Sprintf("https://%s/string/string?commitID=00010001-0001-0001-0001-000100010001", constants.PlatformURL)
 	pjfile := projectfile.Project{
 		Project: projectURL,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169611620

This enables a developer to run a test process reliably in a given working directory - even when running in tests in parallel.

Tests that relied on `os.Chdir` have been updated to use the new `suite.Setwd()` method