### PR TITLE
State projects shows no projects

### DIFF
--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -175,6 +175,8 @@ func (r *Activate) run(params *ActivateParams) error {
 			return locale.WrapError(err, "err_activate_default", "Could not configure your project as the default.")
 		}
 
+		projectfile.StoreProjectMapping(params.Namespace.String(), filepath.Dir(proj.Source().Path()))
+
 		r.out.Notice(output.Heading(locale.Tl("global_default_heading", "Global Default")))
 		r.out.Notice(locale.Tl("global_default_set", "Successfully configured [NOTICE]{{.V0}}[/RESET] as the global default project.", proj.Namespace().String()))
 

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -72,7 +72,7 @@ var (
 )
 
 var (
-	urlProjectRegexStr = fmt.Sprintf(`https:\/\/[\w\.]+\/([\w_.-]*)\/([\w_.-]*)(?:\?commitID=)*(.*)`)
+	urlProjectRegexStr = fmt.Sprintf(`https:\/\/[\w\.]+\/([\w_.-]+)\/([\w_.-]*)(?:\?commitID=)*(.*)`)
 	urlCommitRegexStr  = fmt.Sprintf(`https:\/\/[\w\.]+\/commit\/(.*)`)
 
 	// ProjectURLRe Regex used to validate project fields /orgname/projectname[?commitID=someUUID]
@@ -515,7 +515,7 @@ func Parse(configFilepath string) (*Project, *failures.Failure) {
 	}
 
 	namespace := fmt.Sprintf("%s/%s", project.parsedURL.Owner, project.parsedURL.Name)
-	storeProjectMapping(namespace, filepath.Dir(project.Path()))
+	StoreProjectMapping(namespace, filepath.Dir(project.Path()))
 
 	return project, nil
 }
@@ -718,7 +718,7 @@ func (p *Project) save(path string) *failures.Failure {
 		return failures.FailIO.Wrap(err)
 	}
 
-	storeProjectMapping(fmt.Sprintf("%s/%s", p.parsedURL.Owner, p.parsedURL.Name), filepath.Dir(p.Path()))
+	StoreProjectMapping(fmt.Sprintf("%s/%s", p.parsedURL.Owner, p.parsedURL.Name), filepath.Dir(p.Path()))
 
 	return nil
 }
@@ -1211,9 +1211,9 @@ func GetProjectNameForPath(config configGetter, projectPath string) string {
 	return ""
 }
 
-// storeProjectMapping associates the namespace with the project
+// StoreProjectMapping associates the namespace with the project
 // path in the config
-func storeProjectMapping(namespace, projectPath string) {
+func StoreProjectMapping(namespace, projectPath string) {
 	projectMapMutex.Lock()
 	defer projectMapMutex.Unlock()
 
@@ -1235,6 +1235,10 @@ func storeProjectMapping(namespace, projectPath string) {
 
 	projects[namespace] = paths
 	viper.Set(LocalProjectsConfigKey, projects)
+	err := viper.WriteConfig()
+	if err != nil {
+		logging.Error("Error writing config when storing project mapping: %v", err)
+	}
 }
 
 // CleanProjectMapping removes projects that no longer exist

--- a/pkg/projectfile/projectfile_test.go
+++ b/pkg/projectfile/projectfile_test.go
@@ -513,12 +513,18 @@ func TestValidateProjectURL(t *testing.T) {
 	fail := ValidateProjectURL("https://example.com/")
 	assert.Error(t, fail.ToError(), "This should be an invalid project URL")
 
+	fail = ValidateProjectURL("https://platform.activestate.com//")
+	assert.Error(t, fail.ToError(), "This should be an invalid project URL with no namespace")
+
 	fail = ValidateProjectURL("https://platform.activestate.com/xowner/xproject")
-	assert.Nil(t, fail, "This should not be an invalid project URL")
+	assert.Nil(t, fail, "This should be a valid project URL")
 
 	fail = ValidateProjectURL("https://platform.activestate.com/commit/commitid")
-	assert.Nil(t, fail, "This should not be an invalid project URL using the commit path")
+	assert.Nil(t, fail, "This should be a valid project URL")
 
 	fail = ValidateProjectURL("https://pr1234.activestate.build/commit/commitid")
-	assert.Nil(t, fail, "This should not be an invalid project URL using the commit path")
+	assert.Nil(t, fail, "This should be a valid project URL for a PR build")
+
+	fail = ValidateProjectURL("https://pr1234.activestate.build/commit/00010001-0001-0001-0001-000100010001")
+	assert.Nil(t, fail, "This should be a valid headless project URL")
 }


### PR DESCRIPTION
This is the sequence of events that can lead to `state projects` showing no projects, even though there is a default activation:

1. `state activate --default` a project (This was done using the one-liner)
2. Install a package
3. Uninstall the state tool (or just remove the config directory)
3. `state activate --default` again with the same project in the same directory

Since we added a package in step 2 the project is now in a headless state. When we add the project mapping to the config we get:

```
projects:
  /:
  - C:\Users\Administrator\ActiveState\Perl-5.32
```

This fix writes the mapping during activation using the namespace parameter. There is also a minor update to the project regex. I've also filed a story [here](https://www.pivotaltracker.com/story/show/175901661) to update our handling of headless projects in the config and with `state projects`

 https://www.pivotaltracker.com/story/show/175880344