### PR TITLE
Fix panic with state packages list

### DIFF
--- a/state/package/list.go
+++ b/state/package/list.go
@@ -18,6 +18,7 @@ var ListCommand = &commands.Command{
 	Name:        "list",
 	Description: "package_list_description",
 	Flags:       listFlags,
+	Run:         ExecuteList,
 }
 
 // ListFlags holds the list-related flag values passed through the command line

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -24,6 +24,18 @@ func (suite *PackageIntegrationTestSuite) TestPackage_listingSimple() {
 	suite.Wait()
 }
 
+func (suite *PackageIntegrationTestSuite) TestPackage_listCommand() {
+	tempDir, cleanup := suite.PrepareTemporaryWorkingDirectory(suite.T().Name())
+	defer cleanup()
+
+	suite.PrepareActiveStateYAML(tempDir)
+
+	suite.Spawn("packages", "list")
+	suite.Expect("Name")
+	suite.Expect("pytest")
+	suite.Wait()
+}
+
 func (suite *PackageIntegrationTestSuite) TestPackage_listingWithCommitValid() {
 	tempDir, cleanup := suite.PrepareTemporaryWorkingDirectory(suite.T().Name())
 	defer cleanup()


### PR DESCRIPTION
Quick bugfix and integration test.

Previously `state packages list` was throwing a panic because it didn't have a `Run` function.