### PR TITLE
Fix uninstall bug on release

### DIFF
--- a/pkg/platform/runtime/alternative.go
+++ b/pkg/platform/runtime/alternative.go
@@ -273,12 +273,12 @@ func artifactsToKeepAndDelete(artifactCache []artifactCacheMeta, artifactRequest
 // dirCanBeDeleted checks if the given directory is empty - ignoring files and sub-directories that
 // are not in the cache.
 func dirCanBeDeleted(dir string, cache []artifactCacheMeta) (bool, error) {
-	entries, err := os.ReadDir(dir)
+	entries, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return false, errs.Wrap(err, "Could not read directory.")
 	}
 	for _, entry := range entries {
-		if entry.Type().IsDir() {
+		if entry.IsDir() {
 			if artifactsContainDir(cache, filepath.Join(dir, entry.Name())) {
 				return false, nil
 			}

--- a/pkg/platform/runtime/alternative.go
+++ b/pkg/platform/runtime/alternative.go
@@ -213,6 +213,10 @@ func (ai *AlternativeInstall) PreInstall() error {
 			if !fileutils.TargetExists(file) {
 				continue // don't care it's already deleted (might have been deleted by another artifact that supplied the same file)
 			}
+			if artifactsContainFile(ai.cache, file) {
+				logging.Debug("File %s was marked for deletion, but is also present in artifact that is still installed. File contents may be wrong!", file)
+				continue
+			}
 			if err := os.Remove(file); err != nil {
 				return locale.WrapError(err, "err_rm_artf", "", "Could not remove old package file at {{.V0}}.", file)
 			}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177747606

It took a little longer, because I noticed more issues:
1. We always removed too many files: If a file is in a removed artifact, but also part of an artifact that we are keeping.  That is fixed in b3affe2
2. There were far more directories and files  than `__pycache__` that were created after installation.  Specifically a Cython directory was full of stuff.  I came to the conclusion though, that we want to be re-producible and therefore, should remove everything that we do not install, because a clean installation should produce the exact same result.  We may have to discuss that with language engineering or even Scott though.
3. We are still NOT reproducible.  See 
[attached file](https://github.com/ActiveState/cli/files/6368278/uninstalled_vs_clean_install.diff.txt)  This is the difference between a clean installation and an updated one.  As you can see some of the files have changed, because of (1).  There is a follow-up story here: https://www.pivotaltracker.com/story/show/177894893

 