### PR TITLE
Delete file extensions in MSI on uninstall

### DIFF
--- a/installers/msi-language/ActiveState/FileAssociation.cs
+++ b/installers/msi-language/ActiveState/FileAssociation.cs
@@ -31,7 +31,7 @@ namespace ActiveState
         {
             try
             {
-                // Do not throw if we the extension value was not set anymore, as it may have been deleted by a different programme.
+                // Do not throw if the extension value was not set anymore, as it may have been deleted by a different programme.
                 Registry.LocalMachine.DeleteValue(@"Software\Classes\" + Extension, false);
 
                 Registry.LocalMachine.DeleteSubKeyTree(@"Software\Classes\" + ProgId, true);

--- a/installers/msi-language/ActiveState/FileAssociation.cs
+++ b/installers/msi-language/ActiveState/FileAssociation.cs
@@ -29,9 +29,11 @@ namespace ActiveState
 
         public bool DeleteAssociation()
         {
-            // We only delete the ProgId entry, as the file extension entry could be modified by other programmes
             try
             {
+                // Do not throw if we the extension value was not set anymore, as it may have been deleted by a different programme.
+                Registry.LocalMachine.DeleteValue(@"Software\Classes\" + Extension, false);
+
                 Registry.LocalMachine.DeleteSubKeyTree(@"Software\Classes\" + ProgId, true);
                 return true;
             } catch (ArgumentException)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173972827

I thoroughly tested it by creating two MSIs that write the same file extensions, and the first one that gets uninstalled just removes all values that it sets. possibly removing the file extensions form the registry altogether...  Well, it is how it is.