### PR TITLE
Hotfix: MSI build

### DIFF
--- a/.azure/config.yml
+++ b/.azure/config.yml
@@ -120,7 +120,7 @@ jobs:
           msbuildArguments: >
             /target:Build
             /p:RunWixToolsOutOfProc=true
-        # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       - bash: |
           /c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.16299.0/x86/signtool.exe sign -d "ActiveState State Tool" -f "$(msiCert.secureFilePath)" -p $(CODE_SIGNING_PASSWD) ./public/wix/Deploy/bin/Release/Deploy.msi
         env:


### PR DESCRIPTION
Master is failing because the new custom actions that were added in this: #738 PR did not have their builds configured for `Release|x64`.