### PR TITLE
hotfix: Check administrator rights based on cmd args

### DIFF
--- a/internal/runners/deploy/deploy.go
+++ b/internal/runners/deploy/deploy.go
@@ -26,17 +26,16 @@ import (
 type Params struct {
 	Namespace project.Namespaced
 	Path      string
-	Step      Step
 	Force     bool
 	UserScope bool
 }
 
 // RequiresAdministratorRights checks if the requested deploy command requires administrator privileges.
-func RequiresAdministratorRights(p Params) bool {
+func RequiresAdministratorRights(step Step, userScope bool) bool {
 	if rt.GOOS != "windows" {
 		return false
 	}
-	return (p.Step == UnsetStep || p.Step == ConfigureStep) && !p.UserScope
+	return (step == UnsetStep || step == ConfigureStep) && !userScope
 }
 
 type Deploy struct {
@@ -57,7 +56,7 @@ func NewDeploy(step Step, out output.Outputer) *Deploy {
 }
 
 func (d *Deploy) Run(params *Params) error {
-	if RequiresAdministratorRights(*params) {
+	if RequiresAdministratorRights(d.step, params.UserScope) {
 		isAdmin, err := osutils.IsWindowsAdmin()
 		if err != nil {
 			logging.Error("Could not check for windows administrator privileges: %v", err)


### PR DESCRIPTION
This is another hotfix for one of my commits. 

I found it while testing the other symlink story.  The state tool always wanted me to have administrator rights for my deploy commands.  Even for those where I could not request to *only change* the user PATH. :(