### PR TITLE
Add CommitID to all deploy sub-commands

### DIFF
--- a/installers/msi-language/StateDeploy/CustomAction.cs
+++ b/installers/msi-language/StateDeploy/CustomAction.cs
@@ -459,7 +459,7 @@ namespace StateDeploy
                 deployCMDBuilder.Append(" --force");
             }
             // Add commitID if requested
-            if (subCommand == "install" && commitID != "latest")
+            if (commitID != "latest")
             {
                 projectName += "#" + commitID;
             }


### PR DESCRIPTION
Addendum to https://www.pivotaltracker.com/story/show/174611318

This commit adds the commit id to all `state deploy` sub-commands.

Technically `configure`, `symlink` and `report` do not need them.  But if the build for the `latest` commit is broken, the entire command will fail otherwise.