### PR TITLE
Require .Net 4.5.2

### DIFF
--- a/installers/msi-language/Deploy.wixproj
+++ b/installers/msi-language/Deploy.wixproj
@@ -13,26 +13,26 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug</DefineConstants>
-    <CompilerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension</CompilerAdditionalOptions>
-    <LinkerAdditionalOptions>-sice:ICE91 -sice:ICE64 -sice:ICE71 -sice:ICE68 -ext WixUIExtension -ext WixUtilExtension</LinkerAdditionalOptions>
+    <CompilerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension</CompilerAdditionalOptions>
+    <LinkerAdditionalOptions>-sice:ICE91 -sice:ICE64 -sice:ICE71 -sice:ICE68 -ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension</LinkerAdditionalOptions>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <CompilerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension</CompilerAdditionalOptions>
-    <LinkerAdditionalOptions>-sice:ICE91 -sice:ICE64 -sice:ICE71 -sice:ICE68 -ext WixUIExtension -ext WixUtilExtension</LinkerAdditionalOptions>
+    <CompilerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension</CompilerAdditionalOptions>
+    <LinkerAdditionalOptions>-sice:ICE91 -sice:ICE64 -sice:ICE71 -sice:ICE68 -ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension</LinkerAdditionalOptions>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <DefineConstants>Debug</DefineConstants>
-    <CompilerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension</CompilerAdditionalOptions>
-    <LinkerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension</LinkerAdditionalOptions>
+    <CompilerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension</CompilerAdditionalOptions>
+    <LinkerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension</LinkerAdditionalOptions>
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
     <SuppressIces>ICE91;ICE64;ICE71;ICE69;ICE39</SuppressIces>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <CompilerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension</CompilerAdditionalOptions>
-    <LinkerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension</LinkerAdditionalOptions>
+    <CompilerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension</CompilerAdditionalOptions>
+    <LinkerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension</LinkerAdditionalOptions>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <SuppressIces>ICE91;ICE64;ICE71;ICE69;ICE39</SuppressIces>

--- a/installers/msi-language/Product.p.wxs
+++ b/installers/msi-language/Product.p.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-	<Product Id="{{.ID}}" Name="{{.ProjectName}}" Language="1033" Version="{{.Version}}" Manufacturer="ActiveState" UpgradeCode="{{.ID}}">
-		<Package Id='*' Keywords='Installer' Description="ActiveState Language Runtime"
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
+    <Product Id="{{.ID}}" Name="{{.ProjectName}}" Language="1033" Version="{{.Version}}" Manufacturer="ActiveState" UpgradeCode="{{.ID}}">
+        <Package Id='*' Keywords='Installer' Description="ActiveState Language Runtime"
             Comments='State Tool is a registered trademark of ActiveState' Manufacturer='ActiveState'
             InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' InstallPrivileges='elevated' AdminImage='yes' InstallScope='perMachine' />
 
@@ -16,7 +16,12 @@
 	<Property Id="AS_TOTP" Secure="yes" />
 	<Property Id="CODE_INSTALLED" Value="false" />
     <!-- End Configuration parameters -->
-    
+
+    <PropertyRef Id="WIX_IS_NETFRAMEWORK_462_OR_LATER_INSTALLED"/>
+    <Condition Message="This application requires .NET Framework 4.5.2 or later. Please install the .NET Framework then run this installer again.  The installer can be downloaded from https://www.microsoft.com/en-us/download/details.aspx?id=42643.">
+      <![CDATA[TRUE]]>
+    </Condition>
+
     <!-- Design assets -->
     <WixVariable Id='WixUIBannerBmp' Value='assets\header.bmp'/>
     <WixVariable Id='WixUIDialogBmp' Value='assets\InstallGraphic.bmp'/>

--- a/installers/msi-language/Product.p.wxs
+++ b/installers/msi-language/Product.p.wxs
@@ -17,7 +17,7 @@
 	<Property Id="CODE_INSTALLED" Value="false" />
     <!-- End Configuration parameters -->
 
-    <PropertyRef Id="WIX_IS_NETFRAMEWORK_462_OR_LATER_INSTALLED"/>
+    <PropertyRef Id="WIX_IS_NETFRAMEWORK_452_OR_LATER_INSTALLED"/>
     <Condition Message="This application requires .NET Framework 4.5.2 or later. Please install the .NET Framework then run this installer again.  The installer can be downloaded from https://www.microsoft.com/en-us/download/details.aspx?id=42643.">
       <![CDATA[TRUE]]>
     </Condition>


### PR DESCRIPTION
This presents the following dialog box whenever the user tries to run the installer on a system that does not ship with .Net 4.5.2 or later.

![dotNet452](https://user-images.githubusercontent.com/8608210/90415742-62f91b00-e066-11ea-88f9-decb7a1d4e05.PNG)
