### PR TITLE
Revert "Revert "Get executable from os package""

### DIFF
--- a/cmd/state/internal/cmdtree/clean.go
+++ b/cmd/state/internal/cmdtree/clean.go
@@ -2,7 +2,6 @@ package cmdtree
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/config"
@@ -33,7 +32,7 @@ func newCleanCommand(outputer output.Outputer) *captain.Command {
 		},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {
-			installPath, err := filepath.Abs(os.Args[0])
+			installPath, err := os.Executable()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Reverts ActiveState/cli#562

I initially merged this without rebuilding it on CI. This meant that the necessary files on S3 were not present for the master builds. Merging again and allowing CI to build properly.