### PR TITLE
state projects list help text

### DIFF
--- a/locale/en-us.yaml
+++ b/locale/en-us.yaml
@@ -419,6 +419,8 @@ total:
   other: Total
 projects_description:
   other: Manage Your Projects
+projects_list_description:
+  other: List your platform projects
 err_api_not_authenticated:
   other: You are not authenticated, authenticate with `state auth`. For more information run `state auth --help`.
 err_api_forbidden:

--- a/state/projects/list.go
+++ b/state/projects/list.go
@@ -1,0 +1,9 @@
+package projects
+
+import "github.com/ActiveState/cli/pkg/cmdlets/commands"
+
+// ListCommand holds the details of the list subcommand
+var ListCommand = &commands.Command{
+	Name:        "list",
+	Description: "projects_list_description",
+}

--- a/state/projects/projects.go
+++ b/state/projects/projects.go
@@ -27,6 +27,10 @@ type projectWithOrg struct {
 	Organization string
 }
 
+func init() {
+	Command.Append(ListCommand)
+}
+
 func fetchProjects() ([]projectWithOrg, *failures.Failure) {
 	orgParams := organizations.NewListOrganizationsParams()
 	memberOnly := true


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170369985

Similarly to #507 `state packages` and `state packages list` have the same behaviour.