### PR TITLE
Save config before activating subshell

### DIFF
--- a/internal/globaldefault/default.go
+++ b/internal/globaldefault/default.go
@@ -30,7 +30,6 @@ const shimDenoter = "!DO NOT EDIT! State Tool Shim !DO NOT EDIT!"
 
 type DefaultConfigurer interface {
 	sscommon.Configurable
-	Save() error
 	CachePath() string
 }
 

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -43,6 +43,7 @@ type Configurable interface {
 	Set(string, interface{})
 	GetBool(string) bool
 	GetStringMap(string) map[string]interface{}
+	Save() error
 }
 
 type EnvData struct {
@@ -185,6 +186,10 @@ func SetupProjectRcFile(templateName, ext string, env map[string]string, out out
 		}
 	}
 	cfg.Set(activatedKey, true)
+	if err := cfg.Save(); err != nil {
+		// Save config now because otherwise we'd have to wait until the shell is closed, which might happen prematurely
+		return nil, errs.Wrap(err, "Config could not be saved after setting activatedKey")
+	}
 
 	inuse := []string{}
 	scripts := map[string]string{}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176366619

Ran into this issue when testing vscode; vscode terminates the terminal sessions uncleanly, meaning `Save()` never gets called. Additionally with the old behaviour whether default was called for a project would only be stored once you exited the activated session meaning it could have been called multiple times by then (if the user ran multiple activations).