### PR TITLE
Unit test outlines

### DIFF
--- a/internal/runbits/runtimemsg2.go
+++ b/internal/runbits/runtimemsg2.go
@@ -1,0 +1,4 @@
+package runbits
+
+// RuntimeMessageHandler2 supports the runtime message handling for the new runtime2 package
+type RuntimeMessageHandler2 struct{}

--- a/internal/runbits/runtimemsg2_test.go
+++ b/internal/runbits/runtimemsg2_test.go
@@ -1,0 +1,7 @@
+package runbits
+
+import "testing"
+
+func TestChangeSummary(t *testing.T) {
+
+}

--- a/pkg/platform/runtime2/build/artifact.go
+++ b/pkg/platform/runtime2/build/artifact.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"github.com/ActiveState/cli/pkg/platform/api/headchef/headchef_models"
 	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_models"
 )
 
@@ -15,11 +16,34 @@ type Artifact struct {
 	// ...
 }
 
+type ArtifactChanges struct {
+	Added   []ArtifactID
+	Updated []ArtifactID
+	Removed []ArtifactID
+}
+
+// ArtifactsFromRecipe parses a recipe and returns a map of Artifact structures that we can interpret for our purposes
 func ArtifactsFromRecipe(recipe *inventory_models.Recipe) map[ArtifactID]Artifact {
 	panic("implement me")
 }
 
+// RequestedArtifactChanges parses two recipes and returns the artifact IDs of artifacts that have changed due to changes in the order requirements
+func RequestedArtifactChanges(old, new *inventory_models.Recipe) ArtifactChanges {
+	// Basic outline of what needs to happen here:
+	// - filter for `ResolvedIngredients` that also have `ResolvedRequirements` in both recipes
+	//   - add ArtifactID to the `Added` field if artifactID only appears in the the `new` recipe
+	//   - add ArtifactID to the `Removed` field if artifactID only appears in the the `old` recipe
+	//   - add ArtifactID to the `Updated` field if `ResolvedRequirements.feature` appears in both recipes, but the resolved version has changed.
+	panic("implement me")
+}
+
+// ResolvedArtifactChanges parses two recipes and returns the artifact IDs of the closure artifacts that have changed
+// This includes all artifacts returned by `RequiredArtifactsChanges` and artifacts that have been included, changed or removed due to dependency resolution.
+func ResolvedArtifactChanges(old, new *inventory_models.Recipe) ArtifactChanges {
+	panic("implement me")
+}
+
 // IsBuildComplete checks if the built for this recipe has already completed, or if we need to wait for artifacts to finish.
-func IsBuildComplete(recipe *inventory_models.Recipe) bool {
+func IsBuildComplete(buildStatus *headchef_models.BuildStatusResponse) bool {
 	panic("implement me")
 }

--- a/pkg/platform/runtime2/build/artifact_test.go
+++ b/pkg/platform/runtime2/build/artifact_test.go
@@ -1,9 +1,143 @@
 package build
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ActiveState/cli/pkg/platform/runtime2/testhelper"
+	"github.com/stretchr/testify/assert"
+)
 
 // TestArtifactsFromRecipe ensures that we are able to parse a recipe correctly
 // This is probably good to do, as it is more complicated
 func TestArtifactsFromRecipe(t *testing.T) {
+	tests := []struct {
+		Name                  string
+		recipeName            string
+		expectedArtifactNames []string // TODO: expect full artifact structure maybe
+	}{
+		{
+			"camel recipe",
+			"camel",
+			[]string{},
+		},
+		{
+			"alternative recipe",
+			"alternative",
+			[]string{},
+		},
+		{
+			"alternative with bundles",
+			"alternative-with-bundles",
+			[]string{},
+		},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			recipe := testhelper.LoadRecipe(t, tt.recipeName)
+			/*res := */ ArtifactsFromRecipe(recipe)
+
+			// TODO: ensure some expectations on result
+		})
+	}
+}
+
+func TestRequestedArtifactChanges(t *testing.T) {
+	tests := []struct {
+		Name            string
+		baseRecipeName  string
+		newRecipeName   string
+		expectedChanges ArtifactChanges
+	}{
+		{
+			"no changes",
+			"base",
+			"base",
+			ArtifactChanges{},
+		},
+		{
+			"one package added",
+			"base",
+			"one-requirement-added",
+			ArtifactChanges{},
+		},
+		{
+			"one package removed",
+			"base",
+			"one-requirement-removed",
+			ArtifactChanges{},
+		},
+		{
+			"one package updated",
+			"base",
+			"one-requirement-updated",
+			ArtifactChanges{},
+		},
+		{
+			"complex changes",
+			"base",
+			"complex-changes",
+			ArtifactChanges{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			old := testhelper.LoadRecipe(t, tt.baseRecipeName)
+			new := testhelper.LoadRecipe(t, tt.newRecipeName)
+			res := RequestedArtifactChanges(old, new)
+
+			assert.Equal(t, tt.expectedChanges, res)
+		})
+	}
+}
+
+func TestResolvedArtifactChanges(t *testing.T) {
+	tests := []struct {
+		Name            string
+		baseRecipeName  string
+		newRecipeName   string
+		expectedChanges ArtifactChanges
+	}{
+		{
+			"no changes",
+			"base",
+			"base",
+			ArtifactChanges{},
+		},
+		{
+			"one package added",
+			"base",
+			"one-requirement-added",
+			ArtifactChanges{},
+		},
+		{
+			"one package removed",
+			"base",
+			"one-requirement-removed",
+			ArtifactChanges{},
+		},
+		{
+			"one package updated",
+			"base",
+			"one-requirement-updated",
+			ArtifactChanges{},
+		},
+		{
+			"complex changes",
+			"base",
+			"complex-changes",
+			ArtifactChanges{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			old := testhelper.LoadRecipe(t, tt.baseRecipeName)
+			new := testhelper.LoadRecipe(t, tt.newRecipeName)
+			res := ResolvedArtifactChanges(old, new)
+
+			assert.Equal(t, tt.expectedChanges, res)
+		})
+	}
 }

--- a/pkg/platform/runtime2/build/artifact_test.go
+++ b/pkg/platform/runtime2/build/artifact_test.go
@@ -141,3 +141,34 @@ func TestResolvedArtifactChanges(t *testing.T) {
 		})
 	}
 }
+
+func TestIsBuildComplete(t *testing.T) {
+	tests := []struct {
+		Name            string
+		buildStatusName string
+		expectedResult  bool
+	}{
+		{
+			"camel build",
+			"camel",
+			false,
+		},
+		{
+			"alternative build incomplete",
+			"alternative-incomplete",
+			false,
+		},
+		{
+			"alternative build completed",
+			"alternative-completed",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			bs := testhelper.LoadBuildResponse(t, tt.buildStatusName)
+			assert.Equal(t, tt.expectedResult, IsBuildComplete(bs))
+		})
+	}
+}

--- a/pkg/platform/runtime2/build/build.go
+++ b/pkg/platform/runtime2/build/build.go
@@ -6,6 +6,7 @@ package build
 
 import (
 	"github.com/ActiveState/cli/pkg/platform/api/buildlogstream"
+	"github.com/ActiveState/cli/pkg/platform/api/headchef/headchef_models"
 	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_models"
 )
 
@@ -29,14 +30,9 @@ const (
 
 // BuildResult is the unified response of a Build request
 type BuildResult struct {
-	BuildEngine BuildEngine
-	Recipe      *inventory_models.Recipe
-}
-
-type ArtifactChanges struct {
-	Added   []ArtifactID
-	Updated []ArtifactID
-	Removed []ArtifactID
+	BuildEngine         BuildEngine
+	Recipe              *inventory_models.Recipe
+	BuildStatusResponse *headchef_models.BuildStatusResponse
 }
 
 // MessageHandler is the interface for callback functions that are called during

--- a/pkg/platform/runtime2/build/scheduler.go
+++ b/pkg/platform/runtime2/build/scheduler.go
@@ -4,12 +4,14 @@ import (
 	"context"
 )
 
+// ArtifactScheduler provides a cancelable read-able channel of artifacts to download
 type ArtifactScheduler struct {
 	ctx   context.Context
 	ch    chan Artifact
 	errCh chan error
 }
 
+// NewArtifactScheduler returns a new ArtifactScheduler scheduling the provided artifacts
 func NewArtifactScheduler(ctx context.Context, artifacts map[ArtifactID]Artifact) *ArtifactScheduler {
 	ch := make(chan Artifact)
 	errCh := make(chan error)
@@ -27,6 +29,7 @@ func NewArtifactScheduler(ctx context.Context, artifacts map[ArtifactID]Artifact
 	return &ArtifactScheduler{ctx, ch, errCh}
 }
 
+// Wait waits for all artifacts to be scheduled and returns an error if the scheduling was interrupted
 func (as *ArtifactScheduler) Wait() error {
 	err := <-as.errCh
 	close(as.ch)
@@ -34,6 +37,7 @@ func (as *ArtifactScheduler) Wait() error {
 	return err
 }
 
+// BuiltArtifactsChannel returns the channel to read from
 func (as *ArtifactScheduler) BuiltArtifactsChannel() <-chan Artifact {
 	return as.ch
 }

--- a/pkg/platform/runtime2/build/scheduler.go
+++ b/pkg/platform/runtime2/build/scheduler.go
@@ -1,0 +1,39 @@
+package build
+
+import (
+	"context"
+)
+
+type ArtifactScheduler struct {
+	ctx   context.Context
+	ch    chan Artifact
+	errCh chan error
+}
+
+func NewArtifactScheduler(ctx context.Context, artifacts map[ArtifactID]Artifact) *ArtifactScheduler {
+	ch := make(chan Artifact)
+	errCh := make(chan error)
+	go func() {
+		for _, a := range artifacts {
+			select {
+			case ch <- a:
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			}
+		}
+		errCh <- nil
+	}()
+	return &ArtifactScheduler{ctx, ch, errCh}
+}
+
+func (as *ArtifactScheduler) Wait() error {
+	err := <-as.errCh
+	close(as.ch)
+	close(as.errCh)
+	return err
+}
+
+func (as *ArtifactScheduler) BuiltArtifactsChannel() <-chan Artifact {
+	return as.ch
+}

--- a/pkg/platform/runtime2/build/scheduler_test.go
+++ b/pkg/platform/runtime2/build/scheduler_test.go
@@ -1,0 +1,1 @@
+package build

--- a/pkg/platform/runtime2/build/scheduler_test.go
+++ b/pkg/platform/runtime2/build/scheduler_test.go
@@ -1,1 +1,37 @@
 package build
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/autarch/testify/require"
+)
+
+func TestArtifactScheduler(t *testing.T) {
+	dummyArtifacts := make(map[ArtifactID]Artifact)
+	numArtifacts := 5
+	for i := 0; i < numArtifacts; i++ {
+		artID := ArtifactID(fmt.Sprintf("%d", i))
+		dummyArtifacts[artID] = Artifact{ArtifactID: artID}
+	}
+
+	t.Run("read all artifacts", func(t *testing.T) {
+		sched := NewArtifactScheduler(context.Background(), dummyArtifacts)
+		go func() {
+			for i := 0; i < numArtifacts; i++ {
+				<-sched.BuiltArtifactsChannel()
+			}
+		}()
+		err := sched.Wait()
+		require.NoError(t, err)
+	})
+
+	t.Run("cancel context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		sched := NewArtifactScheduler(ctx, dummyArtifacts)
+		err := sched.Wait()
+		require.EqualError(t, err, context.Canceled.Error())
+	})
+}

--- a/pkg/platform/runtime2/model/buildlog.go
+++ b/pkg/platform/runtime2/model/buildlog.go
@@ -6,24 +6,18 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/runtime2/build"
 )
 
-// DownloadableArtifact stores information needed to download a built artifact from our sever
-type DownloadableArtifact struct {
-	ID          build.ArtifactID
-	DownloadURL string
-}
-
 // BuildLog is an implementation of a build log
 type BuildLog struct {
 	// TODO: This is just a rough outline of how it could look like
 	wg    *sync.WaitGroup
-	ch    chan DownloadableArtifact
+	ch    chan build.Artifact
 	errCh chan error
 }
 
 // NewBuildLog creates a new instance that allows us to wait for incoming build log information
 func NewBuildLog() *BuildLog {
 	wg := new(sync.WaitGroup)
-	ch := make(chan DownloadableArtifact)
+	ch := make(chan build.Artifact)
 	errCh := make(chan error)
 	wg.Add(1)
 	go func() {
@@ -46,8 +40,9 @@ func NewBuildLog() *BuildLog {
 }
 
 // Wait waits for the build log to close because the build is done and all downloadable artifacts are here
-func (bl *BuildLog) Wait() {
+func (bl *BuildLog) Wait() error {
 	bl.wg.Wait()
+	return nil
 }
 
 // Close stops the build log process, eg., due to a user interruption
@@ -58,7 +53,7 @@ func (bl *BuildLog) Close() error {
 }
 
 // BuiltArtifactsChannel returns the channel to listen for downloadable artifacts on
-func (bl *BuildLog) BuiltArtifactsChannel() <-chan DownloadableArtifact {
+func (bl *BuildLog) BuiltArtifactsChannel() <-chan build.Artifact {
 	return bl.ch
 }
 

--- a/pkg/platform/runtime2/model/buildlog_test.go
+++ b/pkg/platform/runtime2/model/buildlog_test.go
@@ -1,0 +1,8 @@
+package model
+
+import "testing"
+
+func TestBuildLog(t *testing.T) {
+	// This should test the build log (probably without using the backend)
+	// Don't know yet if that is actually possible.
+}

--- a/pkg/platform/runtime2/model/default.go
+++ b/pkg/platform/runtime2/model/default.go
@@ -24,6 +24,6 @@ func (d *Default) Build(order *inventory_models.Order) (*build.BuildResult, erro
 	panic("implement me")
 }
 
-func (d *Default) BuildLog(msgHandler buildlogstream.MessageHandler, recipe *inventory_models.Recipe) (BuildLog, error) {
+func (d *Default) BuildLog(msgHandler buildlogstream.MessageHandler, recipe *inventory_models.Recipe) (*BuildLog, error) {
 	panic("implement me")
 }

--- a/pkg/platform/runtime2/model/default.go
+++ b/pkg/platform/runtime2/model/default.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"context"
+
 	"github.com/ActiveState/cli/pkg/platform/api/buildlogstream"
 	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_models"
 	"github.com/ActiveState/cli/pkg/platform/runtime2/build"
@@ -24,6 +26,6 @@ func (d *Default) Build(order *inventory_models.Order) (*build.BuildResult, erro
 	panic("implement me")
 }
 
-func (d *Default) BuildLog(msgHandler buildlogstream.MessageHandler, recipe *inventory_models.Recipe) (*BuildLog, error) {
+func (d *Default) BuildLog(ctx context.Context, msgHandler buildlogstream.MessageHandler, recipe *inventory_models.Recipe) (*BuildLog, error) {
 	panic("implement me")
 }

--- a/pkg/platform/runtime2/runtime.go
+++ b/pkg/platform/runtime2/runtime.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"github.com/ActiveState/cli/pkg/platform/runtime2/build"
 	"github.com/ActiveState/cli/pkg/project"
 )
 
@@ -24,4 +25,9 @@ func new(proj *project.Project, ep EnvProvider) (*Runtime, error) {
 
 func (r *Runtime) Environ() (map[string]string, error) {
 	return r.ep.Environ()
+}
+
+func (r *Runtime) Artifacts() (map[build.ArtifactID]build.Artifact, error) {
+	// read in recipe stored on disk and transform into artifact
+	panic("implement me")
 }

--- a/pkg/platform/runtime2/setup.go
+++ b/pkg/platform/runtime2/setup.go
@@ -81,10 +81,10 @@ func (s *Setup) InstallRuntime() error {
 
 	// Compute and handle the change summary
 	artifacts := build.ArtifactsFromRecipe(buildResult.Recipe)
-	requestedArtifacts, changedArtifacts := s.changeSummaryArgs(buildResult)
+	requestedArtifacts, changedArtifacts := changeSummaryArgs(buildResult)
 	s.msgHandler.ChangeSummary(artifacts, requestedArtifacts, changedArtifacts)
 
-	if build.IsBuildComplete(buildResult.Recipe) {
+	if build.IsBuildComplete(buildResult.BuildStatusResponse) {
 		err := s.installImmediately(buildResult, artifacts)
 		if err != nil {
 			return err
@@ -242,7 +242,8 @@ func (s *Setup) setupArtifact(buildEngine build.BuildEngine, a build.ArtifactID,
 	panic("implement error handling")
 }
 
-func (s *Setup) changeSummaryArgs(buildResult *build.BuildResult) (requested build.ArtifactChanges, changed build.ArtifactChanges) {
+// changeSummaryArgs
+func changeSummaryArgs(buildResult *build.BuildResult) (requested build.ArtifactChanges, changed build.ArtifactChanges) {
 	panic("implement me")
 }
 

--- a/pkg/platform/runtime2/setup_test.go
+++ b/pkg/platform/runtime2/setup_test.go
@@ -1,29 +1,137 @@
 package runtime
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
-	"github.com/ActiveState/cli/pkg/platform/runtime2/impl"
-	"github.com/ActiveState/cli/pkg/platform/runtime2/model/client"
-	"github.com/ActiveState/cli/pkg/project"
+	"github.com/ActiveState/cli/pkg/platform/runtime2/build"
 )
 
-// TestSetup
-func TestSetup(t *testing.T) {
-	var mockProject *project.Project
-	var mockMessageHandler impl.MessageHandler
-	mockClient := client.NewMock()
-	// specify behavior of mock client here.
-	// ...
+// readReadyChannel is helper function that returns how many artifactIDs have been orchestrated
+// This is used TestOrchestrateSetup
+func readReadyChannel(called <-chan build.ArtifactID) int {
+	numCalled := 0
+	for {
+		select {
+		case _ = <-called:
+			numCalled++
+		default:
+			return numCalled
+		}
+	}
+}
 
-	s := NewSetupWithAPI(mockProject, mockMessageHandler, mockClient)
+func TestOrchestrateSetup(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Callback    func(chan<- build.ArtifactID, build.Artifact) error
+		ExpectError bool
+	}{
+		{
+			"without errors",
+			func(called chan<- build.ArtifactID, a build.Artifact) error {
+				called <- a.ArtifactID
+				return nil
+			},
+			false,
+		},
+		{
+			"with timeouts",
+			func(called chan<- build.ArtifactID, a build.Artifact) error {
+				// wait a second to ensure that waiting for tasks to finish works
+				time.Sleep(time.Millisecond * 100)
+				called <- a.ArtifactID
+				return nil
+			},
+			false,
+		},
+		{
+			"with one error",
+			func(called chan<- build.ArtifactID, a build.Artifact) error {
+				if a.ArtifactID == "3" {
+					return errors.New("dummy error")
+				}
+				called <- a.ArtifactID
+				return nil
+			},
+			true,
+		},
+		{
+			"with several errors",
+			func(called chan<- build.ArtifactID, a build.Artifact) error {
+				return errors.New("dummy error")
+			},
+			true,
+		},
+	}
 
-	s.InstallRuntime()
-	// TODO: check error
+	numArtifacts := 5
 
-	// TODO: check messageHandler calls
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			ch := make(chan build.Artifact)
+			go func() {
+				defer close(ch)
+				for i := 0; i < numArtifacts; i++ {
+					ch <- build.Artifact{ArtifactID: build.ArtifactID(fmt.Sprintf("%d", i))}
+				}
+			}()
+			called := make(chan build.ArtifactID, numArtifacts)
+			defer close(called)
+			err := orchestrateArtifactSetup(context.Background(), ch, func(a build.Artifact) error {
+				return tt.Callback(called, a)
+			})
+			if tt.ExpectError == (err == nil) {
+				t.Fatalf("Unexpected error value: %v", err)
+			}
+			if !tt.ExpectError {
+				numCalled := readReadyChannel(called)
+				if numCalled != numArtifacts {
+					t.Fatalf("callback called %d times, expected %d", numCalled, numArtifacts)
+				}
+			}
+		})
+	}
 
-	r, _ := s.InstalledRuntime()
-	// TODO: check runtime works
-	r.Environ()
+	t.Run("queue is closed", func(t *testing.T) {
+		ch := make(chan build.Artifact)
+		close(ch)
+		called := make(chan build.ArtifactID, numArtifacts)
+		defer close(called)
+		err := orchestrateArtifactSetup(context.Background(), ch, func(a build.Artifact) error {
+			called <- a.ArtifactID
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected err=%v", err)
+		}
+		numCalled := readReadyChannel(called)
+		if numCalled != 0 {
+			t.Fatalf("callback should not have been called, was called %d times", numCalled)
+		}
+	})
+
+	t.Run("context is canceled", func(t *testing.T) {
+		ch := make(chan build.Artifact)
+		defer close(ch)
+		called := make(chan build.ArtifactID, numArtifacts)
+		defer close(called)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := orchestrateArtifactSetup(ctx, ch, func(a build.Artifact) error {
+			called <- a.ArtifactID
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected err=%v", err)
+		}
+		numCalled := readReadyChannel(called)
+		if numCalled != 0 {
+			t.Fatalf("callback should not have been called, was called %d times", numCalled)
+		}
+	})
+
 }

--- a/pkg/platform/runtime2/setup_test.go
+++ b/pkg/platform/runtime2/setup_test.go
@@ -135,3 +135,11 @@ func TestOrchestrateSetup(t *testing.T) {
 	})
 
 }
+
+func TestChangeSummaryArgs(t *testing.T) {
+	// TODO: This function should compute the change summary arguments that supports
+	// our message handler function to print out a summary of changes relative to the
+	// installed build.
+	// My suggestion is to implement the message handler function first to understand
+	// the requirements for this function better.
+}

--- a/pkg/platform/runtime2/testhelper/data/builds/alternative-completed.json
+++ b/pkg/platform/runtime2/testhelper/data/builds/alternative-completed.json
@@ -1,0 +1,31 @@
+{
+  "artifacts": [
+    {
+      "artifact_id": "71e4a1fe-eba7-5ee1-a95f-94fd70aa2d87",
+      "build_state": "succeeded",
+      "build_timestamp": "2021-02-03T22:21:39.496Z",
+      "dependency_ids": null,
+      "ingredient_version_id": "a845e482-d3ec-5379-aba3-96e74794570f",
+      "log_uri": "s3://as-builds/production/language/perl/5.32.0/7/71e4a1fe-eba7-5ee1-a95f-94fd70aa2d87/logs.jsonl",
+      "platform_id": "0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a",
+      "uri": "s3://as-builds/production/language/perl/5.32.0/7/71e4a1fe-eba7-5ee1-a95f-94fd70aa2d87/artifact.tar.gz"
+    },
+    {
+      "artifact_id": "ad807d9a-8214-5395-92c4-77b6301248f2",
+      "build_state": "succeeded",
+      "build_timestamp": "2021-02-06T00:17:40.179Z",
+      "dependency_ids": null,
+      "log_uri": "s3://as-builds/noop/logs.jsonl",
+      "platform_id": "0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a",
+      "uri": "s3://as-builds/noop/artifact.tar.gz"
+    }
+  ],
+  "build_engine": "alternative",
+  "build_request_id": "af46a10c-e788-459e-9e17-4e4add8973c0",
+  "errors": [],
+  "is_retryable": false,
+  "message": "Recipe build completed successfully",
+  "recipe_id": "ad807d9a-8214-5395-92c4-77b6301248f2",
+  "timestamp": "2021-02-18T18:03:18.756Z",
+  "type": "build_completed"
+}

--- a/pkg/platform/runtime2/testhelper/data/builds/camel-building.json
+++ b/pkg/platform/runtime2/testhelper/data/builds/camel-building.json
@@ -1,0 +1,11 @@
+{
+  "artifacts": [],
+  "build_engine": "camel",
+  "build_request_id": "ccf8173c-9810-4ae3-afd6-02f7597258ae",
+  "errors": [],
+  "is_retryable": false,
+  "message": "Camel build sent to scheduler with camel commit 3d46a065",
+  "recipe_id": "50dd4b2f-a42e-537e-911c-3122b89f8c36",
+  "timestamp": "2021-02-18T17:58:38.465Z",
+  "type": "build_started"
+}

--- a/pkg/platform/runtime2/testhelper/data/builds/camel-done.json
+++ b/pkg/platform/runtime2/testhelper/data/builds/camel-done.json
@@ -1,0 +1,1 @@
+{"artifacts":null,"build_engine":"camel","build_request_id":"ccf8173c-9810-4ae3-afd6-02f7597258ae","errors":null,"is_retryable":false,"message":"Sent build to scheduler","recipe_id":"50dd4b2f-a42e-537e-911c-3122b89f8c36","timestamp":"2021-02-18T17:58:38.468Z","type":"build_started"}

--- a/pkg/platform/runtime2/testhelper/data/recipes/alternative-bare.json
+++ b/pkg/platform/runtime2/testhelper/data/recipes/alternative-bare.json
@@ -1,0 +1,9002 @@
+{
+  "camel_flags": [],
+  "from_recipe_store": false,
+  "image": {
+    "image_id": "b210b15e-c98a-4259-89c8-b7bae56d237f",
+    "links": {
+      "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/images/b210b15e-c98a-4259-89c8-b7bae56d237f"
+    },
+    "name": "docker-registry.activestate.build/activestate/centos-7.6-builder",
+    "platform_id": "0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a",
+    "type": "Docker",
+    "sortable_version": [
+      "1",
+      "0",
+      "31",
+      "0"
+    ],
+    "version": "1.0.31",
+    "provided_features": [
+      {
+        "feature": "GCC",
+        "is_activestate_version": false,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "7",
+          "3",
+          "0"
+        ],
+        "version": "7.3"
+      },
+      {
+        "feature": "GNU C++03",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "GNU C11",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "GNU C++11",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "GNU C++14",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "GNU C89",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "GNU C++98",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "GNU C99",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO C++03",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO C11",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO C++11",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO C++14",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO C89",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO C++98",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO C99",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO Fortran 77",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO Fortran 90",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      },
+      {
+        "feature": "ISO Fortran 95",
+        "is_activestate_version": true,
+        "is_default_provider": true,
+        "namespace": "compiler",
+        "sortable_version": [
+          "0",
+          "0"
+        ],
+        "version": "0"
+      }
+    ],
+    "author_platform_user_id": "e501c7e7-40cc-4b7a-8fc9-f6a3d314c254",
+    "comment": "Added a new revision to add compiler features to images",
+    "is_stable_revision": true,
+    "conditions": [
+      {
+        "feature": "alternative-builder",
+        "namespace": "builder",
+        "requirements": [
+          {
+            "comparator": "gte",
+            "sortable_version": [
+              "0",
+              "0",
+              "1",
+              "0"
+            ],
+            "version": "0.0.1"
+          }
+        ]
+      },
+      {
+        "feature": "alternative-built-language",
+        "namespace": "language",
+        "requirements": [
+          {
+            "comparator": "gte",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          }
+        ]
+      }
+    ],
+    "status": "stable",
+    "revision": 4,
+    "revision_timestamp": "2020-12-03T22:54:45.160370Z"
+  },
+  "is_indemnified": false,
+  "platform": {
+    "cpu_architecture": {
+      "cpu_architecture_id": "4cdba18d-0851-4925-9ae5-9c8a2987828a",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/cpu-architectures/4cdba18d-0851-4925-9ae5-9c8a2987828a"
+      },
+      "bit_width": "64",
+      "name": "x86",
+      "provided_features": [
+        {
+          "feature": "x86 64-bit",
+          "is_activestate_version": false,
+          "is_default_provider": true,
+          "namespace": "cpu-architecture",
+          "sortable_version": [
+            "1",
+            "0"
+          ],
+          "version": "1"
+        }
+      ],
+      "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+      "comment": "Created prior to addition of revision comments.",
+      "is_stable_revision": true,
+      "revision": 1,
+      "revision_timestamp": "2019-08-06T21:46:35.288458Z"
+    },
+    "cpu_extensions": [],
+    "creation_timestamp": "2019-08-06T21:46:35.288458Z",
+    "display_name": "CentOS 7.6.1810, Linux 4.15.0, glibc 2.17 x86 64-bit",
+    "images": [
+      {
+        "image_id": "0fceabb4-ca86-4846-9b0a-c23947770cdb",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/images/0fceabb4-ca86-4846-9b0a-c23947770cdb"
+        },
+        "name": "activestate/centos-7.6-build",
+        "platform_id": "0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a",
+        "type": "Docker",
+        "sortable_version": [
+          "1",
+          "0",
+          "9",
+          "0"
+        ],
+        "version": "1.0.9",
+        "provided_features": [
+          {
+            "feature": "GCC",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "4",
+              "9",
+              "2",
+              "0"
+            ],
+            "version": "4.9.2"
+          },
+          {
+            "feature": "GNU C++03",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C++11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C89",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C++98",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C99",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++03",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C89",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++98",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C99",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 77",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 90",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 95",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          }
+        ],
+        "author_platform_user_id": "36a36906-04a3-4221-adf1-805632ee9bb7",
+        "comment": "Added a new revision to add compiler features to images",
+        "is_stable_revision": true,
+        "conditions": [
+          {
+            "feature": "alternative-built-language",
+            "namespace": "language",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": []
+              }
+            ]
+          },
+          {
+            "feature": "bogus-dependency",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ]
+          }
+        ],
+        "status": "stable",
+        "revision": 13,
+        "revision_timestamp": "2021-02-04T20:25:44.473616Z"
+      },
+      {
+        "image_id": "b210b15e-c98a-4259-89c8-b7bae56d237f",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/images/b210b15e-c98a-4259-89c8-b7bae56d237f"
+        },
+        "name": "docker-registry.activestate.build/activestate/centos-7.6-builder",
+        "platform_id": "0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a",
+        "type": "Docker",
+        "sortable_version": [
+          "1",
+          "0",
+          "31",
+          "0"
+        ],
+        "version": "1.0.31",
+        "provided_features": [
+          {
+            "feature": "GCC",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "7",
+              "3",
+              "0"
+            ],
+            "version": "7.3"
+          },
+          {
+            "feature": "GNU C++03",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C++11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C++14",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C89",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C++98",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C99",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++03",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++14",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C89",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++98",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C99",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 77",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 90",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 95",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          }
+        ],
+        "author_platform_user_id": "e501c7e7-40cc-4b7a-8fc9-f6a3d314c254",
+        "comment": "Added a new revision to add compiler features to images",
+        "is_stable_revision": true,
+        "conditions": [
+          {
+            "feature": "alternative-builder",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0",
+                  "1",
+                  "0"
+                ],
+                "version": "0.0.1"
+              }
+            ]
+          },
+          {
+            "feature": "alternative-built-language",
+            "namespace": "language",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ]
+          }
+        ],
+        "status": "stable",
+        "revision": 4,
+        "revision_timestamp": "2020-12-03T22:54:45.160370Z"
+      },
+      {
+        "image_id": "74150f63-4452-4bfa-9622-c64552e68346",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/images/74150f63-4452-4bfa-9622-c64552e68346"
+        },
+        "name": "docker-registry.activestate.build/activestate/centos-7.9-build",
+        "platform_id": "0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a",
+        "type": "Docker",
+        "sortable_version": [
+          "1",
+          "1",
+          "1",
+          "0"
+        ],
+        "version": "1.1.1",
+        "provided_features": [
+          {
+            "feature": "GCC",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "7",
+              "3",
+              "0"
+            ],
+            "version": "7.3"
+          },
+          {
+            "feature": "GNU C++03",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C++11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C++14",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C89",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C++98",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "GNU C99",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++03",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++14",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C89",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++98",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C99",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 77",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 90",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO Fortran 95",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          }
+        ],
+        "author_platform_user_id": "36a36906-04a3-4221-adf1-805632ee9bb7",
+        "comment": "Added a new revision to add compiler features to images",
+        "is_stable_revision": true,
+        "conditions": [
+          {
+            "feature": "alternative-built-language",
+            "namespace": "language",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": []
+              }
+            ]
+          }
+        ],
+        "status": "stable",
+        "revision": 1,
+        "revision_timestamp": "2021-02-04T20:25:28.031620Z"
+      }
+    ],
+    "is_user_visible": true,
+    "kernel": {
+      "kernel_id": "ef737274-fff9-4164-b72b-88067613f822",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/kernels/ef737274-fff9-4164-b72b-88067613f822"
+      },
+      "name": "Linux"
+    },
+    "kernel_version": {
+      "kernel_version_id": "2450c462-66e0-4aca-97d4-9910a19996f6",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/kernels/ef737274-fff9-4164-b72b-88067613f822/versions/2450c462-66e0-4aca-97d4-9910a19996f6"
+      },
+      "sortable_version": [
+        "4",
+        "15",
+        "0",
+        "0"
+      ],
+      "version": "4.15.0",
+      "provided_features": [
+        {
+          "feature": "Linux",
+          "is_activestate_version": false,
+          "is_default_provider": true,
+          "namespace": "kernel",
+          "sortable_version": [
+            "4",
+            "15",
+            "0",
+            "0"
+          ],
+          "version": "4.15.0"
+        }
+      ],
+      "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+      "comment": "Created prior to addition of revision comments.",
+      "is_stable_revision": true,
+      "revision": 1,
+      "revision_timestamp": "2019-08-06T21:46:35.288458Z"
+    },
+    "libc": {
+      "libc_id": "09a2eb42-ad34-4734-a93e-4b97395577df",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/libcs/09a2eb42-ad34-4734-a93e-4b97395577df"
+      },
+      "name": "glibc"
+    },
+    "libc_version": {
+      "libc_version_id": "277c8630-948f-449c-9d69-5cf2ce3eb7eb",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/libcs/09a2eb42-ad34-4734-a93e-4b97395577df/versions/277c8630-948f-449c-9d69-5cf2ce3eb7eb"
+      },
+      "sortable_version": [
+        "2",
+        "17",
+        "0"
+      ],
+      "version": "2.17",
+      "provided_features": [
+        {
+          "feature": "glibc",
+          "is_activestate_version": false,
+          "is_default_provider": true,
+          "namespace": "libc",
+          "sortable_version": [
+            "2",
+            "17",
+            "0"
+          ],
+          "version": "2.17"
+        }
+      ],
+      "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+      "comment": "Created prior to addition of revision comments.",
+      "is_stable_revision": true,
+      "revision": 1,
+      "revision_timestamp": "2019-08-06T21:46:35.288458Z"
+    },
+    "links": {
+      "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/platforms/0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a"
+    },
+    "operating_system": {
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/operating-systems/7b3a2dbb-d543-48d6-8390-7e7b63751e99"
+      },
+      "operating_system_id": "7b3a2dbb-d543-48d6-8390-7e7b63751e99",
+      "has_libc": true,
+      "name": "CentOS"
+    },
+    "operating_system_version": {
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/operating-systems/7b3a2dbb-d543-48d6-8390-7e7b63751e99/versions/2cab2f48-fb0b-415f-85f8-ddd045969662"
+      },
+      "operating_system_version_id": "2cab2f48-fb0b-415f-85f8-ddd045969662",
+      "sortable_version": [
+        "7",
+        "6",
+        "1810",
+        "0"
+      ],
+      "version": "7.6.1810",
+      "provided_features": [
+        {
+          "feature": "CentOS",
+          "is_activestate_version": false,
+          "is_default_provider": true,
+          "namespace": "operating-system",
+          "sortable_version": [
+            "7",
+            "6",
+            "1810",
+            "0"
+          ],
+          "version": "7.6.1810"
+        }
+      ],
+      "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+      "comment": "Created prior to addition of revision comments.",
+      "is_stable_revision": true,
+      "revision": 1,
+      "revision_timestamp": "2019-08-06T21:46:35.288458Z"
+    },
+    "platform_id": "0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a"
+  },
+  "recipe_id": "ad807d9a-8214-5395-92c4-77b6301248f2",
+  "resolved_ingredients": [
+    {
+      "alternatives": [],
+      "artifact_id": "ccffef06-ba83-5716-9dd0-b629f2a65f68",
+      "build_scripts": null,
+      "dependencies": [],
+      "ingredient": {
+        "creation_timestamp": "2020-08-10T23:47:40.385229Z",
+        "ingredient_id": "a4128de4-f62c-5349-80e6-b072d5aa3e31",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/a4128de4-f62c-5349-80e6-b072d5aa3e31"
+        },
+        "name": "perl-core-builder",
+        "normalized_name": "perl-core-builder",
+        "primary_namespace": "builder",
+        "description": "Builds the core Perl interpreter on the ActiveState platform.",
+        "website": "https://activestate.com"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2020-09-30T17:58:38.567523Z",
+        "ingredient_id": "a4128de4-f62c-5349-80e6-b072d5aa3e31",
+        "ingredient_version_id": "d5ac8c7c-b025-5418-ab77-a139e60e1d41",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/a4128de4-f62c-5349-80e6-b072d5aa3e31/versions/d5ac8c7c-b025-5418-ab77-a139e60e1d41",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/a4128de4-f62c-5349-80e6-b072d5aa3e31"
+        },
+        "revision": 2,
+        "revision_timestamp": "2020-10-30T17:04:06.702744Z",
+        "copyright_text": "To be added.",
+        "documentation_uri": "https://activestate.com",
+        "is_binary_only": false,
+        "license_expression": "(MIT-1.0)",
+        "release_timestamp": "2020-06-25T07:05:14.000000Z",
+        "source_uri": "https://github.com/ActiveState/platform-builders/builders/perl-core-builder",
+        "sortable_version": [
+          "1",
+          "0",
+          "23",
+          "0"
+        ],
+        "version": "1.0.23",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {},
+        "dependencies": null,
+        "ingredient_options": null,
+        "is_indemnified": false,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/builder/cb4bd9b790715ae38f4bbc1acffafb5b3d7d328fcfe29974e60ded1fece45374/perl-core-builder.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "cb4bd9b790715ae38f4bbc1acffafb5b3d7d328fcfe29974e60ded1fece45374",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "alternative-builder",
+            "is_activestate_version": false,
+            "is_default_provider": false,
+            "namespace": "builder",
+            "sortable_version": [
+              "1",
+              "0",
+              "0",
+              "0"
+            ],
+            "version": "1.0.0"
+          },
+          {
+            "feature": "perl-core-builder",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "builder",
+            "sortable_version": [
+              "1",
+              "0",
+              "23",
+              "0"
+            ],
+            "version": "1.0.23"
+          }
+        ],
+        "author_platform_user_id": "fe7c9294-51d6-4df6-a5b5-44cf5a924ebc",
+        "comment": "Initial builder for perl 5.30+",
+        "is_stable_revision": true
+      },
+      "patches": null,
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "71e4a1fe-eba7-5ee1-a95f-94fd70aa2d87",
+      "build_scripts": null,
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "d5ac8c7c-b025-5418-ab77-a139e60e1d41"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T16:56:32.665096Z",
+        "ingredient_id": "ed4b2154-eaee-5fba-88bb-d1eca86b1206",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/ed4b2154-eaee-5fba-88bb-d1eca86b1206"
+        },
+        "name": "perl",
+        "normalized_name": "perl",
+        "primary_namespace": "language",
+        "description": "Practical Extraction and Report Language"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2020-10-14T19:24:44.505799Z",
+        "ingredient_id": "ed4b2154-eaee-5fba-88bb-d1eca86b1206",
+        "ingredient_version_id": "a845e482-d3ec-5379-aba3-96e74794570f",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/ed4b2154-eaee-5fba-88bb-d1eca86b1206/versions/a845e482-d3ec-5379-aba3-96e74794570f",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/ed4b2154-eaee-5fba-88bb-d1eca86b1206"
+        },
+        "revision": 7,
+        "revision_timestamp": "2021-02-03T21:13:51.365878Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "1970-01-01T00:00:00.000000Z",
+        "source_uri": "https://www.cpan.org/src/5.0/perl-5.32.0.tar.gz",
+        "sortable_version": [
+          "5",
+          "32",
+          "0"
+        ],
+        "version": "5.32.0",
+        "activestate_license_expression": "[\" GPL-1.0-or-later\",\"Artistic-1.0-Perl\"]",
+        "camel_extras": {},
+        "dependencies": [
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "gte",
+                    "sortable_version": [
+                      "0",
+                      "0"
+                    ],
+                    "version": "0"
+                  }
+                ]
+              }
+            ],
+            "description": "The perl language requires a compiler to build",
+            "feature": "Visual Studio",
+            "namespace": "compiler",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "feature": "perl-core-builder",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": []
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "description": "The perl language requires a compiler to build",
+            "feature": "ISO C89",
+            "namespace": "compiler",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/language/efeb1ce1f10824190ad1cadbcccf6fdb8a5d37007d0100d2d9ae5f2b5900c0b4/perl-5.32.0.tar.gz",
+        "scanner_license_expression": "[\" GPL-1.0-or-later\",\"Artistic-1.0-Perl\"]",
+        "source_checksum": "efeb1ce1f10824190ad1cadbcccf6fdb8a5d37007d0100d2d9ae5f2b5900c0b4",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "alternative-built-language",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language",
+            "sortable_version": [
+              "5",
+              "32",
+              "0",
+              "0"
+            ],
+            "version": "5.32.0"
+          },
+          {
+            "feature": "perl",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language",
+            "sortable_version": [
+              "5",
+              "32",
+              "0"
+            ],
+            "version": "5.32.0"
+          },
+          {
+            "feature": "Amiga::ARexx",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "40",
+              "0"
+            ],
+            "version": "0.04"
+          },
+          {
+            "feature": "Amiga::Exec",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "20",
+              "0"
+            ],
+            "version": "0.02"
+          },
+          {
+            "feature": "AnyDBM_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "10",
+              "0"
+            ],
+            "version": "1.01"
+          },
+          {
+            "feature": "App::Cpan",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "675",
+              "0"
+            ],
+            "version": "1.675"
+          },
+          {
+            "feature": "App::Prove",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "App::Prove::State",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "App::Prove::State::Result",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "App::Prove::State::Result::Test",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "Archive::Tar",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "360",
+              "0"
+            ],
+            "version": "2.36"
+          },
+          {
+            "feature": "Archive::Tar::Constant",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "360",
+              "0"
+            ],
+            "version": "2.36"
+          },
+          {
+            "feature": "Archive::Tar::File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "360",
+              "0"
+            ],
+            "version": "2.36"
+          },
+          {
+            "feature": "Attribute::Handlers",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "10",
+              "0"
+            ],
+            "version": "1.01"
+          },
+          {
+            "feature": "AutoLoader",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "740",
+              "0"
+            ],
+            "version": "5.74"
+          },
+          {
+            "feature": "AutoSplit",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "60",
+              "0"
+            ],
+            "version": "1.06"
+          },
+          {
+            "feature": "B",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "800",
+              "0"
+            ],
+            "version": "1.80"
+          },
+          {
+            "feature": "B::Concise",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "4",
+              "0"
+            ],
+            "version": "1.004"
+          },
+          {
+            "feature": "B::Deparse",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "540",
+              "0"
+            ],
+            "version": "1.54"
+          },
+          {
+            "feature": "B::Op_private",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "32",
+              "0"
+            ],
+            "version": "5.032000"
+          },
+          {
+            "feature": "B::Showlex",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "50",
+              "0"
+            ],
+            "version": "1.05"
+          },
+          {
+            "feature": "B::Terse",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "90",
+              "0"
+            ],
+            "version": "1.09"
+          },
+          {
+            "feature": "B::Xref",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "70",
+              "0"
+            ],
+            "version": "1.07"
+          },
+          {
+            "feature": "Benchmark",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "230",
+              "0"
+            ],
+            "version": "1.23"
+          },
+          {
+            "feature": "CPAN",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "270",
+              "0"
+            ],
+            "version": "2.27"
+          },
+          {
+            "feature": "CPAN::Author",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "200"
+            ],
+            "version": "5.5002"
+          },
+          {
+            "feature": "CPAN::Bundle",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "500"
+            ],
+            "version": "5.5005"
+          },
+          {
+            "feature": "CPAN::CacheMgr",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "200"
+            ],
+            "version": "5.5002"
+          },
+          {
+            "feature": "CPAN::Complete",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "100"
+            ],
+            "version": "5.5001"
+          },
+          {
+            "feature": "CPAN::Debug",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "100"
+            ],
+            "version": "5.5001"
+          },
+          {
+            "feature": "CPAN::DeferredCode",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "0"
+            ],
+            "version": "5.50"
+          },
+          {
+            "feature": "CPAN::Distribution",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "270",
+              "0"
+            ],
+            "version": "2.27"
+          },
+          {
+            "feature": "CPAN::Distroprefs",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "6",
+              "0",
+              "100"
+            ],
+            "version": "6.0001"
+          },
+          {
+            "feature": "CPAN::Distrostatus",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "0"
+            ],
+            "version": "5.5"
+          },
+          {
+            "feature": "CPAN::Exception::RecursiveDependency",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "100"
+            ],
+            "version": "5.5001"
+          },
+          {
+            "feature": "CPAN::Exception::blocked_urllist",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "1",
+              "0"
+            ],
+            "version": "1.001"
+          },
+          {
+            "feature": "CPAN::Exception::yaml_not_installed",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "0"
+            ],
+            "version": "5.5"
+          },
+          {
+            "feature": "CPAN::Exception::yaml_process_error",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "0"
+            ],
+            "version": "5.5"
+          },
+          {
+            "feature": "CPAN::FTP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "501",
+              "200"
+            ],
+            "version": "5.5012"
+          },
+          {
+            "feature": "CPAN::FTP::netrc",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "10",
+              "0"
+            ],
+            "version": "1.01"
+          },
+          {
+            "feature": "CPAN::FirstTime",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "531",
+              "400"
+            ],
+            "version": "5.5314"
+          },
+          {
+            "feature": "CPAN::HTTP::Client",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "960",
+              "100"
+            ],
+            "version": "1.9601"
+          },
+          {
+            "feature": "CPAN::HTTP::Credentials",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "960",
+              "100"
+            ],
+            "version": "1.9601"
+          },
+          {
+            "feature": "CPAN::HandleConfig",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "501",
+              "100"
+            ],
+            "version": "5.5011"
+          },
+          {
+            "feature": "CPAN::Index",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "120",
+              "0"
+            ],
+            "version": "2.12"
+          },
+          {
+            "feature": "CPAN::InfoObj",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "0"
+            ],
+            "version": "5.5"
+          },
+          {
+            "feature": "CPAN::Kwalify",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "0"
+            ],
+            "version": "5.50"
+          },
+          {
+            "feature": "CPAN::LWP::UserAgent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "960",
+              "100"
+            ],
+            "version": "1.9601"
+          },
+          {
+            "feature": "CPAN::Meta",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "CPAN::Meta::Converter",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "CPAN::Meta::Feature",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "CPAN::Meta::History",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "CPAN::Meta::Merge",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "CPAN::Meta::Prereqs",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "CPAN::Meta::Requirements",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "140",
+              "0"
+            ],
+            "version": "2.140"
+          },
+          {
+            "feature": "CPAN::Meta::Spec",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "CPAN::Meta::Validator",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "CPAN::Meta::YAML",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "18",
+              "0"
+            ],
+            "version": "0.018"
+          },
+          {
+            "feature": "CPAN::Mirrors",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "270",
+              "0"
+            ],
+            "version": "2.27"
+          },
+          {
+            "feature": "CPAN::Module",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "300"
+            ],
+            "version": "5.5003"
+          },
+          {
+            "feature": "CPAN::Nox",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "100"
+            ],
+            "version": "5.5001"
+          },
+          {
+            "feature": "CPAN::Plugin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "970",
+              "0"
+            ],
+            "version": "0.97"
+          },
+          {
+            "feature": "CPAN::Plugin::Specfile",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "20",
+              "0"
+            ],
+            "version": "0.02"
+          },
+          {
+            "feature": "CPAN::Prompt",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "0"
+            ],
+            "version": "5.5"
+          },
+          {
+            "feature": "CPAN::Queue",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "300"
+            ],
+            "version": "5.5003"
+          },
+          {
+            "feature": "CPAN::Shell",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "900"
+            ],
+            "version": "5.5009"
+          },
+          {
+            "feature": "CPAN::Tarzip",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "501",
+              "300"
+            ],
+            "version": "5.5013"
+          },
+          {
+            "feature": "CPAN::URL",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "0"
+            ],
+            "version": "5.5"
+          },
+          {
+            "feature": "CPAN::Version",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "500",
+              "300"
+            ],
+            "version": "5.5003"
+          },
+          {
+            "feature": "Carp",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "500",
+              "0"
+            ],
+            "version": "1.50"
+          },
+          {
+            "feature": "Carp::Heavy",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "500",
+              "0"
+            ],
+            "version": "1.50"
+          },
+          {
+            "feature": "Class::Struct",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "660",
+              "0"
+            ],
+            "version": "0.66"
+          },
+          {
+            "feature": "Compress::Raw::Bzip2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "Compress::Raw::Zlib",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "Compress::Zlib",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "Config",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "32",
+              "0"
+            ],
+            "version": "5.032"
+          },
+          {
+            "feature": "Config::Extensions",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "30",
+              "0"
+            ],
+            "version": "0.03"
+          },
+          {
+            "feature": "Config::Perl::V",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "320",
+              "0"
+            ],
+            "version": "0.32"
+          },
+          {
+            "feature": "Cwd",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "DB",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "80",
+              "0"
+            ],
+            "version": "1.08"
+          },
+          {
+            "feature": "DBM_Filter",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "60",
+              "0"
+            ],
+            "version": "0.06"
+          },
+          {
+            "feature": "DBM_Filter::compress",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "30",
+              "0"
+            ],
+            "version": "0.03"
+          },
+          {
+            "feature": "DBM_Filter::encode",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "30",
+              "0"
+            ],
+            "version": "0.03"
+          },
+          {
+            "feature": "DBM_Filter::int32",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "30",
+              "0"
+            ],
+            "version": "0.03"
+          },
+          {
+            "feature": "DBM_Filter::null",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "30",
+              "0"
+            ],
+            "version": "0.03"
+          },
+          {
+            "feature": "DBM_Filter::utf8",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "30",
+              "0"
+            ],
+            "version": "0.03"
+          },
+          {
+            "feature": "DB_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "853",
+              "0"
+            ],
+            "version": "1.853"
+          },
+          {
+            "feature": "Data::Dumper",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "174",
+              "0"
+            ],
+            "version": "2.174"
+          },
+          {
+            "feature": "Devel::PPPort",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "570",
+              "0"
+            ],
+            "version": "3.57"
+          },
+          {
+            "feature": "Devel::Peek",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "280",
+              "0"
+            ],
+            "version": "1.28"
+          },
+          {
+            "feature": "Devel::SelfStubber",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "60",
+              "0"
+            ],
+            "version": "1.06"
+          },
+          {
+            "feature": "Digest",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "170",
+              "100"
+            ],
+            "version": "1.17_01"
+          },
+          {
+            "feature": "Digest::MD5",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "550",
+              "100"
+            ],
+            "version": "2.55_01"
+          },
+          {
+            "feature": "Digest::SHA",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "6",
+              "20",
+              "0"
+            ],
+            "version": "6.02"
+          },
+          {
+            "feature": "Digest::base",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "160",
+              "0"
+            ],
+            "version": "1.16"
+          },
+          {
+            "feature": "Digest::file",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "160",
+              "0"
+            ],
+            "version": "1.16"
+          },
+          {
+            "feature": "DirHandle",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "50",
+              "0"
+            ],
+            "version": "1.05"
+          },
+          {
+            "feature": "Dumpvalue",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "210",
+              "0"
+            ],
+            "version": "1.21"
+          },
+          {
+            "feature": "DynaLoader",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "470",
+              "0"
+            ],
+            "version": "1.47"
+          },
+          {
+            "feature": "Encode",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "60",
+              "0"
+            ],
+            "version": "3.06"
+          },
+          {
+            "feature": "Encode::Alias",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "240",
+              "0"
+            ],
+            "version": "2.24"
+          },
+          {
+            "feature": "Encode::Byte",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "40",
+              "0"
+            ],
+            "version": "2.04"
+          },
+          {
+            "feature": "Encode::CJKConstants",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "20",
+              "0"
+            ],
+            "version": "2.02"
+          },
+          {
+            "feature": "Encode::CN",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "30",
+              "0"
+            ],
+            "version": "2.03"
+          },
+          {
+            "feature": "Encode::CN::HZ",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "100",
+              "0"
+            ],
+            "version": "2.10"
+          },
+          {
+            "feature": "Encode::Config",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "50",
+              "0"
+            ],
+            "version": "2.05"
+          },
+          {
+            "feature": "Encode::EBCDIC",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "20",
+              "0"
+            ],
+            "version": "2.02"
+          },
+          {
+            "feature": "Encode::Encoder",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "30",
+              "0"
+            ],
+            "version": "2.03"
+          },
+          {
+            "feature": "Encode::Encoding",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "80",
+              "0"
+            ],
+            "version": "2.08"
+          },
+          {
+            "feature": "Encode::GSM0338",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "70",
+              "0"
+            ],
+            "version": "2.07"
+          },
+          {
+            "feature": "Encode::Guess",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "80",
+              "0"
+            ],
+            "version": "2.08"
+          },
+          {
+            "feature": "Encode::JP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "40",
+              "0"
+            ],
+            "version": "2.04"
+          },
+          {
+            "feature": "Encode::JP::H2Z",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "20",
+              "0"
+            ],
+            "version": "2.02"
+          },
+          {
+            "feature": "Encode::JP::JIS7",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "80",
+              "0"
+            ],
+            "version": "2.08"
+          },
+          {
+            "feature": "Encode::KR",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "30",
+              "0"
+            ],
+            "version": "2.03"
+          },
+          {
+            "feature": "Encode::KR::2022_KR",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "40",
+              "0"
+            ],
+            "version": "2.04"
+          },
+          {
+            "feature": "Encode::MIME::Header",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "280",
+              "0"
+            ],
+            "version": "2.28"
+          },
+          {
+            "feature": "Encode::MIME::Header::ISO_2022_JP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "90",
+              "0"
+            ],
+            "version": "1.09"
+          },
+          {
+            "feature": "Encode::MIME::Name",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Encode::Symbol",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "20",
+              "0"
+            ],
+            "version": "2.02"
+          },
+          {
+            "feature": "Encode::TW",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "30",
+              "0"
+            ],
+            "version": "2.03"
+          },
+          {
+            "feature": "Encode::Unicode",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "180",
+              "0"
+            ],
+            "version": "2.18"
+          },
+          {
+            "feature": "Encode::Unicode::UTF7",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "100",
+              "0"
+            ],
+            "version": "2.10"
+          },
+          {
+            "feature": "English",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "110",
+              "0"
+            ],
+            "version": "1.11"
+          },
+          {
+            "feature": "Env",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "40",
+              "0"
+            ],
+            "version": "1.04"
+          },
+          {
+            "feature": "Errno",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "300",
+              "0"
+            ],
+            "version": "1.30"
+          },
+          {
+            "feature": "Exporter",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "740",
+              "0"
+            ],
+            "version": "5.74"
+          },
+          {
+            "feature": "Exporter::Heavy",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "740",
+              "0"
+            ],
+            "version": "5.74"
+          },
+          {
+            "feature": "ExtUtils::CBuilder",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Base",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::Unix",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::VMS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::Windows",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::Windows::BCC",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::Windows::GCC",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::Windows::MSVC",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::aix",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::android",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::cygwin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::darwin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::dec_osf",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::CBuilder::Platform::os2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "234"
+            ],
+            "version": "0.280234"
+          },
+          {
+            "feature": "ExtUtils::Command",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::Command::MM",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::Constant",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "250",
+              "0"
+            ],
+            "version": "0.25"
+          },
+          {
+            "feature": "ExtUtils::Constant::Base",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "60",
+              "0"
+            ],
+            "version": "0.06"
+          },
+          {
+            "feature": "ExtUtils::Constant::ProxySubs",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "90",
+              "0"
+            ],
+            "version": "0.09"
+          },
+          {
+            "feature": "ExtUtils::Constant::Utils",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "40",
+              "0"
+            ],
+            "version": "0.04"
+          },
+          {
+            "feature": "ExtUtils::Constant::XS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "30",
+              "0"
+            ],
+            "version": "0.03"
+          },
+          {
+            "feature": "ExtUtils::Embed",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "350",
+              "0"
+            ],
+            "version": "1.35"
+          },
+          {
+            "feature": "ExtUtils::Install",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "140",
+              "0"
+            ],
+            "version": "2.14"
+          },
+          {
+            "feature": "ExtUtils::Installed",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "140",
+              "0"
+            ],
+            "version": "2.14"
+          },
+          {
+            "feature": "ExtUtils::Liblist",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::Liblist::Kid",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_AIX",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_Any",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_BeOS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_Cygwin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_DOS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_Darwin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_MacOS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_NW5",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_OS2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_QNX",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_UWIN",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_Unix",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_VMS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_VOS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_Win32",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MM_Win95",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MY",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MakeMaker",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MakeMaker::Config",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MakeMaker::Locale",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MakeMaker::version",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::MakeMaker::version::regex",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::Manifest",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "720",
+              "0"
+            ],
+            "version": "1.72"
+          },
+          {
+            "feature": "ExtUtils::Miniperl",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "90",
+              "0"
+            ],
+            "version": "1.09"
+          },
+          {
+            "feature": "ExtUtils::Mkbootstrap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::Mksymlists",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "ExtUtils::Packlist",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "140",
+              "0"
+            ],
+            "version": "2.14"
+          },
+          {
+            "feature": "ExtUtils::ParseXS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "ExtUtils::ParseXS::Constants",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "ExtUtils::ParseXS::CountLines",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "ExtUtils::ParseXS::Eval",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "ExtUtils::ParseXS::Utilities",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "ExtUtils::Typemaps",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "380",
+              "0"
+            ],
+            "version": "3.38"
+          },
+          {
+            "feature": "ExtUtils::Typemaps::Cmd",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "380",
+              "0"
+            ],
+            "version": "3.38"
+          },
+          {
+            "feature": "ExtUtils::Typemaps::InputMap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "380",
+              "0"
+            ],
+            "version": "3.38"
+          },
+          {
+            "feature": "ExtUtils::Typemaps::OutputMap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "380",
+              "0"
+            ],
+            "version": "3.38"
+          },
+          {
+            "feature": "ExtUtils::Typemaps::Type",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "380",
+              "0"
+            ],
+            "version": "3.38"
+          },
+          {
+            "feature": "ExtUtils::XSSymSet",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "400",
+              "0"
+            ],
+            "version": "1.4"
+          },
+          {
+            "feature": "ExtUtils::testlib",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "7",
+              "440",
+              "0"
+            ],
+            "version": "7.44"
+          },
+          {
+            "feature": "Fatal",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "Fcntl",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "130",
+              "0"
+            ],
+            "version": "1.13"
+          },
+          {
+            "feature": "File::Basename",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "850",
+              "0"
+            ],
+            "version": "2.85"
+          },
+          {
+            "feature": "File::Compare",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "100",
+              "600"
+            ],
+            "version": "1.1006"
+          },
+          {
+            "feature": "File::Copy",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "340",
+              "0"
+            ],
+            "version": "2.34"
+          },
+          {
+            "feature": "File::DosGlob",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "120",
+              "0"
+            ],
+            "version": "1.12"
+          },
+          {
+            "feature": "File::Fetch",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "560",
+              "0"
+            ],
+            "version": "0.56"
+          },
+          {
+            "feature": "File::Find",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "370",
+              "0"
+            ],
+            "version": "1.37"
+          },
+          {
+            "feature": "File::Glob",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "330",
+              "0"
+            ],
+            "version": "1.33"
+          },
+          {
+            "feature": "File::GlobMapper",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "1",
+              "0"
+            ],
+            "version": "1.001"
+          },
+          {
+            "feature": "File::Path",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "160",
+              "0"
+            ],
+            "version": "2.16"
+          },
+          {
+            "feature": "File::Spec",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::AmigaOS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::Cygwin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::Epoc",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::Functions",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::Mac",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::OS2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::Unix",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::VMS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "780",
+              "0"
+            ],
+            "version": "3.78"
+          },
+          {
+            "feature": "File::Spec::Win32",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "790",
+              "0"
+            ],
+            "version": "3.79"
+          },
+          {
+            "feature": "File::Temp",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "230",
+              "900"
+            ],
+            "version": "0.2309"
+          },
+          {
+            "feature": "File::stat",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "90",
+              "0"
+            ],
+            "version": "1.09"
+          },
+          {
+            "feature": "FileCache",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "100",
+              "0"
+            ],
+            "version": "1.10"
+          },
+          {
+            "feature": "FileHandle",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "30",
+              "0"
+            ],
+            "version": "2.03"
+          },
+          {
+            "feature": "Filter::Simple",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "960",
+              "0"
+            ],
+            "version": "0.96"
+          },
+          {
+            "feature": "Filter::Util::Call",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "590",
+              "0"
+            ],
+            "version": "1.59"
+          },
+          {
+            "feature": "FindBin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "510",
+              "0"
+            ],
+            "version": "1.51"
+          },
+          {
+            "feature": "GDBM_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "180",
+              "0"
+            ],
+            "version": "1.18"
+          },
+          {
+            "feature": "Getopt::Long",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "510",
+              "0"
+            ],
+            "version": "2.51"
+          },
+          {
+            "feature": "Getopt::Std",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "120",
+              "0"
+            ],
+            "version": "1.12"
+          },
+          {
+            "feature": "HTTP::Tiny",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "76",
+              "0"
+            ],
+            "version": "0.076"
+          },
+          {
+            "feature": "Hash::Util",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "230",
+              "0"
+            ],
+            "version": "0.23"
+          },
+          {
+            "feature": "Hash::Util::FieldHash",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "200",
+              "0"
+            ],
+            "version": "1.20"
+          },
+          {
+            "feature": "I18N::Collate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "20",
+              "0"
+            ],
+            "version": "1.02"
+          },
+          {
+            "feature": "I18N::LangTags",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "440",
+              "0"
+            ],
+            "version": "0.44"
+          },
+          {
+            "feature": "I18N::LangTags::Detect",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "80",
+              "0"
+            ],
+            "version": "1.08"
+          },
+          {
+            "feature": "I18N::LangTags::List",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "400",
+              "0"
+            ],
+            "version": "0.40"
+          },
+          {
+            "feature": "I18N::Langinfo",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "190",
+              "0"
+            ],
+            "version": "0.19"
+          },
+          {
+            "feature": "IO",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "430",
+              "0"
+            ],
+            "version": "1.43"
+          },
+          {
+            "feature": "IO::Compress::Adapter::Bzip2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Adapter::Deflate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Adapter::Identity",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Base",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Base::Common",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Bzip2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Deflate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Gzip",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Gzip::Constants",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::RawDeflate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Zip",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Zip::Constants",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Zlib::Constants",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Compress::Zlib::Extra",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Dir",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "410",
+              "0"
+            ],
+            "version": "1.41"
+          },
+          {
+            "feature": "IO::File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "410",
+              "0"
+            ],
+            "version": "1.41"
+          },
+          {
+            "feature": "IO::Handle",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "420",
+              "0"
+            ],
+            "version": "1.42"
+          },
+          {
+            "feature": "IO::Pipe",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "410",
+              "0"
+            ],
+            "version": "1.41"
+          },
+          {
+            "feature": "IO::Poll",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "410",
+              "0"
+            ],
+            "version": "1.41"
+          },
+          {
+            "feature": "IO::Seekable",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "410",
+              "0"
+            ],
+            "version": "1.41"
+          },
+          {
+            "feature": "IO::Select",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "420",
+              "0"
+            ],
+            "version": "1.42"
+          },
+          {
+            "feature": "IO::Socket",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "430",
+              "0"
+            ],
+            "version": "1.43"
+          },
+          {
+            "feature": "IO::Socket::INET",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "410",
+              "0"
+            ],
+            "version": "1.41"
+          },
+          {
+            "feature": "IO::Socket::IP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "390",
+              "0"
+            ],
+            "version": "0.39"
+          },
+          {
+            "feature": "IO::Socket::UNIX",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "410",
+              "0"
+            ],
+            "version": "1.41"
+          },
+          {
+            "feature": "IO::Uncompress::Adapter::Bunzip2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::Adapter::Identity",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::Adapter::Inflate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::AnyInflate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::AnyUncompress",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::Base",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::Bunzip2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::Gunzip",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::Inflate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::RawInflate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Uncompress::Unzip",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "93",
+              "0"
+            ],
+            "version": "2.093"
+          },
+          {
+            "feature": "IO::Zlib",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "100",
+              "0"
+            ],
+            "version": "1.10"
+          },
+          {
+            "feature": "IPC::Cmd",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "40",
+              "0"
+            ],
+            "version": "1.04"
+          },
+          {
+            "feature": "IPC::Msg",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "70",
+              "0"
+            ],
+            "version": "2.07"
+          },
+          {
+            "feature": "IPC::Open2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "50",
+              "0"
+            ],
+            "version": "1.05"
+          },
+          {
+            "feature": "IPC::Open3",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "210",
+              "0"
+            ],
+            "version": "1.21"
+          },
+          {
+            "feature": "IPC::Semaphore",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "70",
+              "0"
+            ],
+            "version": "2.07"
+          },
+          {
+            "feature": "IPC::SharedMem",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "70",
+              "0"
+            ],
+            "version": "2.07"
+          },
+          {
+            "feature": "IPC::SysV",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "70",
+              "0"
+            ],
+            "version": "2.07"
+          },
+          {
+            "feature": "JSON::PP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "40",
+              "0"
+            ],
+            "version": "4.04"
+          },
+          {
+            "feature": "JSON::PP::Boolean",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "40",
+              "0"
+            ],
+            "version": "4.04"
+          },
+          {
+            "feature": "List::Util",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "550",
+              "0"
+            ],
+            "version": "1.55"
+          },
+          {
+            "feature": "List::Util::XS",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "550",
+              "0"
+            ],
+            "version": "1.55"
+          },
+          {
+            "feature": "Locale::Maketext",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "290",
+              "0"
+            ],
+            "version": "1.29"
+          },
+          {
+            "feature": "Locale::Maketext::Guts",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "200",
+              "0"
+            ],
+            "version": "1.20"
+          },
+          {
+            "feature": "Locale::Maketext::GutsLoader",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "200",
+              "0"
+            ],
+            "version": "1.20"
+          },
+          {
+            "feature": "Locale::Maketext::Simple",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "210",
+              "100"
+            ],
+            "version": "0.21_01"
+          },
+          {
+            "feature": "MIME::Base64",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "150",
+              "0"
+            ],
+            "version": "3.15"
+          },
+          {
+            "feature": "MIME::QuotedPrint",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "130",
+              "0"
+            ],
+            "version": "3.13"
+          },
+          {
+            "feature": "Math::BigFloat",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "999",
+              "818"
+            ],
+            "version": "1.999818"
+          },
+          {
+            "feature": "Math::BigFloat::Trace",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "510",
+              "0"
+            ],
+            "version": "0.51"
+          },
+          {
+            "feature": "Math::BigInt",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "999",
+              "818"
+            ],
+            "version": "1.999818"
+          },
+          {
+            "feature": "Math::BigInt::Calc",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "999",
+              "818"
+            ],
+            "version": "1.999818"
+          },
+          {
+            "feature": "Math::BigInt::FastCalc",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "500",
+              "900"
+            ],
+            "version": "0.5009"
+          },
+          {
+            "feature": "Math::BigInt::Lib",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "999",
+              "818"
+            ],
+            "version": "1.999818"
+          },
+          {
+            "feature": "Math::BigInt::Trace",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "510",
+              "0"
+            ],
+            "version": "0.51"
+          },
+          {
+            "feature": "Math::BigRat",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "261",
+              "400"
+            ],
+            "version": "0.2614"
+          },
+          {
+            "feature": "Math::Complex",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "590",
+              "100"
+            ],
+            "version": "1.5901"
+          },
+          {
+            "feature": "Math::Trig",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "230",
+              "0"
+            ],
+            "version": "1.23"
+          },
+          {
+            "feature": "Memoize",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "100"
+            ],
+            "version": "1.03_01"
+          },
+          {
+            "feature": "Memoize::AnyDBM_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Memoize::Expire",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Memoize::ExpireFile",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Memoize::ExpireTest",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Memoize::NDBM_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Memoize::SDBM_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Memoize::Storable",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Module::CoreList",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "202",
+              "6",
+              "200"
+            ],
+            "version": "5.20200620"
+          },
+          {
+            "feature": "Module::CoreList::Utils",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "202",
+              "6",
+              "200"
+            ],
+            "version": "5.20200620"
+          },
+          {
+            "feature": "Module::Load",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "340",
+              "0"
+            ],
+            "version": "0.34"
+          },
+          {
+            "feature": "Module::Load::Conditional",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "700",
+              "0"
+            ],
+            "version": "0.70"
+          },
+          {
+            "feature": "Module::Loaded",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "80",
+              "0"
+            ],
+            "version": "0.08"
+          },
+          {
+            "feature": "Module::Metadata",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "0",
+              "37"
+            ],
+            "version": "1.000037"
+          },
+          {
+            "feature": "Moped::Msg",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "10",
+              "0"
+            ],
+            "version": "0.01"
+          },
+          {
+            "feature": "NDBM_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "150",
+              "0"
+            ],
+            "version": "1.15"
+          },
+          {
+            "feature": "NEXT",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "670",
+              "100"
+            ],
+            "version": "0.67_01"
+          },
+          {
+            "feature": "Net::Cmd",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::Config",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::Domain",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::FTP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::FTP::A",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::FTP::E",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::FTP::I",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::FTP::L",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::FTP::dataconn",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::NNTP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::Netrc",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::POP3",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::Ping",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "720",
+              "0"
+            ],
+            "version": "2.72"
+          },
+          {
+            "feature": "Net::SMTP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::Time",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "110",
+              "0"
+            ],
+            "version": "3.11"
+          },
+          {
+            "feature": "Net::hostent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "20",
+              "0"
+            ],
+            "version": "1.02"
+          },
+          {
+            "feature": "Net::netent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "10",
+              "0"
+            ],
+            "version": "1.01"
+          },
+          {
+            "feature": "Net::protoent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "10",
+              "0"
+            ],
+            "version": "1.01"
+          },
+          {
+            "feature": "Net::servent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "20",
+              "0"
+            ],
+            "version": "1.02"
+          },
+          {
+            "feature": "O",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "ODBM_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "160",
+              "0"
+            ],
+            "version": "1.16"
+          },
+          {
+            "feature": "OS2::DLL",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "70",
+              "0"
+            ],
+            "version": "1.07"
+          },
+          {
+            "feature": "OS2::ExtAttr",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "40",
+              "0"
+            ],
+            "version": "0.04"
+          },
+          {
+            "feature": "OS2::PrfDB",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "40",
+              "0"
+            ],
+            "version": "0.04"
+          },
+          {
+            "feature": "OS2::Process",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "120",
+              "0"
+            ],
+            "version": "1.12"
+          },
+          {
+            "feature": "OS2::REXX",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "50",
+              "0"
+            ],
+            "version": "1.05"
+          },
+          {
+            "feature": "Opcode",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "470",
+              "0"
+            ],
+            "version": "1.47"
+          },
+          {
+            "feature": "POSIX",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "940",
+              "0"
+            ],
+            "version": "1.94"
+          },
+          {
+            "feature": "Params::Check",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "380",
+              "0"
+            ],
+            "version": "0.38"
+          },
+          {
+            "feature": "Parse::CPAN::Meta",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "150",
+              "10"
+            ],
+            "version": "2.150010"
+          },
+          {
+            "feature": "Perl::OSType",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "10",
+              "0"
+            ],
+            "version": "1.010"
+          },
+          {
+            "feature": "PerlIO",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "110",
+              "0"
+            ],
+            "version": "1.11"
+          },
+          {
+            "feature": "PerlIO::encoding",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "280",
+              "0"
+            ],
+            "version": "0.28"
+          },
+          {
+            "feature": "PerlIO::mmap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "16",
+              "0"
+            ],
+            "version": "0.016"
+          },
+          {
+            "feature": "PerlIO::scalar",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "300",
+              "0"
+            ],
+            "version": "0.30"
+          },
+          {
+            "feature": "PerlIO::via",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "180",
+              "0"
+            ],
+            "version": "0.18"
+          },
+          {
+            "feature": "PerlIO::via::QuotedPrint",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "80",
+              "0"
+            ],
+            "version": "0.08"
+          },
+          {
+            "feature": "Pod::Checker",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "730",
+              "0"
+            ],
+            "version": "1.73"
+          },
+          {
+            "feature": "Pod::Escapes",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "70",
+              "0"
+            ],
+            "version": "1.07"
+          },
+          {
+            "feature": "Pod::Functions",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "130",
+              "0"
+            ],
+            "version": "1.13"
+          },
+          {
+            "feature": "Pod::Functions::Functions",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "130",
+              "0"
+            ],
+            "version": "1.13"
+          },
+          {
+            "feature": "Pod::Html",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "250",
+              "0"
+            ],
+            "version": "1.25"
+          },
+          {
+            "feature": "Pod::Man",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "140",
+              "0"
+            ],
+            "version": "4.14"
+          },
+          {
+            "feature": "Pod::ParseLink",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "140",
+              "0"
+            ],
+            "version": "4.14"
+          },
+          {
+            "feature": "Pod::Perldoc",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "100"
+            ],
+            "version": "3.2801"
+          },
+          {
+            "feature": "Pod::Perldoc::BaseTo",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::GetOptsOO",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToANSI",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToChecker",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToMan",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToNroff",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToPod",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToRtf",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToTerm",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToText",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToTk",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Perldoc::ToXml",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "280",
+              "0"
+            ],
+            "version": "3.28"
+          },
+          {
+            "feature": "Pod::Simple",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::BlackBox",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::Checker",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::Debug",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::DumpAsText",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::DumpAsXML",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::HTML",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::HTMLBatch",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::HTMLLegacy",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "10",
+              "0"
+            ],
+            "version": "5.01"
+          },
+          {
+            "feature": "Pod::Simple::LinkSection",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::Methody",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::Progress",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::PullParser",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::PullParserEndToken",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::PullParserStartToken",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::PullParserTextToken",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::PullParserToken",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::RTF",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::Search",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::SimpleTree",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::Text",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::TextContent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::TiedOutFH",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::Transcode",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::TranscodeDumb",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::TranscodeSmart",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::XHTML",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Simple::XMLOutStream",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "400",
+              "0"
+            ],
+            "version": "3.40"
+          },
+          {
+            "feature": "Pod::Text",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "140",
+              "0"
+            ],
+            "version": "4.14"
+          },
+          {
+            "feature": "Pod::Text::Color",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "140",
+              "0"
+            ],
+            "version": "4.14"
+          },
+          {
+            "feature": "Pod::Text::Overstrike",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "140",
+              "0"
+            ],
+            "version": "4.14"
+          },
+          {
+            "feature": "Pod::Text::Termcap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "140",
+              "0"
+            ],
+            "version": "4.14"
+          },
+          {
+            "feature": "Pod::Usage",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "690",
+              "0"
+            ],
+            "version": "1.69"
+          },
+          {
+            "feature": "SDBM_File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "150",
+              "0"
+            ],
+            "version": "1.15"
+          },
+          {
+            "feature": "Safe",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "410",
+              "0"
+            ],
+            "version": "2.41"
+          },
+          {
+            "feature": "Scalar::Util",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "550",
+              "0"
+            ],
+            "version": "1.55"
+          },
+          {
+            "feature": "Search::Dict",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "70",
+              "0"
+            ],
+            "version": "1.07"
+          },
+          {
+            "feature": "SelectSaver",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "20",
+              "0"
+            ],
+            "version": "1.02"
+          },
+          {
+            "feature": "SelfLoader",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "260",
+              "0"
+            ],
+            "version": "1.26"
+          },
+          {
+            "feature": "Socket",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "29",
+              "0"
+            ],
+            "version": "2.029"
+          },
+          {
+            "feature": "Storable",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "210",
+              "0"
+            ],
+            "version": "3.21"
+          },
+          {
+            "feature": "Sub::Util",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "550",
+              "0"
+            ],
+            "version": "1.55"
+          },
+          {
+            "feature": "Symbol",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "80",
+              "0"
+            ],
+            "version": "1.08"
+          },
+          {
+            "feature": "Sys::Hostname",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "230",
+              "0"
+            ],
+            "version": "1.23"
+          },
+          {
+            "feature": "Sys::Syslog",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "360",
+              "0"
+            ],
+            "version": "0.36"
+          },
+          {
+            "feature": "TAP::Base",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Formatter::Base",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Formatter::Color",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Formatter::Console",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Formatter::Console::ParallelSession",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Formatter::Console::Session",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Formatter::File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Formatter::File::Session",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Formatter::Session",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Harness",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Harness::Env",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Object",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Aggregator",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Grammar",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Iterator",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Iterator::Array",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Iterator::Process",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Iterator::Stream",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::IteratorFactory",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Multiplexer",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result::Bailout",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result::Comment",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result::Plan",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result::Pragma",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result::Test",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result::Unknown",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result::Version",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Result::YAML",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::ResultFactory",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Scheduler",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Scheduler::Job",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Scheduler::Spinner",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::Source",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::SourceHandler",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::SourceHandler::Executable",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::SourceHandler::File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::SourceHandler::Handle",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::SourceHandler::Perl",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::SourceHandler::RawTAP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::YAMLish::Reader",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "TAP::Parser::YAMLish::Writer",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "Term::ANSIColor",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "10",
+              "0"
+            ],
+            "version": "5.01"
+          },
+          {
+            "feature": "Term::Cap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "170",
+              "0"
+            ],
+            "version": "1.17"
+          },
+          {
+            "feature": "Term::Complete",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "403",
+              "0"
+            ],
+            "version": "1.403"
+          },
+          {
+            "feature": "Term::ReadLine",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "170",
+              "0"
+            ],
+            "version": "1.17"
+          },
+          {
+            "feature": "Test",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "310",
+              "0"
+            ],
+            "version": "1.31"
+          },
+          {
+            "feature": "Test2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::API",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::API::Breakage",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::API::Context",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::API::Instance",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::API::Stack",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Bail",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Diag",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Encoding",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Exception",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Fail",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Generic",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Note",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Ok",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Pass",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Plan",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Skip",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Subtest",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::TAP::Version",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::V2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Event::Waiting",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::About",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Amnesty",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Assert",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Control",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Error",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Hub",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Info",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Info::Table",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Meta",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Parent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Plan",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Render",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::EventFacet::Trace",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Formatter",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Formatter::TAP",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Hub",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Hub::Interceptor",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Hub::Interceptor::Terminator",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Hub::Subtest",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::IPC",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::IPC::Driver",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::IPC::Driver::Files",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Tools::Tiny",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Util",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Util::ExternalMeta",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Util::Facets2Legacy",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Util::HashBase",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test2::Util::Trace",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Builder",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Builder::Formatter",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Builder::IO::Scalar",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "114",
+              "0"
+            ],
+            "version": "2.114"
+          },
+          {
+            "feature": "Test::Builder::Module",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Builder::Tester",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Builder::Tester::Color",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Builder::TodoDiag",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Harness",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "420",
+              "0"
+            ],
+            "version": "3.42"
+          },
+          {
+            "feature": "Test::More",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Simple",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Tester",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Tester::Capture",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Tester::CaptureRunner",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::Tester::Delegate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Test::use::ok",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "Text::Abbrev",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "20",
+              "0"
+            ],
+            "version": "1.02"
+          },
+          {
+            "feature": "Text::Balanced",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "30",
+              "0"
+            ],
+            "version": "2.03"
+          },
+          {
+            "feature": "Text::ParseWords",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "300",
+              "0"
+            ],
+            "version": "3.30"
+          },
+          {
+            "feature": "Text::Tabs",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2013",
+              "52",
+              "300"
+            ],
+            "version": "2013.0523"
+          },
+          {
+            "feature": "Text::Wrap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2013",
+              "52",
+              "300"
+            ],
+            "version": "2013.0523"
+          },
+          {
+            "feature": "Thread",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "50",
+              "0"
+            ],
+            "version": "3.05"
+          },
+          {
+            "feature": "Thread::Queue",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "140",
+              "0"
+            ],
+            "version": "3.14"
+          },
+          {
+            "feature": "Thread::Semaphore",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "130",
+              "0"
+            ],
+            "version": "2.13"
+          },
+          {
+            "feature": "Tie::Array",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "70",
+              "0"
+            ],
+            "version": "1.07"
+          },
+          {
+            "feature": "Tie::File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "60",
+              "0"
+            ],
+            "version": "1.06"
+          },
+          {
+            "feature": "Tie::Handle",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "200",
+              "0"
+            ],
+            "version": "4.2"
+          },
+          {
+            "feature": "Tie::Hash",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "50",
+              "0"
+            ],
+            "version": "1.05"
+          },
+          {
+            "feature": "Tie::Hash::NamedCapture",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "130",
+              "0"
+            ],
+            "version": "0.13"
+          },
+          {
+            "feature": "Tie::Memoize",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "100",
+              "0"
+            ],
+            "version": "1.1"
+          },
+          {
+            "feature": "Tie::RefHash",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "390",
+              "0"
+            ],
+            "version": "1.39"
+          },
+          {
+            "feature": "Tie::Scalar",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "50",
+              "0"
+            ],
+            "version": "1.05"
+          },
+          {
+            "feature": "Tie::StdHandle",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "4",
+              "600",
+              "0"
+            ],
+            "version": "4.6"
+          },
+          {
+            "feature": "Tie::SubstrHash",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "0",
+              "0"
+            ],
+            "version": "1.0"
+          },
+          {
+            "feature": "Time::HiRes",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "976",
+              "400"
+            ],
+            "version": "1.9764"
+          },
+          {
+            "feature": "Time::Local",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "280",
+              "0"
+            ],
+            "version": "1.28"
+          },
+          {
+            "feature": "Time::Piece",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "340",
+              "100"
+            ],
+            "version": "1.3401"
+          },
+          {
+            "feature": "Time::Seconds",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "340",
+              "100"
+            ],
+            "version": "1.3401"
+          },
+          {
+            "feature": "Time::gmtime",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "40",
+              "0"
+            ],
+            "version": "1.04"
+          },
+          {
+            "feature": "Time::localtime",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "Time::tm",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "0",
+              "0"
+            ],
+            "version": "1.0"
+          },
+          {
+            "feature": "UNIVERSAL",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "130",
+              "0"
+            ],
+            "version": "1.13"
+          },
+          {
+            "feature": "Unicode",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "13",
+              "0",
+              "0"
+            ],
+            "version": "13.0.0"
+          },
+          {
+            "feature": "Unicode::Collate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Collate::CJK::Big5",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Collate::CJK::GB2312",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Collate::CJK::JISX0208",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Collate::CJK::Korean",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Collate::CJK::Pinyin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Collate::CJK::Stroke",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Collate::CJK::Zhuyin",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Collate::Locale",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::Normalize",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "270",
+              "0"
+            ],
+            "version": "1.27"
+          },
+          {
+            "feature": "Unicode::UCD",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "750",
+              "0"
+            ],
+            "version": "0.75"
+          },
+          {
+            "feature": "User::grent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "User::pwent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "10",
+              "0"
+            ],
+            "version": "1.01"
+          },
+          {
+            "feature": "VMS::DCLsym",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "90",
+              "0"
+            ],
+            "version": "1.09"
+          },
+          {
+            "feature": "VMS::Filespec",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "120",
+              "0"
+            ],
+            "version": "1.12"
+          },
+          {
+            "feature": "VMS::Stdio",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "450",
+              "0"
+            ],
+            "version": "2.45"
+          },
+          {
+            "feature": "Win32",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "530",
+              "0"
+            ],
+            "version": "0.53"
+          },
+          {
+            "feature": "Win32API::File",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "120",
+              "301"
+            ],
+            "version": "0.1203_01"
+          },
+          {
+            "feature": "Win32API::File::inc::ExtUtils::Myconst2perl",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "0",
+              "0"
+            ],
+            "version": "1"
+          },
+          {
+            "feature": "Win32CORE",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "40",
+              "0"
+            ],
+            "version": "0.04"
+          },
+          {
+            "feature": "XS::APItest",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "90",
+              "0"
+            ],
+            "version": "1.09"
+          },
+          {
+            "feature": "XS::Typemap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "170",
+              "0"
+            ],
+            "version": "0.17"
+          },
+          {
+            "feature": "XSLoader",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "300",
+              "0"
+            ],
+            "version": "0.30"
+          },
+          {
+            "feature": "_charnames",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "480",
+              "0"
+            ],
+            "version": "1.48"
+          },
+          {
+            "feature": "attributes",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "330",
+              "0"
+            ],
+            "version": "0.33"
+          },
+          {
+            "feature": "autodie",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "autodie::Scope::Guard",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "autodie::Scope::GuardStack",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "autodie::Util",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "autodie::exception",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "autodie::exception::system",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "autodie::hints",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "autodie::skip",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "320",
+              "0"
+            ],
+            "version": "2.32"
+          },
+          {
+            "feature": "autouse",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "110",
+              "0"
+            ],
+            "version": "1.11"
+          },
+          {
+            "feature": "base",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "270",
+              "0"
+            ],
+            "version": "2.27"
+          },
+          {
+            "feature": "bigint",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "510",
+              "0"
+            ],
+            "version": "0.51"
+          },
+          {
+            "feature": "bignum",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "510",
+              "0"
+            ],
+            "version": "0.51"
+          },
+          {
+            "feature": "bigrat",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "510",
+              "0"
+            ],
+            "version": "0.51"
+          },
+          {
+            "feature": "blib",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "70",
+              "0"
+            ],
+            "version": "1.07"
+          },
+          {
+            "feature": "bytes",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "70",
+              "0"
+            ],
+            "version": "1.07"
+          },
+          {
+            "feature": "charnames",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "480",
+              "0"
+            ],
+            "version": "1.48"
+          },
+          {
+            "feature": "constant",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "330",
+              "0"
+            ],
+            "version": "1.33"
+          },
+          {
+            "feature": "deprecate",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "40",
+              "0"
+            ],
+            "version": "0.04"
+          },
+          {
+            "feature": "diagnostics",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "370",
+              "0"
+            ],
+            "version": "1.37"
+          },
+          {
+            "feature": "encoding",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "3",
+              "0",
+              "0"
+            ],
+            "version": "3.00"
+          },
+          {
+            "feature": "encoding::warnings",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "130",
+              "0"
+            ],
+            "version": "0.13"
+          },
+          {
+            "feature": "experimental",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "20",
+              "0"
+            ],
+            "version": "0.020"
+          },
+          {
+            "feature": "feature",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "580",
+              "0"
+            ],
+            "version": "1.58"
+          },
+          {
+            "feature": "fields",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "240",
+              "0"
+            ],
+            "version": "2.24"
+          },
+          {
+            "feature": "filetest",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "if",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "60",
+              "800"
+            ],
+            "version": "0.0608"
+          },
+          {
+            "feature": "integer",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "10",
+              "0"
+            ],
+            "version": "1.01"
+          },
+          {
+            "feature": "less",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "30",
+              "0"
+            ],
+            "version": "0.03"
+          },
+          {
+            "feature": "lib",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "650",
+              "0"
+            ],
+            "version": "0.65"
+          },
+          {
+            "feature": "locale",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "90",
+              "0"
+            ],
+            "version": "1.09"
+          },
+          {
+            "feature": "mro",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "230",
+              "0"
+            ],
+            "version": "1.23"
+          },
+          {
+            "feature": "ok",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "302",
+              "175"
+            ],
+            "version": "1.302175"
+          },
+          {
+            "feature": "open",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "120",
+              "0"
+            ],
+            "version": "1.12"
+          },
+          {
+            "feature": "ops",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "20",
+              "0"
+            ],
+            "version": "1.02"
+          },
+          {
+            "feature": "overload",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "310",
+              "0"
+            ],
+            "version": "1.31"
+          },
+          {
+            "feature": "overloading",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "20",
+              "0"
+            ],
+            "version": "0.02"
+          },
+          {
+            "feature": "parent",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "238",
+              "0"
+            ],
+            "version": "0.238"
+          },
+          {
+            "feature": "perlfaq",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "5",
+              "202",
+              "5",
+              "230"
+            ],
+            "version": "5.20200523"
+          },
+          {
+            "feature": "re",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "400",
+              "0"
+            ],
+            "version": "0.40"
+          },
+          {
+            "feature": "sigtrap",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "90",
+              "0"
+            ],
+            "version": "1.09"
+          },
+          {
+            "feature": "sort",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "40",
+              "0"
+            ],
+            "version": "2.04"
+          },
+          {
+            "feature": "strict",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "110",
+              "0"
+            ],
+            "version": "1.11"
+          },
+          {
+            "feature": "subs",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "30",
+              "0"
+            ],
+            "version": "1.03"
+          },
+          {
+            "feature": "threads",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "2",
+              "250",
+              "0"
+            ],
+            "version": "2.25"
+          },
+          {
+            "feature": "threads::shared",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "610",
+              "0"
+            ],
+            "version": "1.61"
+          },
+          {
+            "feature": "utf8",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "220",
+              "0"
+            ],
+            "version": "1.22"
+          },
+          {
+            "feature": "vars",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "50",
+              "0"
+            ],
+            "version": "1.05"
+          },
+          {
+            "feature": "version",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "992",
+              "400"
+            ],
+            "version": "0.9924"
+          },
+          {
+            "feature": "version::regex",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "0",
+              "992",
+              "400"
+            ],
+            "version": "0.9924"
+          },
+          {
+            "feature": "vmsish",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "40",
+              "0"
+            ],
+            "version": "1.04"
+          },
+          {
+            "feature": "warnings",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "470",
+              "0"
+            ],
+            "version": "1.47"
+          },
+          {
+            "feature": "warnings::register",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/perl",
+            "sortable_version": [
+              "1",
+              "40",
+              "0"
+            ],
+            "version": "1.04"
+          }
+        ],
+        "author_platform_user_id": "fe7c9294-51d6-4df6-a5b5-44cf5a924ebc",
+        "comment": "Bump again",
+        "is_stable_revision": true
+      },
+      "patches": null,
+      "resolved_requirements": [
+        {
+          "feature": "perl",
+          "namespace": "language",
+          "version_requirements": [
+            {
+              "comparator": "eq",
+              "version": "5.32.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "solver_version": 1
+}

--- a/pkg/platform/runtime2/testhelper/data/recipes/camel.json
+++ b/pkg/platform/runtime2/testhelper/data/recipes/camel.json
@@ -1,0 +1,3137 @@
+{
+  "camel_flags": [],
+  "from_recipe_store": false,
+  "image": {
+    "image_id": "4b8b53b0-609b-4a02-865a-0fb2974f9952",
+    "links": {
+      "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/images/4b8b53b0-609b-4a02-865a-0fb2974f9952"
+    },
+    "name": "macos1013-camel-builder",
+    "platform_id": "96b7e6f2-bebf-564c-bc1c-f04482398f38",
+    "type": "Mac",
+    "sortable_version": [
+      "4",
+      "0"
+    ],
+    "version": "4",
+    "provided_features": [],
+    "author_platform_user_id": "e501c7e7-40cc-4b7a-8fc9-f6a3d314c254",
+    "comment": "Added a new revision to add compiler features to images",
+    "is_stable_revision": true,
+    "conditions": [
+      {
+        "feature": "alternative-built-language",
+        "namespace": "language",
+        "requirements": [
+          {
+            "comparator": "eq",
+            "sortable_version": []
+          }
+        ]
+      }
+    ],
+    "status": "stable",
+    "revision": 5,
+    "revision_timestamp": "2020-12-03T22:54:45.160370Z"
+  },
+  "is_indemnified": false,
+  "platform": {
+    "cpu_architecture": {
+      "cpu_architecture_id": "4cdba18d-0851-4925-9ae5-9c8a2987828a",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/cpu-architectures/4cdba18d-0851-4925-9ae5-9c8a2987828a"
+      },
+      "bit_width": "64",
+      "name": "x86",
+      "provided_features": [
+        {
+          "feature": "x86 64-bit",
+          "is_activestate_version": false,
+          "is_default_provider": true,
+          "namespace": "cpu-architecture",
+          "sortable_version": [
+            "1",
+            "0"
+          ],
+          "version": "1"
+        }
+      ],
+      "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+      "comment": "Created prior to addition of revision comments.",
+      "is_stable_revision": true,
+      "revision": 1,
+      "revision_timestamp": "2019-08-06T21:46:35.288458Z"
+    },
+    "cpu_extensions": [],
+    "creation_timestamp": "2019-08-06T21:46:35.288458Z",
+    "display_name": "macOS 10.12.6, Darwin 16.6.0, libSystem 1238.60.2 x86 64-bit",
+    "end_of_support_date": "2030-02-03",
+    "images": [
+      {
+        "image_id": "4b8b53b0-609b-4a02-865a-0fb2974f9952",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/images/4b8b53b0-609b-4a02-865a-0fb2974f9952"
+        },
+        "name": "macos1013-camel-builder",
+        "platform_id": "96b7e6f2-bebf-564c-bc1c-f04482398f38",
+        "type": "Mac",
+        "sortable_version": [
+          "4",
+          "0"
+        ],
+        "version": "4",
+        "provided_features": [
+          {
+            "feature": "clang",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "1000",
+              "10",
+              "44",
+              "4",
+              "0"
+            ],
+            "version": "1000.10.44.4"
+          },
+          {
+            "feature": "ISO C++03",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++11",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++14",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++17",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C89",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C++98",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          },
+          {
+            "feature": "ISO C99",
+            "is_activestate_version": true,
+            "is_default_provider": true,
+            "namespace": "compiler",
+            "sortable_version": [
+              "0",
+              "0"
+            ],
+            "version": "0"
+          }
+        ],
+        "author_platform_user_id": "e501c7e7-40cc-4b7a-8fc9-f6a3d314c254",
+        "comment": "Added a new revision to add compiler features to images",
+        "is_stable_revision": true,
+        "conditions": [
+          {
+            "feature": "alternative-built-language",
+            "namespace": "language",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": []
+              }
+            ]
+          }
+        ],
+        "status": "stable",
+        "revision": 5,
+        "revision_timestamp": "2020-12-03T22:54:45.160370Z"
+      }
+    ],
+    "is_user_visible": true,
+    "kernel": {
+      "kernel_id": "7d600f8a-bc24-4875-a09c-8e63c4da078c",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/kernels/7d600f8a-bc24-4875-a09c-8e63c4da078c"
+      },
+      "name": "Darwin"
+    },
+    "kernel_version": {
+      "kernel_version_id": "e7d8c941-4dfd-49fe-81f7-5bb90df0edd9",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/kernels/7d600f8a-bc24-4875-a09c-8e63c4da078c/versions/e7d8c941-4dfd-49fe-81f7-5bb90df0edd9"
+      },
+      "sortable_version": [
+        "16",
+        "6",
+        "0",
+        "0"
+      ],
+      "version": "16.6.0",
+      "provided_features": [
+        {
+          "feature": "Darwin",
+          "is_activestate_version": false,
+          "is_default_provider": true,
+          "namespace": "kernel",
+          "sortable_version": [
+            "16",
+            "6",
+            "0",
+            "0"
+          ],
+          "version": "16.6.0"
+        }
+      ],
+      "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+      "comment": "Created prior to addition of revision comments.",
+      "is_stable_revision": true,
+      "revision": 1,
+      "revision_timestamp": "2019-08-06T21:46:35.288458Z"
+    },
+    "libc": {
+      "libc_id": "669bbbe3-1f57-48d3-a11e-018780809b4a",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/libcs/669bbbe3-1f57-48d3-a11e-018780809b4a"
+      },
+      "name": "libSystem"
+    },
+    "libc_version": {
+      "libc_version_id": "6e0f402c-3837-4d73-a36c-9cd4ace9d002",
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/libcs/669bbbe3-1f57-48d3-a11e-018780809b4a/versions/6e0f402c-3837-4d73-a36c-9cd4ace9d002"
+      },
+      "sortable_version": [
+        "1238",
+        "60",
+        "2",
+        "0"
+      ],
+      "version": "1238.60.2",
+      "provided_features": [
+        {
+          "feature": "libSystem",
+          "is_activestate_version": false,
+          "is_default_provider": true,
+          "namespace": "libc",
+          "sortable_version": [
+            "1238",
+            "60",
+            "2",
+            "0"
+          ],
+          "version": "1238.60.2"
+        }
+      ],
+      "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+      "comment": "Created prior to addition of revision comments.",
+      "is_stable_revision": true,
+      "revision": 1,
+      "revision_timestamp": "2019-08-06T21:46:35.288458Z"
+    },
+    "links": {
+      "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/platforms/96b7e6f2-bebf-564c-bc1c-f04482398f38"
+    },
+    "operating_system": {
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/operating-systems/63d8f1cc-5f5c-47e1-bab0-74d38938d919"
+      },
+      "operating_system_id": "63d8f1cc-5f5c-47e1-bab0-74d38938d919",
+      "has_libc": true,
+      "name": "macOS"
+    },
+    "operating_system_version": {
+      "links": {
+        "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/operating-systems/63d8f1cc-5f5c-47e1-bab0-74d38938d919/versions/da15b51d-12d8-484d-8006-cc5f93198817"
+      },
+      "operating_system_version_id": "da15b51d-12d8-484d-8006-cc5f93198817",
+      "sortable_version": [
+        "10",
+        "12",
+        "6",
+        "0"
+      ],
+      "version": "10.12.6",
+      "provided_features": [
+        {
+          "feature": "macOS",
+          "is_activestate_version": false,
+          "is_default_provider": true,
+          "namespace": "operating-system",
+          "sortable_version": [
+            "10",
+            "12",
+            "6",
+            "0"
+          ],
+          "version": "10.12.6"
+        }
+      ],
+      "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+      "comment": "Created prior to addition of revision comments.",
+      "is_stable_revision": true,
+      "revision": 1,
+      "revision_timestamp": "2019-08-06T21:46:35.288458Z"
+    },
+    "platform_id": "96b7e6f2-bebf-564c-bc1c-f04482398f38"
+  },
+  "recipe_id": "0adc81a2-760d-5577-9827-309c9c9c645f",
+  "resolved_ingredients": [
+    {
+      "alternatives": [],
+      "artifact_id": "e8a2b6cc-19de-5b87-bb84-8ba67039aa79",
+      "build_scripts": null,
+      "dependencies": [],
+      "ingredient": {
+        "creation_timestamp": "2019-10-21T19:16:38.749062Z",
+        "ingredient_id": "20816534-c073-5d68-9eb7-11c1d6be09f5",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/20816534-c073-5d68-9eb7-11c1d6be09f5"
+        },
+        "name": "camel",
+        "normalized_name": "camel",
+        "primary_namespace": "builder",
+        "description": "The camel unified build system",
+        "website": "https://platform.activestate.com"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2021-02-16T17:50:29.599906Z",
+        "ingredient_id": "20816534-c073-5d68-9eb7-11c1d6be09f5",
+        "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/20816534-c073-5d68-9eb7-11c1d6be09f5/versions/c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/20816534-c073-5d68-9eb7-11c1d6be09f5"
+        },
+        "revision": 1,
+        "revision_timestamp": "2021-02-16T17:50:29.599906Z",
+        "copyright_text": "Copyright © ActiveState Inc, 2004-2020",
+        "documentation_uri": "https://github.com/ActiveState/camel/tree/3d46a065883c88b560d67edf7ea1f96bef125ae6/docs",
+        "is_binary_only": false,
+        "license_expression": "UNLICENSED",
+        "release_timestamp": "2021-02-16T17:50:24.296928Z",
+        "source_uri": "https://github.com/ActiveState/camel/tree/3d46a065883c88b560d67edf7ea1f96bef125ae6",
+        "sortable_version": [
+          "20210216",
+          "125023",
+          "3",
+          "100",
+          "46",
+          "97",
+          "65",
+          "0"
+        ],
+        "version": "20210216.125023.3d46a065",
+        "activestate_license_expression": "UNLICENSED",
+        "camel_extras": {},
+        "dependencies": null,
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://INVALID",
+        "scanner_license_expression": "UNLICENSED",
+        "source_checksum": "3d46a065883c88b560d67edf7ea1f96bef125ae6",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "camel",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "builder",
+            "sortable_version": [
+              "20210216",
+              "125023",
+              "3",
+              "100",
+              "46",
+              "97",
+              "65",
+              "0"
+            ],
+            "version": "20210216.125023.3d46a065"
+          }
+        ],
+        "author_platform_user_id": "8fd0aa9c-0483-4ee7-9197-96c9194c0318",
+        "comment": "Camel commit.",
+        "is_stable_revision": true
+      },
+      "patches": null,
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "bdd5642b-928c-5770-9e12-5816c9676960",
+      "build_scripts": null,
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "06b8597a-4cc1-5e3c-b548-f0baa7861688"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "3bde6cf9-2445-563f-8e65-1437d1737a8f"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "491568f3-50a4-56f6-a971-580eaa99715f"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "54cbf7c2-c87c-51b5-a2cc-72b3b284d68c"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "8d5d63b0-e941-59a3-8653-35470bd70056"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "a45dc564-3e7d-5b43-b2b3-2a941b0f5807"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "a61c1442-98a0-576c-b606-3046b22c3413"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "b0d9a189-aedb-5461-b872-5e643ac97551"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c3b7c513-8be8-56d9-8d30-b19e9c56e393"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T17:06:08.287941Z",
+        "ingredient_id": "161a6a17-6b8a-54c9-a476-2c8c960b054e",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/161a6a17-6b8a-54c9-a476-2c8c960b054e"
+        },
+        "name": "python",
+        "normalized_name": "python",
+        "primary_namespace": "language",
+        "description": "It's just a flesh wound!"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-10-01T17:06:08.287941Z",
+        "ingredient_id": "161a6a17-6b8a-54c9-a476-2c8c960b054e",
+        "ingredient_version_id": "be4744a4-89a6-58bb-b345-d15468657076",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/161a6a17-6b8a-54c9-a476-2c8c960b054e/versions/be4744a4-89a6-58bb-b345-d15468657076",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/161a6a17-6b8a-54c9-a476-2c8c960b054e"
+        },
+        "revision": 13,
+        "revision_timestamp": "2020-12-08T19:15:07.163109Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "1970-01-01T00:00:00.000000Z",
+        "source_uri": "https://s3.amazonaws.com/camel-sources/src/ActivePython/vendor/Python-3.7.4.tgz",
+        "sortable_version": [
+          "0",
+          "3",
+          "7",
+          "4",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0"
+        ],
+        "version": "3.7.4",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {},
+        "dependencies": [
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "gte",
+                    "sortable_version": [
+                      "0",
+                      "0"
+                    ],
+                    "version": "0"
+                  }
+                ]
+              }
+            ],
+            "feature": "windows-python-core-openssl",
+            "namespace": "language/python",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Linux",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "gte",
+                    "sortable_version": [
+                      "0",
+                      "0"
+                    ],
+                    "version": "0"
+                  }
+                ]
+              }
+            ],
+            "feature": "lzma",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": [
+                  "5",
+                  "2",
+                  "4",
+                  "0"
+                ],
+                "version": "5.2.4"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "tk",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": [
+                  "8",
+                  "6",
+                  "8",
+                  "0"
+                ],
+                "version": "8.6.8"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "AIX",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              },
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "sqlite3",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": [
+                  "3",
+                  "15",
+                  "2",
+                  "0"
+                ],
+                "version": "3.15.2"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "bzip2",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": [
+                  "1",
+                  "0",
+                  "6",
+                  "0"
+                ],
+                "version": "1.0.6"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "description": "All ingredients have a build-time dependency on the camel build system",
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "expat",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "2",
+                  "2",
+                  "7",
+                  "0"
+                ],
+                "version": "2.2.7"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "tix",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "8",
+                  "4",
+                  "3",
+                  "0"
+                ],
+                "version": "8.4.3"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "gte",
+                    "sortable_version": [
+                      "0.0",
+                      "0.0"
+                    ],
+                    "version": "0"
+                  }
+                ]
+              }
+            ],
+            "description": "The python language requires a compiler to build",
+            "feature": "Visual Studio",
+            "namespace": "compiler",
+            "requirements": [
+              {
+                "comparator": "lt",
+                "sortable_version": [
+                  "15.0",
+                  "0.0"
+                ],
+                "version": "15"
+              },
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "14.0",
+                  "0.0"
+                ],
+                "version": "14"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "tcl",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": [
+                  "8",
+                  "6",
+                  "8",
+                  "0"
+                ],
+                "version": "8.6.8"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "openssl",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "1",
+                  "11",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "1.11.0.0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "zlib",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": [
+                  "1",
+                  "2",
+                  "11",
+                  "0"
+                ],
+                "version": "1.2.11"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "description": "The python language requires a compiler to build",
+            "feature": "ISO C89",
+            "namespace": "compiler",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0.0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "Windows",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "bsddb",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": [
+                  "4",
+                  "4",
+                  "20",
+                  "0"
+                ],
+                "version": "4.4.20"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/languages/d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3/Python-3.7.4.tgz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "python",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language",
+            "sortable_version": [
+              "0",
+              "3",
+              "7",
+              "4",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0"
+            ],
+            "version": "3.7.4"
+          },
+          {
+            "feature": "pip",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/python",
+            "sortable_version": [
+              "0",
+              "18",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0"
+            ],
+            "version": "18.0"
+          },
+          {
+            "feature": "setuptools",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/python",
+            "sortable_version": [
+              "0",
+              "40",
+              "8",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0"
+            ],
+            "version": "40.8.0"
+          }
+        ],
+        "author_platform_user_id": "ddfb4cc7-4a50-45a5-a6a5-1336b3ad1ef2",
+        "comment": "Created prior to addition of revision comments.",
+        "is_stable_revision": true
+      },
+      "patches": [
+        {
+          "creation_timestamp": "2020-08-31T18:14:54.204215Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/8869b8cc-11d5-43cf-8d4d-0c93ada5dba3"
+          },
+          "patch_id": "8869b8cc-11d5-43cf-8d4d-0c93ada5dba3",
+          "conditions": null,
+          "content": "s3://platform-sources/patches/7ddd664c4f000ae9c38e8730add4cd501514439c400ae3b78f76d68be2881c47.patch",
+          "description": "From 6299dd58bb662ebd801d6d86f82ade7f533b692b Mon Sep 17 00:00:00 2001\nFrom: Ashley Whetter <ashleyw@activestate.com>\nDate: Thu, 2 Jan 2020 08:57:44 -0800\nSubject: [PATCH] v3.7.4 patched from apy/3.7/*\n\nd057759576 activepython: Merge tag 'v3.7.4' into apy/3.7/activepython\n839b605c44 activepython: Add changes needed for V3.7\nd057759576 nix: Merge tag 'v3.7.4' into apy/3.7/activepython\n839b605c44 nix: Add changes needed for V3.7\n738a9121c4 win32: Compile openssl from source and build against it\n78c745359f win32: Revert \"Support downloading externals directly from cpython-bin-deps\"\n16ebbdc015 win32: Support downloading externals directly from cpython-bin-deps\n04e6fc4fcf win32: Can override version of openssl\n54d8f0462c win32: Support downloading externals directly from cpython-source-deps\nd2745843cf win32: Build against OpenSSL sources\n9309e799e8 win32: bump versions for tcl, tk, openssl and remove commands that are no longer used\nddf9c43ece win32: Merge branch 'apy/3.7/activepython' into apy/3.7/win32\nd057759576 win32: Merge tag 'v3.7.4' into apy/3.7/activepython\n839b605c44 win32: Add changes needed for V3.7\n7b3d6b9d7e win32: Update OpenSSL to 1.1.0k\n5b9627c322 win32: Add tcl 8.6.8 and openssl 1.1.0j to 3.7\n69570872c7 win32: Upgrade sqlite3 to 3.24.0.0\n0de3cf0acd win32: Set tcltk and openssl bins\n1ce01cc66a win32: Remove bin from openssl tarball name\nbaa340b145 win32: Add zlib to list of files to get for Windows\n81257a43c7 win32: Add AS specific build scripts for building",
+          "sequence_number": 1
+        },
+        {
+          "creation_timestamp": "2020-08-31T18:14:54.492940Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/80bef92b-2971-49b3-b5c5-448230d0675e"
+          },
+          "patch_id": "80bef92b-2971-49b3-b5c5-448230d0675e",
+          "conditions": null,
+          "content": "python-3.7.4-python.props.patch",
+          "description": "HEAD~1 patched from activepython/3.7/*",
+          "sequence_number": 2
+        }
+      ],
+      "resolved_requirements": [
+        {
+          "feature": "python",
+          "namespace": "language",
+          "version_requirements": [
+            {
+              "comparator": "eq",
+              "version": "3.7.4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "decfc04f-5770-5663-8d00-e029402e6917",
+      "build_scripts": null,
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "806b06ad-3f32-52e1-aecb-677759ce8c74"
+        },
+        {
+          "dependency_types": [
+            "build",
+            "runtime",
+            "test"
+          ],
+          "ingredient_version_id": "be4744a4-89a6-58bb-b345-d15468657076"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2020-10-18T02:02:00.611863Z",
+        "ingredient_id": "39750e64-e0bf-5a97-9caa-d6ec8ec8c456",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/39750e64-e0bf-5a97-9caa-d6ec8ec8c456"
+        },
+        "name": "json2",
+        "normalized_name": "json2",
+        "primary_namespace": "language/python",
+        "description": "# Logfast\n\n## Purpose\nPython package which just wraps the default python json but with.\n```json2.load_file``` and ```json2.save_file```\n\n## Installation\n\n```pip install json2```\n\n## Usage\n\n```\nimport ...",
+        "website": "https://github.com/ThoenigAdrian/json2"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2020-10-23T02:19:24.740864Z",
+        "ingredient_id": "39750e64-e0bf-5a97-9caa-d6ec8ec8c456",
+        "ingredient_version_id": "a30e7169-d1b8-5f34-b50b-6be74d369e9c",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/39750e64-e0bf-5a97-9caa-d6ec8ec8c456/versions/a30e7169-d1b8-5f34-b50b-6be74d369e9c",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/39750e64-e0bf-5a97-9caa-d6ec8ec8c456"
+        },
+        "revision": 1,
+        "revision_timestamp": "2020-10-23T02:19:24.740864Z",
+        "copyright_text": "Could not be determined",
+        "is_binary_only": false,
+        "license_expression": "UNKNOWN",
+        "release_timestamp": "2020-10-18T21:56:38.000000Z",
+        "source_uri": "https://files.pythonhosted.org/packages/91/2a/ec4045f29cacf6eb06c8b7577ce783149d5ec0349c2959937fe867124cfa/json2-0.4.0.tar.gz",
+        "sortable_version": [
+          "0",
+          "0",
+          "4",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0"
+        ],
+        "version": "0.4.0",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {},
+        "dependencies": [
+          {
+            "conditions": null,
+            "description": "Extracted from source distribution in PyPI.",
+            "feature": "wheel",
+            "namespace": "language/python",
+            "original_requirement": "wheel",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "description": "Extracted from source distribution in PyPI.",
+            "feature": "python",
+            "namespace": "language",
+            "original_requirement": "python >=0",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "runtime"
+          },
+          {
+            "conditions": null,
+            "description": "Extracted from source distribution in PyPI.",
+            "feature": "python",
+            "namespace": "language",
+            "original_requirement": "python >=0",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "description": "Extracted from source distribution in PyPI.",
+            "feature": "python",
+            "namespace": "language",
+            "original_requirement": "python >=0",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "test"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": false,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/data-acquisition/eab80bdfcc30fd0ee934c3c67a959d76ea1a45a629c4c10cdf6f8078c6224fc8/json2-0.4.0.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "eab80bdfcc30fd0ee934c3c67a959d76ea1a45a629c4c10cdf6f8078c6224fc8",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "json2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/python",
+            "sortable_version": [
+              "0",
+              "0",
+              "4",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0"
+            ],
+            "version": "0.4.0"
+          }
+        ],
+        "author_platform_user_id": "2e044215-1b51-498f-a440-ae0cc11bdd4c",
+        "comment": "Data Acquisition import run with commit ID abef5908904fe908ad93c6140e56044dd4b47f72 and reason: Automated sync of newly whitelisted language/python ingredient versions",
+        "is_stable_revision": true
+      },
+      "patches": null,
+      "resolved_requirements": [
+        {
+          "feature": "json2",
+          "namespace": "language/python",
+          "version_requirements": null
+        }
+      ]
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "e6997088-7854-5498-8c57-afbe4343036a",
+      "build_scripts": null,
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build",
+            "runtime",
+            "test"
+          ],
+          "ingredient_version_id": "be4744a4-89a6-58bb-b345-d15468657076"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T17:08:07.349831Z",
+        "ingredient_id": "9d592341-b78d-5e0f-b7ee-83b4533441b2",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/9d592341-b78d-5e0f-b7ee-83b4533441b2"
+        },
+        "name": "wheel",
+        "normalized_name": "wheel",
+        "primary_namespace": "language/python",
+        "description": "The wheel package"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2020-11-13T23:46:48.685681Z",
+        "ingredient_id": "9d592341-b78d-5e0f-b7ee-83b4533441b2",
+        "ingredient_version_id": "806b06ad-3f32-52e1-aecb-677759ce8c74",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/9d592341-b78d-5e0f-b7ee-83b4533441b2/versions/806b06ad-3f32-52e1-aecb-677759ce8c74",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/9d592341-b78d-5e0f-b7ee-83b4533441b2"
+        },
+        "revision": 3,
+        "revision_timestamp": "2020-11-20T23:08:03.168261Z",
+        "copyright_text": "Could not be determined",
+        "is_binary_only": false,
+        "license_expression": "UNKNOWN",
+        "release_timestamp": "2020-08-15T02:23:59.000000Z",
+        "source_uri": "https://files.pythonhosted.org/packages/83/72/611c121b6bd15479cb62f1a425b2e3372e121b324228df28e64cc28b01c2/wheel-0.35.1.tar.gz",
+        "sortable_version": [
+          "0",
+          "0",
+          "35",
+          "1",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0",
+          "0"
+        ],
+        "version": "0.35.1",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {},
+        "dependencies": [
+          {
+            "conditions": null,
+            "description": "Extracted from source distribution in PyPI.",
+            "feature": "python",
+            "namespace": "language",
+            "original_requirement": "python >=0",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "3",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "3"
+              }
+            ],
+            "type": "runtime"
+          },
+          {
+            "conditions": null,
+            "description": "Extracted from source distribution in PyPI.",
+            "feature": "python",
+            "namespace": "language",
+            "original_requirement": "python >=0",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "3",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "3"
+              }
+            ],
+            "type": "test"
+          },
+          {
+            "conditions": null,
+            "description": "Extracted from source distribution in PyPI.",
+            "feature": "python",
+            "namespace": "language",
+            "original_requirement": "python >=0",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "3",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0",
+                  "0"
+                ],
+                "version": "3"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": false,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/data-acquisition/99a22d87add3f634ff917310a3d87e499f19e663413a52eb9232c447aa646c9f/wheel-0.35.1.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "99a22d87add3f634ff917310a3d87e499f19e663413a52eb9232c447aa646c9f",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "wheel",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "language/python",
+            "sortable_version": [
+              "0",
+              "0",
+              "35",
+              "1",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0"
+            ],
+            "version": "0.35.1"
+          }
+        ],
+        "author_platform_user_id": "e51a58da-d22b-49c2-9fe6-f143159120eb",
+        "comment": "Data Acquisition import run with commit ID 0000000000000000000000000000000000000000 and reason: Could not be determined from the database query",
+        "is_stable_revision": true
+      },
+      "patches": null,
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "2a2dc52f-8324-59bf-ae5e-082ea2468a28",
+      "build_scripts": [
+        {
+          "build_script_id": "e00c71e5-6c74-487b-a67f-6a120e17f068",
+          "creation_timestamp": "2019-10-01T17:01:14.537345Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/e00c71e5-6c74-487b-a67f-6a120e17f068"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "db-4.4.20-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T17:01:14.890567Z",
+        "ingredient_id": "5a6e935d-3fb3-5629-a4cf-34e78b035e5f",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/5a6e935d-3fb3-5629-a4cf-34e78b035e5f"
+        },
+        "name": "bsddb",
+        "normalized_name": "bsddb",
+        "primary_namespace": "shared",
+        "description": "Berkeley Database"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-10-01T17:01:14.890567Z",
+        "ingredient_id": "5a6e935d-3fb3-5629-a4cf-34e78b035e5f",
+        "ingredient_version_id": "06b8597a-4cc1-5e3c-b548-f0baa7861688",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/5a6e935d-3fb3-5629-a4cf-34e78b035e5f/versions/06b8597a-4cc1-5e3c-b548-f0baa7861688",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/5a6e935d-3fb3-5629-a4cf-34e78b035e5f"
+        },
+        "revision": 2,
+        "revision_timestamp": "2019-10-24T21:51:00.179770Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "1970-01-01T00:00:00.000000Z",
+        "source_uri": "https://s3.amazonaws.com/camel-sources/src/vendor-sources/python/db-4.4.20.NC-pysvn.zip",
+        "sortable_version": [
+          "4",
+          "4",
+          "20",
+          "0"
+        ],
+        "version": "4.4.20",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "skip_test": "yes"
+        },
+        "dependencies": [
+          {
+            "conditions": null,
+            "description": "All ingredients have a build-time dependency on the camel build system",
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/0732630da52af56e1d8a92a4a386405b5b13aa21715aa4e8d28da647c57affba/db-4.4.20.NC-pysvn.zip",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "0732630da52af56e1d8a92a4a386405b5b13aa21715aa4e8d28da647c57affba",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "bsddb",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "4",
+              "4",
+              "20",
+              "0"
+            ],
+            "version": "4.4.20"
+          }
+        ],
+        "author_platform_user_id": "7f320133-2c9a-476e-9c09-8970ac525a8f",
+        "comment": "Created prior to addition of revision comments.",
+        "is_stable_revision": true
+      },
+      "patches": null,
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "f6f7099a-2a86-5a30-8098-a111661cfbc5",
+      "build_scripts": [
+        {
+          "build_script_id": "9c94a935-e12a-4211-8c69-151cc0cea019",
+          "creation_timestamp": "2019-11-21T00:41:56.108670Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/9c94a935-e12a-4211-8c69-151cc0cea019"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "bzip2-1.0.6-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T16:55:29.800792Z",
+        "ingredient_id": "c9621f15-45d3-5da0-849a-f2979aa8e0d5",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/c9621f15-45d3-5da0-849a-f2979aa8e0d5"
+        },
+        "name": "bzip2",
+        "normalized_name": "bzip2",
+        "primary_namespace": "shared",
+        "description": "bzip2 is a data compressor."
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-10-01T16:55:29.800792Z",
+        "ingredient_id": "c9621f15-45d3-5da0-849a-f2979aa8e0d5",
+        "ingredient_version_id": "3bde6cf9-2445-563f-8e65-1437d1737a8f",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/c9621f15-45d3-5da0-849a-f2979aa8e0d5/versions/3bde6cf9-2445-563f-8e65-1437d1737a8f",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/c9621f15-45d3-5da0-849a-f2979aa8e0d5"
+        },
+        "revision": 5,
+        "revision_timestamp": "2020-09-16T16:53:25.145774Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "2018-11-03T00:00:00.000000Z",
+        "source_uri": "https://s3.amazonaws.com/camel-sources/src/vendor-sources/bzip2-1.0.6.tar.gz",
+        "sortable_version": [
+          "1",
+          "0",
+          "6",
+          "0"
+        ],
+        "version": "1.0.6",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "ppm_pkg": "no",
+          "skip_test": "yes"
+        },
+        "dependencies": [
+          {
+            "conditions": null,
+            "description": "All ingredients have a build-time dependency on the camel build system",
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd/bzip2-1.0.6.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "bzip2",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "1",
+              "0",
+              "6",
+              "0"
+            ],
+            "version": "1.0.6"
+          }
+        ],
+        "author_platform_user_id": "a19a07b9-313a-4e8f-916b-633457d72be8",
+        "comment": "Convert patch content to S3 URI and add condition on camel builder",
+        "is_stable_revision": true
+      },
+      "patches": [
+        {
+          "creation_timestamp": "2020-09-16T16:53:24.890193Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/0e0735a7-c5cd-47ed-a599-e2c9475b37c8"
+          },
+          "patch_id": "0e0735a7-c5cd-47ed-a599-e2c9475b37c8",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "s3://platform-sources/patches/Libraries/patches/bzip2-1.0.6-Makefile-install.patch",
+          "description": "Only install headers and lib, some of these paths broke on\n Windows. Add an MSVC install target.",
+          "sequence_number": 1
+        }
+      ],
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "1931b61b-5e8b-5bce-a5ff-5663a0b9b9c3",
+      "build_scripts": [
+        {
+          "build_script_id": "2bca6c96-626f-472b-a3e0-6fc2e19d5da1",
+          "creation_timestamp": "2021-01-11T17:46:35.461471Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/2bca6c96-626f-472b-a3e0-6fc2e19d5da1"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "s3://platform-sources/build_scripts/2dd5db9d3d82fffed2a682f960dc4bc4f41dcdbb62f4e83f4586c793452709f7/expat-2.2.9-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T16:55:36.729403Z",
+        "ingredient_id": "005fec58-7763-5ccf-9fce-d35fa3bfd791",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/005fec58-7763-5ccf-9fce-d35fa3bfd791"
+        },
+        "name": "expat",
+        "normalized_name": "expat",
+        "primary_namespace": "shared",
+        "description": "The expat package"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-11-05T00:40:36.179438Z",
+        "ingredient_id": "005fec58-7763-5ccf-9fce-d35fa3bfd791",
+        "ingredient_version_id": "a45dc564-3e7d-5b43-b2b3-2a941b0f5807",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/005fec58-7763-5ccf-9fce-d35fa3bfd791/versions/a45dc564-3e7d-5b43-b2b3-2a941b0f5807",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/005fec58-7763-5ccf-9fce-d35fa3bfd791"
+        },
+        "revision": 11,
+        "revision_timestamp": "2021-01-11T17:46:36.186158Z",
+        "copyright_text": "To be added.",
+        "documentation_uri": "https://libexpat.github.io/doc/",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "2019-09-24T00:00:00.000000Z",
+        "source_uri": "https://github.com/libexpat/libexpat/archive/R_2_2_9.tar.gz",
+        "sortable_version": [
+          "2",
+          "2",
+          "9",
+          "0"
+        ],
+        "version": "2.2.9",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "skip_test": "yes"
+        },
+        "dependencies": [
+          {
+            "conditions": [
+              {
+                "feature": "alternative-built-language",
+                "namespace": "language",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "alternative-built-language",
+                "namespace": "language",
+                "requirements": [
+                  {
+                    "comparator": "gte",
+                    "sortable_version": [
+                      "0",
+                      "0"
+                    ],
+                    "version": "0"
+                  }
+                ]
+              }
+            ],
+            "feature": "autotools-builder",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/4456e0aa72ecc7e1d4b3368cd545a5eec7f9de5133a8dc37fdb1efa6174c4947/expat-2.2.9.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "4456e0aa72ecc7e1d4b3368cd545a5eec7f9de5133a8dc37fdb1efa6174c4947",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "expat",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "2",
+              "2",
+              "9",
+              "0"
+            ],
+            "version": "2.2.9"
+          }
+        ],
+        "author_platform_user_id": "8fd0aa9c-0483-4ee7-9197-96c9194c0318",
+        "comment": "Created prior to addition of revision comments.",
+        "is_stable_revision": true
+      },
+      "patches": [
+        {
+          "creation_timestamp": "2021-01-11T17:46:35.593158Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/57c568bc-9f1e-4a0b-904d-cd41ba27cd05"
+          },
+          "patch_id": "57c568bc-9f1e-4a0b-904d-cd41ba27cd05",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "s3://platform-sources/patches/239341623ebad1490c7f33ec81681f497c1e2f1ffe75e6810162e7c1e40757c7.patch",
+          "description": "expat ~ Add MSVC Makefile. Created for expat-2.2.9.",
+          "sequence_number": 1
+        },
+        {
+          "creation_timestamp": "2021-01-11T17:46:35.711198Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/a55c2d03-bae1-40f1-ae5b-fbb050c702fb"
+          },
+          "patch_id": "a55c2d03-bae1-40f1-ae5b-fbb050c702fb",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "s3://platform-sources/patches/ac8dcdeb798a847dc56d29de262552e873ac88883e6630552a668997a9a64b4f.patch",
+          "description": "expat ~ Remove hidden flag for AIX. Created for expat-2.2.9.",
+          "sequence_number": 2
+        },
+        {
+          "creation_timestamp": "2021-01-11T17:46:35.846122Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/798eadbe-103f-422b-a761-938cbef16a5a"
+          },
+          "patch_id": "798eadbe-103f-422b-a761-938cbef16a5a",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "s3://platform-sources/patches/00b3bb81c1032a8854cf469ac7208dc6e192bc0e0acfbe41677aca61a67ad457.patch",
+          "description": "expat ~ Update for C89. Created for expat-2.2.9",
+          "sequence_number": 3
+        },
+        {
+          "creation_timestamp": "2021-01-11T17:46:36.033025Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/586a3c05-b1a4-433a-a673-7b382c681906"
+          },
+          "patch_id": "586a3c05-b1a4-433a-a673-7b382c681906",
+          "conditions": null,
+          "content": "s3://platform-sources/patches/92f35efe9d078a78bc8ab10b92649ed3f814a3242b91d83ebe1f36f4bdd0e9a4.patch",
+          "description": "expat ~ Fix tests trying to use wine when not cross-compiling",
+          "sequence_number": 4
+        }
+      ],
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "fb916bb5-73f9-55f8-9a01-ad79a876e00c",
+      "build_scripts": [
+        {
+          "build_script_id": "844336b4-e883-44c8-bf22-de11ddfbd482",
+          "creation_timestamp": "2020-10-29T19:15:40.719565Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/844336b4-e883-44c8-bf22-de11ddfbd482"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "s3://platform-sources/build_scripts/4432de517c9e851a7f7772843cb30f6dda380a5e330ce39f3169186421048566/openssl-1.1.1-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T16:56:17.721017Z",
+        "ingredient_id": "c1256669-2a2d-5cf2-8860-804bf43ceb5f",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/c1256669-2a2d-5cf2-8860-804bf43ceb5f"
+        },
+        "name": "openssl",
+        "normalized_name": "openssl",
+        "primary_namespace": "shared",
+        "description": "Open Secure Sockets Layer general cryptography library."
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2020-06-16T06:27:06.148324Z",
+        "ingredient_id": "c1256669-2a2d-5cf2-8860-804bf43ceb5f",
+        "ingredient_version_id": "491568f3-50a4-56f6-a971-580eaa99715f",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/c1256669-2a2d-5cf2-8860-804bf43ceb5f/versions/491568f3-50a4-56f6-a971-580eaa99715f",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/c1256669-2a2d-5cf2-8860-804bf43ceb5f"
+        },
+        "revision": 6,
+        "revision_timestamp": "2020-10-29T19:15:41.225634Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "2020-04-21T02:22:00.000000Z",
+        "source_uri": "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1g.tar.gz",
+        "sortable_version": [
+          "1",
+          "11",
+          "0",
+          "7",
+          "0"
+        ],
+        "version": "1.11.0.7",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "ppm_pkg": "no"
+        },
+        "dependencies": [
+          {
+            "conditions": [
+              {
+                "feature": "alternative-built-language",
+                "namespace": "language",
+                "requirements": [
+                  {
+                    "comparator": "gte",
+                    "sortable_version": [
+                      "0",
+                      "0"
+                    ],
+                    "version": "0"
+                  }
+                ]
+              }
+            ],
+            "feature": "openssl-builder",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "alternative-built-language",
+                "namespace": "language",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/281e4f13142b53657bd154481e18195b2d477572fdffa8ed1065f73ef5a19777/OpenSSL_1_1_1g.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "281e4f13142b53657bd154481e18195b2d477572fdffa8ed1065f73ef5a19777",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "openssl",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "1",
+              "11",
+              "0",
+              "7",
+              "0"
+            ],
+            "version": "1.11.0.7"
+          }
+        ],
+        "author_platform_user_id": "8fd0aa9c-0483-4ee7-9197-96c9194c0318",
+        "comment": "Convert patch content to S3 URI and add condition on camel builder",
+        "is_stable_revision": true
+      },
+      "patches": [
+        {
+          "creation_timestamp": "2020-10-29T19:15:40.956403Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/df530ca2-a174-4148-a843-c7f34dd13652"
+          },
+          "patch_id": "df530ca2-a174-4148-a843-c7f34dd13652",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "s3://platform-sources/patches/6a990e80dad9a75de34a762d621f4b56b93dd8d68e37cf805e820f889726e886.patch",
+          "description": "Do not attempt to install non-existent .pdb files",
+          "sequence_number": 1
+        }
+      ],
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "7b9a5527-a6d0-50b9-a6fe-0c5c73d242cd",
+      "build_scripts": [
+        {
+          "build_script_id": "e9ffe653-3f26-4dfe-b588-2883dd5eeb94",
+          "creation_timestamp": "2020-08-31T18:13:08.145236Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/e9ffe653-3f26-4dfe-b588-2883dd5eeb94"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "sqlite3-3.15.2-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T17:07:11.488759Z",
+        "ingredient_id": "380e1f63-4050-59d3-b14d-2b431b5fa2e0",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/380e1f63-4050-59d3-b14d-2b431b5fa2e0"
+        },
+        "name": "sqlite3",
+        "normalized_name": "sqlite3",
+        "primary_namespace": "shared",
+        "description": "SQL Lite Database"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-10-01T17:07:11.488759Z",
+        "ingredient_id": "380e1f63-4050-59d3-b14d-2b431b5fa2e0",
+        "ingredient_version_id": "54cbf7c2-c87c-51b5-a2cc-72b3b284d68c",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/380e1f63-4050-59d3-b14d-2b431b5fa2e0/versions/54cbf7c2-c87c-51b5-a2cc-72b3b284d68c",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/380e1f63-4050-59d3-b14d-2b431b5fa2e0"
+        },
+        "revision": 3,
+        "revision_timestamp": "2020-08-31T18:13:08.393927Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "1970-01-01T00:00:00.000000Z",
+        "source_uri": "https://s3.amazonaws.com/camel-sources/src/vendor-sources/python/sqlite-autoconf-3150200.tar.gz",
+        "sortable_version": [
+          "3",
+          "15",
+          "2",
+          "0"
+        ],
+        "version": "3.15.2",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "skip_test": "yes"
+        },
+        "dependencies": [
+          {
+            "conditions": null,
+            "description": "All ingredients have a build-time dependency on the camel build system",
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/07b35063b9386865b78226cdaca9a299d938a87aaa8fdc4d73edb0cef30f3149/sqlite-autoconf-3150200.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "07b35063b9386865b78226cdaca9a299d938a87aaa8fdc4d73edb0cef30f3149",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "sqlite3",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "3",
+              "15",
+              "2",
+              "0"
+            ],
+            "version": "3.15.2"
+          }
+        ],
+        "author_platform_user_id": "ddfb4cc7-4a50-45a5-a6a5-1336b3ad1ef2",
+        "comment": "Created prior to addition of revision comments.",
+        "is_stable_revision": true
+      },
+      "patches": null,
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "06e6c26f-7645-5971-a6ad-277497bdec0c",
+      "build_scripts": [
+        {
+          "build_script_id": "b5e19267-2ad1-450e-a3d1-a9b7ed1cd344",
+          "creation_timestamp": "2019-11-26T20:46:06.363894Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/b5e19267-2ad1-450e-a3d1-a9b7ed1cd344"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "tcl-8.6.8-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T17:07:20.968772Z",
+        "ingredient_id": "040ef024-47fa-5220-aa7e-becd3b44e203",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/040ef024-47fa-5220-aa7e-becd3b44e203"
+        },
+        "name": "tcl",
+        "normalized_name": "tcl",
+        "primary_namespace": "shared",
+        "description": "Toolkit Command Language"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-10-01T17:07:20.968772Z",
+        "ingredient_id": "040ef024-47fa-5220-aa7e-becd3b44e203",
+        "ingredient_version_id": "b0d9a189-aedb-5461-b872-5e643ac97551",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/040ef024-47fa-5220-aa7e-becd3b44e203/versions/b0d9a189-aedb-5461-b872-5e643ac97551",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/040ef024-47fa-5220-aa7e-becd3b44e203"
+        },
+        "revision": 4,
+        "revision_timestamp": "2020-09-16T16:53:54.537734Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "1970-01-01T00:00:00.000000Z",
+        "source_uri": "https://s3.amazonaws.com/camel-sources/src/vendor-sources/tcl/tcl8.6.8-src.tar.gz",
+        "sortable_version": [
+          "8",
+          "6",
+          "8",
+          "0"
+        ],
+        "version": "8.6.8",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "cold_storage_dirs": {
+            "src": "__SRC__"
+          },
+          "skip_test": "yes"
+        },
+        "dependencies": [
+          {
+            "conditions": null,
+            "description": "All ingredients have a build-time dependency on the camel build system",
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "AIX",
+                "namespace": "kernel",
+                "requirements": [
+                  {
+                    "comparator": "gte",
+                    "sortable_version": [
+                      "0",
+                      "0"
+                    ],
+                    "version": "0"
+                  }
+                ]
+              }
+            ],
+            "feature": "zlib",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a/tcl8.6.8-src.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "tcl",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "8",
+              "6",
+              "8",
+              "0"
+            ],
+            "version": "8.6.8"
+          }
+        ],
+        "author_platform_user_id": "a19a07b9-313a-4e8f-916b-633457d72be8",
+        "comment": "Convert patch content to S3 URI and add condition on camel builder",
+        "is_stable_revision": true
+      },
+      "patches": [
+        {
+          "creation_timestamp": "2020-09-16T16:53:54.314313Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/126a4875-aec6-476b-9ff5-83944e0c08b2"
+          },
+          "patch_id": "126a4875-aec6-476b-9ff5-83944e0c08b2",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "tcl/8.6.8/0001-Add-lm-for-AIX.patch",
+          "description": "Add lm for AIX",
+          "sequence_number": 1
+        }
+      ],
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "060cc2b8-01e4-5afe-8618-c44ccb25a592",
+      "build_scripts": [
+        {
+          "build_script_id": "efe458cc-4f5f-410a-ba71-ff9ff6514dc7",
+          "creation_timestamp": "2019-11-21T00:46:19.305262Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/efe458cc-4f5f-410a-ba71-ff9ff6514dc7"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "tix-8.4.3-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "8d5d63b0-e941-59a3-8653-35470bd70056"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "b0d9a189-aedb-5461-b872-5e643ac97551"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T17:07:40.922846Z",
+        "ingredient_id": "be9d279c-48f3-5233-9250-fc5a61dc8b07",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/be9d279c-48f3-5233-9250-fc5a61dc8b07"
+        },
+        "name": "tix",
+        "normalized_name": "tix",
+        "primary_namespace": "shared",
+        "description": "Tk Interface Extension"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-10-01T17:07:40.922846Z",
+        "ingredient_id": "be9d279c-48f3-5233-9250-fc5a61dc8b07",
+        "ingredient_version_id": "a61c1442-98a0-576c-b606-3046b22c3413",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/be9d279c-48f3-5233-9250-fc5a61dc8b07/versions/a61c1442-98a0-576c-b606-3046b22c3413",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/be9d279c-48f3-5233-9250-fc5a61dc8b07"
+        },
+        "revision": 4,
+        "revision_timestamp": "2020-09-16T16:53:55.795504Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "1970-01-01T00:00:00.000000Z",
+        "source_uri": "https://s3.amazonaws.com/camel-sources/src/vendor-sources/python-core/tix-8.4.3.6-pysvn.tar.gz",
+        "sortable_version": [
+          "8",
+          "4",
+          "3",
+          "6",
+          "0"
+        ],
+        "version": "8.4.3.6",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "skip_test": "yes"
+        },
+        "dependencies": [
+          {
+            "conditions": null,
+            "feature": "tcl",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "feature": "tk",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "description": "All ingredients have a build-time dependency on the camel build system",
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/d6a92d5dd259d51a40d2293e495f34a4925ee7b360b213bb8a64360892065d35/tix-8.4.3.6-pysvn.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "d6a92d5dd259d51a40d2293e495f34a4925ee7b360b213bb8a64360892065d35",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "tix",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "8",
+              "4",
+              "3",
+              "6",
+              "0"
+            ],
+            "version": "8.4.3.6"
+          }
+        ],
+        "author_platform_user_id": "a19a07b9-313a-4e8f-916b-633457d72be8",
+        "comment": "Convert patch content to S3 URI and add condition on camel builder",
+        "is_stable_revision": true
+      },
+      "patches": [
+        {
+          "creation_timestamp": "2020-09-16T16:53:55.513963Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/ce6ba6d3-4a26-4b60-be52-4db4e2fadf4b"
+          },
+          "patch_id": "ce6ba6d3-4a26-4b60-be52-4db4e2fadf4b",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "tix/8.4.3.6/0001-Work-around-deprecated-access-to-Tcl_Interp-result.patch",
+          "description": "[PATCH 1/2] Work around deprecated access to Tcl_Interp->result",
+          "sequence_number": 1
+        },
+        {
+          "creation_timestamp": "2020-09-16T16:53:55.608640Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/c441dcb9-546a-4cc0-a386-f491539b5e98"
+          },
+          "patch_id": "c441dcb9-546a-4cc0-a386-f491539b5e98",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "tix/8.4.3.6/0002-gcc64-fix.patch",
+          "description": "[PATCH 2/2] gcc64 fix",
+          "sequence_number": 2
+        }
+      ],
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "2c8a61b6-995c-5e59-8d52-fac8604c3e88",
+      "build_scripts": [
+        {
+          "build_script_id": "72d59ea6-6a31-4af4-acb8-a4c8cf3c5b2e",
+          "creation_timestamp": "2020-09-28T21:06:07.393481Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/72d59ea6-6a31-4af4-acb8-a4c8cf3c5b2e"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "s3://platform-sources/build_scripts/815b591199017b6171f96b1411ca33d87bba4c8241a8325321f6e4eb3f8b6efc/tk-8.6.8-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "b0d9a189-aedb-5461-b872-5e643ac97551"
+        },
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T17:07:42.897332Z",
+        "ingredient_id": "5edfd4e0-b20a-5016-8447-635029f35565",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/5edfd4e0-b20a-5016-8447-635029f35565"
+        },
+        "name": "tk",
+        "normalized_name": "tk",
+        "primary_namespace": "shared",
+        "description": "Toolkit GUI Kit"
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-10-01T17:07:42.897332Z",
+        "ingredient_id": "5edfd4e0-b20a-5016-8447-635029f35565",
+        "ingredient_version_id": "8d5d63b0-e941-59a3-8653-35470bd70056",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/5edfd4e0-b20a-5016-8447-635029f35565/versions/8d5d63b0-e941-59a3-8653-35470bd70056",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/5edfd4e0-b20a-5016-8447-635029f35565"
+        },
+        "revision": 9,
+        "revision_timestamp": "2020-09-28T21:06:41.439268Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "1970-01-01T00:00:00.000000Z",
+        "source_uri": "https://s3.amazonaws.com/camel-sources/src/vendor-sources/tcl/tk8.6.8-src.tar.gz",
+        "sortable_version": [
+          "8",
+          "6",
+          "8",
+          "0"
+        ],
+        "version": "8.6.8",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "cold_storage_dirs": {
+            "src": "__SRC__"
+          },
+          "skip_test": "yes"
+        },
+        "dependencies": [
+          {
+            "conditions": null,
+            "description": "All ingredients have a build-time dependency on the camel build system",
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": null,
+            "feature": "tcl",
+            "namespace": "shared",
+            "requirements": [
+              {
+                "comparator": "eq",
+                "sortable_version": [
+                  "8",
+                  "6",
+                  "8",
+                  "0"
+                ],
+                "version": "8.6.8"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33/tk8.6.8-src.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "tk",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "8",
+              "6",
+              "8",
+              "0"
+            ],
+            "version": "8.6.8"
+          }
+        ],
+        "author_platform_user_id": "2b378791-a94b-4bf1-9547-692b7e79dfef",
+        "comment": "Created prior to addition of revision comments.",
+        "is_stable_revision": true
+      },
+      "patches": null,
+      "resolved_requirements": []
+    },
+    {
+      "alternatives": [],
+      "artifact_id": "7b923ae1-94a9-574c-bb9e-a89163f0ccb8",
+      "build_scripts": [
+        {
+          "build_script_id": "4dba9721-e655-4da3-a414-44c346460ab5",
+          "creation_timestamp": "2020-10-02T18:32:51.953001Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/build-scripts/4dba9721-e655-4da3-a414-44c346460ab5"
+          },
+          "conditions": null,
+          "language": "perl",
+          "script": "zlib-1.2.8-AS-Makefile.PL"
+        }
+      ],
+      "dependencies": [
+        {
+          "dependency_types": [
+            "build"
+          ],
+          "ingredient_version_id": "c6688f9c-b7bc-5f6e-a1f3-903ae5b8d0bc"
+        }
+      ],
+      "ingredient": {
+        "creation_timestamp": "2019-10-01T16:58:37.399441Z",
+        "ingredient_id": "aaa00228-14b4-5dce-9fe2-3370801e423b",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/aaa00228-14b4-5dce-9fe2-3370801e423b"
+        },
+        "name": "zlib",
+        "normalized_name": "zlib",
+        "primary_namespace": "shared",
+        "description": "General purpose data compression library."
+      },
+      "ingredient_options": null,
+      "ingredient_version": {
+        "creation_timestamp": "2019-10-01T16:58:37.399441Z",
+        "ingredient_id": "aaa00228-14b4-5dce-9fe2-3370801e423b",
+        "ingredient_version_id": "c3b7c513-8be8-56d9-8d30-b19e9c56e393",
+        "links": {
+          "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/aaa00228-14b4-5dce-9fe2-3370801e423b/versions/c3b7c513-8be8-56d9-8d30-b19e9c56e393",
+          "ingredient": "https://platform.activestate.com/sv/inventory-api-v1/v1/ingredients/aaa00228-14b4-5dce-9fe2-3370801e423b"
+        },
+        "revision": 5,
+        "revision_timestamp": "2020-10-02T18:32:52.928805Z",
+        "copyright_text": "To be added.",
+        "is_binary_only": false,
+        "license_expression": "Unknown",
+        "release_timestamp": "2017-01-15T00:00:00.000000Z",
+        "source_uri": "https://s3.amazonaws.com/camel-sources/src/Libraries/vendor/zlib-1.2.11.tar.gz",
+        "sortable_version": [
+          "1",
+          "2",
+          "11",
+          "0"
+        ],
+        "version": "1.2.11",
+        "activestate_license_expression": "unknown",
+        "camel_extras": {
+          "ppm_pkg": "no",
+          "skip_test": "yes"
+        },
+        "dependencies": [
+          {
+            "conditions": [
+              {
+                "feature": "alternative-built-language",
+                "namespace": "language",
+                "requirements": [
+                  {
+                    "comparator": "gte",
+                    "sortable_version": [
+                      "0",
+                      "0"
+                    ],
+                    "version": "0"
+                  }
+                ]
+              }
+            ],
+            "feature": "zlib-builder",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          },
+          {
+            "conditions": [
+              {
+                "feature": "alternative-built-language",
+                "namespace": "language",
+                "requirements": [
+                  {
+                    "comparator": "eq",
+                    "sortable_version": []
+                  }
+                ]
+              }
+            ],
+            "feature": "camel",
+            "namespace": "builder",
+            "requirements": [
+              {
+                "comparator": "gte",
+                "sortable_version": [
+                  "0",
+                  "0"
+                ],
+                "version": "0"
+              }
+            ],
+            "type": "build"
+          }
+        ],
+        "ingredient_options": null,
+        "is_indemnified": true,
+        "is_stable_release": true,
+        "platform_source_uri": "s3://platform-sources/shared/c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1/zlib-1.2.11.tar.gz",
+        "scanner_license_expression": "unknown",
+        "source_checksum": "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        "status": "stable",
+        "provided_features": [
+          {
+            "feature": "zlib",
+            "is_activestate_version": false,
+            "is_default_provider": true,
+            "namespace": "shared",
+            "sortable_version": [
+              "1",
+              "2",
+              "11",
+              "0"
+            ],
+            "version": "1.2.11"
+          }
+        ],
+        "author_platform_user_id": "a4603881-68af-4a9f-9e4c-6de870d9cbb4",
+        "comment": "Created prior to addition of revision comments.",
+        "is_stable_revision": true
+      },
+      "patches": [
+        {
+          "creation_timestamp": "2020-10-02T18:32:52.140755Z",
+          "links": {
+            "self": "https://platform.activestate.com/sv/inventory-api-v1/v1/patches/8c1dc792-b9e1-44d8-9dfe-27cd3c9884c6"
+          },
+          "patch_id": "8c1dc792-b9e1-44d8-9dfe-27cd3c9884c6",
+          "conditions": [
+            {
+              "feature": "camel",
+              "namespace": "builder",
+              "requirements": [
+                {
+                  "comparator": "gte",
+                  "sortable_version": [
+                    "0",
+                    "0"
+                  ],
+                  "version": "0"
+                }
+              ]
+            }
+          ],
+          "content": "s3://platform-sources/patches/Libraries/patches/zlib-1.2.8-remove-Makefile.patch",
+          "description": "Remove Makefile, use EU::MM to build",
+          "sequence_number": 1
+        }
+      ],
+      "resolved_requirements": []
+    }
+  ],
+  "solver_version": 1
+}

--- a/pkg/platform/runtime2/testhelper/testhelper.go
+++ b/pkg/platform/runtime2/testhelper/testhelper.go
@@ -1,0 +1,42 @@
+package testhelper
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/ActiveState/cli/internal/environment"
+	"github.com/ActiveState/cli/pkg/platform/api/headchef/headchef_models"
+	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_models"
+	"github.com/autarch/testify/require"
+)
+
+func dataPath(t *testing.T) string {
+	root, err := environment.GetRootPath()
+	require.NoError(t, err)
+	return filepath.Join(root, "pkg", "platform", "runtime2", "testhelper", "data")
+}
+
+func LoadRecipe(t *testing.T, name string) *inventory_models.Recipe {
+	d, err := ioutil.ReadFile(filepath.Join(dataPath(t), "recipes", fmt.Sprintf("%s.json", name)))
+	require.NoError(t, err)
+
+	var recipe inventory_models.Recipe
+	err = json.Unmarshal(d, &recipe)
+	require.NoError(t, err)
+
+	return &recipe
+}
+
+func LoadBuildResponse(t *testing.T, name string) *headchef_models.BuildStatusResponse {
+	d, err := ioutil.ReadFile(filepath.Join(dataPath(t), "builds", fmt.Sprintf("%s.json", name)))
+	require.NoError(t, err)
+
+	var status headchef_models.BuildStatusResponse
+	err = json.Unmarshal(d, &status)
+	require.NoError(t, err)
+
+	return &status
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176968135

I re-arranged the `InstallRuntime()` function a little bit, such that the most complicated logic is all in one function named `orchestrateArtifactSetup()`.  A unit test is added for it, and actually already passes.

Some other unit tests mostly for the interpretation of the `BuildStatus` and `Recipes` are added. As these structures are very complex, I added a `testhelper` package where we can collect test recipes and build status responses as JSON files.  I believe that this should be easy enough to maintain for the future.  It also gives us some feedback on incompatible backend changes (that shouldn't happen): If we update the swagger definitions, and our old recipes and build status responses cannot be read anymore, something may require our attention.