### PR TITLE
Update invoke silent error to be user error

### DIFF
--- a/internal/runbits/invoke.go
+++ b/internal/runbits/invoke.go
@@ -48,7 +48,7 @@ func InvokeSilent(args ...string) error {
 	err = cmd.Run()
 
 	if err != nil {
-		return locale.WrapError(err, "err_tutorial_invoke_run", "Errors occurred while invoking State Tool command: `state {{.V0}}`.", strings.Join(args, " "))
+		return locale.WrapInputError(err, "err_tutorial_invoke_run", "Errors occurred while invoking State Tool command: `state {{.V0}}`.", strings.Join(args, " "))
 	}
 
 	return nil


### PR DESCRIPTION
I think it's safe for this to be an input error as it is invoking the state tool. Any errors in that state tool process should also be reported. Most of the errors from the rollbar report are from the ppm shim invoking `state install`.

 https://www.pivotaltracker.com/story/show/177208087