### PR TITLE
enforce ascii encoding when writing to installsource.txt on Windows

### DIFF
--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -373,7 +373,7 @@ function install()
     $Command = "$StatePath export config --filter=dir"
     $ConfigDir = & Invoke-Expression $Command | Out-String
     $InstallFilePath = Join-Path -Path $ConfigDir.Trim() -ChildPath "installsource.txt"
-    "install.ps1" | Out-File -FilePath $InstallFilePath
+    "install.ps1" | Out-File -Encoding ascii -FilePath $InstallFilePath
 
     # Check if installation is in $PATH
     if (isStateToolInstallationOnPath $installDir) {

--- a/installers/msi-language/StateDeploy/CustomAction.cs
+++ b/installers/msi-language/StateDeploy/CustomAction.cs
@@ -161,7 +161,7 @@ namespace StateDeploy
             {
                 return result;
             }
-            
+
 
             SHA256 sha = SHA256.Create();
             FileStream fInfo = File.OpenRead(zipPath);
@@ -234,7 +234,7 @@ namespace StateDeploy
                 try
                 {
                     string installFilePath = Path.Combine(output.Trim(), "installsource.txt");
-                    File.WriteAllText(installFilePath, contents);
+                    File.WriteAllText(installFilePath, contents, Encoding.ASCII);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174664622

This is really only an issue for install.ps1, as powershell 5.1
defaulted to utf-16 and later powershell versions to utf-8.

So much about Microsoft ensuring backwards-compatibility.
