### PR TITLE
add integration test for install.ps1

### DIFF
--- a/.github/workflows-src/steps.lib.yml
+++ b/.github/workflows-src/steps.lib.yml
@@ -103,7 +103,7 @@ shell: bash
 run: |
   export SHELL=''
   set +e
-  go test -timeout 10m github.com/ActiveState/cli/test/integration -test.v -test.run "^TestLanguageMsiActivePerl|TestDeployIntegrationTestSuite|TestInitIntegrationTestSuite|TestPushIntegrationTestSuite|TestUpdateIntegrationTestSuite|PrepareIntegrationTestSuite$"
+  go test -timeout 10m github.com/ActiveState/cli/test/integration -test.v -test.run "^TestLanguageMsiActivePerl|TestDeployIntegrationTestSuite|TestInitIntegrationTestSuite|TestPushIntegrationTestSuite|TestUpdateIntegrationTestSuite|PrepareIntegrationTestSuite|InstallScriptsIntegrationTestSuite$"
   testCode=$?
   head -n-0 build/*log 2>/dev/null
   exit ${testCode}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
       run: |
         export SHELL=''
         set +e
-        go test -timeout 10m github.com/ActiveState/cli/test/integration -test.v -test.run "^TestLanguageMsiActivePerl|TestDeployIntegrationTestSuite|TestInitIntegrationTestSuite|TestPushIntegrationTestSuite|TestUpdateIntegrationTestSuite|PrepareIntegrationTestSuite$"
+        go test -timeout 10m github.com/ActiveState/cli/test/integration -test.v -test.run "^TestLanguageMsiActivePerl|TestDeployIntegrationTestSuite|TestInitIntegrationTestSuite|TestPushIntegrationTestSuite|TestUpdateIntegrationTestSuite|PrepareIntegrationTestSuite|InstallScriptsIntegrationTestSuite$"
         testCode=$?
         head -n-0 build/*log 2>/dev/null
         exit ${testCode}

--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -162,7 +162,7 @@ function activateIfRequested() {
         & $script:STATEEXE activate $script:ACTIVATE
     } elseif ( $script:ACTIVATE_DEFAULT -ne "" ) {
         # This creates an interactive sub-shell.
-        Write-Host "`nActivating project $script:ACTIVATE as default`n" -ForegroundColor Yellow
+        Write-Host "`nActivating project $script:ACTIVATE_DEFAULT as default`n" -ForegroundColor Yellow
         & $script:STATEEXE activate $script:ACTIVATE_DEFAULT --default
     }
 }
@@ -425,7 +425,7 @@ function install() {
         [Environment]::SetEnvironmentVariable(
             'Path',
             $installDir + ";" + [Environment]::GetEnvironmentVariable(
-                'Path', [EnvironmentVariableTarget]::Machine),
+                'Path', $envTarget),
             $envTarget)
 
         notifySettingChange

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -166,6 +166,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstallPerl5_32() {
 	pathEnv, err := cmdEnv.get("PATH")
 	suite.Require().NoError(err, "could not get PATH")
 	paths := strings.Split(pathEnv, string(os.PathListSeparator))
+	suite.Assert().Contains(paths, filepath.Join(ts.Dirs.Cache, "bin"), "Could not find global binary directory on PATH")
 	suite.Assert().Contains(paths, ts.Dirs.Work, "Could not find installation path in PATH")
 }
 func TestInstallScriptsIntegrationTestSuite(t *testing.T) {

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -1,0 +1,173 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ActiveState/cli/internal/environment"
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/stretchr/testify/suite"
+)
+
+type OpenKeyFn func(path string) (osutils.RegistryKey, error)
+
+type CmdEnv struct {
+	openKeyFn OpenKeyFn
+	// whether this updates the system environment
+	userScope bool
+}
+
+func NewCmdEnv(userScope bool) *CmdEnv {
+	openKeyFn := osutils.OpenSystemKey
+	if userScope {
+		openKeyFn = osutils.OpenUserKey
+	}
+	return &CmdEnv{
+		openKeyFn: openKeyFn,
+		userScope: userScope,
+	}
+}
+
+func (c *CmdEnv) set(name, newValue string) error {
+	key, err := c.openKeyFn(getEnvironmentPath(c.userScope))
+	if err != nil {
+		return err
+	}
+	defer key.Close()
+
+	_, valType, err := key.GetStringValue(name)
+	if err != nil {
+		return err
+	}
+	return osutils.SetStringValue(key, name, valType, newValue)
+}
+
+func (c *CmdEnv) get(name string) (string, error) {
+	key, err := c.openKeyFn(getEnvironmentPath(c.userScope))
+	if err != nil {
+		return "", err
+	}
+	defer key.Close()
+
+	v, _, err := key.GetStringValue(name)
+	return v, err
+}
+
+func getEnvironmentPath(userScope bool) string {
+	if userScope {
+		return "Environment"
+	}
+	return `SYSTEM\ControlSet001\Control\Session Manager\Environment`
+}
+
+func scriptPath(t *testing.T) string {
+	name := "install.ps1"
+	root := environment.GetRootPathUnsafe()
+	subdir := "installers"
+
+	exec := filepath.Join(root, subdir, name)
+	if !fileutils.FileExists(exec) {
+		t.Fatalf("Could not find install script %s", exec)
+	}
+
+	return exec
+}
+
+type InstallScriptsIntegrationTestSuite struct {
+	tagsuite.Suite
+}
+
+func (suite *InstallScriptsIntegrationTestSuite) TestInstallPs1() {
+	if runtime.GOOS != "windows" {
+		suite.T().SkipNow()
+	}
+	suite.OnlyRunForTags(tagsuite.Critical)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	script := scriptPath(suite.T())
+
+	isAdmin, err := osutils.IsWindowsAdmin()
+	suite.Require().NoError(err, "Could not determine if running as administrator")
+
+	cmdEnv := NewCmdEnv(!isAdmin)
+	oldPathEnv, err := cmdEnv.get("PATH")
+	suite.Require().NoError(err, "could not get PATH")
+
+	defer func() {
+		err := cmdEnv.set("PATH", oldPathEnv)
+		suite.Assert().NoError(err, "Unexpected error re-setting paths")
+	}()
+
+	cp := ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(script, "-t", ts.Dirs.Work))
+	cp.Expect("Installing to")
+	cp.Expect("Continue?")
+
+	cp.SendLine("y")
+	cp.Expect("Fetching the latest version")
+	cp.Expect("State Tool successfully installed to")
+	cp.ExpectExitCode(0)
+
+	pathEnv, err := cmdEnv.get("PATH")
+	suite.Require().NoError(err, "could not get PATH")
+	paths := strings.Split(pathEnv, string(os.PathListSeparator))
+	suite.Assert().Contains(paths, ts.Dirs.Work, "Could not find installation path in PATH")
+}
+
+func (suite *InstallScriptsIntegrationTestSuite) TestInstallPerl5_32() {
+	if runtime.GOOS != "windows" {
+		suite.T().SkipNow()
+	}
+	suite.OnlyRunForTags(tagsuite.Critical)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	script := scriptPath(suite.T())
+
+	isAdmin, err := osutils.IsWindowsAdmin()
+	suite.Require().NoError(err, "Could not determine if running as administrator")
+
+	cmdEnv := NewCmdEnv(!isAdmin)
+	oldPathEnv, err := cmdEnv.get("PATH")
+	suite.Require().NoError(err, "could not get PATH")
+
+	defer func() {
+		err := cmdEnv.set("PATH", oldPathEnv)
+		suite.Assert().NoError(err, "Unexpected error re-setting paths")
+	}()
+
+	cp := ts.SpawnCmdWithOpts(
+		"powershell.exe",
+		e2e.WithArgs(script, "-t", ts.Dirs.Work, "-activate-default", "ActiveState/Perl-5.32"),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
+	cp.Expect("Installing to")
+	cp.Expect("Continue?")
+
+	cp.SendLine("y")
+	cp.Expect("Fetching the latest version")
+	cp.Expect("State Tool successfully installed to")
+	cp.Expect("Activating project ActiveState/Perl-5.32 as default")
+	cp.Expect("Cloning Repository")
+	cp.Expect("Downloading missing artifacts")
+	cp.Expect("Updating missing artifacts")
+	cp.ExpectLongString("Successfully configured ActiveState/Perl-5.32 as the global default project")
+	cp.Expect("activated state")
+	cp.SendLine("exit")
+	cp.ExpectExitCode(0)
+
+	pathEnv, err := cmdEnv.get("PATH")
+	suite.Require().NoError(err, "could not get PATH")
+	paths := strings.Split(pathEnv, string(os.PathListSeparator))
+	suite.Assert().Contains(paths, ts.Dirs.Work, "Could not find installation path in PATH")
+}
+func TestInstallScriptsIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(InstallScriptsIntegrationTestSuite))
+}

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -15,26 +15,26 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type OpenKeyFn func(path string) (osutils.RegistryKey, error)
+type openKeyFn func(path string) (osutils.RegistryKey, error)
 
-type CmdEnv struct {
-	openKeyFn OpenKeyFn
+type cmdEnv struct {
+	openKeyFn openKeyFn
 	// whether this updates the system environment
 	userScope bool
 }
 
-func NewCmdEnv(userScope bool) *CmdEnv {
+func newCmdEnv(userScope bool) *cmdEnv {
 	openKeyFn := osutils.OpenSystemKey
 	if userScope {
 		openKeyFn = osutils.OpenUserKey
 	}
-	return &CmdEnv{
+	return &cmdEnv{
 		openKeyFn: openKeyFn,
 		userScope: userScope,
 	}
 }
 
-func (c *CmdEnv) set(name, newValue string) error {
+func (c *cmdEnv) set(name, newValue string) error {
 	key, err := c.openKeyFn(getEnvironmentPath(c.userScope))
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func (c *CmdEnv) set(name, newValue string) error {
 	return osutils.SetStringValue(key, name, valType, newValue)
 }
 
-func (c *CmdEnv) get(name string) (string, error) {
+func (c *cmdEnv) get(name string) (string, error) {
 	key, err := c.openKeyFn(getEnvironmentPath(c.userScope))
 	if err != nil {
 		return "", err
@@ -97,7 +97,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstallPs1() {
 	isAdmin, err := osutils.IsWindowsAdmin()
 	suite.Require().NoError(err, "Could not determine if running as administrator")
 
-	cmdEnv := NewCmdEnv(!isAdmin)
+	cmdEnv := newCmdEnv(!isAdmin)
 	oldPathEnv, err := cmdEnv.get("PATH")
 	suite.Require().NoError(err, "could not get PATH")
 
@@ -135,7 +135,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstallPerl5_32() {
 	isAdmin, err := osutils.IsWindowsAdmin()
 	suite.Require().NoError(err, "Could not determine if running as administrator")
 
-	cmdEnv := NewCmdEnv(!isAdmin)
+	cmdEnv := newCmdEnv(!isAdmin)
 	oldPathEnv, err := cmdEnv.get("PATH")
 	suite.Require().NoError(err, "could not get PATH")
 
@@ -169,7 +169,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstallPerl5_32() {
 	userPaths := paths
 	if isAdmin {
 		// `state prepare` writes the global bin directory to the USER path
-		userCmdEnv := NewCmdEnv(true)
+		userCmdEnv := newCmdEnv(true)
 		userPathEnv, err := userCmdEnv.get("PATH")
 		suite.Require().NoError(err, "could not get PATH")
 		userPaths = strings.Split(userPathEnv, string(os.PathListSeparator))

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -166,7 +166,15 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstallPerl5_32() {
 	pathEnv, err := cmdEnv.get("PATH")
 	suite.Require().NoError(err, "could not get PATH")
 	paths := strings.Split(pathEnv, string(os.PathListSeparator))
-	suite.Assert().Contains(paths, filepath.Join(ts.Dirs.Cache, "bin"), "Could not find global binary directory on PATH")
+	userPaths := paths
+	if isAdmin {
+		// `state prepare` writes the global bin directory to the USER path
+		userCmdEnv := NewCmdEnv(true)
+		userPathEnv, err := userCmdEnv.get("PATH")
+		suite.Require().NoError(err, "could not get PATH")
+		userPaths = strings.Split(userPathEnv, string(os.PathListSeparator))
+	}
+	suite.Assert().Contains(userPaths, filepath.Join(ts.Dirs.Cache, "bin"), "Could not find global binary directory on PATH")
 	suite.Assert().Contains(paths, ts.Dirs.Work, "Could not find installation path in PATH")
 }
 func TestInstallScriptsIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173785323

This fixes two errors in the `install.ps1` script:

- [MINOR] Project name was not re-printed correctly during `-activate-default`
- [MAJOR] When updating the State Tool Path as a user we wrote the old SYSTEM path to the USER(!) environment. Ooops!