### PR TITLE
State push creates projects on platform with commits

### DIFF
--- a/pkg/platform/model/vcs.go
+++ b/pkg/platform/model/vcs.go
@@ -275,6 +275,11 @@ func CommitInitial(projectOwner, projectName, language, langVersion string) (*mo
 		return nil, "", FailAddCommit.New(locale.Tr("err_add_commit", api.ErrorMessageFromPayload(err)))
 	}
 
+	fail = UpdateBranchCommit(branch.BranchID, res.Payload.CommitID)
+	if fail != nil {
+		return nil, "", fail
+	}
+
 	return proj, res.Payload.CommitID, nil
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169630505

`state init` was creating the new project and the initial commit however it wasn't updating the new project's default branch with the commit. This adds back a function call that was originally in `CommitInitial` but removed during the state activate refactor.