### PR TITLE
Fix update on Windows

### DIFF
--- a/internal/constants/preprocess/preprocess.go
+++ b/internal/constants/preprocess/preprocess.go
@@ -43,11 +43,11 @@ func init() {
 func gitBranchName() string {
 	// branch name variable set by Azure CI during pull request
 	if branch, isset := os.LookupEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH"); isset {
-		return branch
+		return "origin/" + branch
 	}
 	// branch name variable set by Azure CI
 	if branch, isset := os.LookupEnv("BUILD_SOURCEBRANCHNAME"); isset {
-		return branch
+		return "origin/" + branch
 	}
 	branch := getCmdOutput("git rev-parse --abbrev-ref HEAD")
 	return branch
@@ -58,7 +58,7 @@ func gitBranchName() string {
 // `BRANCH_OVERRIDE` is set
 func branchName() (string, string) {
 	branch := gitBranchName()
-	releaseName := branch
+	releaseName := strings.Trim(branch, "origin/")
 
 	if releaseOverride, isset := os.LookupEnv("BRANCH_OVERRIDE"); isset {
 		releaseName = releaseOverride


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171756484

On Azure we were uploading the build json to S3 at `update/state/origin/unstable/<platform>.json` but the update mechanism wants to download from `update/state/unstable/<platform>.json`. This had to do with how we generate the `BranchName` constant when on Azure.