### PR TITLE
Do not prepare global binary directory twice

### DIFF
--- a/internal/globaldefault/default.go
+++ b/internal/globaldefault/default.go
@@ -44,13 +44,6 @@ func isBinDirOnWindowsUserPath(binDir string) bool {
 		return false
 	}
 
-	isWindowsAdmin, err := osutils.IsWindowsAdmin()
-	if err != nil {
-		logging.Error("Failed to determine if we are running as administrator: %v", err)
-	}
-	if !isWindowsAdmin {
-		return false
-	}
 	cmdEnv := cmd.NewCmdEnv(true)
 	path, fail := cmdEnv.Get("PATH")
 	if fail != nil {
@@ -58,14 +51,10 @@ func isBinDirOnWindowsUserPath(binDir string) bool {
 		return false
 	}
 
-	if funk.ContainsString(
+	return funk.ContainsString(
 		strings.Split(path, string(os.PathListSeparator)),
 		binDir,
-	) {
-		return true
-	}
-
-	return false
+	)
 }
 
 func Prepare(subshell subshell.SubShell) error {
@@ -80,6 +69,14 @@ func Prepare(subshell subshell.SubShell) error {
 		}
 	}
 
+	isWindowsAdmin, err := osutils.IsWindowsAdmin()
+	if err != nil {
+		logging.Error("Failed to determine if we are running as administrator: %v", err)
+	}
+	if isWindowsAdmin {
+		logging.Debug("Skip preparation step as it is not supported for Windows Administrators.")
+		return nil
+	}
 	if isBinDirOnWindowsUserPath(binDir) {
 		logging.Debug("Skip preparation step as it has been done previously for the current user.")
 		return nil

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/stretchr/testify/suite"
@@ -32,6 +33,13 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 		// e2e.AppendEnv(fmt.Sprintf("ACTIVESTATE_CLI_CONFIGDIR=%s", ts.Dirs.Work)),
 	)
 	cp.ExpectExitCode(0)
+
+	isAdmin, err := osutils.IsWindowsAdmin()
+	suite.Require().NoError(err, "Could not determine if we are a Windows Administrator")
+	// For Windows Administrator users `state _prepare` is doing nothing now (because it doesn't make sense...)
+	if isAdmin {
+		return
+	}
 	suite.AssertConfig(filepath.Join(ts.Dirs.Cache, "bin"))
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176003625

I (probably) messed up the previous PR https://www.pivotaltracker.com/story/show/175672636.  For regular users, it ran the `state _prepare` step that adds the global binary directory to the PATH on every default activation.  That created the problem described below.  *Note*: This changes the behavior in a way that *Administrator* users *never* add the directory to the `PATH`, which probably is the correct way to do, as it hasn't worked correctly so far.  Follow-up story (to potentially re-implement and fix that part) is here: https://www.pivotaltracker.com/story/show/176040664

The problem that happened here though, is due to the fact that we are `cmd.WriteUserEnv()` to update the `PATH` variable.  And that (IMO) is broken right now if it is called more than once, which is why this PR fixes it.  Follow up story for that one is here: https://www.pivotaltracker.com/story/show/176040319

How this affected the call of `./install.ps1 --activate-default ActiveState/Perl-5.32`:

1. The install script called `state _prepare` to set global binary directory `<global_bin>` on PATH
   - User env variable `PATH_ORIGINAL` was set to old `PATH`
   - Env variable `PATH` is set to `<global_bin>;%PATH_ORIGINAL%`
1. The install script prepended the State Tool Path `<state_path>` to the `PATH`
   - Env Variable `PATH` is set to `<state_path>;<global_bin>;%PATH_ORIGINAL%`
1. The Install script calls `state activate --default ActiveState/Perl-5.32`
   - We call `cmd.WriteUserEnv` again which does the following because it notices that we have `PATH_ORIGINAL` set:
   - Set `PATH` to `<global_bin>;%PATH_ORIGINAL%` *discarding the State Tool Path*

With this PR, we ensure that the third step is not run, if `<global_bin>` is already on the `PATH`, but ultimately we should probably fix the `cmd.WriteUserEnv` behavior ie., https://www.pivotaltracker.com/story/show/176040319