### PR TITLE
Clean-up before updating from old State Tool

### DIFF
--- a/assets/scripts/removePaths.bat
+++ b/assets/scripts/removePaths.bat
@@ -35,7 +35,7 @@ for /d %%i in (%paths%) do (
     if exist %%i\* (
         rmdir /s /q %%i >> %logfile%
     ) else (
-        del /s /q %%i >> %logfile%
+        del /q %%i >> %logfile%
     )
     if %ERRORLEVEL% NEQ 0 (
         echo "Could not remove directory: %%i" >> %logfile%

--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -76,7 +76,6 @@ func run(out output.Outputer) error {
 	logging.UpdateConfig(cfg)
 
 	var installPath string
-	var extraRemoves []string
 	if len(os.Args) > 1 {
 		installPath, err = filepath.Abs(os.Args[1])
 		if err != nil {
@@ -90,7 +89,7 @@ func run(out output.Outputer) error {
 	}
 
 	logging.Debug("Installing to %s", installPath)
-	if err := install(installPath, cfg, out, extraRemoves); err != nil {
+	if err := install(installPath, cfg, out); err != nil {
 		// Todo This is running in the background, so these error messages will not be seen and only be written to the log file.
 		// https://www.pivotaltracker.com/story/show/177691644
 		return errs.Wrap(err, "Installing to %s failed", installPath)
@@ -99,7 +98,7 @@ func run(out output.Outputer) error {
 	return nil
 }
 
-func install(installPath string, cfg *config.Instance, out output.Outputer, extraRemoves []string) error {
+func install(installPath string, cfg *config.Instance, out output.Outputer) error {
 	out.Print(fmt.Sprintf("Install Location: %s", installPath))
 	exe, err := osutils.Executable()
 	if err != nil {
@@ -136,7 +135,7 @@ func install(installPath string, cfg *config.Instance, out output.Outputer, extr
 		return errs.Wrap(err, "Could not get system install path")
 	}
 
-	inst := installer.New(tmpDir, installPath, appDir, extraRemoves)
+	inst := installer.New(tmpDir, installPath, appDir)
 	defer func() {
 		os.RemoveAll(tmpDir)
 		err := inst.RemoveBackupFiles()

--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -89,6 +89,7 @@ func run(out output.Outputer) error {
 		}
 	}
 
+	logging.Debug("Installing to %s", installPath)
 	if err := install(installPath, cfg, out, extraRemoves); err != nil {
 		// Todo This is running in the background, so these error messages will not be seen and only be written to the log file.
 		// https://www.pivotaltracker.com/story/show/177691644

--- a/cmd/state-installer/internal/installer/installation.go
+++ b/cmd/state-installer/internal/installer/installation.go
@@ -58,9 +58,9 @@ func restoreFiles(backupFiles []string) error {
 	return nil
 }
 
-func New(fromDir, binaryDir, appDir string, extraRemoves []string) *Installation {
+func New(fromDir, binaryDir, appDir string) *Installation {
 	return &Installation{
-		fromDir, binaryDir, appDir, extraRemoves,
+		fromDir, binaryDir, appDir, nil,
 	}
 }
 

--- a/cmd/state-installer/internal/installer/installation.go
+++ b/cmd/state-installer/internal/installer/installation.go
@@ -58,9 +58,9 @@ func restoreFiles(backupFiles []string) error {
 	return nil
 }
 
-func New(fromDir, binaryDir, appDir string) *Installation {
+func New(fromDir, binaryDir, appDir string, extraRemoves []string) *Installation {
 	return &Installation{
-		fromDir, binaryDir, appDir, nil,
+		fromDir, binaryDir, appDir, extraRemoves,
 	}
 }
 
@@ -99,7 +99,7 @@ func (i *Installation) BackupFiles() error {
 	if err != nil {
 		return errs.Wrap(err, "Backup of existing files failed.")
 	}
-	i.backups = backups
+	i.backups = append(i.backups, backups...)
 	return nil
 }
 

--- a/cmd/state-installer/internal/installer/installation_test.go
+++ b/cmd/state-installer/internal/installer/installation_test.go
@@ -131,7 +131,7 @@ func TestInstallation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			inst := installer.New(from, to, systemPath)
+			inst := installer.New(from, to, systemPath, []string{})
 			err := inst.Install()
 
 			if tt.ExpectSuccess {

--- a/cmd/state-installer/internal/installer/installation_test.go
+++ b/cmd/state-installer/internal/installer/installation_test.go
@@ -131,7 +131,7 @@ func TestInstallation(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			inst := installer.New(from, to, systemPath, []string{})
+			inst := installer.New(from, to, systemPath)
 			err := inst.Install()
 
 			if tt.ExpectSuccess {

--- a/cmd/state-svc/internal/resolver/resolver.go
+++ b/cmd/state-svc/internal/resolver/resolver.go
@@ -2,12 +2,14 @@ package resolver
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"time"
 
 	"golang.org/x/net/context"
 
 	genserver "github.com/ActiveState/cli/cmd/state-svc/internal/server/generated"
+	"github.com/ActiveState/cli/internal/appinfo"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -90,7 +92,8 @@ func (r *Resolver) Update(ctx context.Context, channel *string, version *string)
 	if up == nil {
 		return &graph.DeferredUpdate{}, nil
 	}
-	proc, err := up.InstallDeferred()
+	installTargetPath := filepath.Dir(appinfo.StateApp().Exec())
+	proc, err := up.InstallDeferred(installTargetPath)
 	if err != nil {
 		return nil, fmt.Errorf("Deferring update failed: %w", errs.Join(err, ": "))
 	}

--- a/cmd/state-transition-update/main.go
+++ b/cmd/state-transition-update/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/ActiveState/cli/internal/appinfo"
@@ -12,7 +11,6 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/events"
-	"github.com/ActiveState/cli/internal/exeutils"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/machineid"
 	"github.com/ActiveState/cli/internal/osutils"
@@ -117,11 +115,6 @@ func run() error {
 
 	// if the transitional state tool has been replaced by the installer, we are done
 	if oldInfo.ModTime() != info.ModTime() {
-		return nil
-	}
-
-	stdout, _, err := exeutils.ExecSimple(appinfo.StateApp().Exec(), "__is_transitional")
-	if err != nil || strings.TrimSpace(stdout) != "true" {
 		return nil
 	}
 

--- a/cmd/state-transition-update/main.go
+++ b/cmd/state-transition-update/main.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/ActiveState/cli/internal/appinfo"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -90,9 +91,10 @@ func run() error {
 		return errs.Wrap(err, "failed to remove environment settings from old State Tool installation")
 	}
 
-	err = up.InstallBlocking()
+	installTargetPath := filepath.Dir(appinfo.StateApp().Exec())
+	err = up.InstallBlocking(installTargetPath)
 	if err != nil {
-		return errs.Wrap(err, "Failed to install mult-file update.")
+		return errs.Wrap(err, "Failed to install multi-file update.")
 	}
 
 	return nil

--- a/cmd/state-transition-update/remove_lin_mac.go
+++ b/cmd/state-transition-update/remove_lin_mac.go
@@ -1,0 +1,13 @@
+// +build linux darwin
+
+package main
+
+import (
+	"os"
+
+	"github.com/ActiveState/cli/internal/appinfo"
+)
+
+func removeSelf() error {
+	return os.Remove(appinfo.StateApp().Exec())
+}

--- a/cmd/state-transition-update/remove_windows.go
+++ b/cmd/state-transition-update/remove_windows.go
@@ -1,0 +1,21 @@
+// +build windows
+
+func removeSelf() error {
+	scriptName := "removePaths"
+	box := packr.NewBox("../../../assets/scripts/")
+	scriptBlock := box.String(fmt.Sprintf("%s.bat", scriptName))
+	sf, err := scriptfile.New(language.Batch, scriptName, scriptBlock)
+	if err != nil {
+		return locale.WrapError(err, "err_clean_script", "Could not create new scriptfile")
+	}
+
+	exe := appinfo.StateApp().Exec()
+
+	args := []string{"/C", sf.Filename(), logFile, fmt.Sprintf("%d", os.Getpid()), filepath.Base(exe), exe}
+	_, err = exeutils.ExecuteAndForget("cmd.exe", args)
+	if err != nil {
+		return locale.WrapError(err, "err_clean_start", "Could not start remove the transitional State Tool")
+	}
+
+	return nil
+}

--- a/cmd/state-transition-update/remove_windows.go
+++ b/cmd/state-transition-update/remove_windows.go
@@ -1,5 +1,22 @@
 // +build windows
 
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/ActiveState/cli/internal/appinfo"
+	"github.com/ActiveState/cli/internal/exeutils"
+	"github.com/ActiveState/cli/internal/language"
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/logging"
+	"github.com/ActiveState/cli/internal/scriptfile"
+	"github.com/gobuffalo/packr"
+)
+
 func removeSelf() error {
 	scriptName := "removePaths"
 	box := packr.NewBox("../../../assets/scripts/")
@@ -11,6 +28,13 @@ func removeSelf() error {
 
 	exe := appinfo.StateApp().Exec()
 
+	var logFile string = "remove-old-state.log"
+	logDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		logging.Error("Failed to create temporary dir for old State Tool removal-log file: %v", err)
+	} else {
+		logFile = filepath.Join(logDir, "remove-old-state.log")
+	}
 	args := []string{"/C", sf.Filename(), logFile, fmt.Sprintf("%d", os.Getpid()), filepath.Base(exe), exe}
 	_, err = exeutils.ExecuteAndForget("cmd.exe", args)
 	if err != nil {

--- a/cmd/state-transition-update/remove_windows.go
+++ b/cmd/state-transition-update/remove_windows.go
@@ -19,7 +19,7 @@ import (
 
 func removeSelf() error {
 	scriptName := "removePaths"
-	box := packr.NewBox("../../../assets/scripts/")
+	box := packr.NewBox("../../assets/scripts/")
 	scriptBlock := box.String(fmt.Sprintf("%s.bat", scriptName))
 	sf, err := scriptfile.New(language.Batch, scriptName, scriptBlock)
 	if err != nil {

--- a/cmd/state-update-dialog/bindings.go
+++ b/cmd/state-update-dialog/bindings.go
@@ -3,9 +3,11 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/ActiveState/cli/cmd/state-update-dialog/internal/lockedprj"
+	"github.com/ActiveState/cli/internal/appinfo"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -56,7 +58,8 @@ func (b *Bindings) Changelog() string {
 
 func (b *Bindings) Install() error {
 	logging.Debug("Bindings:Install called")
-	proc, err := b.update.InstallWithProgress(func(output string, done bool) {
+	installTargetPath := filepath.Dir(appinfo.StateApp().Exec())
+	proc, err := b.update.InstallWithProgress(installTargetPath, func(output string, done bool) {
 		b.installLog = b.installLog + "\n" + output
 		b.installDone = done
 	})

--- a/installers/legacy-install.ps1
+++ b/installers/legacy-install.ps1
@@ -16,6 +16,7 @@ param (
     ,[Parameter(Mandatory=$False)][switch]$n
     ,[Parameter(Mandatory=$False)][switch]$f
     ,[Parameter(Mandatory=$False)][string]$c
+    ,[Parameter(Mandatory=$True)][string]$v
     ,[Parameter(Mandatory=$False)][switch]$h
     ,[Parameter(Mandatory=$False)]
         [ValidateScript({[IO.Path]::GetExtension($_) -eq '.exe'})]
@@ -36,6 +37,7 @@ $script:TARGET = ($t).Trim()
 $script:STATEEXE = ($e).Trim()
 $script:STATE = $e.Substring(0, $e.IndexOf("."))
 $script:BRANCH = ($b).Trim()
+$script:VERSION = ($v).Trim()
 $script:POST_INSTALL_COMMAND = ($c).Trim()
 $script:ACTIVATE = ($activate).Trim()
 $script:ACTIVATE_DEFAULT = (${activate-default}).Trim()
@@ -196,14 +198,12 @@ function fetchArtifacts($downloadDir, $statejson, $statepkg) {
     Write-Host "Preparing for installation...`n"
 
     # Get version and checksum
-    $jsonurl = "$STATEURL/$script:BRANCH/$statejson"
-    Write-Host "Determining latest version...`n"
+    $jsonurl = "$STATEURL/$script:BRANCH/$script:VERSION/$statejson"
+    Write-Host "Fetching version info...`n"
     try{
-        $branchJson = ConvertFrom-Json -InputObject (download $jsonurl)
-        $latestVersion = $branchJson.Version
-        $versionedJson = ConvertFrom-Json -InputObject (download "$STATEURL/$script:BRANCH/$latestVersion/$statejson")
+        $versionedJson = ConvertFrom-Json -InputObject (download $jsonurl)
     } catch [System.Exception] {
-        Write-Warning "Unable to retrieve the latest version number from $STATEURL/$script:BRANCH/$latestVersion/$statejson"
+        Write-Warning "Unable to retrieve version info from $jsonurl"
         Write-Error $_.Exception.Message
         return 1
     }
@@ -216,8 +216,8 @@ function fetchArtifacts($downloadDir, $statejson, $statepkg) {
         Remove-Item $downloadDir -Recurse
     }
     New-Item -Path $downloadDir -ItemType Directory | Out-Null # There is output from this command, don't show the user.
-    $zipURL = "$STATEURL/$script:BRANCH/$latestVersion/$statepkg"
-    Write-Host "Fetching the latest version: $latestVersion...`n"
+    $zipURL = "$STATEURL/$script:BRANCH/$script:VERSION/$statepkg"
+    Write-Host "Fetching archive for version: $script:VERSION...`n"
     try{
         download $zipURL $zipPath
     } catch [System.Exception] {

--- a/installers/legacy-install.ps1
+++ b/installers/legacy-install.ps1
@@ -42,7 +42,7 @@ $script:POST_INSTALL_COMMAND = ($c).Trim()
 $script:ACTIVATE = ($activate).Trim()
 $script:ACTIVATE_DEFAULT = (${activate-default}).Trim()
 
-if ($script:VERSION == "") {
+if ($script:VERSION -eq "") {
   Write-Error "Please provide an argument for parameter '-v'. This installation script only installs specific State Tool versions."
   Write-Host "Use 'https://platform.activestate.com/dl/cli/install.ps1' to install the latest version of the State Tool."
   exit 1

--- a/installers/legacy-install.ps1
+++ b/installers/legacy-install.ps1
@@ -16,7 +16,7 @@ param (
     ,[Parameter(Mandatory=$False)][switch]$n
     ,[Parameter(Mandatory=$False)][switch]$f
     ,[Parameter(Mandatory=$False)][string]$c
-    ,[Parameter(Mandatory=$True)][string]$v
+    ,[Parameter(Mandatory=$False)][string]$v
     ,[Parameter(Mandatory=$False)][switch]$h
     ,[Parameter(Mandatory=$False)]
         [ValidateScript({[IO.Path]::GetExtension($_) -eq '.exe'})]
@@ -41,6 +41,12 @@ $script:VERSION = ($v).Trim()
 $script:POST_INSTALL_COMMAND = ($c).Trim()
 $script:ACTIVATE = ($activate).Trim()
 $script:ACTIVATE_DEFAULT = (${activate-default}).Trim()
+
+if ($script:VERSION == "") {
+  Write-Error "Please provide an argument for parameter '-v'. This installation script only installs specific State Tool versions."
+  Write-Host "Use 'https://platform.activestate.com/dl/cli/install.ps1' to install the latest version of the State Tool."
+  exit 1
+}
 
 # For recipe installation without prompts we need to be able to disable
 # prompots through an environment variable.

--- a/installers/legacy-install.sh
+++ b/installers/legacy-install.sh
@@ -186,7 +186,7 @@ if [ -n "$ACTIVATE" ] && [ -n "$ACTIVATE_DEFAULT" ]; then
 fi
 
 if [ -z "$VERSION" ]; then
-  error "A State Tool version needs to be specified with this installation script."
+  error "Please provide an argument for parameter '-v'. This installation script only installs specific State Tool versions."
   info "Use 'https://platform.activestate.com/dl/cli/install.sh' to install the latest version of the State Tool."
   exit 1
 fi

--- a/installers/legacy-install.sh
+++ b/installers/legacy-install.sh
@@ -18,6 +18,7 @@ Flags:
  --activate <project>            Activate a project when State Tool is correctly installed
  --activate-default <project>    Activate a project and make it the system default
  -h                              Show usage information (what you're currently reading)
+ -v <version-SHA>                The version of the State Tool to install
 EOF
 `
 
@@ -162,6 +163,9 @@ while getopts "nb:t:e:c:f?h-:" opt; do
   n)
     NOPROMPT=true
     ;;
+  v)
+    VERSION=$OPTARG
+    ;;
   h|?)
     echo "${USAGE}"
     exit 0
@@ -178,6 +182,12 @@ fi
 
 if [ -n "$ACTIVATE" ] && [ -n "$ACTIVATE_DEFAULT" ]; then
   error "Flags --activate and --activate-default cannot be set at the same time."
+  exit 1
+fi
+
+if [ -z "$VERSION" ]; then
+  error "A specific State Tool version needs to be specified with this installation script."
+  info "Use 'https://platform.activestate.com/dl/cli/install.sh' to install the latest version of the State Tool."
   exit 1
 fi
 
@@ -248,20 +258,21 @@ if [ -f $TMPDIR/$TMPEXE ]; then
 fi
 
 fetchArtifact () {
-  info "Determining latest version..."
+  info "Determining version info..."
   # Determine the latest version to fetch.
-  $FETCH $TMPDIR/$STATEJSON $STATEURL$STATEJSON || exit 1
-  VERSION=`cat $TMPDIR/$STATEJSON | grep -m 1 '"Version":' | awk '{print $2}' | tr -d '",'`
+  $FETCH $TMPDIR/$STATEJSON $STATEURL$VERSION$STATEJSON
+  if [ $? -ne 0 ]; then
+    error "Failed to fetch info for version $VERSION.  Please check that the version string is valid."
+  fi
   SUM=`cat $TMPDIR/$STATEJSON | grep -m 1 '"Sha256v2":' | awk '{print $2}' | tr -d '",'`
   rm $TMPDIR/$STATEJSON
 
-  if [ -z "$VERSION" ]; then
-    error "Unable to retrieve the latest version number"
-    exit 1
-  fi
-  info "Fetching the latest version: $VERSION..."
+  info "Fetching version: $VERSION..."
   # Fetch it.
-  $FETCH $TMPDIR/$STATEPKG ${STATEURL}${VERSION}/${STATEPKG} || exit 1
+  $FETCH $TMPDIR/$STATEPKG ${STATEURL}${VERSION}/${STATEPKG}
+  if [ $? -ne 0 ]; then
+    error "Failed to download the State Tool archive.  Please try again later."
+  fi
 
   # Extract the State binary after verifying its checksum.
   # Verify checksum.

--- a/installers/legacy-install.sh
+++ b/installers/legacy-install.sh
@@ -130,7 +130,7 @@ if [ -z "$TMPDIR" ]; then
 fi
 
 # Process command line arguments.
-while getopts "nb:t:e:c:f?h-:" opt; do
+while getopts "nb:t:e:c:v:f?h-:" opt; do
   case $opt in
   -)  # parse long options
     case ${OPTARG} in
@@ -186,7 +186,7 @@ if [ -n "$ACTIVATE" ] && [ -n "$ACTIVATE_DEFAULT" ]; then
 fi
 
 if [ -z "$VERSION" ]; then
-  error "A specific State Tool version needs to be specified with this installation script."
+  error "A State Tool version needs to be specified with this installation script."
   info "Use 'https://platform.activestate.com/dl/cli/install.sh' to install the latest version of the State Tool."
   exit 1
 fi
@@ -258,11 +258,12 @@ if [ -f $TMPDIR/$TMPEXE ]; then
 fi
 
 fetchArtifact () {
-  info "Determining version info..."
+  info "Fetching version info..."
   # Determine the latest version to fetch.
-  $FETCH $TMPDIR/$STATEJSON $STATEURL$VERSION$STATEJSON
+  $FETCH $TMPDIR/$STATEJSON $STATEURL$VERSION/$STATEJSON
   if [ $? -ne 0 ]; then
     error "Failed to fetch info for version $VERSION.  Please check that the version string is valid."
+    exit 1
   fi
   SUM=`cat $TMPDIR/$STATEJSON | grep -m 1 '"Sha256v2":' | awk '{print $2}' | tr -d '",'`
   rm $TMPDIR/$STATEJSON
@@ -272,6 +273,7 @@ fetchArtifact () {
   $FETCH $TMPDIR/$STATEPKG ${STATEURL}${VERSION}/${STATEPKG}
   if [ $? -ne 0 ]; then
     error "Failed to download the State Tool archive.  Please try again later."
+    exit 1
   fi
 
   # Extract the State binary after verifying its checksum.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -304,3 +304,9 @@ const ToplevelInstallArchiveDir = "state-install"
 
 // FirstMultiFileStateToolVersion is the State Tool version that introduced multi-file updates
 const FirstMultiFileStateToolVersion = "0.29.0"
+
+// OverwriteDefaultInstallationPath is the environment variable name to overwrite the default installation path FOR TESTING PURPOSES ONLY
+const OverwriteDefaultInstallationPathEnvVarName = "_TEST_INSTALL_PATH"
+
+// OverwriteDefaultSystemPathEnvVarName is the environment variable name to overwrite the system app installation directory updates FOR TESTING PURPOSES ONLY
+const OverwriteDefaultSystemPathEnvVarName = "_TEST_SYSTEM_PATH"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -306,7 +306,7 @@ const ToplevelInstallArchiveDir = "state-install"
 const FirstMultiFileStateToolVersion = "0.29.0"
 
 // OverwriteDefaultInstallationPath is the environment variable name to overwrite the default installation path FOR TESTING PURPOSES ONLY
-const OverwriteDefaultInstallationPathEnvVarName = "_TEST_INSTALL_PATH"
+const OverwriteDefaultInstallationPathEnvVarName = "ACTIVESTATE_TEST_INSTALL_PATH"
 
 // OverwriteDefaultSystemPathEnvVarName is the environment variable name to overwrite the system app installation directory updates FOR TESTING PURPOSES ONLY
-const OverwriteDefaultSystemPathEnvVarName = "_TEST_SYSTEM_PATH"
+const OverwriteDefaultSystemPathEnvVarName = "ACTIVESTATE_TEST_SYSTEM_PATH"

--- a/internal/installation/paths.go
+++ b/internal/installation/paths.go
@@ -15,6 +15,9 @@ func InstallPath() (string, error) {
 	if !rtutils.BuiltViaCI && strings.Contains(appinfo.StateApp().Exec(), "/build/") {
 		return filepath.Dir(appinfo.StateApp().Exec()), nil
 	}
+	if path, ok := os.LookupEnv("_TEST_INSTALL_PATH"); ok {
+		return path, nil
+	}
 	return defaultInstallPath()
 }
 

--- a/internal/installation/paths.go
+++ b/internal/installation/paths.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ActiveState/cli/internal/appinfo"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/rtutils"
 )
 
@@ -15,14 +16,14 @@ func InstallPath() (string, error) {
 	if !rtutils.BuiltViaCI && strings.Contains(appinfo.StateApp().Exec(), "/build/") {
 		return filepath.Dir(appinfo.StateApp().Exec()), nil
 	}
-	if path, ok := os.LookupEnv("_TEST_INSTALL_PATH"); ok {
+	if path, ok := os.LookupEnv(constants.OverwriteDefaultInstallationPathEnvVarName); ok {
 		return path, nil
 	}
 	return defaultInstallPath()
 }
 
 func LauncherInstallPath() (string, error) {
-	if path, ok := os.LookupEnv("_TEST_SYSTEM_PATH"); ok {
+	if path, ok := os.LookupEnv(constants.OverwriteDefaultSystemPathEnvVarName); ok {
 		return path, nil
 	}
 	return defaultSystemInstallPath()

--- a/internal/osutils/env_lin_mac.go
+++ b/internal/osutils/env_lin_mac.go
@@ -28,7 +28,8 @@ func CreateCurrentUserKey(path string) (RegistryKey, bool, error) {
 	panic("Not supported outside of Windows, this only exists to facilitate unit tests")
 }
 
-func PropagateEnv() {
+func PropagateEnv() error {
+	return nil
 }
 
 func SetStringValue(key RegistryKey, name string, valType uint32, value string) error {

--- a/internal/subshell/bash/bash.go
+++ b/internal/subshell/bash/bash.go
@@ -60,6 +60,28 @@ func (v *SubShell) WriteUserEnv(cfg sscommon.Configurable, env map[string]string
 	return sscommon.WriteRcFile("bashrc_append.sh", rcFile, envType, env)
 }
 
+func (v *SubShell) CleanUserEnv(cfg sscommon.Configurable, envType sscommon.RcIdentification, _ bool) error {
+	rcFile, err := v.RcFile()
+	if err != nil {
+		return errs.Wrap(err, "RcFile-failure")
+	}
+
+	if err := sscommon.CleanRcFile(rcFile, envType); err != nil {
+		return errs.Wrap(err, "Failed to remove %s from rcFile", envType)
+	}
+
+	return nil
+}
+
+func (v *SubShell) RemoveLegacyInstallPath(cfg sscommon.Configurable) error {
+	rcFile, err := v.RcFile()
+	if err != nil {
+		return errs.Wrap(err, "RcFile-failure")
+	}
+
+	return sscommon.RemoveLegacyInstallPath(rcFile)
+}
+
 func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	dir := "/usr/local/etc/bash_completion.d/"
 	if runtime.GOOS != "darwin" {

--- a/internal/subshell/cmd/cmd.go
+++ b/internal/subshell/cmd/cmd.go
@@ -90,6 +90,25 @@ func (v *SubShell) WriteUserEnv(cfg sscommon.Configurable, env map[string]string
 	return nil
 }
 
+func (v *SubShell) CleanUserEnv(cfg sscommon.Configurable, envType sscommon.RcIdentification, userScope bool) error {
+	cmdEnv := NewCmdEnv(userScope)
+
+	// Clean up old entries
+	oldEnv := cfg.GetStringMap(envType.Key)
+	for k, v := range oldEnv {
+		if err := cmdEnv.unset(k, v.(string)); err != nil {
+			return err
+		}
+	}
+
+	osutils.PropagateEnv()
+	return nil
+}
+
+func (v *SubShell) RemoveLegacyInstallPath(_ sscommon.Configurable) error {
+	return nil
+}
+
 func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	return locale.NewError("err_writecompletions_notsupported", "{{.V0}} does not support completions.", v.Shell())
 }

--- a/internal/subshell/cmd/cmd.go
+++ b/internal/subshell/cmd/cmd.go
@@ -86,7 +86,9 @@ func (v *SubShell) WriteUserEnv(cfg sscommon.Configurable, env map[string]string
 		}
 	}
 
-	osutils.PropagateEnv()
+	if err := osutils.PropagateEnv(); err != nil {
+		return errs.Wrap(err, "Sending OS signal to update environment failed.")
+	}
 	return nil
 }
 
@@ -101,7 +103,9 @@ func (v *SubShell) CleanUserEnv(cfg sscommon.Configurable, envType sscommon.RcId
 		}
 	}
 
-	osutils.PropagateEnv()
+	if err := osutils.PropagateEnv(); err != nil {
+		return errs.Wrap(err, "Sending OS signal to update environment failed.")
+	}
 	return nil
 }
 

--- a/internal/subshell/fish/fish.go
+++ b/internal/subshell/fish/fish.go
@@ -59,6 +59,28 @@ func (v *SubShell) WriteUserEnv(cfg sscommon.Configurable, env map[string]string
 	return sscommon.WriteRcFile("fishrc_append.fish", rcFile, envType, env)
 }
 
+func (v *SubShell) CleanUserEnv(cfg sscommon.Configurable, envType sscommon.RcIdentification, _ bool) error {
+	rcFile, err := v.RcFile()
+	if err != nil {
+		return errs.Wrap(err, "RcFile failure")
+	}
+
+	if err := sscommon.CleanRcFile(rcFile, envType); err != nil {
+		return errs.Wrap(err, "Failed to remove %s from rcFile", envType)
+	}
+
+	return nil
+}
+
+func (v *SubShell) RemoveLegacyInstallPath(cfg sscommon.Configurable) error {
+	rcFile, err := v.RcFile()
+	if err != nil {
+		return errs.Wrap(err, "RcFile-failure")
+	}
+
+	return sscommon.RemoveLegacyInstallPath(rcFile)
+}
+
 func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	homeDir, err := fileutils.HomeDir()
 	if err != nil {

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -67,7 +67,7 @@ func WriteRcFile(rcTemplateName string, path string, data RcIdentification, env 
 		"Env":   env,
 	}
 
-	if err := cleanRcFile(path, data); err != nil {
+	if err := CleanRcFile(path, data); err != nil {
 		return err
 	}
 
@@ -95,7 +95,7 @@ func WriteRcData(data string, path string, identification RcIdentification) erro
 		return err
 	}
 
-	if err := cleanRcFile(path, identification); err != nil {
+	if err := CleanRcFile(path, identification); err != nil {
 		return err
 	}
 
@@ -104,9 +104,36 @@ func WriteRcData(data string, path string, identification RcIdentification) erro
 	return fileutils.AppendToFile(path, []byte(fileutils.LineEnd+data))
 }
 
-func cleanRcFile(path string, data RcIdentification) error {
+// RemoveLegacyInstallPath removes the PATH modification statement from the s
+func RemoveLegacyInstallPath(path string) error {
 	readFile, err := os.Open(path)
+	if err != nil {
+		return errs.Wrap(err, "IO failure")
+	}
 
+	scanner := bufio.NewScanner(readFile)
+	scanner.Split(bufio.ScanLines)
+
+	var fileContents []string
+	for scanner.Scan() {
+		text := scanner.Text()
+
+		if strings.Contains(text, "# ActiveState State Tool") {
+			continue
+		}
+
+		// Rebuild file contents
+		fileContents = append(fileContents, scanner.Text())
+	}
+	if err := readFile.Close(); err != nil {
+		return errs.Wrap(err, "failed to close %s", path)
+	}
+
+	return fileutils.WriteFile(path, []byte(strings.Join(fileContents, fileutils.LineEnd)))
+}
+
+func CleanRcFile(path string, data RcIdentification) error {
+	readFile, err := os.Open(path)
 	if err != nil {
 		return errs.Wrap(err, "IO failure")
 	}

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -104,7 +104,7 @@ func WriteRcData(data string, path string, identification RcIdentification) erro
 	return fileutils.AppendToFile(path, []byte(fileutils.LineEnd+data))
 }
 
-// RemoveLegacyInstallPath removes the PATH modification statement from the s
+// RemoveLegacyInstallPath removes the PATH modification statement added to the shell-rc file by the legacy install script
 func RemoveLegacyInstallPath(path string) error {
 	readFile, err := os.Open(path)
 	if err != nil {
@@ -118,6 +118,7 @@ func RemoveLegacyInstallPath(path string) error {
 	for scanner.Scan() {
 		text := scanner.Text()
 
+		// remove lines with marker added by legacy install script
 		if strings.Contains(text, "# ActiveState State Tool") {
 			continue
 		}

--- a/internal/subshell/subshell.go
+++ b/internal/subshell/subshell.go
@@ -52,6 +52,12 @@ type SubShell interface {
 	// WriteUserEnv writes the given env map to the users environment
 	WriteUserEnv(sscommon.Configurable, map[string]string, sscommon.RcIdentification, bool) error
 
+	// CleanUserEnv removes the environment setting identified
+	CleanUserEnv(sscommon.Configurable, sscommon.RcIdentification, bool) error
+
+	// RemoveLegacyInstallPath removes the install path added to shell configuration by the legacy install scripts
+	RemoveLegacyInstallPath(sscommon.Configurable) error
+
 	// WriteCompletionScript writes the completions script for the current shell
 	WriteCompletionScript(string) error
 

--- a/internal/subshell/tcsh/tcsh.go
+++ b/internal/subshell/tcsh/tcsh.go
@@ -58,6 +58,28 @@ func (v *SubShell) WriteUserEnv(cfg sscommon.Configurable, env map[string]string
 	return sscommon.WriteRcFile("tcshrc_append.sh", rcFile, envType, env)
 }
 
+func (v *SubShell) CleanUserEnv(cfg sscommon.Configurable, envType sscommon.RcIdentification, _ bool) error {
+	rcFile, err := v.RcFile()
+	if err != nil {
+		return errs.Wrap(err, "RcFile failure")
+	}
+
+	if err := sscommon.CleanRcFile(rcFile, envType); err != nil {
+		return errs.Wrap(err, "Failed to remove %s from rcFile", envType)
+	}
+
+	return nil
+}
+
+func (v *SubShell) RemoveLegacyInstallPath(cfg sscommon.Configurable) error {
+	rcFile, err := v.RcFile()
+	if err != nil {
+		return errs.Wrap(err, "RcFile-failure")
+	}
+
+	return sscommon.RemoveLegacyInstallPath(rcFile)
+}
+
 func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	return locale.NewError("err_writecompletions_notsupported", "{{.V0}} does not support completions.", v.Shell())
 }

--- a/internal/subshell/zsh/zsh.go
+++ b/internal/subshell/zsh/zsh.go
@@ -65,6 +65,28 @@ func (v *SubShell) WriteUserEnv(cfg sscommon.Configurable, env map[string]string
 	return sscommon.WriteRcFile("zshrc_append.sh", rcFile, envType, env)
 }
 
+func (v *SubShell) CleanUserEnv(cfg sscommon.Configurable, envType sscommon.RcIdentification, _ bool) error {
+	rcFile, err := v.RcFile()
+	if err != nil {
+		return errs.Wrap(err, "RcFile failure")
+	}
+
+	if err := sscommon.CleanRcFile(rcFile, envType); err != nil {
+		return errs.Wrap(err, "Failed to remove %s from rcFile", envType)
+	}
+
+	return nil
+}
+
+func (v *SubShell) RemoveLegacyInstallPath(cfg sscommon.Configurable) error {
+	rcFile, err := v.RcFile()
+	if err != nil {
+		return errs.Wrap(err, "RcFile-failure")
+	}
+
+	return sscommon.RemoveLegacyInstallPath(rcFile)
+}
+
 func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	dir := "/usr/local/share/zsh/site-functions"
 	if fpath := os.Getenv("FPATH"); fpath != "" {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -83,17 +83,17 @@ func (u *AvailableUpdate) InstallBlocking(installTargetPath string) error {
 	if installTargetPath != "" {
 		args = append(args, installTargetPath)
 	}
-	_, _, err = exeutils.ExecuteAndPipeStd(installerPath, args, []string{})
+	stdout, stderr, err := exeutils.ExecuteAndPipeStd(installerPath, args, []string{})
 	if err != nil {
-		return errs.Wrap(err, "Could not run installer")
+		return errs.Wrap(err, "Could not run installer, stdout=%s\nstderr=%s\n", stdout, stderr)
 	}
 
 	return nil
 }
 
 // InstallWithProgress will fetch the update and run its installer
-func (u *AvailableUpdate) InstallWithProgress(progressCb func(string, bool)) (*os.Process, error) {
-	installerPath, installTargetPath, err := u.prepare()
+func (u *AvailableUpdate) InstallWithProgress(installTargetPath string, progressCb func(string, bool)) (*os.Process, error) {
+	installerPath, err := u.prepare()
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not download update")
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -83,9 +83,9 @@ func (u *AvailableUpdate) InstallBlocking(installTargetPath string) error {
 	if installTargetPath != "" {
 		args = append(args, installTargetPath)
 	}
-	stdout, stderr, err := exeutils.ExecuteAndPipeStd(installerPath, args, []string{})
+	_, _, err = exeutils.ExecuteAndPipeStd(installerPath, args, []string{})
 	if err != nil {
-		return errs.Wrap(err, "Could not run installer, stdout=%s\nstderr=%s\n", stdout, stderr)
+		return errs.Wrap(err, "Could not run installer")
 	}
 
 	return nil

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/ActiveState/cli/internal/appinfo"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/exeutils"
@@ -37,33 +36,36 @@ func NewAvailableUpdate(version, channel, platform, path, sha256 string) *Availa
 
 const InstallerName = "state-installer" + osutils.ExeExt
 
-func (u *AvailableUpdate) prepare() (string, string, error) {
+func (u *AvailableUpdate) prepare() (string, error) {
 	tmpDir, err := ioutil.TempDir("", "state-update")
 	if err != nil {
-		return "", "", errs.Wrap(err, "Could not create temp dir")
+		return "", errs.Wrap(err, "Could not create temp dir")
 	}
 
 	if err := NewFetcher().Fetch(u, tmpDir); err != nil {
-		return "", "", errs.Wrap(err, "Could not download and unpack update")
+		return "", errs.Wrap(err, "Could not download and unpack update")
 	}
 
 	installerPath := filepath.Join(tmpDir, constants.ToplevelInstallArchiveDir, InstallerName)
 	if !fileutils.FileExists(installerPath) {
-		return "", "", errs.Wrap(err, "Downloaded update does not have installer")
+		return "", errs.Wrap(err, "Downloaded update does not have installer")
 	}
 
-	installTargetPath := filepath.Dir(appinfo.StateApp().Exec())
-
-	return installerPath, installTargetPath, nil
+	return installerPath, nil
 }
 
 // InstallDeferred will fetch the update and run its installer in a deferred process
-func (u *AvailableUpdate) InstallDeferred() (*os.Process, error) {
-	installerPath, installTargetPath, err := u.prepare()
+func (u *AvailableUpdate) InstallDeferred(installTargetPath string) (*os.Process, error) {
+	installerPath, err := u.prepare()
 	if err != nil {
 		return nil, err
 	}
-	proc, err := exeutils.ExecuteAndForget(installerPath, []string{installTargetPath})
+
+	var args []string
+	if installTargetPath != "" {
+		args = append(args, installTargetPath)
+	}
+	proc, err := exeutils.ExecuteAndForget(installerPath, args)
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not start installer")
 	}
@@ -71,13 +73,17 @@ func (u *AvailableUpdate) InstallDeferred() (*os.Process, error) {
 	return proc, nil
 }
 
-func (u *AvailableUpdate) InstallBlocking() error {
-	installerPath, installTargetPath, err := u.prepare()
+func (u *AvailableUpdate) InstallBlocking(installTargetPath string) error {
+	installerPath, err := u.prepare()
 	if err != nil {
 		return err
 	}
 
-	_, _, err = exeutils.ExecuteAndPipeStd(installerPath, []string{installTargetPath}, []string{})
+	var args []string
+	if installTargetPath != "" {
+		args = append(args, installTargetPath)
+	}
+	_, _, err = exeutils.ExecuteAndPipeStd(installerPath, args, []string{})
 	if err != nil {
 		return errs.Wrap(err, "Could not run installer")
 	}

--- a/pkg/platform/model/svc.go
+++ b/pkg/platform/model/svc.go
@@ -40,7 +40,7 @@ func (m *SvcModel) StateVersion() (*graph.Version, error) {
 
 func (m *SvcModel) LocalProjects() ([]*graph.Project, error) {
 	r := request.NewLocalProjectsRequest()
-	response := graph.ProjectsResponse{[]*graph.Project{}}
+	response := graph.ProjectsResponse{Projects: []*graph.Project{}}
 	if err := m.client.RunWithContext(m.ctx, r, &response); err != nil {
 		return nil, err
 	}

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -202,7 +202,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallShInstallMulti
 	}
 	suite.OnlyRunForTags(tagsuite.InstallScripts, tagsuite.Critical)
 
-	ts := e2e.New(suite.T(), true)
+	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
 	script := scriptPath(suite.T(), ts.Dirs.Work, true, true)
@@ -219,7 +219,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallShInstallMulti
 	cp.Expect("State Tool Installed")
 	cp.ExpectExitCode(0)
 
-	// Note: When updating from an old update, we always installing to the default installation path.
+	// Note: When updating from an old update, we always install to the default installation path.
 	// The default installation path is set to <ts.Dirs.Work>/multi-file for this test.
 	suite.NoFileExists(filepath.Join(ts.Dirs.Work, "state"))
 	suite.FileExists(filepath.Join(ts.Dirs.Work, "multi-file", "state-svc"))

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -122,8 +122,8 @@ func expectLegacyStateToolInstallation(cp *termtest.ConsoleProcess, addToPathAns
 	cp.Expect("Installing to")
 	cp.Expect("Continue?")
 	cp.SendLine("y")
-	cp.Expect("Fetching the latest version")
-	cp.Expect("Allow $PATH to be appended in your")
+	cp.Expect("Fetching version info")
+	cp.Expect("Allow $PATH to be appended in your", 20*time.Second)
 	cp.SendLine(addToPathAnswer)
 	cp.Expect("State Tool installation complete")
 }
@@ -187,6 +187,9 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallSh() {
 	script := scriptPath(suite.T(), ts.Dirs.Work, true, false)
 
 	cp := ts.SpawnCmdWithOpts("bash", e2e.WithArgs(script, "-t", ts.Dirs.Work))
+	cp.Expect("A State Tool version needs to be specified")
+	cp.ExpectExitCode(1)
+	cp = ts.SpawnCmdWithOpts("bash", e2e.WithArgs(script, "-t", ts.Dirs.Work, "-v", oldReleaseUpdateVersion))
 	expectLegacyStateToolInstallation(cp, "n")
 	cp.Expect("State Tool Installed")
 	cp.ExpectExitCode(0)

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -212,7 +212,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallShInstallMulti
 		e2e.WithArgs(script, "-t", ts.Dirs.Work, "-b", constants.BranchName, "-v", constants.Version),
 		e2e.AppendEnv(
 			fmt.Sprintf("_TEST_UPDATE_URL=http://localhost:%s/", testPort),
-			fmt.Sprintf("_TEST_INSTALL_PATH=%s", filepath.Join(ts.Dirs.Work, "multi-file")),
+			fmt.Sprintf("%s=%s", constants.OverwriteDefaultInstallationPathEnvVarName, filepath.Join(ts.Dirs.Work, "multi-file")),
 		))
 
 	expectLegacyStateToolInstallation(cp, "n")
@@ -544,7 +544,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallPs1MultiFileUp
 		e2e.AppendEnv(
 			"SHELL=",
 			fmt.Sprintf("_TEST_UPDATE_URL=http://localhost:%s/", testPort),
-			fmt.Sprintf("_TEST_INSTALL_PATH=%s", filepath.Join(ts.Dirs.Work, "multi-file")),
+			fmt.Sprintf("%s=%s", constants.OverwriteDefaultInstallationPathEnvVarName, filepath.Join(ts.Dirs.Work, "multi-file")),
 		))
 
 	expectLegacyStateToolInstallationWindows(cp)

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -160,7 +160,7 @@ func expectLegacyStateToolInstallationWindows(cp *termtest.ConsoleProcess) {
 	cp.Expect("Installing to")
 	cp.Expect("Continue?")
 	cp.SendLine("y")
-	cp.Expect("Fetching the latest version")
+	cp.Expect("Fetching version info")
 	cp.Expect("State Tool successfully installed to")
 }
 
@@ -502,7 +502,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallPs1() {
 	}()
 
 	cp := ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(script, "-t", ts.Dirs.Work), e2e.AppendEnv("SHELL="))
-	cp.Expect("Please provide an argument for parameter '-v'")
+	cp.ExpectLongString("Please provide an argument for parameter '-v'")
 	cp.ExpectExitCode(1)
 
 	cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(script, "-t", ts.Dirs.Work, "-v", oldReleaseUpdateVersion), e2e.AppendEnv("SHELL="))
@@ -558,6 +558,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallPs1MultiFileUp
 	// Note: When updating from an old update, we always installing to the default installation path.
 	// The default installation path is set to <ts.Dirs.Work>/multi-file for this test.
 	suite.NoFileExists(filepath.Join(ts.Dirs.Work, "state.exe"))
+	suite.FileExists(filepath.Join(ts.Dirs.Work, "multi-file", "state.exe"))
 	suite.FileExists(filepath.Join(ts.Dirs.Work, "multi-file", "state-svc.exe"))
 	suite.FileExists(filepath.Join(ts.Dirs.Work, "multi-file", "state-tray.exe"))
 }

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -555,7 +555,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallPs1MultiFileUp
 	paths := strings.Split(pathEnv, string(os.PathListSeparator))
 	suite.Assert().Contains(paths, ts.Dirs.Work, "Could not find installation path, output: %s", cp.TrimmedSnapshot())
 
-	// Note: When updating from an old update, we always installing to the default installation path.
+	// Note: When updating from an old update, we always install to the default installation path.
 	// The default installation path is set to <ts.Dirs.Work>/multi-file for this test.
 	suite.NoFileExists(filepath.Join(ts.Dirs.Work, "state.exe"))
 	suite.FileExists(filepath.Join(ts.Dirs.Work, "multi-file", "state.exe"))

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -187,7 +187,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallSh() {
 	script := scriptPath(suite.T(), ts.Dirs.Work, true, false)
 
 	cp := ts.SpawnCmdWithOpts("bash", e2e.WithArgs(script, "-t", ts.Dirs.Work))
-	cp.Expect("A State Tool version needs to be specified")
+	cp.Expect("Please provide an argument for parameter '-v'")
 	cp.ExpectExitCode(1)
 
 	cp = ts.SpawnCmdWithOpts("bash", e2e.WithArgs(script, "-t", ts.Dirs.Work, "-v", oldReleaseUpdateVersion))
@@ -502,7 +502,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallPs1() {
 	}()
 
 	cp := ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(script, "-t", ts.Dirs.Work), e2e.AppendEnv("SHELL="))
-	cp.Expect("Supply values for the following parameters")
+	cp.Expect("Please provide an argument for parameter '-v'")
 	cp.ExpectExitCode(1)
 
 	cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(script, "-t", ts.Dirs.Work, "-v", oldReleaseUpdateVersion), e2e.AppendEnv("SHELL="))

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -502,6 +502,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestLegacyInstallPs1() {
 	}()
 
 	cp := ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(script, "-t", ts.Dirs.Work), e2e.AppendEnv("SHELL="))
+	cp.Expect("Supply values for the following parameters")
 	cp.ExpectExitCode(1)
 
 	cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(script, "-t", ts.Dirs.Work, "-v", oldReleaseUpdateVersion), e2e.AppendEnv("SHELL="))

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -41,6 +41,7 @@ type matcherFunc func(expected interface{}, actual interface{}, msgAndArgs ...in
 var targetBranch = "beta"
 var testBranch = "test-channel"
 var oldUpdateVersion = "beta@0.28.1-SHA8592c6a"
+var oldReleaseUpdateVersion = "0.28.2-SHAbdac00e"
 var specificVersion = "0.29.0-SHA9f570a0"
 
 func init() {

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -94,7 +94,7 @@ func (suite *UpdateIntegrationTestSuite) env(disableUpdates, testUpdate bool) []
 
 	dir, err := ioutil.TempDir("", "system*")
 	suite.NoError(err)
-	env = append(env, fmt.Sprintf("_TEST_SYSTEM_PATH=%s", dir))
+	env = append(env, fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir))
 
 	return env
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178254157

I finally realized that all the cleanup can be done in the transitional state tool, as it is called if and only if we are updating from a single-file State Tool to our new State Tool distribution.