### PR TITLE
Add registry to captain command registration

### DIFF
--- a/cmd/state/internal/cmdtree/activate.go
+++ b/cmd/state/internal/cmdtree/activate.go
@@ -8,18 +8,17 @@ import (
 	"github.com/ActiveState/cli/pkg/project"
 )
 
-func newActivateCommand(prime *primer.Values) *captain.Command {
+func newActivateCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := activate.NewActivate(prime)
 
 	params := activate.ActivateParams{
 		Namespace: &project.Namespaced{},
 	}
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"activate",
 		locale.Tl("activate_title", "Activating Your Runtime"),
 		locale.T("activate_project"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "path",

--- a/cmd/state/internal/cmdtree/auth.go
+++ b/cmd/state/internal/cmdtree/auth.go
@@ -7,16 +7,15 @@ import (
 	"github.com/ActiveState/cli/internal/runners/auth"
 )
 
-func newAuthCommand(prime *primer.Values) *captain.Command {
+func newAuthCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	authRunner := auth.NewAuth(prime)
 
 	params := auth.AuthParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"auth",
 		locale.Tl("auth_title", "Signing In To The ActiveState Platform"),
 		locale.T("auth_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "token",
@@ -50,13 +49,12 @@ func newAuthCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newSignupCommand(prime *primer.Values) *captain.Command {
+func newSignupCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	signupRunner := auth.NewSignup(prime)
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"signup",
 		locale.Tl("signup_title", "Signing Up With The ActiveState Platform"),
 		locale.T("signup_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {
@@ -65,13 +63,12 @@ func newSignupCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newLogoutCommand(prime *primer.Values) *captain.Command {
+func newLogoutCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	logoutRunner := auth.NewLogout(prime)
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"logout",
 		locale.Tl("logout_title", "Logging Out Of The ActiveState Platform"),
 		locale.T("logout_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {

--- a/cmd/state/internal/cmdtree/clean.go
+++ b/cmd/state/internal/cmdtree/clean.go
@@ -7,12 +7,11 @@ import (
 	"github.com/ActiveState/cli/internal/runners/clean"
 )
 
-func newCleanCommand(prime *primer.Values) *captain.Command {
-	return captain.NewCommand(
+func newCleanCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
+	return registry.NewCommand(
 		"clean",
 		locale.Tl("clean_title", "Cleaning Resources"),
 		locale.T("clean_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {
@@ -22,13 +21,12 @@ func newCleanCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newUninstallCommand(prime *primer.Values) *captain.Command {
+func newUninstallCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	params := clean.UninstallParams{}
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"uninstall",
 		locale.Tl("clean_uninstall_title", "Uninstalling"),
 		locale.T("uninstall_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "force",
@@ -49,14 +47,13 @@ func newUninstallCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newCacheCommand(prime *primer.Values) *captain.Command {
+func newCacheCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := clean.NewCache(prime)
 	params := clean.CacheParams{}
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"cache",
 		locale.Tl("clean_cache_title", "Cleaning Cached Runtimes"),
 		locale.T("cache_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "force",
@@ -79,14 +76,13 @@ func newCacheCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newConfigCommand(prime *primer.Values) *captain.Command {
+func newConfigCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := clean.NewConfig(prime)
 	params := clean.ConfigParams{}
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"config",
 		locale.Tl("clean_config_title", "Cleaning Configuration"),
 		locale.T("config_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "force",

--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -20,95 +20,97 @@ type CmdTree struct {
 func New(prime *primer.Values, args ...string) *CmdTree {
 	globals := newGlobalOptions()
 
-	authCmd := newAuthCommand(prime)
+	registry := captain.NewRegistry(prime.Output())
+
+	authCmd := newAuthCommand(registry, prime)
 	authCmd.AddChildren(
-		newSignupCommand(prime),
-		newLogoutCommand(prime),
+		newSignupCommand(registry, prime),
+		newLogoutCommand(registry, prime),
 	)
 
-	exportCmd := newExportCommand(prime)
+	exportCmd := newExportCommand(registry, prime)
 	exportCmd.AddChildren(
-		newRecipeCommand(prime),
-		newJWTCommand(prime),
-		newPrivateKeyCommand(prime),
-		newAPIKeyCommand(prime),
-		newExportConfigCommand(prime),
-		newExportGithubActionCommand(prime),
+		newRecipeCommand(registry, prime),
+		newJWTCommand(registry, prime),
+		newPrivateKeyCommand(registry, prime),
+		newAPIKeyCommand(registry, prime),
+		newExportConfigCommand(registry, prime),
+		newExportGithubActionCommand(registry, prime),
 	)
 
-	packagesCmd := newPackagesCommand(prime)
+	packagesCmd := newPackagesCommand(registry, prime)
 	packagesCmd.AddChildren(
-		newPackagesAddCommand(prime),
-		newPackagesUpdateCommand(prime),
-		newPackagesRemoveCommand(prime),
-		newPackagesImportCommand(prime),
-		newPackagesSearchCommand(prime),
+		newPackagesAddCommand(registry, prime),
+		newPackagesUpdateCommand(registry, prime),
+		newPackagesRemoveCommand(registry, prime),
+		newPackagesImportCommand(registry, prime),
+		newPackagesSearchCommand(registry, prime),
 	)
 
-	platformsCmd := newPlatformsCommand(prime)
+	platformsCmd := newPlatformsCommand(registry, prime)
 	platformsCmd.AddChildren(
-		newPlatformsSearchCommand(prime),
-		newPlatformsAddCommand(prime),
-		newPlatformsRemoveCommand(prime),
+		newPlatformsSearchCommand(registry, prime),
+		newPlatformsAddCommand(registry, prime),
+		newPlatformsRemoveCommand(registry, prime),
 	)
 
-	scriptsCmd := newScriptsCommand(prime)
+	scriptsCmd := newScriptsCommand(registry, prime)
 	scriptsCmd.AddChildren(
-		newScriptsEditCommand(prime),
+		newScriptsEditCommand(registry, prime),
 	)
 
-	languagesCmd := newLanguagesCommand(prime)
-	languagesCmd.AddChildren(newLanguageUpdateCommand(prime))
+	languagesCmd := newLanguagesCommand(registry, prime)
+	languagesCmd.AddChildren(newLanguageUpdateCommand(registry, prime))
 
-	cleanCmd := newCleanCommand(prime)
+	cleanCmd := newCleanCommand(registry, prime)
 	cleanCmd.AddChildren(
-		newUninstallCommand(prime),
-		newCacheCommand(prime),
-		newConfigCommand(prime),
+		newUninstallCommand(registry, prime),
+		newCacheCommand(registry, prime),
+		newConfigCommand(registry, prime),
 	)
 
-	deployCmd := newDeployCommand(prime)
+	deployCmd := newDeployCommand(registry, prime)
 	deployCmd.AddChildren(
-		newDeployInstallCommand(prime),
-		newDeployConfigureCommand(prime),
-		newDeploySymlinkCommand(prime),
-		newDeployReportCommand(prime),
+		newDeployInstallCommand(registry, prime),
+		newDeployConfigureCommand(registry, prime),
+		newDeploySymlinkCommand(registry, prime),
+		newDeployReportCommand(registry, prime),
 	)
 
-	tutorialCmd := newTutorialCommand(prime)
-	tutorialCmd.AddChildren(newTutorialProjectCommand(prime))
+	tutorialCmd := newTutorialCommand(registry, prime)
+	tutorialCmd.AddChildren(newTutorialProjectCommand(registry, prime))
 
-	eventsCmd := newEventsCommand(prime)
-	eventsCmd.AddChildren(newEventsLogCommand(prime))
+	eventsCmd := newEventsCommand(registry, prime)
+	eventsCmd.AddChildren(newEventsLogCommand(registry, prime))
 
-	stateCmd := newStateCommand(globals, prime)
+	stateCmd := newStateCommand(registry, globals, prime)
 	stateCmd.AddChildren(
-		newActivateCommand(prime),
-		newInitCommand(prime),
-		newPushCommand(prime),
-		newProjectsCommand(prime),
+		newActivateCommand(registry, prime),
+		newInitCommand(registry, prime),
+		newPushCommand(registry, prime),
+		newProjectsCommand(registry, prime),
 		authCmd,
 		exportCmd,
-		newOrganizationsCommand(prime),
-		newRunCommand(prime),
-		newShowCommand(prime),
+		newOrganizationsCommand(registry, prime),
+		newRunCommand(registry, prime),
+		newShowCommand(registry, prime),
 		packagesCmd,
 		platformsCmd,
-		newHistoryCommand(prime),
+		newHistoryCommand(registry, prime),
 		cleanCmd,
 		languagesCmd,
 		deployCmd,
 		scriptsCmd,
 		eventsCmd,
-		newPullCommand(prime),
-		newUpdateCommand(prime),
-		newForkCommand(prime),
-		newPpmCommand(prime),
-		newInviteCommand(prime),
+		newPullCommand(registry, prime),
+		newUpdateCommand(registry, prime),
+		newForkCommand(registry, prime),
+		newPpmCommand(registry, prime),
+		newInviteCommand(registry, prime),
 		tutorialCmd,
-		newPrepareCommand(prime),
-		newProtocolCommand(prime),
-		newShimCommand(prime, args...),
+		newPrepareCommand(registry, prime),
+		newProtocolCommand(registry, prime),
+		newShimCommand(registry, prime, args...),
 	)
 
 	applyLegacyChildren(stateCmd, globals)
@@ -128,15 +130,14 @@ func newGlobalOptions() *globalOptions {
 	return &globalOptions{}
 }
 
-func newStateCommand(globals *globalOptions, prime *primer.Values) *captain.Command {
+func newStateCommand(registry *captain.Registry, globals *globalOptions, prime *primer.Values) *captain.Command {
 	opts := state.NewOptions()
 
 	runner := state.New(opts, prime)
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"state",
 		"",
 		locale.T("state_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "locale",

--- a/cmd/state/internal/cmdtree/deploy.go
+++ b/cmd/state/internal/cmdtree/deploy.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ActiveState/cli/internal/runners/deploy"
 )
 
-func newDeployCommand(prime *primer.Values) *captain.Command {
+func newDeployCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := deploy.NewDeploy(deploy.UnsetStep, prime)
 
 	params := &deploy.Params{}
@@ -34,11 +34,10 @@ func newDeployCommand(prime *primer.Values) *captain.Command {
 		})
 	}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"deploy",
 		locale.Tl("deploy_title", "Deploying Runtime"),
 		locale.T("deploy_cmd_description"),
-		prime.Output(),
 		flags,
 		[]*captain.Argument{
 			{
@@ -53,16 +52,15 @@ func newDeployCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newDeployInstallCommand(prime *primer.Values) *captain.Command {
+func newDeployInstallCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := deploy.NewDeploy(deploy.InstallStep, prime)
 
 	params := &deploy.Params{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"install",
 		locale.Tl("deploy_install_title", "Installing Runtime (Unconfigured)"),
 		locale.T("deploy_install_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "path",
@@ -83,7 +81,7 @@ func newDeployInstallCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newDeployConfigureCommand(prime *primer.Values) *captain.Command {
+func newDeployConfigureCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := deploy.NewDeploy(deploy.ConfigureStep, prime)
 
 	params := &deploy.Params{}
@@ -103,11 +101,10 @@ func newDeployConfigureCommand(prime *primer.Values) *captain.Command {
 		})
 	}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"configure",
 		locale.Tl("deploy_configure_title", "Configuring Runtime For Your Shell"),
 		locale.T("deploy_configure_cmd_description"),
-		prime.Output(),
 		flags,
 		[]*captain.Argument{
 			{
@@ -122,16 +119,15 @@ func newDeployConfigureCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newDeploySymlinkCommand(prime *primer.Values) *captain.Command {
+func newDeploySymlinkCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := deploy.NewDeploy(deploy.SymlinkStep, prime)
 
 	params := &deploy.Params{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"symlink",
 		locale.Tl("deploy_symlink_title", "Symlinking Executables"),
 		locale.T("deploy_symlink_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "path",
@@ -157,16 +153,15 @@ func newDeploySymlinkCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newDeployReportCommand(prime *primer.Values) *captain.Command {
+func newDeployReportCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := deploy.NewDeploy(deploy.ReportStep, prime)
 
 	params := &deploy.Params{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"report",
 		locale.Tl("deploy_report_title", "Reporting Deployment Information"),
 		locale.T("deploy_report_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "path",

--- a/cmd/state/internal/cmdtree/events.go
+++ b/cmd/state/internal/cmdtree/events.go
@@ -7,14 +7,13 @@ import (
 	"github.com/ActiveState/cli/internal/runners/events"
 )
 
-func newEventsCommand(prime *primer.Values) *captain.Command {
+func newEventsCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := events.New(prime)
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"events",
 		locale.Tl("events_title", "Listing Events"),
 		locale.Tl("events_description", "Manage project events"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(cmd *captain.Command, args []string) error {
@@ -22,15 +21,14 @@ func newEventsCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newEventsLogCommand(prime *primer.Values) *captain.Command {
+func newEventsLogCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := events.NewLog(prime)
 	params := events.EventLogParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"log",
 		locale.Tl("events_log_title", "Showing Events Log"),
 		locale.Tl("events_log_description", "View a log of events"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "follow",

--- a/cmd/state/internal/cmdtree/export.go
+++ b/cmd/state/internal/cmdtree/export.go
@@ -11,14 +11,13 @@ import (
 	"github.com/ActiveState/cli/internal/runners/export/ghactions"
 )
 
-func newExportCommand(prime *primer.Values) *captain.Command {
+func newExportCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := export.NewExport()
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"export",
 		locale.Tl("export_title", "Exporting Information"),
 		locale.T("export_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {
@@ -26,16 +25,15 @@ func newExportCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newRecipeCommand(prime *primer.Values) *captain.Command {
+func newRecipeCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	recipe := export.NewRecipe(prime)
 
 	params := export.RecipeParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"recipe",
 		locale.Tl("export_recipe_title", "Exporting Recipe Data"),
 		locale.T("export_recipe_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "pretty",
@@ -61,16 +59,15 @@ func newRecipeCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newJWTCommand(prime *primer.Values) *captain.Command {
+func newJWTCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	jwt := export.NewJWT(prime)
 
 	params := export.JWTParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"jwt",
 		locale.Tl("export_jwt_title", "Exporting Credentials"),
 		locale.T("export_jwt_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {
@@ -78,16 +75,15 @@ func newJWTCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newPrivateKeyCommand(prime *primer.Values) *captain.Command {
+func newPrivateKeyCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	privateKey := export.NewPrivateKey(prime)
 
 	params := export.PrivateKeyParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"private-key",
 		locale.Tl("export_privkey_title", "Exporting Private Key"),
 		locale.T("export_privkey_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {
@@ -95,15 +91,14 @@ func newPrivateKeyCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newAPIKeyCommand(prime *primer.Values) *captain.Command {
+func newAPIKeyCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	apikey := export.NewAPIKey(prime)
 	params := export.APIKeyRunParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"new-api-key",
 		locale.Tl("export_new_api_key_title", "Exporting New API Key"),
 		locale.T("export_new_api_key_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{
 			{
@@ -119,15 +114,14 @@ func newAPIKeyCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newExportConfigCommand(prime *primer.Values) *captain.Command {
+func newExportConfigCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := config.New(prime)
 	params := config.ConfigParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"config",
 		locale.Tl("export_config_title", "Exporting Configuration Data"),
 		locale.T("export_config_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name: "filter",
@@ -144,15 +138,14 @@ func newExportConfigCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newExportGithubActionCommand(prime *primer.Values) *captain.Command {
+func newExportGithubActionCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := ghactions.New(prime)
 	params := ghactions.Params{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"github-actions",
 		locale.Tl("export_ghactions_title", "Exporting Github Action Workflow"),
 		locale.Tl("export_ghactions_description", "Create a github action workflow for your project"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {

--- a/cmd/state/internal/cmdtree/fork.go
+++ b/cmd/state/internal/cmdtree/fork.go
@@ -7,15 +7,14 @@ import (
 	"github.com/ActiveState/cli/internal/runners/fork"
 )
 
-func newForkCommand(prime *primer.Values) *captain.Command {
+func newForkCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := fork.New(prime)
 	params := &fork.Params{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"fork",
 		locale.Tl("fork_title", "Forking Project"),
 		locale.Tl("fork_description", "Fork an existing ActiveState Platform project"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "org",

--- a/cmd/state/internal/cmdtree/history.go
+++ b/cmd/state/internal/cmdtree/history.go
@@ -14,15 +14,14 @@ type historyOpts struct {
 	Namespace string
 }
 
-func newHistoryCommand(prime *primer.Values) *captain.Command {
+func newHistoryCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	initRunner := history.NewHistory()
 
 	opts := historyOpts{}
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"history",
 		locale.Tl("history_title", "Viewing Project History"),
 		locale.T("history_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "namespace",

--- a/cmd/state/internal/cmdtree/init.go
+++ b/cmd/state/internal/cmdtree/init.go
@@ -8,18 +8,17 @@ import (
 	"github.com/ActiveState/cli/pkg/project"
 )
 
-func newInitCommand(prime *primer.Values) *captain.Command {
+func newInitCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	initRunner := initialize.New(prime)
 
 	params := initialize.RunParams{
 		Namespace: &project.Namespaced{},
 	}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"init",
 		locale.Tl("init_title", "Initializing Project"),
 		locale.T("init_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "path",

--- a/cmd/state/internal/cmdtree/invite.go
+++ b/cmd/state/internal/cmdtree/invite.go
@@ -7,16 +7,15 @@ import (
 	"github.com/ActiveState/cli/internal/runners/invite"
 )
 
-func newInviteCommand(prime *primer.Values) *captain.Command {
+func newInviteCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	inviteRunner := invite.New(prime)
 
 	params := invite.Params{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"invite",
 		locale.Tl("invite_title", "Inviting New Members"),
 		locale.Tl("invite_description", "Invite new members to an organization"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "organization",

--- a/cmd/state/internal/cmdtree/languages.go
+++ b/cmd/state/internal/cmdtree/languages.go
@@ -8,14 +8,13 @@ import (
 	"github.com/ActiveState/cli/pkg/project"
 )
 
-func newLanguagesCommand(prime *primer.Values) *captain.Command {
+func newLanguagesCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := languages.NewLanguages(prime)
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"languages",
 		locale.Tl("languages_title", "Listing Languages"),
 		locale.T("languages_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {
@@ -30,16 +29,15 @@ func newLanguagesCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newLanguageUpdateCommand(prime *primer.Values) *captain.Command {
+func newLanguageUpdateCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := languages.NewUpdate(prime)
 
 	params := languages.UpdateParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"update",
 		locale.Tl("languages_update_title", "Updating Languages"),
 		locale.T("languages_update_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{
 			{

--- a/cmd/state/internal/cmdtree/organizations.go
+++ b/cmd/state/internal/cmdtree/organizations.go
@@ -7,16 +7,15 @@ import (
 	"github.com/ActiveState/cli/internal/runners/organizations"
 )
 
-func newOrganizationsCommand(prime *primer.Values) *captain.Command {
+func newOrganizationsCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := organizations.NewOrganizations(prime)
 
 	params := organizations.OrgParams{}
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"organizations",
 		locale.Tl("organizations_title", "Listing Organizations"),
 		locale.T("organizations_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {

--- a/cmd/state/internal/cmdtree/packages.go
+++ b/cmd/state/internal/cmdtree/packages.go
@@ -7,16 +7,15 @@ import (
 	"github.com/ActiveState/cli/internal/runners/packages"
 )
 
-func newPackagesCommand(prime *primer.Values) *captain.Command {
+func newPackagesCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := packages.NewList(prime)
 
 	params := packages.ListRunParams{}
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"packages",
 		locale.Tl("package_title", "Listing Packages"),
 		locale.T("package_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "commit",
@@ -44,16 +43,15 @@ func newPackagesCommand(prime *primer.Values) *captain.Command {
 	return cmd
 }
 
-func newPackagesAddCommand(prime *primer.Values) *captain.Command {
+func newPackagesAddCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := packages.NewAdd(prime)
 
 	params := packages.AddRunParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"add",
 		locale.Tl("package_add_title", "Adding Package"),
 		locale.T("package_add_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{
 			{
@@ -69,16 +67,15 @@ func newPackagesAddCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newPackagesUpdateCommand(prime *primer.Values) *captain.Command {
+func newPackagesUpdateCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := packages.NewUpdate(prime)
 
 	params := packages.UpdateRunParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"update",
 		locale.Tl("package_update_title", "Updating Packages"),
 		locale.T("package_update_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{
 			{
@@ -94,16 +91,15 @@ func newPackagesUpdateCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newPackagesRemoveCommand(prime *primer.Values) *captain.Command {
+func newPackagesRemoveCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := packages.NewRemove(prime)
 
 	params := packages.RemoveRunParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"remove",
 		locale.Tl("package_remove_title", "Removing Package"),
 		locale.T("package_remove_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{
 			{
@@ -119,16 +115,15 @@ func newPackagesRemoveCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newPackagesImportCommand(prime *primer.Values) *captain.Command {
+func newPackagesImportCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := packages.NewImport(prime)
 
 	params := packages.NewImportRunParams()
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"import",
 		locale.Tl("package_import_title", "Importing Packages"),
 		locale.T("package_import_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "force",
@@ -150,16 +145,15 @@ func newPackagesImportCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newPackagesSearchCommand(prime *primer.Values) *captain.Command {
+func newPackagesSearchCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := packages.NewSearch(prime)
 
 	params := packages.SearchRunParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"search",
 		locale.Tl("package_search_title", "Searching Packages"),
 		locale.T("package_search_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "language",

--- a/cmd/state/internal/cmdtree/platforms.go
+++ b/cmd/state/internal/cmdtree/platforms.go
@@ -8,16 +8,15 @@ import (
 	"github.com/ActiveState/cli/pkg/project"
 )
 
-func newPlatformsCommand(prime *primer.Values) *captain.Command {
+func newPlatformsCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := platforms.NewList(prime)
 
 	params := platforms.ListRunParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"platforms",
 		locale.Tl("platforms_title", "Listing Platforms"),
 		locale.T("platforms_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(_ *captain.Command, _ []string) error {
@@ -32,14 +31,13 @@ func newPlatformsCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newPlatformsSearchCommand(prime *primer.Values) *captain.Command {
+func newPlatformsSearchCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := platforms.NewSearch(prime)
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"search",
 		locale.Tl("platforms_search_title", "Searching Platforms"),
 		locale.T("platforms_search_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(_ *captain.Command, _ []string) error {
@@ -48,16 +46,15 @@ func newPlatformsSearchCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newPlatformsAddCommand(prime *primer.Values) *captain.Command {
+func newPlatformsAddCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := platforms.NewAdd(prime)
 
 	params := platforms.AddRunParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"add",
 		locale.Tl("platforms_add_title", "Adding Platform"),
 		locale.T("platforms_add_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        locale.T("flag_platforms_shared_bitwidth"),
@@ -91,16 +88,15 @@ func newPlatformsAddCommand(prime *primer.Values) *captain.Command {
 	)
 }
 
-func newPlatformsRemoveCommand(prime *primer.Values) *captain.Command {
+func newPlatformsRemoveCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := platforms.NewRemove()
 
 	params := platforms.RemoveRunParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"remove",
 		locale.Tl("platforms_remove_title", "Removing Platform"),
 		locale.T("platforms_remove_cmd_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        locale.T("flag_platforms_shared_bitwidth"),

--- a/cmd/state/internal/cmdtree/ppm.go
+++ b/cmd/state/internal/cmdtree/ppm.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ActiveState/cli/internal/runners/ppm"
 )
 
-func newPpmCommand(prime *primer.Values) *captain.Command {
+func newPpmCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	shim := ppm.NewShim(prime)
 	conversion := ppm.NewConversionFlow(prime)
 	rootCmd := captain.NewHiddenShimCommand(
@@ -28,18 +28,18 @@ func newPpmCommand(prime *primer.Values) *captain.Command {
 	)
 
 	var children []*captain.Command
-	children = addPackagesCommands(prime, children)
-	children = addRepositoryCommands(prime, children)
-	children = addProjectCommands(prime, children)
-	children = addVersionCommand(prime, children)
-	children = addInfoCommand(prime, children)
-	children = addOtherCommands(prime, children)
+	children = addPackagesCommands(registry, prime, children)
+	children = addRepositoryCommands(registry, prime, children)
+	children = addProjectCommands(registry, prime, children)
+	children = addVersionCommand(registry, prime, children)
+	children = addInfoCommand(registry, prime, children)
+	children = addOtherCommands(registry, prime, children)
 
 	rootCmd.AddChildren(children...)
 	return rootCmd
 }
 
-func addPackagesCommands(prime *primer.Values, cmds []*captain.Command) []*captain.Command {
+func addPackagesCommands(registry *captain.Registry, prime *primer.Values, cmds []*captain.Command) []*captain.Command {
 	shim := ppm.NewShim(prime)
 	conversion := ppm.NewConversionFlow(prime)
 	return append(cmds,
@@ -82,7 +82,7 @@ func addPackagesCommands(prime *primer.Values, cmds []*captain.Command) []*capta
 	)
 }
 
-func addVersionCommand(prime *primer.Values, cmds []*captain.Command) []*captain.Command {
+func addVersionCommand(registry *captain.Registry, prime *primer.Values, cmds []*captain.Command) []*captain.Command {
 	shim := ppm.NewShim(prime)
 	return append(cmds,
 		captain.NewShimCommand(
@@ -95,7 +95,7 @@ func addVersionCommand(prime *primer.Values, cmds []*captain.Command) []*captain
 	)
 }
 
-func addProjectCommands(prime *primer.Values, cmds []*captain.Command) []*captain.Command {
+func addProjectCommands(registry *captain.Registry, prime *primer.Values, cmds []*captain.Command) []*captain.Command {
 	shim := ppm.NewShim(prime)
 	conversion := ppm.NewConversionFlow(prime)
 	return append(cmds,
@@ -143,7 +143,7 @@ func addProjectCommands(prime *primer.Values, cmds []*captain.Command) []*captai
 	)
 }
 
-func addRepositoryCommands(prime *primer.Values, cmds []*captain.Command) []*captain.Command {
+func addRepositoryCommands(registry *captain.Registry, prime *primer.Values, cmds []*captain.Command) []*captain.Command {
 	shim := ppm.NewShim(prime)
 	return append(cmds,
 		// The repo sub-commands in ppm configure alternative package
@@ -182,7 +182,7 @@ func addRepositoryCommands(prime *primer.Values, cmds []*captain.Command) []*cap
 	)
 }
 
-func addOtherCommands(prime *primer.Values, cmds []*captain.Command) []*captain.Command {
+func addOtherCommands(registry *captain.Registry, prime *primer.Values, cmds []*captain.Command) []*captain.Command {
 	shim := ppm.NewShim(prime)
 	return append(cmds,
 		// The repo sub-commands in ppm configure alternative package
@@ -206,7 +206,7 @@ func addOtherCommands(prime *primer.Values, cmds []*captain.Command) []*captain.
 	)
 }
 
-func addInfoCommand(prime *primer.Values, cmds []*captain.Command) []*captain.Command {
+func addInfoCommand(registry *captain.Registry, prime *primer.Values, cmds []*captain.Command) []*captain.Command {
 	shim := ppm.NewShim(prime)
 	return append(cmds, captain.NewShimCommand(
 		"info",

--- a/cmd/state/internal/cmdtree/prepare.go
+++ b/cmd/state/internal/cmdtree/prepare.go
@@ -7,14 +7,13 @@ import (
 	"github.com/ActiveState/cli/internal/runners/prepare"
 )
 
-func newPrepareCommand(prime *primer.Values) *captain.Command {
+func newPrepareCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := prepare.New(prime)
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"_prepare",
 		"",
 		locale.Tl("prepare_description", "Prepare environment for use with the State Tool."),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(_ *captain.Command, _ []string) error {

--- a/cmd/state/internal/cmdtree/projects.go
+++ b/cmd/state/internal/cmdtree/projects.go
@@ -1,21 +1,21 @@
 package cmdtree
 
 import (
+	"github.com/spf13/viper"
+
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/runners/projects"
-	"github.com/spf13/viper"
 )
 
-func newProjectsCommand(prime *primer.Values) *captain.Command {
+func newProjectsCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := projects.NewProjects(prime, viper.GetViper())
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"projects",
 		locale.Tl("projects_title", "Listing Projects"),
 		locale.T("projects_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {

--- a/cmd/state/internal/cmdtree/protocol.go
+++ b/cmd/state/internal/cmdtree/protocol.go
@@ -7,15 +7,14 @@ import (
 	"github.com/ActiveState/cli/internal/runners/protocol"
 )
 
-func newProtocolCommand(prime *primer.Values) *captain.Command {
+func newProtocolCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := protocol.New(prime)
 	params := protocol.Params{}
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"_protocol",
 		"",
 		locale.Tl("protocol_description", "Process URLs that use the state protocol"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{
 			{

--- a/cmd/state/internal/cmdtree/pull.go
+++ b/cmd/state/internal/cmdtree/pull.go
@@ -7,14 +7,13 @@ import (
 	"github.com/ActiveState/cli/internal/runners/pull"
 )
 
-func newPullCommand(prime *primer.Values) *captain.Command {
+func newPullCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := pull.New(prime)
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"pull",
 		locale.Tl("pull_title", "Pulling Remote Project"),
 		locale.Tl("pull_description", "Pull in the latest version of your project from the ActiveState Platform"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(cmd *captain.Command, args []string) error {

--- a/cmd/state/internal/cmdtree/push.go
+++ b/cmd/state/internal/cmdtree/push.go
@@ -9,14 +9,13 @@ import (
 	"github.com/ActiveState/cli/internal/runners/push"
 )
 
-func newPushCommand(prime *primer.Values) *captain.Command {
+func newPushCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	pushRunner := push.NewPush(viper.GetViper(), prime)
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"push",
 		locale.Tl("push_title", "Pushing Local Project"),
 		locale.T("push_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {

--- a/cmd/state/internal/cmdtree/run.go
+++ b/cmd/state/internal/cmdtree/run.go
@@ -7,16 +7,15 @@ import (
 	"github.com/ActiveState/cli/internal/runners/run"
 )
 
-func newRunCommand(prime *primer.Values) *captain.Command {
+func newRunCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := run.New(prime)
 
 	var name string
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"run",
 		locale.Tl("run_title", "Running Script"),
 		locale.T("run_description"),
-		prime.Output(),
 		nil,
 		[]*captain.Argument{
 			{

--- a/cmd/state/internal/cmdtree/scripts.go
+++ b/cmd/state/internal/cmdtree/scripts.go
@@ -7,14 +7,13 @@ import (
 	"github.com/ActiveState/cli/internal/runners/scripts"
 )
 
-func newScriptsCommand(prime *primer.Values) *captain.Command {
+func newScriptsCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := scripts.NewScripts(prime)
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"scripts",
 		locale.Tl("scripts_title", "Listing Scripts"),
 		locale.T("scripts_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {
@@ -22,15 +21,14 @@ func newScriptsCommand(prime *primer.Values) *captain.Command {
 		})
 }
 
-func newScriptsEditCommand(prime *primer.Values) *captain.Command {
+func newScriptsEditCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	editRunner := scripts.NewEdit(prime)
 	params := scripts.EditParams{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"edit",
 		locale.Tl("scripts_edit_title", "Editing Script"),
 		locale.T("edit_description"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "expand",

--- a/cmd/state/internal/cmdtree/shim.go
+++ b/cmd/state/internal/cmdtree/shim.go
@@ -9,14 +9,13 @@ import (
 	"github.com/ActiveState/cli/internal/runners/shim"
 )
 
-func newShimCommand(prime *primer.Values, args ...string) *captain.Command {
+func newShimCommand(registry *captain.Registry, prime *primer.Values, args ...string) *captain.Command {
 	runner := shim.New(prime)
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"shim",
 		"",
 		locale.T("shim_description"),
-		prime.Output(),
 		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {

--- a/cmd/state/internal/cmdtree/show.go
+++ b/cmd/state/internal/cmdtree/show.go
@@ -7,16 +7,15 @@ import (
 	"github.com/ActiveState/cli/internal/runners/show"
 )
 
-func newShowCommand(prime *primer.Values) *captain.Command {
+func newShowCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := show.New(prime)
 
 	params := show.Params{}
 
-	return captain.NewCommand(
+	return registry.NewCommand(
 		"show",
 		locale.Tl("show_title", "Showing Project Details"),
 		locale.T("show_project"),
-		prime.Output(),
 		nil,
 		[]*captain.Argument{
 			{

--- a/cmd/state/internal/cmdtree/tutorial.go
+++ b/cmd/state/internal/cmdtree/tutorial.go
@@ -9,12 +9,11 @@ import (
 	"github.com/ActiveState/cli/internal/runners/tutorial"
 )
 
-func newTutorialCommand(prime *primer.Values) *captain.Command {
-	cmd := captain.NewCommand(
+func newTutorialCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
+	cmd := registry.NewCommand(
 		"tutorial",
 		locale.Tl("tutorial_title", "Running Tutorial"),
 		locale.Tl("tutorial_description", "Learn how to use the State Tool"),
-		prime.Output(),
 		nil,
 		nil,
 		func(ccmd *captain.Command, args []string) error {
@@ -26,15 +25,14 @@ func newTutorialCommand(prime *primer.Values) *captain.Command {
 	return cmd
 }
 
-func newTutorialProjectCommand(prime *primer.Values) *captain.Command {
+func newTutorialProjectCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := tutorial.New(prime)
 	params := tutorial.NewProjectParams{}
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"new-project",
 		locale.Tl("tutorial_new_project", `Running "New Project" Tutorial`),
 		locale.Tl("tutorial_description", "Learn how to create new projects. (ie. virtual environments)"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name:        "skip-intro",

--- a/cmd/state/internal/cmdtree/update.go
+++ b/cmd/state/internal/cmdtree/update.go
@@ -8,15 +8,14 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 )
 
-func newUpdateCommand(prime *primer.Values) *captain.Command {
+func newUpdateCommand(registry *captain.Registry, prime *primer.Values) *captain.Command {
 	runner := update.New(prime)
 	params := update.Params{}
 
-	cmd := captain.NewCommand(
+	cmd := registry.NewCommand(
 		"update",
 		locale.Tl("update_title", "Updating The State Tool"),
 		locale.Tl("update_description", "Updates the State Tool to the latest available version"),
-		prime.Output(),
 		[]*captain.Flag{
 			{
 				Name: "lock",

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -42,7 +42,15 @@ type Command struct {
 	out output.Outputer
 }
 
-func NewCommand(name, title, description string, out output.Outputer, flags []*Flag, args []*Argument, executor Executor) *Command {
+type Registry struct {
+	out output.Outputer
+}
+
+func NewRegistry(out output.Outputer) *Registry {
+	return &Registry{out}
+}
+
+func (r *Registry) NewCommand(name, title, description string, flags []*Flag, args []*Argument, executor Executor) *Command {
 	// Validate args
 	for idx, arg := range args {
 		if idx > 0 && arg.Required && !args[idx-1].Required {
@@ -60,7 +68,7 @@ func NewCommand(name, title, description string, out output.Outputer, flags []*F
 		arguments: args,
 		flags:     flags,
 		commands:  make([]*Command, 0),
-		out:       out,
+		out:       r.out,
 	}
 
 	short := description


### PR DESCRIPTION
Some groundwork for upcoming sprint stories. This is so we can have a single place to instruct logic for all registered commands (eg. events).