### PR TITLE
MoveAllFilesRecursively() works the same on all platforms

### DIFF
--- a/.github/workflows-src/jobs.lib.yml
+++ b/.github/workflows-src/jobs.lib.yml
@@ -1,4 +1,4 @@
-#@ load("steps.lib.yml", "steps_preprocess", "steps_build", "steps_build_svc", "steps_build_tray", "steps_build_tray_linux", "steps_build_installer", "steps_build_32bit", "steps_build_svc_32bit", "steps_build_tray_32bit", "steps_build_installer_32bit", "steps_genupdate", "steps_gentest_update", "steps_genupdate_32bit", "steps_installgo", "steps_setup", "steps_test", "steps_inttestcrit", "steps_inttest", "steps_uploadartifacts", "steps_uploadsessartifacts", "steps_downloadsessartifacts", "steps_deletesessartifacts", "steps_deploy", "steps_build_state_msi", "steps_build_languages_msi", "steps_cleanbuild", "steps_sign", "steps_sign_installscript", "steps_build_installscripts", "steps_downloadallsessartifacts", "steps_sanitizeallsessartifacts")
+#@ load("steps.lib.yml", "steps_preprocess", "steps_build", "steps_build_svc", "steps_build_tray", "steps_build_tray_linux", "steps_build_installer", "steps_build_32bit", "steps_build_svc_32bit", "steps_build_tray_32bit", "steps_build_installer_32bit", "steps_genupdate", "steps_gentest_update", "steps_genupdate_32bit", "steps_installgo", "steps_setup", "steps_test", "steps_inttestcrit", "steps_inttest", "steps_uploadartifacts", "steps_uploadsessartifacts", "steps_downloadsessartifacts", "steps_deletesessartifacts", "steps_deploy", "steps_build_state_msi", "steps_build_languages_msi", "steps_cleanbuild", "steps_sign", "steps_sign_installscript", "steps_build_installscripts", "steps_downloadallsessartifacts", "steps_sanitizeallsessartifacts", "steps_install_wails_deps")
 
 #@ def strategy(fail_fast=True):
 matrix:
@@ -57,6 +57,7 @@ steps:
   - #@ steps_installgo()
   - #@ steps_setup()
   - #@ steps_preprocess()
+  - #@ steps_install_wails_deps()
   - #@ steps_test()
 #@ end
 

--- a/.github/workflows-src/steps.lib.yml
+++ b/.github/workflows-src/steps.lib.yml
@@ -10,6 +10,14 @@ shell: bash
 run: state run build-svc
 #@ end
 ---
+#@ def steps_install_wails_deps():
+name: Install Wails Dependencies
+shell: bash
+if: runner.os == 'Linux'
+run: |
+  sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev -y
+#@ end
+---
 #@ def steps_build_tray_linux():
 name: Build Tray App (linux)
 shell: bash

--- a/.github/workflows-src/steps.lib.yml
+++ b/.github/workflows-src/steps.lib.yml
@@ -15,6 +15,7 @@ name: Install Wails Dependencies
 shell: bash
 if: runner.os == 'Linux'
 run: |
+  sudo apt-get update
   sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev -y
 #@ end
 ---

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,11 @@ jobs:
       shell: bash
       run: |
         state run preprocess
+    - name: Install Wails Dependencies
+      shell: bash
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev -y
     - name: Unit Tests
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,28 +90,12 @@ jobs:
     - name: Sign
       shell: bash
       if: runner.os == 'Windows'
-      run: "echo $MSI_CERT_BASE64 | base64 --decode > Cert.p12\nexport PATH=/c/Program\\
-        Files\\ \\(x86\\)/WiX\\ Toolset\\ v3.11/bin/:/c/Program\\ Files\\ \\(x86\\)/Windows\\
-        Kits/10/bin/10.0.16299.0/x86/:$PATH\n\nsigntool.exe sign -d \"ActiveState
-        State Tool\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/state.exe \nsigntool.exe
-        sign -d \"ActiveState State Service\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD}
-        ./build/state-svc.exe \nsigntool.exe sign -d \"ActiveState State Tray\" -f
-        \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/state-tray.exe \nsigntool.exe
-        sign -d \"ActiveState State Installer\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD}
-        ./build/state-installer.exe \nsigntool.exe sign -d \"ActiveState State Tool
-        (32bit)\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/386/state.exe
-        \nsigntool.exe sign -d \"ActiveState State Service (32bit)\" -f \"Cert.p12\"
-        -p ${CODE_SIGNING_PASSWD} ./build/386/state-svc.exe \nsigntool.exe sign -d
-        \"ActiveState State Tray (32bit)\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD}
-        ./build/386/state-tray.exe \nsigntool.exe sign -d \"ActiveState State Installer
-        (32bit)\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/386/state-installer.exe
-        \n"
+      run: "echo $MSI_CERT_BASE64 | base64 --decode > Cert.p12\nexport PATH=/c/Program\\ Files\\ \\(x86\\)/WiX\\ Toolset\\ v3.11/bin/:/c/Program\\ Files\\ \\(x86\\)/Windows\\ Kits/10/bin/10.0.16299.0/x86/:$PATH\n\nsigntool.exe sign -d \"ActiveState State Tool\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/state.exe \nsigntool.exe sign -d \"ActiveState State Service\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/state-svc.exe \nsigntool.exe sign -d \"ActiveState State Tray\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/state-tray.exe \nsigntool.exe sign -d \"ActiveState State Installer\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/state-installer.exe \nsigntool.exe sign -d \"ActiveState State Tool (32bit)\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/386/state.exe \nsigntool.exe sign -d \"ActiveState State Service (32bit)\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/386/state-svc.exe \nsigntool.exe sign -d \"ActiveState State Tray (32bit)\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/386/state-tray.exe \nsigntool.exe sign -d \"ActiveState State Installer (32bit)\" -f \"Cert.p12\" -p ${CODE_SIGNING_PASSWD} ./build/386/state-installer.exe \n"
       env:
         CODE_SIGNING_PASSWD: ${{ secrets.CODE_SIGNING_PASSWD }}
         MSI_CERT_BASE64: ${{ secrets.MSI_CERT_BASE64 }}
     - name: Sign install.PS1
-      if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/master", "refs/heads/beta",
-        "refs/heads/release"]'), github.ref)
+      if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/release"]'), github.ref)
       shell: powershell
       run: |
         $branchInfix = $Env:GITHUB_REF.Replace("refs/heads/", "").Replace("release", "")
@@ -200,14 +184,14 @@ jobs:
       shell: bash
       if: runner.os == 'Linux'
       run: |
+        sudo apt-get update
         sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev -y
     - name: Unit Tests
       shell: bash
       run: |
         go test `go list ./... | grep -v api | grep -v integration | grep -v expect | grep -v state-tray | grep -v state-svc`
   inttest_critical:
-    if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/beta' && github.ref
-      != 'refs/heads/release'
+    if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/beta' && github.ref != 'refs/heads/release'
     name: Critical Integration Test
     strategy:
       matrix:
@@ -428,8 +412,7 @@ jobs:
       run: rm build/state* || true
     - name: Deploy
       shell: bash
-      if: contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/release"]'),
-        github.ref)
+      if: contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/release"]'), github.ref)
       run: |
         state run deploy-updates
         state run deploy-installers

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -486,30 +486,33 @@ func MoveAllFilesRecursively(fromPath, toPath string, cb MoveAllFilesCallback) e
 			if fileInfo.Mode() != toInfo.Mode() {
 				logging.Warning(locale.Tr("warn_move_incompatible_modes", "", subFromPath, subToPath))
 			}
+
+			// If we are moving to an existing directory, call function recursively to overwrite and add files in that directory
+			if toInfo.IsDir() {
+				err := MoveAllFilesRecursively(subFromPath, subToPath, cb)
+				if err != nil {
+					return err
+				}
+				// source path should be empty now
+				err = os.Remove(subFromPath)
+				if err != nil {
+					return errs.Wrap(err, "os.Remove %s failed", subFromPath)
+				}
+
+				continue
+			}
+
+			// If the subToPath file exists, we remove it first - in order to ensure compatibility between platforms:
+			// On Windows, the following renaming step can otherwise fail if subToPath is read-only (file removal is allowed)
+			err = os.Remove(subToPath)
+			logging.Error("Failed to remove destination file %s: %v", subToPath, err)
 		}
-		if toPathExists && toInfo.IsDir() {
-			err := MoveAllFilesRecursively(subFromPath, subToPath, cb)
-			if err != nil {
-				return err
-			}
-			// source path should be empty now
-			err = os.Remove(subFromPath)
-			if err != nil {
-				return errs.Wrap(err, "os.Remove %s failed", subFromPath)
-			}
-		} else {
-			// If the subToPath file exists, we remove it first - to ensure compatibility between in platforms:
-			// On Windows, the renaming step can otherwise fail if subToPath is read-only (file removal is allowed)
-			if toPathExists {
-				err = os.Remove(subToPath)
-				logging.Error("Failed to remove destination file %s: %v", subToPath, err)
-			}
-			err = os.Rename(subFromPath, subToPath)
-			if err != nil {
-				return errs.Wrap(err, "os.Rename %s:%s failed", subFromPath, subToPath)
-			}
-			cb(subFromPath, subToPath)
+
+		err = os.Rename(subFromPath, subToPath)
+		if err != nil {
+			return errs.Wrap(err, "os.Rename %s:%s failed", subFromPath, subToPath)
 		}
+		cb(subFromPath, subToPath)
 	}
 	return nil
 }

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -498,6 +498,12 @@ func MoveAllFilesRecursively(fromPath, toPath string, cb MoveAllFilesCallback) e
 				return errs.Wrap(err, "os.Remove %s failed", subFromPath)
 			}
 		} else {
+			// If the subToPath file exists, we remove it first - to ensure compatibility between in platforms:
+			// On Windows, the renaming step can otherwise fail if subToPath is read-only (file removal is allowed)
+			if toPathExists {
+				err = os.Remove(subToPath)
+				logging.Error("Failed to remove destination file %s: %v", subToPath, err)
+			}
 			err = os.Rename(subFromPath, subToPath)
 			if err != nil {
 				return errs.Wrap(err, "os.Rename %s:%s failed", subFromPath, subToPath)

--- a/internal/fileutils/fileutils_test.go
+++ b/internal/fileutils/fileutils_test.go
@@ -466,7 +466,13 @@ func TestMoveAllFilesRecursively(t *testing.T) {
 
 	counter := mock.NewMockIncrementer()
 
-	MoveAllFilesRecursively(fromDir, toDir, func(string, string) { counter.Increment() })
+	err = os.Chmod(filepath.Join(fromDir, "root_in_1_and_2"), 0440)
+	require.NoError(t, err)
+	err = os.Chmod(filepath.Join(toDir, "root_in_1_and_2"), 0440)
+	require.NoError(t, err)
+
+	err = MoveAllFilesRecursively(fromDir, toDir, func(string, string) { counter.Increment() })
+	assert.NoError(t, err)
 
 	assertFileWithContent(t, "1", toDir, "only_in_1", "t1")
 	assertFileWithContent(t, "1", toDir, "in_1_and_2", "only_in_1")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177628756

These fix ensures that we can copy artifact files in the target installation directory, even if they already exist (with read-only permissions on Windows).