### PR TITLE
Hotfix - install.sh missing back tick

### DIFF
--- a/cmd/state/forward.go
+++ b/cmd/state/forward.go
@@ -39,7 +39,6 @@ func forwardFn(args []string, out output.Outputer, pj *project.Project) (forward
 	if fail != nil {
 		// if we are running `state update`, we just print the error message, but don't fail, as we can still update the state tool executable
 		logging.Error("Could not parse version info from projectifle: %s", fail.Error())
-		fmt.Println("Could not parse version info from projectifle: %s", fail.Error())
 		if funk.Contains(args, "update") { // Handle use case of update being called as anything but the first argument (unlikely, but possible)
 			out.Error(locale.T("err_version_parse"))
 			return nil, nil

--- a/cmd/state/forward.go
+++ b/cmd/state/forward.go
@@ -39,6 +39,7 @@ func forwardFn(args []string, out output.Outputer, pj *project.Project) (forward
 	if fail != nil {
 		// if we are running `state update`, we just print the error message, but don't fail, as we can still update the state tool executable
 		logging.Error("Could not parse version info from projectifle: %s", fail.Error())
+		fmt.Println("Could not parse version info from projectifle: %s", fail.Error())
 		if funk.Contains(args, "update") { // Handle use case of update being called as anything but the first argument (unlikely, but possible)
 			out.Error(locale.T("err_version_parse"))
 			return nil, nil

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -18,6 +18,7 @@ Flags:
  --activate-default <project>    Activate a project and make it the system default
  -h                              Show usage information (what you're currently reading)
 EOF
+`
 
 # ignore project file if we are already in an activated environment
 unset ACTIVESTATE_PROJECT

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -1103,7 +1103,7 @@ func ParseVersionInfo(projectFilePath string) (*VersionInfo, *failures.Failure) 
 	}
 
 	lock := strings.TrimSpace(versionStruct.Lock)
-	match, fail := regexp.MatchString(`^([\w\/\-]+@)\d+\.\d+\.\d+-(SHA)?[a-f0-9]+`, lock)
+	match, fail := regexp.MatchString(`^([\w\/\-\.]+@)\d+\.\d+\.\d+-(SHA)?[a-f0-9]+`, lock)
 	if fail != nil || !match {
 		return nil, FailInvalidVersion.New(locale.T("err_invalid_version"))
 	}


### PR DESCRIPTION
This was removed in the latest commit and produced:

```
» ./installers/install.sh -f
Installing the State Tool ..
./installers/install.sh: line 398: unexpected EOF while looking for matching ``'
./installers/install.sh: line 430: syntax error: unexpected end of file
```