### PR TITLE
Skip cachedir fix

### DIFF
--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -779,7 +779,7 @@ func ResolvePath(path string) (string, error) {
 		return "", errs.Wrap(err, "cannot get absolute filepath of %q", path)
 	}
 
-	if !TargetExists(path string) {
+	if !TargetExists(path) {
 		return absPath, nil
 	}
 


### PR DESCRIPTION
On Windows we pass the `target/bin` to the `symlinkWithTarget` step. Since we haven't created the bin dir yet the resolve step (specifically evaluating the symlinks) fails.