### PR TITLE
State activate output specific env vars

### DIFF
--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -81,7 +81,7 @@ func (r *Activate) run(params *ActivateParams, activatorLoop activationLoopFunc)
 		if err != nil {
 			return err
 		}
-		jsonString, err := envOutput()
+		jsonString, err := envOutput(false)
 		if err != nil {
 			return err
 		}

--- a/internal/runners/activate/output_lin_mac.go
+++ b/internal/runners/activate/output_lin_mac.go
@@ -9,14 +9,14 @@ import (
 	"github.com/ActiveState/cli/internal/virtualenvironment"
 )
 
-func envOutput() (string, error) {
+func envOutput(inherit bool) (string, error) {
 	venv := virtualenvironment.Get()
 	fail := venv.Activate()
 	if fail != nil {
 		return "", fail
 	}
 
-	env := venv.GetEnvSlice(false)
+	env := venv.GetEnvSlice(inherit)
 	envJSON := make([]string, len(env))
 	for i, kv := range env {
 		eq := strings.Index(kv, "=")

--- a/internal/runners/activate/output_win.go
+++ b/internal/runners/activate/output_win.go
@@ -10,14 +10,14 @@ import (
 	"github.com/ActiveState/cli/internal/virtualenvironment"
 )
 
-func envOutput() (string, error) {
+func envOutput(inherit bool) (string, error) {
 	venv := virtualenvironment.Get()
 	fail := venv.Activate()
 	if fail != nil {
 		return "", fail
 	}
 
-	env := virtualenvironment.Get().GetEnvSlice(false)
+	env := virtualenvironment.Get().GetEnvSlice(inherit)
 	envJSON := make([]string, len(env))
 	dynamicEnvVarRe := regexp.MustCompile(`(^=.+)=(.+)`)
 	var key, value string


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170141646

On Linux/Windows this includes the following keys:
```
PATH
PYTHONPATH
PYTHONIOENCODING
ACTIVESTATE_ACTIVATED
ACTIVESTATE_ACTIVATED_ID
```
