### PR TITLE
Add missing format string to log output

### DIFF
--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -287,7 +287,7 @@ func sendS3Pixel(category, action, label string, dimensions map[string]string) {
 	}
 	pixelURL.RawQuery = query.Encode()
 
-	logging.Debug("Using S3 pixel URL: ", pixelURL.String())
+	logging.Debug("Using S3 pixel URL: %v", pixelURL.String())
 	_, err = http.Head(pixelURL.String())
 	if err != nil {
 		logging.Error("Could not download S3 pixel: %v", err)


### PR DESCRIPTION
The format string for this log line was missing the relevant expansion
string causing malformed log output:

```
[DEBUG analytics.go:266] Using S3 pixel URL: %!(EXTRA string=...)
```