### PR TITLE
Fix build on master due to incorrect branch name

### DIFF
--- a/internal/constants/preprocess/github.go
+++ b/internal/constants/preprocess/github.go
@@ -83,7 +83,6 @@ func (g *GithubIncrementProvider) IncrementMaster() (*semver.Version, error) {
 		return nil, err
 	}
 
-	fmt.Println("Found version string: ", versionString)
 	return semver.New(versionString)
 }
 

--- a/internal/constants/preprocess/preprocess.go
+++ b/internal/constants/preprocess/preprocess.go
@@ -20,7 +20,7 @@ func init() {
 	branchName, branchNameFull := branchName()
 	buildNumber := buildNumber()
 
-	incrementer, err := NewVersionIncrementer(NewGithubProvider(os.Getenv("GITHUB_REPO_TOKEN")), "master", buildEnvironment())
+	incrementer, err := NewVersionIncrementer(NewGithubProvider(os.Getenv("GITHUB_REPO_TOKEN")), branchName, buildEnvironment())
 	if err != nil {
 		log.Fatalf("Could not initialize verion incrementer: %s", err)
 	}


### PR DESCRIPTION
The branch name returned from the github API is prefixed with `ActiveState:`. This needs to be trimmed in order to get the version file from the correct S3 bucket.