### PR TITLE
Fix State Tool wizard launch

### DIFF
--- a/installers/msi-language/Product.p.wxs
+++ b/installers/msi-language/Product.p.wxs
@@ -108,8 +108,9 @@
 			<Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
 			<Publish Dialog="CustomExitDialog" Control="Finish2" Event="EndDialog" Value="Return" Order="999">1</Publish>
-      		<Publish Dialog="CustomExitDialog" Control="Finish2" Event="DoAction" Value="LaunchStateToolWizard">STATE_TOOL_WIZARD_CHECK_BOX=1 and NOT Installed</Publish>
-      		<Publish Dialog="CustomExitDialog" Control="Finish2" Event="DoAction" Value="LaunchReleaseNotes">STATE_TOOL_WIZARD_REL_NOTES_CHECK_BOX=1 and NOT Installed</Publish>
+      		<Publish Dialog="CustomExitDialog" Control="Finish2" Event="DoAction" Value="LaunchStateToolWizardInstalled">STATE_TOOL_WIZARD_CHECK_BOX=1 and NOT Installed and STATE_TOOL_INSTALLED = "true"</Publish>
+      		<Publish Dialog="CustomExitDialog" Control="Finish2" Event="DoAction" Value="LaunchStateToolWizardNotInstalled">STATE_TOOL_WIZARD_CHECK_BOX=1 and NOT Installed and STATE_TOOL_INSTALLED = "false"</Publish>
+			<Publish Dialog="CustomExitDialog" Control="Finish2" Event="DoAction" Value="LaunchReleaseNotes">STATE_TOOL_WIZARD_REL_NOTES_CHECK_BOX=1 and NOT Installed</Publish>
 			<Publish Dialog="CustomExitDialog" Control="Finish2" Event="DoAction" Value="InstallVSCodeExt">INSTALL_VSCODE_EXT_CHECK_BOX=1 and NOT Installed</Publish>
 
 			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="PrivacyConsentDlg">NOT Installed</Publish>
@@ -147,8 +148,9 @@
 
 		</UI>
 
-    <CustomAction Id="LaunchStateToolWizard" Execute="immediate" Directory="INSTALLDIR" ExeCommand="cmd.exe /k &quot;[AppDataFolder]\ActiveState\bin\state.exe&quot; tutorial new-project" Impersonate="yes" Return="asyncNoWait" />
-    <CustomAction Id='LaunchReleaseNotes' Execute="immediate" Directory="INSTALLDIR" ExeCommand="explorer.exe [REL_NOTES]" Impersonate="yes" Return="asyncNoWait" />
+    <CustomAction Id="LaunchStateToolWizardInstalled" Execute="immediate" Directory="INSTALLDIR" ExeCommand="cmd.exe /k &quot;[STATE_TOOL_PATH]&quot; tutorial new-project" Impersonate="yes" Return="asyncNoWait" />
+    <CustomAction Id="LaunchStateToolWizardNotInstalled" Execute="immediate" Directory="INSTALLDIR" ExeCommand="cmd.exe /k &quot;[AppDataFolder]\ActiveState\bin\state.exe&quot; tutorial new-project" Impersonate="yes" Return="asyncNoWait" />
+	<CustomAction Id='LaunchReleaseNotes' Execute="immediate" Directory="INSTALLDIR" ExeCommand="explorer.exe [REL_NOTES]" Impersonate="yes" Return="asyncNoWait" />
 	<CustomAction Id='InstallVSCodeExt' Execute="immediate" Directory="INSTALLDIR" ExeCommand="cmd.exe /c &quot;[CODE_PATH]&quot; --install-extension ActiveState.activestate-platform" Impersonate="yes" Return="asyncNoWait" />
 
 

--- a/installers/msi-language/Product.p.wxs
+++ b/installers/msi-language/Product.p.wxs
@@ -147,7 +147,7 @@
 
 		</UI>
 
-    <CustomAction Id="LaunchStateToolWizard" Execute="immediate" Directory="INSTALLDIR" ExeCommand="cmd.exe /k &quot;[STATE_TOOL_PATH]&quot; tutorial new-project" Impersonate="yes" Return="asyncNoWait" />
+    <CustomAction Id="LaunchStateToolWizard" Execute="immediate" Directory="INSTALLDIR" ExeCommand="cmd.exe /k &quot;[AppDataFolder]\ActiveState\bin\state.exe&quot; tutorial new-project" Impersonate="yes" Return="asyncNoWait" />
     <CustomAction Id='LaunchReleaseNotes' Execute="immediate" Directory="INSTALLDIR" ExeCommand="explorer.exe [REL_NOTES]" Impersonate="yes" Return="asyncNoWait" />
 	<CustomAction Id='InstallVSCodeExt' Execute="immediate" Directory="INSTALLDIR" ExeCommand="cmd.exe /c &quot;[CODE_PATH]&quot; --install-extension ActiveState.activestate-platform" Impersonate="yes" Return="asyncNoWait" />
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174224476

Discovered during testing of the MSI on Windows 7. The custom action being used to launch the State Tool wizard is immediate. This means that the property `STATE_TOOL_PATH` will always be `state.exe` and not the actual path set in the deferred custom actions. In the State Tool installation custom action we force the installation to `<AppDataDir>/ActiveState/bin`, so I've used that here.