### PR TITLE
Paid tiers were still set to 'privateAllowed=false'

### DIFF
--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -111,7 +111,11 @@ func userToJSON(username string) ([]byte, *failures.Failure) {
 	tier := organization.Tier
 	privateProjects := false
 	for _, t := range tiers {
-		privateProjects = (tier == t.Name && t.RequiresPayment)
+		if tier == t.Name && t.RequiresPayment {
+			privateProjects = true
+			break
+		}
+
 	}
 
 	userJ := userJSON{username, organization.URLname, tier, privateProjects}

--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -111,8 +111,8 @@ func userToJSON(username string) ([]byte, *failures.Failure) {
 	tier := organization.Tier
 	privateProjects := false
 	for _, t := range tiers {
-		if tier == t.Name && t.RequiresPayment {
-			privateProjects = true
+		if pp := (tier == t.Name && t.RequiresPayment); pp {
+			privateProjects = pp
 			break
 		}
 

--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -111,8 +111,8 @@ func userToJSON(username string) ([]byte, *failures.Failure) {
 	tier := organization.Tier
 	privateProjects := false
 	for _, t := range tiers {
-		if pp := (tier == t.Name && t.RequiresPayment); pp {
-			privateProjects = pp
+		if tier == t.Name && t.RequiresPayment {
+			privateProjects = true
 			break
 		}
 


### PR DESCRIPTION
`privateProjects` was being set to false even when the user was on a paid tier.  We wouldn't break out of the loop when we found the tier we wanted so unless the tier was last  in the list, it would always get set to false.

 https://www.pivotaltracker.com/story/show/174131275