### PR TITLE
install.sh does not run `set -i`

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -399,8 +399,6 @@ else
 fi
 
 if [ -n "${ACTIVATE}" ]; then
-  # switch this shell to interactive mode
-  set -i
   # control flow of this script ends with this line: replace the shell with the activated project's shell
   exec $STATEPATH activate ${ACTIVATE}
 fi


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174780799

Apprently the flag is without effect in the bash shell:
https://unix.stackexchange.com/a/364618
and also in other shells.

I tested that it still works in minimal POSIX compatible shells.


 https://www.pivotaltracker.com/story/show/174780799