### PR TITLE
Hotfix: main tests

### DIFF
--- a/cmd/state/main_test.go
+++ b/cmd/state/main_test.go
@@ -10,12 +10,18 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/testhelpers/outputhelper"
+	"github.com/spf13/viper"
 
 	"github.com/stretchr/testify/suite"
 )
 
 type MainTestSuite struct {
 	suite.Suite
+}
+
+func (suite *MainTestSuite) AfterTest(suiteName, testName string) {
+	// Reset viper config so deprecation mock is always used
+	viper.Reset()
 }
 
 func (suite *MainTestSuite) TestDeprecated() {


### PR DESCRIPTION
When run together the tests were caching the mocked results and using them for subsequent tests. Resetting the viper config forces each test to use the mock every time. SSH'd into one of the Circle containers to confirm this works