### PR TITLE
Install source fix

### DIFF
--- a/installers/msi-language/ActiveState/Command.cs
+++ b/installers/msi-language/ActiveState/Command.cs
@@ -32,6 +32,8 @@ namespace ActiveState
                 procStartInfo.RedirectStandardOutput = true;
                 procStartInfo.RedirectStandardError = true;
                 procStartInfo.UseShellExecute = false;
+                procStartInfo.StandardOutputEncoding = Encoding.UTF8;
+                procStartInfo.StandardErrorEncoding = Encoding.UTF8;
                 // Do not create the black window.
                 procStartInfo.CreateNoWindow = true;
 

--- a/installers/msi-language/StateDeploy/CustomAction.cs
+++ b/installers/msi-language/StateDeploy/CustomAction.cs
@@ -199,7 +199,6 @@ namespace StateDeploy
                 {
                     contents = "msi-silent";
                 }
-
                 try
                 {
                     string installFilePath = Path.Combine(output.Trim(), "installsource.txt");

--- a/installers/msi-language/StateDeploy/CustomAction.cs
+++ b/installers/msi-language/StateDeploy/CustomAction.cs
@@ -200,19 +200,6 @@ namespace StateDeploy
                     contents = "msi-silent";
                 }
 
-                // The State Tool should have created the config directory, but incase not
-                // we create it here.
-                try
-                {
-                    Directory.CreateDirectory(output.Trim());
-                }
-                catch (Exception e)
-                {
-                    string msg = string.Format("Could not create State Tool configuration directory at: {0}, encountered exception: {1}", output.Trim(), e.ToString());
-                    session.Log(msg);
-                    RollbarReport.Critical(msg);
-                }
-
                 try
                 {
                     string installFilePath = Path.Combine(output.Trim(), "installsource.txt");

--- a/installers/msi-language/StateDeploy/CustomAction.cs
+++ b/installers/msi-language/StateDeploy/CustomAction.cs
@@ -199,6 +199,20 @@ namespace StateDeploy
                 {
                     contents = "msi-silent";
                 }
+
+                // The State Tool should have created the config directory, but incase not
+                // we create it here.
+                try
+                {
+                    Directory.CreateDirectory(output.Trim());
+                }
+                catch (Exception e)
+                {
+                    string msg = string.Format("Could not create State Tool configuration directory at: {0}, encountered exception: {1}", output.Trim(), e.ToString());
+                    session.Log(msg);
+                    RollbarReport.Critical(msg);
+                }
+
                 try
                 {
                     string installFilePath = Path.Combine(output.Trim(), "installsource.txt");


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174515752

Simple change but required a fair bit of debugging to determine.

I was able to reproduce the rollbar error [here](https://rollbar.com/activestate/msi/items/316/occurrences/133889127978/) by creating a user named `Iñaki` and setting the cmd.exe code page to `1252-ANSI Latin 1; Western European (Windows)` more info [here](https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers?redirectedfrom=MSDN). With the default stdout encoding the output received from cmd.exe when running `state export config --filter=dir` is `C:\Users\IÃ±aki\AppData\Roaming\activestate\cli-unstable` and we fail to write `installsource.txt` as that directory doesn't exist. Changing the encoding interprets the stdout correctly and we can successfully write the install source file.