### PR TITLE
Ensure user_network event is properly captured

### DIFF
--- a/installers/msi-language/ActiveState/ActiveState.csproj
+++ b/installers/msi-language/ActiveState/ActiveState.csproj
@@ -127,6 +127,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Error.cs" />
+    <Compile Include="TimeoutWebClient.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="UserEnvironment.cs" />
     <Compile Include="Logging.cs" />
     <Compile Include="Retry.cs" />

--- a/installers/msi-language/ActiveState/Logging.cs
+++ b/installers/msi-language/ActiveState/Logging.cs
@@ -72,21 +72,20 @@ namespace ActiveState
 
         public static string GetCountry(Session session)
         {
-            string locationJSON = "";
             try
             {
                 using (WebClient wc = new WebClient())
                 {
-                    locationJSON = wc.DownloadString("https://freegeoip.app/json/");
+                    var locationJSON = wc.DownloadString("https://freegeoip.app/json/");
+                    Localization loc = JsonConvert.DeserializeObject<Localization>(locationJSON);
+                    return loc.Country;
                 }
             }
             catch (WebException e)
             {
                 session.Log("Could not get location JSON. Exception: {0}", e.ToString());
+                return "unknown";
             }
-
-            Localization loc = JsonConvert.DeserializeObject<Localization>(locationJSON);
-            return loc.Country;
         }
 
         public static bool PrivacyAgreementAccepted(Session session)

--- a/installers/msi-language/ActiveState/TimeoutWebClient.cs
+++ b/installers/msi-language/ActiveState/TimeoutWebClient.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ActiveState
+{
+    // Modify WebClient so we can set a timeout
+    public class TimeoutWebClient : System.Net.WebClient
+    {
+        public int Timeout { get; set; }
+
+        protected override WebRequest GetWebRequest(Uri uri)
+        {
+            WebRequest lWebRequest = base.GetWebRequest(uri);
+            lWebRequest.Timeout = Timeout;
+            ((HttpWebRequest)lWebRequest).ReadWriteTimeout = Timeout;
+            return lWebRequest;
+        }
+    }
+}

--- a/installers/msi-language/StateDeploy/CustomAction.cs
+++ b/installers/msi-language/StateDeploy/CustomAction.cs
@@ -589,6 +589,7 @@ namespace StateDeploy
             {
                 Object errorType = productKey.GetValue(Error.TypeRegistryKey);
                 Object errorMessage = productKey.GetValue(Error.MessageRegistryKey);
+                session.Log("errorType={0}, error_message={1}", errorType, errorMessage);
                 session["ERROR"] = errorType as string;
                 session["ERROR_MESSAGE"] = errorMessage as string;
             } catch (Exception e)

--- a/internal/retryhttp/client.go
+++ b/internal/retryhttp/client.go
@@ -88,7 +88,7 @@ func normalizeResponse(res *http.Response, err error) (*http.Response, error) {
 	}
 
 	var dnsError *net.DNSError
-	if errors.Is(err, dnsError) {
+	if errors.As(err, &dnsError) {
 		return res, locale.WrapError(&UserNetworkError{}, "err_user_network_dns", "Request failed due to DNS error: {{.V0}}. {{.V1}}", err.Error(), solutionLocale)
 	}
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174783031

I ran the MSI without an internet connection, as this should certainly cause some `user_network` errrors.

Issues found and corrected:

- Dns errors were not correctly reported as (exit code 11 - user_network errors) in State Tool
- Sending a Rollbar report could crash the entire MSI if the geo-location service failed
- The GA/S3 tracking could block for ever on an offline computer (probably also one with a bad internet-connection)

I also cancelled the installation right at the start of the artifact installation, and observed the following:

- As the State Tool command was already inside the first HTTP request, it created the timeout error (after my cancellation).
- Instead of showing the cancellation screen, I got the user network error finishing screen.

All of this is probably good and means that it would be rather the other way round now: When the user cancels, there is still a chance that the `user_network` event gets reported instead of the cancel event.