### PR TITLE
Update commit ID, and account for non-alternate builds

### DIFF
--- a/locale/en-us.yaml
+++ b/locale/en-us.yaml
@@ -1693,3 +1693,5 @@ prepare_instructions_windows:
   other: "To add the global installations directory to your environment please add the path `{{.V0}}` to your user PATH in the System Properties dialog"
 prepare_env_warning:
   other: Could not update user environment
+err_package_update_pjfile:
+  other: "Coult not update your activestate.yaml with the new commit ID. Please run `state pull` manually."

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -88,7 +88,7 @@ func IngredientWithLatestVersion(language, name string) (*IngredientAndVersion, 
 	}
 
 	if latest == nil {
-		return nil, locale.NewInputError("inventory_ingredient_no_version_available", "No versions are available for package {{.V1}} on the ActiveState Platform", name)
+		return nil, locale.NewInputError("inventory_ingredient_no_version_available", "No versions are available for package {{.V0}} on the ActiveState Platform", name)
 	}
 	return latest, nil
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174895290

I realized after pushing the other PR that it breaks camel based package changes. And it also doesn't set the commitID in the activestate.yaml despite updating the runtime, which will cause the runtime to think it's not up to date.