### PR TITLE
Handle invalid semantic version values

### DIFF
--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -128,7 +128,7 @@ func MakeByName(name string) Language {
 func MakeByNameAndVersion(name, version string) (Language, error) {
 	if strings.ToLower(name) == Python2.Requirement() {
 		parts := strings.Split(version, ".")
-		if len(parts) == 0 {
+		if len(parts) == 0 || parts[0] == "" {
 			return Unknown, locale.NewError("err_invalid_version", "Invalid langauage version number: {{.V0}}", version)
 		}
 		name = name + parts[0]

--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -2,10 +2,7 @@ package language
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
-
-	"github.com/blang/semver"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/exeutils"
@@ -131,14 +128,10 @@ func MakeByName(name string) Language {
 func MakeByNameAndVersion(name, version string) (Language, error) {
 	if strings.ToLower(name) == Python2.Requirement() {
 		parts := strings.Split(version, ".")
-		if len(parts) > 3 {
-			version = strings.Join(parts[:len(parts)-1], ".")
+		if len(parts) == 0 {
+			return Unknown, locale.NewError("err_invalid_version", "Invalid langauage version number: {{.V0}}", version)
 		}
-		version, err := semver.Parse(version)
-		if err != nil {
-			return Unknown, err
-		}
-		name = name + strconv.FormatUint(version.Major, 10)
+		name = name + parts[0]
 	}
 	return MakeByName(name), nil
 }

--- a/internal/language/language_test.go
+++ b/internal/language/language_test.go
@@ -146,6 +146,12 @@ func TestMakeByNameAndVersion(t *testing.T) {
 			false,
 		},
 		{
+			"Valid Python3 invalid patch",
+			args{"python", "3.9"},
+			Python3,
+			false,
+		},
+		{
 			"Invalid version",
 			args{"python", ""},
 			Unknown,


### PR DESCRIPTION
In order to lookup the proper language enum for python we need the name to be `python2` or `python3`. To do this we would parse the version number and then append the major value to the language name. Previously we were handling semver values like `2.7.18.2` by trimming off the last value and then parsing the semver. Now we have values that are just `3.9` without a patch. If we are going to continue to get invalid semvers then there is little point in modifying them in order to parse if all we want is the major value.

 https://www.pivotaltracker.com/story/show/176059694