### PR TITLE
MSI cannot remove directory on uninstall

### DIFF
--- a/installers/msi-language/Uninstall/CustomAction.cs
+++ b/installers/msi-language/Uninstall/CustomAction.cs
@@ -47,7 +47,6 @@ namespace Uninstall
                 if (result.Equals(ActionResult.Failure))
                 {
                     session.Log("Could not remove installation directory");
-                    ActiveState.RollbarHelper.Report("Could not remove installation directory");
 
                     Record record = new Record();
                     record.FormatString = string.Format("Could not remove installation directory entry at: {0}, please ensure no files in the directory are currently being used and try again", installDir);

--- a/installers/msi-language/Uninstall/CustomAction.cs
+++ b/installers/msi-language/Uninstall/CustomAction.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Windows.Forms;
 using ActiveState;
 using Microsoft.Deployment.WindowsInstaller;
 using Preset;
@@ -47,6 +48,11 @@ namespace Uninstall
                 {
                     session.Log("Could not remove installation directory");
                     ActiveState.RollbarHelper.Report("Could not remove installation directory");
+
+                    Record record = new Record();
+                    record.FormatString = string.Format("Could not remove installation directory entry at: {0}, please ensure no files in the directory are currently being used and try again", installDir);
+
+                    session.Message(InstallMessage.Error | (InstallMessage)MessageBoxButtons.OK, record);
                     return ActionResult.Failure;
                 }
 
@@ -100,7 +106,7 @@ namespace Uninstall
                 {
                     Directory.Delete(dir, true);
                 }
-                catch (IOException e)
+                catch (Exception e)
                 {
                     session.Log(string.Format("Could not delete install directory, got error: {0}", e.ToString()));
                     ActiveState.RollbarHelper.Report(string.Format("Could not delete install directory, got error: {0}", e.ToString()));

--- a/installers/msi-language/Uninstall/Uninstall.csproj
+++ b/installers/msi-language/Uninstall/Uninstall.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173947659

It appears that this error can occur when there is an open handle to a file within the directory, though I wasn't able to reproduce. This could include: the directory being open in Explorer, an antivirus scanner using a file, backup software, and a number of other possibilities. This PR adds an error message to the user when we cannot remove a directory. We could also add a retry mechanism if we think it is necessary.