### PR TITLE
Fix locale error

### DIFF
--- a/internal/locale/errors.go
+++ b/internal/locale/errors.go
@@ -52,7 +52,7 @@ type ErrorInput interface {
 	InputError() bool
 }
 
-// NewError creates a new error, it does a locale.Tt lookup of the given id, if the lookup fails it will use the
+// NewError creates a new error, it does a locale.Tl lookup of the given id, if the lookup fails it will use the
 // locale string instead
 func NewError(id string, args ...string) error {
 	return WrapError(nil, id, args...)

--- a/internal/runners/export/config/filter.go
+++ b/internal/runners/export/config/filter.go
@@ -60,7 +60,7 @@ func (f *Filter) Set(value string) error {
 	}
 
 	if len(f.terms) == 0 {
-		return locale.NewError("err_invalid_filter", value, strings.Join(SupportedFilters(), ", "))
+		return locale.NewError("err_invalid_filter", "Invalid filter term specified: '{{.V0}}'; Supported terms: {{.V1}}", value, strings.Join(SupportedFilters(), ", "))
 	}
 	return nil
 }

--- a/locale/en-us.yaml
+++ b/locale/en-us.yaml
@@ -990,8 +990,6 @@ export_config_flag_filter_description:
   other: "Filter configuration output. Accepts: {{.V0}}"
 export_config_dir_description:
   other: Export the config directory details
-err_invalid_filter:
-  other: "Invalid filter term specified: '{{.V0}}'; Supported terms: {{.V1}}"
 export_apikey_user_notice:
   other: "[BLUE]Note that this key is not stored by ActiveState. Please store the value for later use as you cannot retrieve it again.[/RESET]"
 err_apikey_name_required:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174103645

Turns out this ticket was spawned from an incorrect used of `locale.NewError`. Updated the usage and the docstring.