### PR TITLE
Rollbar is missing reports

### DIFF
--- a/cmd/state/errors.go
+++ b/cmd/state/errors.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
-	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -110,7 +109,8 @@ func unwrapError(err error) (int, error) {
 	return code, &OutputError{err}
 }
 
-func handlePanics(exiter func(int)) {
+// handlePanics produces actionable output for panic events (that shouldn't happen) and returns whether a panic event has been handled
+func handlePanics() bool {
 	if r := recover(); r != nil {
 		if msg, ok := r.(string); ok && msg == "exiter" {
 			panic(r) // don't capture exiter panics
@@ -122,10 +122,9 @@ func handlePanics(exiter func(int)) {
 		fmt.Fprintln(os.Stderr, fmt.Sprintf(`An unexpected error occurred while running the State Tool.
 Check the error log for more information.
 Your error log is located at: %s`, logging.FilePath()))
-
-		time.Sleep(time.Second) // Give rollbar a second to complete its async request (switching this to sync isnt simple)
-		exiter(1)
+		return true
 	}
+	return false
 }
 
 type SilencedError struct{ error }

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -202,8 +202,8 @@ func run(args []string, isInteractive bool, out output.Outputer) error {
 	if childCmd == nil || !childCmd.SkipChecks() {
 		// Auto update to latest state tool version, only runs once per day
 		// Todo: This is better done in the `state-svc` process  https://www.pivotaltracker.com/story/show/177730748
-		if updated, err := autoUpdate(args, cfg, pjPath); err != nil || updated {
-			return err
+		if _, err := autoUpdate(args, cfg, pjPath); err != nil {
+			logging.Error("Failed to initialize auto update: %v", err)
 		}
 	}
 

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/ActiveState/sysinfo"
 	"github.com/rollbar/rollbar-go"
@@ -18,6 +19,7 @@ import (
 	"github.com/ActiveState/cli/internal/constraints"
 	"github.com/ActiveState/cli/internal/deprecation"
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/events"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/machineid"
@@ -33,20 +35,31 @@ import (
 	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
-func _main() (exitCode int) {
+func main() {
+	var exitCode int
 	// Set up logging
 	logging.SetupRollbar(constants.StateToolRollbarToken)
-	defer rollbar.Close()
 
-	// Handle panics gracefully
-	defer handlePanics(os.Exit)
+	defer func() {
+		// Handle panics gracefully, and ensure that we exit with non-zero code
+		if handlePanics() {
+			exitCode = 1
+		}
+
+		// ensure rollbar messages are called
+		events.WaitForEvents(time.Second, rollbar.Close)
+
+		// exit with exitCode
+		os.Exit(exitCode)
+	}()
 
 	// Set up our output formatter/writer
 	outFlags := parseOutputFlags(os.Args)
 	out, err := initOutput(outFlags, "")
 	if err != nil {
 		os.Stderr.WriteString(locale.Tr("err_main_outputer", err.Error()))
-		return 1
+		exitCode = 1
+		return
 	}
 
 	if runtime.GOOS == "windows" {
@@ -69,10 +82,9 @@ func _main() (exitCode int) {
 		!outFlags.NonInteractive &&
 		terminal.IsTerminal(int(os.Stdin.Fd()))
 	// Run our main command logic, which is logic that defers to the error handling logic below
-	code := 0
 	err = run(os.Args, isInteractive, out)
 	if err != nil {
-		code, err = unwrapError(err)
+		exitCode, err = unwrapError(err)
 		if !isSilent(err) {
 			out.Error(err)
 		}
@@ -87,15 +99,6 @@ func _main() (exitCode int) {
 			br := bufio.NewReader(os.Stdin)
 			br.ReadLine()
 		}
-	}
-
-	return code
-}
-
-func main() {
-	code := _main()
-	if code != 0 {
-		os.Exit(code)
 	}
 }
 

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -36,7 +37,10 @@ import (
 func main() {
 	// Set up logging
 	logging.SetupRollbar(constants.StateToolRollbarToken)
-	defer rollbar.Close()
+	defer func() {
+		rollbar.Close()
+		fmt.Printf("closing rollbar")
+	}()
 
 	// Handle panics gracefully
 	defer handlePanics(os.Exit)

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -34,7 +34,7 @@ import (
 	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
-func main() {
+func _main() (exitCode int) {
 	// Set up logging
 	logging.SetupRollbar(constants.StateToolRollbarToken)
 	defer func() {
@@ -50,7 +50,7 @@ func main() {
 	out, err := initOutput(outFlags, "")
 	if err != nil {
 		os.Stderr.WriteString(locale.Tr("err_main_outputer", err.Error()))
-		os.Exit(1)
+		return 1
 	}
 
 	if runtime.GOOS == "windows" {
@@ -93,7 +93,14 @@ func main() {
 		}
 	}
 
-	os.Exit(code)
+	return code
+}
+
+func main() {
+	code := _main()
+	if code != 0 {
+		os.Exit(code)
+	}
 }
 
 func run(args []string, isInteractive bool, out output.Outputer) error {

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -37,10 +36,7 @@ import (
 func _main() (exitCode int) {
 	// Set up logging
 	logging.SetupRollbar(constants.StateToolRollbarToken)
-	defer func() {
-		rollbar.Close()
-		fmt.Printf("closing rollbar")
-	}()
+	defer rollbar.Close()
 
 	// Handle panics gracefully
 	defer handlePanics(os.Exit)

--- a/pkg/platform/runtime/setup/implementations/camel/runtime.go
+++ b/pkg/platform/runtime/setup/implementations/camel/runtime.go
@@ -24,8 +24,9 @@ func (s *Setup) ReusableArtifacts(_ artifact.ArtifactChangeset, _ store.StoredAr
 }
 
 func (s *Setup) DeleteOutdatedArtifacts(_ artifact.ArtifactChangeset, _, _ store.StoredArtifactMap) error {
-	err := os.RemoveAll(s.store.InstallPath())
-	logging.Error("Error removing previous camel installation: %v", err)
+	if err := os.RemoveAll(s.store.InstallPath()); err != nil {
+		logging.Error("Error removing previous camel installation: %v", err)
+	}
 	return nil
 }
 

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -260,13 +260,14 @@ func aggregateErrors() (chan<- error, <-chan error) {
 	aggErr := make(chan error)
 	bgErrs := make(chan error)
 	go func() {
-		var errs []error
+		var es []error
 		for err := range bgErrs {
-			errs = append(errs, err)
+			es = append(es, err)
 		}
+		es = append(es, errs.New("test error"))
 
-		if len(errs) > 0 {
-			aggErr <- &ArtifactSetupErrors{errs}
+		if len(es) > 0 {
+			aggErr <- &ArtifactSetupErrors{es}
 		} else {
 			aggErr <- nil
 		}

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -260,14 +260,13 @@ func aggregateErrors() (chan<- error, <-chan error) {
 	aggErr := make(chan error)
 	bgErrs := make(chan error)
 	go func() {
-		var es []error
+		var errs []error
 		for err := range bgErrs {
-			es = append(es, err)
+			errs = append(errs, err)
 		}
-		es = append(es, errs.New("test error"))
 
-		if len(es) > 0 {
-			aggErr <- &ArtifactSetupErrors{es}
+		if len(errs) > 0 {
+			aggErr <- &ArtifactSetupErrors{errs}
 		} else {
 			aggErr <- nil
 		}

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -88,13 +88,13 @@ func (suite *UpdateIntegrationTestSuite) env(disableUpdates, testUpdate bool) []
 
 	if testUpdate {
 		env = append(env, fmt.Sprintf("_TEST_UPDATE_URL=http://localhost:%s/", testPort))
-
-		dir, err := ioutil.TempDir("", "system*")
-		suite.NoError(err)
-		env = append(env, fmt.Sprintf("_TEST_SYSTEM_PATH=%s", dir))
 	} else {
 		env = append(env, fmt.Sprintf("%s=%s", constants.UpdateBranchEnvVarName, targetBranch))
 	}
+
+	dir, err := ioutil.TempDir("", "system*")
+	suite.NoError(err)
+	env = append(env, fmt.Sprintf("_TEST_SYSTEM_PATH=%s", dir))
 
 	return env
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178029680

What I did:
- I created a fake error message during `setup`, and forced it to report to the `master` branch on rollbar
- The error did not show up, but this falsely sent message appeared: https://rollbar.com/activestate/state-tool/items/22759/  (I fixed that in f19088d.
- Then I added a7be149, and ran it again.
- The error message appeared: https://rollbar.com/activestate/state-tool/items/22761/

It is possible that this also affected the analytics reporting, but I am not sure about this, of course...
I also do not know if current changes somehow made this more likely to happen.