### PR TITLE
Use reponse message rather than entire response struct

### DIFF
--- a/pkg/platform/runtime/download.go
+++ b/pkg/platform/runtime/download.go
@@ -135,7 +135,7 @@ func (r *Download) FetchArtifacts() ([]*HeadChefArtifact, *failures.Failure) {
 	for {
 		select {
 		case resp := <-buildStatus.Completed:
-			logging.Debug("BuildCompleted:", resp)
+			logging.Debug(resp.Message)
 
 			if len(resp.Artifacts) == 0 {
 				return nil, FailNoArtifacts.New(locale.T("err_no_artifacts"))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169586743

This will produce a log line like:
```
[DEBUG Jan  3 22:34:51.684895400, download.go:138] Build completed successfully
```

Rather than the log line seen in the PT story