### PR TITLE
Make flock in Linux/MacOS a write-lock

### DIFF
--- a/internal/osutils/pidlock_lin_mac.go
+++ b/internal/osutils/pidlock_lin_mac.go
@@ -46,7 +46,7 @@ func LockFile(f *os.File) error {
 		Start:  0,
 		Len:    0,
 		Pid:    int32(os.Getpid()),
-		Type:   syscall.F_RDLCK,
+		Type:   syscall.F_WRLCK,
 	}
 
 	err := syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, ft)


### PR DESCRIPTION
I noticed that the `pidlock_test` still failed occasionally.  So, I debugged and fixed it: The file lock had to be a write lock instead of a read-lock.
 
This commit also refactors the tests, such that they do not have to time-out on a failure.  (Which shouldn't happen anyways.)
