### PR TITLE
change logging messages to Debug level

### DIFF
--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -739,12 +739,12 @@ func HomeDir() (string, error) {
 func IsWritable(path string) bool {
 	fpath := filepath.Join(path, uuid.New().String())
 	if fail := Touch(fpath); fail != nil {
-		logging.Error("Could not create file: %v", fail.ToError())
+		logging.Debug("Could not create file: %v", fail.ToError())
 		return false
 	}
 
 	if errr := os.Remove(fpath); errr != nil {
-		logging.Error("Could not clean up test file: %v", errr)
+		logging.Debug("Could not clean up test file: %v", errr)
 		return false
 	}
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172829461

`IsWritable()` is called to find a writable directory on the path.  Everytime we touch a path that is not writable, an error was logged to rollbar.  This is changed by this PR.

@MDrakos Was there a reason to create a temporary file to test for the write-ability of the directory, instead of checking file permissions?  I believe that (if systems are configured to have protected directories, like this Windows feature: https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/enable-controlled-folders) this will create notifications about blocked write-attempts for folders that we are not even writing to.  That may look  a little sketchy...