### PR TITLE
stop requiring version label to start CI

### DIFF
--- a/.github/workflows-src/build.yml
+++ b/.github/workflows-src/build.yml
@@ -9,7 +9,7 @@ name: Build-Test-Deploy
       - beta
       - release
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types: [labeled, opened, synchronize, reopened]
 
 jobs:
   prepare: #@ jobs_prepare()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ name: Build-Test-Deploy
   pull_request:
     types:
     - labeled
+    - opened
     - synchronize
     - reopened
 jobs:


### PR DESCRIPTION
I noticed that the CI tasks were not running when I just opened my PRs, because it was waiting for me to specify a `version:*` label.  This PR fixes that.