### PR TITLE
Update version file

### DIFF
--- a/scripts/update-generator/main.go
+++ b/scripts/update-generator/main.go
@@ -217,7 +217,6 @@ func run() {
 	createBuildDir()
 
 	// If dir is given create update for each file
-	fmt.Println("Path: ", appPath)
 	fi, err := os.Stat(appPath)
 	if err != nil {
 		panic(err)

--- a/scripts/update-generator/main.go
+++ b/scripts/update-generator/main.go
@@ -96,6 +96,13 @@ func createUpdate(path string, platform string) {
 		panic(err)
 	}
 
+	versionPath := filepath.Join(genDir, "version.json")
+	fmt.Printf("Updating version file at %s\n", versionPath)
+	err = ioutil.WriteFile(versionPath, b, 0755)
+	if err != nil {
+		panic(err)
+	}
+
 	copy(jsonPath, filepath.Join(genDir, branch, version, platform+".json"))
 }
 
@@ -210,6 +217,7 @@ func run() {
 	createBuildDir()
 
 	// If dir is given create update for each file
+	fmt.Println("Path: ", appPath)
 	fi, err := os.Stat(appPath)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173738908

The `version.json` that we download has the current master version in it. Before this file can be deployed to s3 and overwrite the existing one, we have to update the files contents with the new version information.