### PR TITLE
Revert "state deploy checks for clean target directory"

### DIFF
--- a/internal/runners/deploy/deploy.go
+++ b/internal/runners/deploy/deploy.go
@@ -182,29 +182,7 @@ func runStepsWithFuncs(targetPath string, force, userScope bool, namespace proje
 
 type installFunc func(path string, installer installable, out output.Outputer) (runtime.EnvGetter, error)
 
-func ensurePathIsClean(path string) error {
-	if !fileutils.TargetExists(path) {
-		return nil
-	}
-	if !fileutils.IsDir(path) {
-		return locale.NewError("deploy_install_path_no_directory", "The installation target {{.V0}} needs to be a directory.", path)
-	}
-	empty, fail := fileutils.IsEmptyDir(path)
-	if fail != nil {
-		return errs.Wrap(fail, "Failed to check if %s is empty.", path)
-	}
-	if !empty {
-		return locale.NewError("deploy_install_path_not_empty", "The installation directory {{.V0}} needs to be empty.", path)
-	}
-	return nil
-}
-
 func install(path string, installer installable, out output.Outputer) (runtime.EnvGetter, error) {
-	// check that path is empty or does not exist yet
-	err := ensurePathIsClean(path)
-	if err != nil {
-		return nil, locale.WrapError(err, "deploy_ensure_path_is_clean", "Could not ensure that installation path is clean.")
-	}
 	out.Notice(locale.T("deploy_install"))
 	envGetter, installed, fail := installer.Install()
 	if fail != nil {

--- a/test/integration/deploy_int_test.go
+++ b/test/integration/deploy_int_test.go
@@ -198,21 +198,6 @@ func (suite *DeployIntegrationTestSuite) TestDeployPython() {
 	suite.AssertConfig(ts)
 }
 
-func (suite *DeployIntegrationTestSuite) TestDeployInstallNonEmptyDirectory() {
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
-	targetDir := filepath.Join(ts.Dirs.Work, "target")
-	fail := fileutils.MkdirUnlessExists(targetDir)
-	suite.Require().NoError(fail.ToError(), "error creating target directory")
-	fail = fileutils.Touch(filepath.Join(targetDir, "dummy"))
-	suite.Require().NoError(fail.ToError(), "error creating a dummy file in target directory")
-
-	cp := ts.Spawn("deploy", "install", "ActiveState-CLI/Python3", "--path", targetDir)
-	cp.ExpectLongString("needs to be empty")
-	cp.ExpectNotExitCode(0)
-}
-
 func (suite *DeployIntegrationTestSuite) TestDeployInstall() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()


### PR DESCRIPTION
This reverts commit 808dbb9b35ab7e1361ab548c55bc1d71d2bdf2bd.

# Conflicts:
#	internal/runners/deploy/deploy.go

https://www.pivotaltracker.com/story/show/174739175