### PR TITLE
state deploy fixes for msi installer

### DIFF
--- a/internal/runners/deploy/deploy.go
+++ b/internal/runners/deploy/deploy.go
@@ -298,7 +298,7 @@ func symlinkWithTarget(overwrite bool, symlinkPath string, exePaths []string, ou
 				return locale.WrapError(err, "err_deploy_shouldskip", "Could not determine if link already exists.")
 			}
 			if skip {
-				return nil
+				continue
 			}
 
 			// If we're trying to overwrite a link not owned by us but overwrite=false then we should fail


### PR DESCRIPTION
This fixes two problems with the `state deploy` command that are blockers for https://www.pivotaltracker.com/story/show/172970079 to work:

1. If there are no usable paths to globally symlink to, it is not an error on Windows
2. We continue symlinking after skipping one link