### PR TITLE
Auth logout fix

### DIFF
--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ActiveState/cli/internal/machineid"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/output"
-	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/panics"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/rollbar/rollbar-go"
@@ -29,7 +29,7 @@ import (
 func main() {
 	var exitCode int
 	defer func() {
-		if runbits.HandlePanics() {
+		if panics.HandlePanics() {
 			exitCode = 1
 		}
 		events.WaitForEvents(1*time.Second, rollbar.Close)

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/events"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/panics"
 	"github.com/rollbar/rollbar-go"
 )
 
@@ -35,7 +35,7 @@ var commands = []command{
 func main() {
 	var exitCode int
 	defer func() {
-		if runbits.HandlePanics() {
+		if panics.HandlePanics() {
 			exitCode = 1
 		}
 		events.WaitForEvents(1*time.Second, rollbar.Close)

--- a/cmd/state-transition-update/main.go
+++ b/cmd/state-transition-update/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/machineid"
 	"github.com/ActiveState/cli/internal/osutils"
-	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/panics"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/internal/updater"
@@ -24,7 +24,7 @@ import (
 func main() {
 	var exitCode int
 	defer func() {
-		if runbits.HandlePanics() {
+		if panics.HandlePanics() {
 			exitCode = 1
 		}
 		events.WaitForEvents(1*time.Second, rollbar.Close)

--- a/cmd/state-tray/main.go
+++ b/cmd/state-tray/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils/autostart"
-	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/panics"
 	"github.com/ActiveState/cli/internal/svcmanager"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/getlantern/systray"
@@ -44,7 +44,7 @@ func main() {
 func onReady() {
 	var exitCode int
 	defer func() {
-		if runbits.HandlePanics() {
+		if panics.HandlePanics() {
 			exitCode = 1
 		}
 		events.WaitForEvents(1*time.Second, rollbar.Close)

--- a/cmd/state-update-dialog/main.go
+++ b/cmd/state-update-dialog/main.go
@@ -11,14 +11,14 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/events"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/panics"
 	"github.com/rollbar/rollbar-go"
 )
 
 func main() {
 	var exitCode int
 	defer func() {
-		if runbits.HandlePanics() {
+		if panics.HandlePanics() {
 			exitCode = 1
 		}
 		events.WaitForEvents(1*time.Second, rollbar.Close)

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/panics"
 	"github.com/ActiveState/cli/internal/svcmanager"
 	"github.com/ActiveState/sysinfo"
 	"github.com/rollbar/rollbar-go"
@@ -44,7 +44,7 @@ func main() {
 
 	defer func() {
 		// Handle panics gracefully, and ensure that we exit with non-zero code
-		if runbits.HandlePanics() {
+		if panics.HandlePanics() {
 			exitCode = 1
 		}
 

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -229,7 +229,6 @@ func sendEventAndLog(category, action, label string, dimensions map[string]strin
 
 func sendEvent(category, action, label string, dimensions map[string]string) error {
 	if deferAnalytics {
-		// TODO: figure out a way to pass configuration
 		cfg, err := config.Get()
 		if err != nil {
 			return locale.WrapError(err, "config_get_error")

--- a/internal/runbits/panics/panics.go
+++ b/internal/runbits/panics/panics.go
@@ -1,4 +1,4 @@
-package runbits
+package panics
 
 import (
 	"fmt"

--- a/test/integration/auth_int_test.go
+++ b/test/integration/auth_int_test.go
@@ -59,7 +59,7 @@ func (suite *AuthIntegrationTestSuite) interactiveLogin(ts *e2e.Session, usernam
 func (suite *AuthIntegrationTestSuite) loginFlags(ts *e2e.Session, username string) {
 	cp := ts.Spawn("auth", "--username", username, "--password", "bad-password")
 	cp.Expect("Authentication failed")
-	cp.Expect("You are not authorized, did you provide valid login credentials?")
+	cp.ExpectLongString("You are not authorized, did you provide valid login credentials?")
 	cp.ExpectExitCode(1)
 }
 
@@ -80,7 +80,7 @@ func (suite *AuthIntegrationTestSuite) authOutput(method string) {
 	user := userJSON{
 		Username:        "cli-integration-tests",
 		URLName:         "cli-integration-tests",
-		Tier:            "free",
+		Tier:            "free_legacy",
 		PrivateProjects: false,
 	}
 	data, err := json.Marshal(user)

--- a/test/integration/auth_int_test.go
+++ b/test/integration/auth_int_test.go
@@ -62,6 +62,12 @@ func (suite *AuthIntegrationTestSuite) loginFlags(ts *e2e.Session, username stri
 	cp.ExpectExitCode(1)
 }
 
+func (suite *AuthIntegrationTestSuite) ensureLogout(ts *e2e.Session) {
+	cp := ts.Spawn("auth")
+	cp.Expect("username:")
+	cp.SendCtrlC()
+}
+
 type userJSON struct {
 	Username        string `json:"username,omitempty"`
 	URLName         string `json:"urlname,omitempty"`

--- a/test/integration/auth_int_test.go
+++ b/test/integration/auth_int_test.go
@@ -38,6 +38,7 @@ func (suite *AuthIntegrationTestSuite) TestAuth() {
 	suite.interactiveLogin(ts, username)
 	ts.LogoutUser()
 	suite.loginFlags(ts, username)
+	suite.ensureLogout(ts)
 }
 
 func (suite *AuthIntegrationTestSuite) interactiveLogin(ts *e2e.Session, username string) {

--- a/test/integration/komodo_int_test.go
+++ b/test/integration/komodo_int_test.go
@@ -33,7 +33,7 @@ func (suite *AuthIntegrationTestSuite) TestAuth_EditorV0() {
 	user := userJSON{
 		Username: "cli-integration-tests",
 		URLName:  "cli-integration-tests",
-		Tier:     "free",
+		Tier:     "free_legacy",
 	}
 	data, err := json.Marshal(user)
 	suite.Require().NoError(err)
@@ -121,7 +121,7 @@ func (suite *OrganizationsIntegrationTestSuite) TestOrganizations_EditorV0() {
 	}{
 		"Test-Organization",
 		"Test-Organization",
-		"free",
+		"free_legacy",
 		false,
 	}
 

--- a/test/integration/vscode_int_test.go
+++ b/test/integration/vscode_int_test.go
@@ -97,7 +97,7 @@ func (suite *PushIntegrationTestSuite) TestOrganizations_VSCode() {
 	}{
 		"Test-Organization",
 		"Test-Organization",
-		"free",
+		"free_legacy",
 		false,
 	}
 

--- a/test/integration/vscode_int_test.go
+++ b/test/integration/vscode_int_test.go
@@ -112,7 +112,7 @@ func (suite *AuthIntegrationTestSuite) TestAuth_VSCode() {
 	user := userJSON{
 		Username: "cli-integration-tests",
 		URLName:  "cli-integration-tests",
-		Tier:     "free",
+		Tier:     "free_legacy",
 	}
 	data, err := json.Marshal(user)
 	suite.Require().NoError(err)


### PR DESCRIPTION
Through the imports of `state-svc` the `init` function from the `analytics` package is being called. This leads to an `authentication.Get` call however the configuration at that point is not up to date. For a more detailed explanation see here: https://www.pivotaltracker.com/story/show/178440926/comments/224797191. 

From tracing the import chain it was the `runbits` package that imports `analytics`. Moving the `HandlePanics` function to its own package fixed the log out bug in my testing.

Filed a follow-up story here: https://www.pivotaltracker.com/story/show/178529229 to remove the `init` function from the `analytics` package.

https://www.pivotaltracker.com/story/show/178440926