### PR TITLE
Hotfix: fix broken update generation script

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -52,9 +52,8 @@ scripts:
   - name: generate-update
     description: Generate update files
     value: |
-      local out
-      outfile=$(outFile) || return $?
       $scripts.preprocess
+      outfile=$(outFile) || exit $?
       mkdir -p public/update
       go run scripts/update-generator/main.go -o public/update ${outfile}
   - name: install


### PR DESCRIPTION
- The `outFile` function is only defined after `preprocess` has been run.
- Some of the script commands were only allowed inside of functions (return, local)