### PR TITLE
Fix value method failures.Failure.Error called using nil *Failure pointer

### DIFF
--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -2,7 +2,6 @@ package captain
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/analytics"
@@ -200,7 +199,10 @@ func (c *Command) argValidator(cobraCmd *cobra.Command, args []string) error {
 // setupSensibleErrors inspects an error value for certain errors and returns a
 // wrapped error that can be checked and that is localized.
 func setupSensibleErrors(err error) error {
-	if err == nil || (reflect.ValueOf(err).Kind() == reflect.Ptr && reflect.ValueOf(err).IsNil()) {
+	if fail, ok := err.(*failures.Failure); ok && fail == nil {
+		return nil
+	}
+	if err == nil {
 		return nil
 	}
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171153458