### PR TITLE
Fix state pull on Windows

### DIFF
--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -276,7 +276,7 @@ var (
 	// everything after until a "?" or newline is reached. Everything after
 	// that is targeted, but not captured so that only the first capture
 	// group can be used in the replace value.
-	setCommitRE = regexp.MustCompile(`(?m:^(project:.*\/[^?\n]*).*)`)
+	setCommitRE = regexp.MustCompile(`(?m:^(project:.*\/[^?\r\n]*).*)`)
 )
 
 func setCommitInYAML(data []byte, commitID string) ([]byte, *failures.Failure) {

--- a/pkg/projectfile/projectfile_test.go
+++ b/pkg/projectfile/projectfile_test.go
@@ -375,6 +375,23 @@ project: https://example.com/xowner/xproject?commitID=123
 	assert.Equal(t, string(expectedYAML), string(out1))
 }
 
+func TestSetCommitInYAML_NoCommitID(t *testing.T) {
+	exampleYAML := []byte(`
+junk: xgarbage
+project: https://example.com/xowner/xproject
+123: xvalue
+`)
+	expectedYAML := []byte(`
+junk: xgarbage
+project: https://example.com/xowner/xproject?commitID=123
+123: xvalue
+`)
+
+	out, fail := setCommitInYAML(exampleYAML, "123")
+	assert.NoError(t, fail.ToError())
+	assert.Equal(t, string(expectedYAML), string(out))
+}
+
 func TestNewProjectfile(t *testing.T) {
 	dir, err := ioutil.TempDir("", "projectfile-test")
 	assert.NoError(t, err, "Should be no error when getting a temp directory")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169745786

Turns out this had to do with the differences between newline characters on Unix and Windows. On Windows `\n` is fine to recognize `LF` however Windows requires `CR+LF` which has an escape sequence of `\r\n`. I've tested this on Windows, Linux, and MacOS. Give it a shot for your use case before you approve