### PR TITLE
Allow state update if version field cannot be parsed

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -159,6 +159,8 @@ func run(args []string, outputer output.Outputer) (int, error) {
 		// if we are running `state update`, we just print the error message, but don't fail, as we can still update the state tool executable
 		logging.Error("Could not parse version info from projectifle: %s", fail.Error())
 		if funk.Contains(args, "update") {
+			// invalidate versionInfo, as it could not be parsed
+			versionInfo = nil
 			outputer.Error(locale.T("err_version_parse"))
 		} else {
 			return 1, failures.FailUser.Wrap(fail, locale.T("err_version_parse"))

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -737,7 +737,7 @@ func ParseVersionInfo() (*VersionInfo, *failures.Failure) {
 	version := strings.TrimSpace(versionStruct.Version)
 	match, fail := regexp.MatchString(`^\d+\.\d+\.\d+-(SHA)?[a-f0-9]+`, version)
 	if fail != nil || !match {
-		return nil, FailInvalidVersion.New(locale.T("err_invalid_version"))
+		return &versionStruct, FailInvalidVersion.New(locale.T("err_invalid_version"))
 	}
 
 	return &versionStruct, nil


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172187821

If the version field cannot be parsed in the activestate.yaml but we are running `state update`, we just print the error but do not fail, as we can still update the state tool.

The error message thrown is also updated saying that we don't know what version of the state tool to run the command with, as more specific errors about why the activestate.yaml file could not be parsed are wrapped are displayed anyways.