### PR TITLE
Fix Komodo integration test

### DIFF
--- a/internal/runners/secrets/secrets.go
+++ b/internal/runners/secrets/secrets.go
@@ -42,6 +42,11 @@ type secretData struct {
 	Usage       string `locale:"usage,[HEADING]Usage[/RESET]"`
 }
 
+type listOutput struct {
+	out  output.Outputer
+	data []*secretData
+}
+
 // NewList prepares a list execution context for use.
 func NewList(client *secretsapi.Client, p listPrimeable) *List {
 	return &List{
@@ -71,13 +76,39 @@ func (l *List) Run(params ListRunParams) error {
 		return locale.WrapError(err, "secrets_err_values")
 	}
 
-	l.out.Print(struct {
-		Data []*secretData `opts:"verticalTable" locale:","`
-	}{
-		Data: meta,
-	})
+	data := &listOutput{l.out, meta}
+	l.out.Print(data)
 
 	return nil
+}
+
+func (l *listOutput) MarshalOutput(format output.Format) interface{} {
+	switch format {
+	case output.EditorV0FormatName:
+		var output []*SecretExport
+		for _, d := range l.data {
+			out := &SecretExport{
+				Name:        d.Name,
+				Scope:       d.Scope,
+				Description: d.Description,
+			}
+
+			if d.HasValue == locale.T("secrets_row_value_set") {
+				out.HasValue = true
+			}
+
+			output = append(output, out)
+		}
+		l.out.Print(output)
+	default:
+		l.out.Print(struct {
+			Data []*secretData `opts:"verticalTable" locale:","`
+		}{
+			l.data,
+		})
+	}
+
+	return output.Suppress
 }
 
 // checkSecretsAccess is reusable "runner-level" logic and provides a directly

--- a/test/integration/komodo_int_test.go
+++ b/test/integration/komodo_int_test.go
@@ -213,7 +213,7 @@ func (suite *SecretsIntegrationTestSuite) TestSecretsOutput_EditorV0() {
 	secret := secrets.SecretExport{
 		Name:        "test-secret",
 		Scope:       "project",
-		Description: "",
+		Description: "Not provided.",
 		HasValue:    true,
 	}
 


### PR DESCRIPTION
This was introduced when we updated the `state secrets` UX.  In order to use the vertical table output we have to wrap the output data in a struct to include the `veritcalTable` option. Also the `HasValue` field is not compatible with what Komodo expects. This PR updates the output to do some processing before printing in the `editor.V0` case.

 https://www.pivotaltracker.com/story/show/176807110