### PR TITLE
Update tip for locked state tool versions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,8 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - We've replaced the auto updating system with a manual updating system, updates
   will from now on be made available through the system tray application and you
   will have the choice to install it at your own convenience.
-- Added a flag `--set-version` to the `state update` command to update to a
-  specific State Tool version.  ([PR #1385](https://github.com/ActiveState/cli/pull/1385))
+- You can now switch to specific State Tool versions by running `state update --set-version <version>` ([PR #1385](https://github.com/ActiveState/cli/pull/1385))
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - We've replaced the auto updating system with a manual updating system, updates
   will from now on be made available through the system tray application and you
   will have the choice to install it at your own convenience.
+- Added a flag `--set-version` to the `state update` command to update to a
+  specific State Tool version.  ([PR #1385](https://github.com/ActiveState/cli/pull/1385))
 
 ### Changed
 

--- a/cmd/state/forward.go
+++ b/cmd/state/forward.go
@@ -87,7 +87,10 @@ func forwardFn(bindir string, args []string, out output.Outputer, pj *project.Pr
 		return fn, nil
 	}
 
-	updateTip := locale.Tl("lock_update_legacy_version", "See [ACTIONABLE]{{.V0}}[/RESET] for more information on version locking and how to install a specific State Tool version.", "https://docs.activestate.com/platform/state/advanced-topics/locking/")
+	updateTip := locale.Tl("lock_update_version", "Run [ACTIONABLE]state update --set-version {{.V0}}[/RESET] to change to the locked State Tool version.", versionInfo.Version)
+	if !version.IsMultiFileUpdate(sv) {
+		updateTip = locale.Tl("lock_update_legacy_version", "See [ACTIONABLE]{{.V0}}[/RESET] for more information on version locking and how to install a specific State Tool version.", "https://docs.activestate.com/platform/state/advanced-topics/locking/")
+	}
 	return nil, errs.AddTips(
 		locale.NewInputError("locked_version_mismatch", "This project is locked at State Tool version {{.V0}}. Your current State Tool version is {{.V1}}.", versionInfo.Version, constants.Version),
 		updateTip,

--- a/test/integration/update_lock_int_test.go
+++ b/test/integration/update_lock_int_test.go
@@ -99,7 +99,7 @@ func (suite *UpdateIntegrationTestSuite) TestLockedChannel() {
 			if tt.expectLockError {
 				cp = ts.SpawnWithOpts(e2e.WithArgs("--version"), e2e.AppendEnv(suite.env(true, false)...))
 				cp.Expect("This project is locked at State Tool version")
-				cp.ExpectLongString("See https://docs.activestate.com/platform/state/advanced-topics/locking/")
+				cp.ExpectLongString("Run state update --set-version")
 				cp.ExpectExitCode(1)
 				return
 			}


### PR DESCRIPTION
Follow-up to PR #1385.  I forgot to update the changelog file and to update the error tip in case the State Tool is locked at a specific State Tool version.