### PR TITLE
Remove fmt print from rollbar setup

### DIFF
--- a/internal/logging/rollbar.go
+++ b/internal/logging/rollbar.go
@@ -22,7 +22,6 @@ func SetupRollbar() {
 	if _, ok := rollbar.Custom()["UserID"]; !ok {
 		UpdateRollbarPerson("unknown", "unknown", "unknown")
 	}
-	fmt.Println("Using install source: ", config.InstallSource())
 	rollbar.SetToken(constants.RollbarToken)
 	rollbar.SetEnvironment(fmt.Sprintf("%s-%s", constants.BranchName, config.InstallSource()))
 	rollbar.SetCodeVersion(constants.RevisionHash)


### PR DESCRIPTION
This breaks all editor plugins, as the output is not a clean JSON blob anymore...

https://www.pivotaltracker.com/story/show/174261665