### PR TITLE
Fail if `state show` is not under a project dir

### DIFF
--- a/internal/locale/errors.go
+++ b/internal/locale/errors.go
@@ -54,13 +54,18 @@ type ErrorInput interface {
 
 // NewError creates a new error, it does a locale.Tt lookup of the given id, if the lookup fails it will use the
 // locale string instead
-func NewError(id, locale string, args ...string) error {
-	return WrapError(nil, id, locale, args...)
+func NewError(id string, args ...string) error {
+	return WrapError(nil, id, args...)
 }
 
 // WrapError creates a new error that wraps the given error, it does a locale.Tt lookup of the given id, if the lookup
 // fails it will use the locale string instead
-func WrapError(err error, id, locale string, args ...string) error {
+func WrapError(err error, id string, args ...string) error {
+	locale := id
+	if len(args) > 0 {
+		locale, args = args[0], args[1:]
+	}
+
 	l := &LocalizedError{}
 	translation := Tl(id, locale, args...)
 	l.wrapped = err
@@ -70,12 +75,17 @@ func WrapError(err error, id, locale string, args ...string) error {
 }
 
 // NewInputError is like NewError but marks it as an input error
-func NewInputError(id, locale string, args ...string) error {
-	return WrapInputError(nil, id, locale, args...)
+func NewInputError(id string, args ...string) error {
+	return WrapInputError(nil, id, args...)
 }
 
 // WrapInputError is like WrapError but marks it as an input error
-func WrapInputError(err error, id, locale string, args ...string) error {
+func WrapInputError(err error, id string, args ...string) error {
+	locale := id
+	if len(args) > 0 {
+		locale, args = args[0], args[1:]
+	}
+
 	l := &LocalizedError{}
 	translation := Tl(id, locale, args...)
 	l.inputErr = true

--- a/internal/locale/errors_test.go
+++ b/internal/locale/errors_test.go
@@ -22,6 +22,14 @@ func TestIsError(t *testing.T) {
 		isInputError    bool
 	}{
 		{
+			"NewError from ID",
+			locale.NewError("id_error"),
+			"id_error",
+			"id_error",
+			true,
+			false,
+		},
+		{
 			"NewError",
 			locale.NewError("", "Localized {{.V0}}", "Error"),
 			"Localized Error",

--- a/internal/runners/show/show.go
+++ b/internal/runners/show/show.go
@@ -40,6 +40,10 @@ func New(pj *project.Project, out output.Outputer) *Show {
 func (s *Show) Run(params Params) error {
 	logging.Debug("Execute")
 
+	if s.project == nil {
+		return locale.NewError("err_no_projectfile")
+	}
+
 	pj := s.project
 
 	if params.Remote != "" {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173542263

Since this is a very small change I went ahead and added the error change into this, which allows us to create localized errors without providing the localization (just the ID)