### PR TITLE
State shim should not call itself recursively

### DIFF
--- a/assets/shim/shim.bat
+++ b/assets/shim/shim.bat
@@ -2,4 +2,4 @@
 
 REM {{.denote}}
 
-{{.exe}} shim -- {{.command}} %*
+{{.exe}} shim --path {{.projectPath}} -- {{.command}} %*

--- a/assets/shim/shim.sh
+++ b/assets/shim/shim.sh
@@ -2,4 +2,4 @@
 
 # {{.denote}}
 
-{{.exe}} shim -- {{.command}} $*
+{{.exe}} shim --path {{.projectPath}} -- {{.command}} "$@"

--- a/cmd/state/internal/cmdtree/shim.go
+++ b/cmd/state/internal/cmdtree/shim.go
@@ -12,17 +12,26 @@ import (
 func newShimCommand(prime *primer.Values, args ...string) *captain.Command {
 	runner := shim.New(prime)
 
+	params := shim.NewParams()
+
 	cmd := captain.NewCommand(
 		"shim",
 		"",
 		locale.T("shim_description"),
 		prime.Output(),
-		[]*captain.Flag{},
+		[]*captain.Flag{
+			{
+				Name:        "path",
+				Description: locale.Tl("flag_state_shim_path_description", "Path to project that is providing the default environment."),
+				Value:       &params.Path,
+			},
+		},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {
-			return runner.Run(args...)
+			return runner.Run(params, args...)
 		},
 	)
+	cmd.SetHidden(true)
 	cmd.SetSkipChecks(true)
 
 	// Cobra will handle the `--` delimiter if flag parsing is enabled.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -27,6 +27,9 @@ const ConfigEnvVarName = "ACTIVESTATE_CLI_CONFIGDIR"
 // CacheEnvVarName is the env var used to override the cache dir that the State Tool uses
 const CacheEnvVarName = "ACTIVESTATE_CLI_CACHEDIR"
 
+// ShimEnvVarName is the env var used to find out if we are shimming recursively
+const ShimEnvVarName = "ACTIVESTATE_CLI_SHIMMED_COMMAND"
+
 // DisableUpdates is the env var used to disable auto update
 const DisableUpdates = "ACTIVESTATE_CLI_DISABLE_UPDATES"
 

--- a/internal/runners/shim/shim.go
+++ b/internal/runners/shim/shim.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/failures"
 	"github.com/ActiveState/cli/internal/language"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -31,6 +33,10 @@ type primeable interface {
 	primer.Projecter
 }
 
+type Params struct {
+	Path string
+}
+
 func New(prime primeable) *Shim {
 	return &Shim{
 		prime.Subshell(),
@@ -39,34 +45,49 @@ func New(prime primeable) *Shim {
 	}
 }
 
-func (s *Shim) Run(args ...string) error {
-	project, fail := project.GetSafe()
-	if fail != nil {
-		// Do not fail if we can't find the projectfile
-		logging.Debug("Project not found, error: %v", fail)
+func NewParams() *Params {
+	return &Params{}
+}
+
+func (s *Shim) Run(params *Params, args ...string) error {
+	if params.Path != "" {
+		var fail *failures.Failure
+		s.proj, fail = project.FromPath(params.Path)
+		if fail != nil {
+			return locale.WrapInputError(fail.ToError(), "shim_no_project_at_path", "Could not find project file at {{.V0}}", params.Path)
+		}
 	}
-
-	if project != nil && !subshell.IsActivated() {
-		runtime, err := runtime.NewRuntime(s.proj.Source().Path(), s.proj.CommitUUID(), s.proj.Owner(), s.proj.Name(), runbits.NewRuntimeMessageHandler(s.out))
-		if err != nil {
-			return locale.WrapError(err, "err_shim_runtime_init", "Could not initialize runtime for shim command.")
-		}
-		venv := virtualenvironment.New(runtime)
-		if fail := venv.Activate(); fail != nil {
-			logging.Errorf("Unable to activate state: %s", fail.Error())
-			return locale.WrapError(fail.ToError(), "err_shim_activate", "Could not activate environment for shim command")
-		}
-
-		env, err := venv.GetEnv(true, filepath.Dir(projectfile.Get().Path()))
-		if err != nil {
-			return err
-		}
-		s.subshell.SetEnv(env)
+	if s.proj == nil {
+		return locale.NewError("shim_no_project_found", "Could not find a project.  You need to be in a project directory or specify a global default project via `state activate --default`")
 	}
 
 	if len(args) == 0 {
 		return nil
 	}
+
+	runtime, err := runtime.NewRuntime(s.proj.Source().Path(), s.proj.CommitUUID(), s.proj.Owner(), s.proj.Name(), runbits.NewRuntimeMessageHandler(s.out))
+	if err != nil {
+		return locale.WrapError(err, "err_shim_runtime_init", "Could not initialize runtime for shim command.")
+	}
+	venv := virtualenvironment.New(runtime)
+	if fail := venv.Activate(); fail != nil {
+		logging.Errorf("Unable to activate state: %s", fail.Error())
+		return locale.WrapError(fail.ToError(), "err_shim_activate", "Could not activate environment for shim command")
+	}
+
+	env, err := venv.GetEnv(true, filepath.Dir(projectfile.Get().Path()))
+	if err != nil {
+		return err
+	}
+	logging.Debug("Trying to shim %s on PATH=%s", args[0], env["PATH"])
+	// Ensure that we are not calling the shim recursively
+	oldval, ok := env[constants.ShimEnvVarName]
+	if ok && oldval == args[0] {
+		return locale.NewError("err_shim_recursive_loop", "Could not resolve shimmed executable {{.V0}}", args[0])
+	}
+	env[constants.ShimEnvVarName] = args[0]
+
+	s.subshell.SetEnv(env)
 
 	lang := language.Bash
 	scriptArgs := fmt.Sprintf(`%s "$@"`, args[0])

--- a/internal/virtualenvironment/virtualenvironment.go
+++ b/internal/virtualenvironment/virtualenvironment.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/failures"
-	"github.com/ActiveState/cli/internal/fileutils"
-	"github.com/ActiveState/cli/internal/globaldefault"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils"
@@ -80,23 +78,6 @@ func (v *VirtualEnvironment) Setup(installIfNecessary bool) *failures.Failure {
 	return nil
 }
 
-func removePath(envMap map[string]string, path string) map[string]string {
-	oldPath, ok := envMap["PATH"]
-	if !ok {
-		return envMap
-	}
-
-	var newPath []string
-	for _, p := range strings.Split(oldPath, string(os.PathListSeparator)) {
-		eq, err := fileutils.PathsEqual(p, path)
-		if err != nil || !eq {
-			newPath = append(newPath, p)
-		}
-	}
-	envMap["PATH"] = strings.Join(newPath, string(os.PathListSeparator))
-	return envMap
-}
-
 // GetEnv returns a map of the cumulative environment variables for all active virtual environments
 func (v *VirtualEnvironment) GetEnv(inherit bool, projectDir string) (map[string]string, error) {
 	envMap := make(map[string]string)
@@ -131,9 +112,6 @@ func (v *VirtualEnvironment) GetEnv(inherit bool, projectDir string) (map[string
 			}
 		}
 	}
-
-	// remove the global bin path from the environment PATH variable to avoid recursions
-	envMap = removePath(envMap, globaldefault.BinDir())
 
 	if inherit {
 		return inheritEnv(envMap), nil

--- a/internal/virtualenvironment/virtualenvironment.go
+++ b/internal/virtualenvironment/virtualenvironment.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/failures"
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/globaldefault"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils"
@@ -78,6 +80,23 @@ func (v *VirtualEnvironment) Setup(installIfNecessary bool) *failures.Failure {
 	return nil
 }
 
+func removePath(envMap map[string]string, path string) map[string]string {
+	oldPath, ok := envMap["PATH"]
+	if !ok {
+		return envMap
+	}
+
+	var newPath []string
+	for _, p := range strings.Split(oldPath, string(os.PathListSeparator)) {
+		eq, err := fileutils.PathsEqual(p, path)
+		if err != nil || !eq {
+			newPath = append(newPath, p)
+		}
+	}
+	envMap["PATH"] = strings.Join(newPath, string(os.PathListSeparator))
+	return envMap
+}
+
 // GetEnv returns a map of the cumulative environment variables for all active virtual environments
 func (v *VirtualEnvironment) GetEnv(inherit bool, projectDir string) (map[string]string, error) {
 	envMap := make(map[string]string)
@@ -112,6 +131,9 @@ func (v *VirtualEnvironment) GetEnv(inherit bool, projectDir string) (map[string
 			}
 		}
 	}
+
+	// remove the global bin path from the environment PATH variable to avoid recursions
+	envMap = removePath(envMap, globaldefault.BinDir())
 
 	if inherit {
 		return inheritEnv(envMap), nil


### PR DESCRIPTION
I disabled the removal of the global bin path, because it is actually not
necessary anymore if the --default flag specifies the associated project
explicitly.


 https://www.pivotaltracker.com/story/show/175487411