### PR TITLE
install.ps1: enable no prompt install with environment variable

### DIFF
--- a/public/install.ps1
+++ b/public/install.ps1
@@ -32,6 +32,13 @@ $script:STATE = $e.Substring(0, $e.IndexOf("."))
 $script:BRANCH = ($b).Trim()
 $script:ACTIVATE =($activate).Trim()
 
+# For recipe installation without prompts we need to be able to disable
+# prompots through an environment variable.
+if ($Env:NOPROMPT_INSTALL -eq "true") {
+    $script:NOPROMPT = $true
+    $script:FORCEOVERWRITE = $true
+}
+
 # Some cmd-lets throw exceptions that don't stop the script.  Force them to stop.
 $ErrorActionPreference = "Stop"
 


### PR DESCRIPTION
Unfortunately, this is needed for story: https://www.pivotaltracker.com/story/show/169471001

The one-line snippet for Windows then looks like this:

```
powershell &quot; Set-Item -Path Env:NOPROMPT_INSTALL -Value 'true'; IEX (New-Object Net.WebClient).downloadString('https://platform.activestate.com/dl/cli/install.ps1') &quot; && state activate --path %APPDATA%\{{ object.state_project }} {{ object.state_project }}"
```

@th3coop Could you please update that on the as.code.com website too?  Thanks, Martin