### PR TITLE
Ensure that we have the activation events necessary to measure success

### DIFF
--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
 var client *ga.Client
@@ -39,6 +40,9 @@ const CatTutorial = "tutorial"
 // CatCommandExit is the event category used to track the success of state commands
 const CatCommandExit = "command-exit"
 
+// CatActivationFlow is for events that outline the activation flow
+const CatActivationFlow = "activation"
+
 type customDimensions struct {
 	version       string
 	branchName    string
@@ -48,6 +52,7 @@ type customDimensions struct {
 	osVersion     string
 	installSource string
 	machineID     string
+	projectName   string
 }
 
 func (d *customDimensions) SetOutput(output string) {
@@ -55,17 +60,23 @@ func (d *customDimensions) SetOutput(output string) {
 }
 
 func (d *customDimensions) toMap() map[string]string {
+	pj := projectfile.GetPersisted()
+	d.projectName = ""
+	if pj != nil {
+		d.projectName = pj.Owner() + "/" + pj.Name()
+	}
 	return map[string]string{
 		// Commented out idx 1 so it's clear why we start with 2. We used to log the hostname while dogfooding internally.
 		// "1": "hostname (deprected)"
-		"2": d.version,
-		"3": d.branchName,
-		"4": d.userID,
-		"5": d.output,
-		"6": d.osName,
-		"7": d.osVersion,
-		"8": d.installSource,
-		"9": d.machineID,
+		"2":  d.version,
+		"3":  d.branchName,
+		"4":  d.userID,
+		"5":  d.output,
+		"6":  d.osName,
+		"7":  d.osVersion,
+		"8":  d.installSource,
+		"9":  d.machineID,
+		"10": d.projectName,
 	}
 }
 
@@ -162,6 +173,6 @@ func eventWithValue(category string, action string, value int64) error {
 	}
 	client.CustomDimensionMap(CustomDimensions.toMap())
 
-	logging.Debug("Event+value: %s, %s, %s", category, action, value)
+	logging.Debug("Event+value: %s, %s, %d", category, action, value)
 	return client.Send(ga.NewEvent(category, action).Value(value))
 }

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 	"unicode"
@@ -416,7 +417,7 @@ func (c *Command) runner(cobraCmd *cobra.Command, args []string) error {
 	err := c.execute(c, args)
 	if !c.deferAnalytics {
 		exitCode := errs.UnwrapExitCode(failures.ToError(err))
-		analytics.EventWithValue(analytics.CatCommandExit, subCommandString, int64(exitCode))
+		analytics.EventWithLabel(analytics.CatCommandExit, subCommandString, strconv.Itoa(exitCode))
 	}
 	return err
 }

--- a/internal/errs/unwrap.go
+++ b/internal/errs/unwrap.go
@@ -19,17 +19,20 @@ func UnwrapExitCode(errFail error) int {
 	var fail *failures.Failure
 	isFailure := errors.As(errFail, &fail)
 	if !isFailure {
+		if errFail == nil {
+			return 0
+		}
 		return 1
 	}
 
-	if !fail.Type.Matches(failures.FailExecCmdExit) {
-		return 1
-	}
 	err := fail.ToError()
-
 	isExitError = errors.As(err, &eerr)
 	if isExitError {
 		return eerr.ExitCode()
+	}
+
+	if fail.Type.Matches(failures.FailExecCmdExit) {
+		return 1
 	}
 
 	return 1

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -120,9 +120,6 @@ func (r *Activate) run(params *ActivateParams) error {
 	}
 	proj.Source().Persist()
 
-	// Send google analytics event with label set to project namespace
-	analytics.EventWithLabel(analytics.CatRunCmd, "activate", proj.Namespace().String())
-
 	if params.Command != "" {
 		r.subshell.SetActivateCommand(params.Command)
 	}

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -109,6 +109,9 @@ func (r *Activate) run(params *ActivateParams) error {
 		}
 	}
 
+	// Have to call this once the project has been set
+	analytics.Event(analytics.CatActivationFlow, "start")
+
 	// on --replace, replace namespace and commit id in as.yaml
 	if params.ReplaceWith.IsValid() {
 		if err := updateProjectFile(proj, params.ReplaceWith); err != nil {

--- a/internal/runners/activate/activation.go
+++ b/internal/runners/activate/activation.go
@@ -8,6 +8,7 @@ import (
 	rt "runtime"
 	"syscall"
 
+	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/fileevents"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -51,6 +52,8 @@ func (r *Activate) activateAndWait(proj *project.Project, venv *virtualenvironme
 		return locale.WrapError(err, "err_activate_fileevents", "Could not start file event watcher.")
 	}
 	defer fe.Close()
+
+	analytics.Event(analytics.CatActivationFlow, "before-subshell")
 
 	fail := <-r.subshell.Failures()
 	if fail != nil {

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -879,6 +879,11 @@ func Get() *Project {
 	return project
 }
 
+// GetPersisted gets the persisted project, if any
+func GetPersisted() *Project {
+	return persistentProject
+}
+
 // GetSafe returns the project configuration in a safe manner (returns error)
 func GetSafe() (*Project, *failures.Failure) {
 	if persistentProject != nil {


### PR DESCRIPTION
New event category: activation
Possible event actions:
 - start -- right at the start of activation, before anything happens
 - before-subshell -- right before the subshell is created (this would be our “success state”, as we cannot reliably appropriate subshell activations to successes)
 - error - an error happened during activation that warrants further investigation (via rollbar, not actionable on analytics beyond signalling the type of exit)
 - user-input-error -- activation failed due to user input (eg. they cancelled, entered an invalid path, etc.)
 - user-exit-error -- subshell exited with non-zero. This isn’t an issue we need to look into (eg. user ran “exit 1")

New dimension: projectName (eg. ActiveState/Perl-5.32)

Using this data you can assert eg.

Succesful activations - cat: activation, action: before-subshell, project dimension: ActiveState/Perl-5.32
Activation failures - # of activation starts minus # of before-subshell events