### PR TITLE
"build" install scripts only on their target OS

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -79,10 +79,17 @@ scripts:
   - name: build-install-scripts
     language: bash
     standalone: true
+    if: eq .OS.Name "Windows"
+    description: Copies install scripts to build dir, this script exists for transparency with CI behavior
+    value: |
+      cp installers/install.ps1 build/install.ps1
+  - name: build-install-scripts
+    language: bash
+    standalone: true
+    if: ne .OS.Name "Windows"
     description: Copies install scripts to build dir, this script exists for transparency with CI behavior
     value: |
       cp installers/install.sh build/install.sh
-      cp installers/install.ps1 build/install.ps1
   - name: deploy-installers
     language: bash
     description: Deploys update files to S3. This steps is automated by CI and should never be ran manually unless you KNOW WHAT YOU'RE DOING.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173967922

This ensures that the line endings of the script files checked out from
git are compatible with the OS.
