### PR TITLE
Revert "Get executable from os package"

### DIFF
--- a/cmd/state/internal/cmdtree/clean.go
+++ b/cmd/state/internal/cmdtree/clean.go
@@ -2,6 +2,7 @@ package cmdtree
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/config"
@@ -32,7 +33,7 @@ func newCleanCommand(outputer output.Outputer) *captain.Command {
 		},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {
-			installPath, err := os.Executable()
+			installPath, err := filepath.Abs(os.Args[0])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Reverts ActiveState/cli#557

Merged this before rebuilding. With the Azure fix this branch needed to be rebuilt before it could be merged.

