### PR TITLE
Uninstall fix

### DIFF
--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -442,6 +442,21 @@ func IsEmptyDir(path string) (bool, error) {
 	return (len(files) == 0), nil
 }
 
+// IsEmptyDirs returns true if the directory at the provide path has no files
+// within it or any of its sub directories
+func IsEmptyDirs(path string) bool {
+	empty := true
+	filepath.Walk(path, func(p string, _ os.FileInfo, _ error) error {
+		if !IsDir(p) {
+			empty = false
+		}
+
+		return nil
+	})
+
+	return empty
+}
+
 // MoveAllFilesCallback is invoked for every file that we move
 type MoveAllFilesCallback func(fromPath, toPath string)
 

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -442,21 +442,6 @@ func IsEmptyDir(path string) (bool, error) {
 	return (len(files) == 0), nil
 }
 
-// IsEmptyDirs returns true if the directory at the provide path has no files
-// within it or any of its sub directories
-func IsEmptyDirs(path string) bool {
-	empty := true
-	filepath.Walk(path, func(p string, _ os.FileInfo, _ error) error {
-		if !IsDir(p) {
-			empty = false
-		}
-
-		return nil
-	})
-
-	return empty
-}
-
 // MoveAllFilesCallback is invoked for every file that we move
 type MoveAllFilesCallback func(fromPath, toPath string)
 


### PR DESCRIPTION
It appears that with newer versions of `python` simply having a directory in `site_packages` will allow you to import it. In the case of `rich` all of the contents of the directory were removed (except for a `__pycache__` directory) on `state uninstall`. You could still import this module but it would be unusable.

```
>>> import rich
>>> print(rich.__file__)
None
```

https://www.pivotaltracker.com/story/show/177550106