### PR TITLE
Use functions for state script instead of aliases

### DIFF
--- a/assets/shells/bashrc.sh
+++ b/assets/shells/bashrc.sh
@@ -21,7 +21,10 @@ alias {{.ExecName}}='{{.ExecAlias}}'
 {{ end }}
 
 {{range $K, $CMD := .Scripts}}
-alias {{$K}}='{{$.ExecName}} run {{$CMD}}'
+function {{$K}} {
+    {{$.ExecName}} run {{$CMD}} "$@"
+}
+export -f {{$K}}
 {{end}}
 
 echo "{{.ActivateEventMessage}}"

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -137,16 +137,13 @@ func (suite *RunIntegrationTestSuite) TestInActivatedEnv() {
 // tests that convenience commands for activestate.yaml scripts are available
 // in bash subshells from the activated state
 func (suite *RunIntegrationTestSuite) TestScriptBashSubshell() {
-	suite.OnlyRunForTags(tagsuite.Run, tagsuite.Activate, tagsuite.Interrupt)
-	if runtime.GOOS == "windows" && e2e.RunningOnCI() {
-		suite.T().Skip("Not testing bash on Windows")
-	}
+	suite.OnlyRunForTags(tagsuite.Run)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
 	suite.createProjectFile(ts, 3)
 
-	cp := ts.Spawn("activate")
+	cp := ts.SpawnWithOpts(e2e.WithArgs("activate"), e2e.AppendEnv("SHELL=bash"))
 	cp.Expect("Default Project")
 	cp.Expect("y/N")
 	cp.Send("n")


### PR DESCRIPTION
Using aliases in bash to add state tool scripts to the virtual
environments has a number of disadvantage.  One major drawback is that
these aliases are not available in subshells, or available to scripts.

That means doing things like:
```
$ myvar=$(mystatescript)
```
don't work.

Instead, create shell functions and export them with `export -f` so that
they can be used everywhere a regular command could be.

 https://www.pivotaltracker.com/story/show/178030472