### PR TITLE
Do not overwrite PYTHONPATH on darwin

### DIFF
--- a/pkg/platform/runtime/setup/implementations/camel/artifact.go
+++ b/pkg/platform/runtime/setup/implementations/camel/artifact.go
@@ -97,6 +97,15 @@ func convertToEnvVars(metadata *MetaData) []envdef.EnvironmentVariable {
 			Inherit: false,
 		})
 	}
+	for k, v := range metadata.PathListEnv {
+		res = append(res, envdef.EnvironmentVariable{
+			Name:      k,
+			Values:    []string{v},
+			Join:      envdef.Prepend,
+			Separator: string(os.PathListSeparator),
+			Inherit:   true,
+		})
+	}
 	var binPaths []string
 
 	// set up PATH according to binary locations

--- a/pkg/platform/runtime/setup/implementations/camel/metadata.go
+++ b/pkg/platform/runtime/setup/implementations/camel/metadata.go
@@ -35,7 +35,7 @@ type MetaData struct {
 	// Env is a key value map containing all the env vars, values can contain the RelocationDir value (which will be replaced)
 	Env map[string]string `json:"env"`
 
-	// Env is a key value map containing all env vars, where the value is a list of paths that we have to prepend to the existing environment
+	// PathListEnv is a key value map containing all env vars, where the value is a list of paths that we have to prepend to the existing environment
 	PathListEnv map[string]string `json:"path_list_env"`
 
 	// BinaryLocations are locations that we should add to the PATH

--- a/pkg/platform/runtime/setup/implementations/camel/metadata.go
+++ b/pkg/platform/runtime/setup/implementations/camel/metadata.go
@@ -35,6 +35,9 @@ type MetaData struct {
 	// Env is a key value map containing all the env vars, values can contain the RelocationDir value (which will be replaced)
 	Env map[string]string `json:"env"`
 
+	// Env is a key value map containing all env vars, where the value is a list of paths that we have to prepend to the existing environment
+	PathListEnv map[string]string `json:"path_list_env"`
+
 	// BinaryLocations are locations that we should add to the PATH
 	BinaryLocations []MetaDataBinary `json:"binaries_in"`
 
@@ -79,6 +82,10 @@ func InitMetaData(rootDir string) (*MetaData, error) {
 
 	if metaData.Env == nil {
 		metaData.Env = map[string]string{}
+	}
+
+	if metaData.PathListEnv == nil {
+		metaData.PathListEnv = map[string]string{}
 	}
 
 	var relInstallDir string

--- a/pkg/platform/runtime/setup/implementations/camel/prepare_mac.go
+++ b/pkg/platform/runtime/setup/implementations/camel/prepare_mac.go
@@ -4,7 +4,6 @@ package camel
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 
@@ -53,7 +52,7 @@ func (m *MetaData) Prepare(installRoot string) error {
 	}
 
 	if fileutils.DirExists(sitePackages) {
-		m.Env["PYTHONPATH"] = m.Env["PYTHONPATH"] + string(os.PathListSeparator) + sitePackages
+		m.PathListEnv["PYTHONPATH"] = sitePackages
 	}
 
 	if m.TargetedRelocations == nil {

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -158,6 +158,7 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 	cp := ts.SpawnWithOpts(
 		e2e.WithArgs("activate", namespace),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.AppendEnv("PYTHONPATH=/custom_pythonpath"),
 		e2e.AppendEnv(extraEnv...),
 	)
 	cp.Expect("Where would you like to place")
@@ -207,6 +208,10 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 	pipVersionMatch := pipVersionRe.FindStringSubmatch(cp.TrimmedSnapshot())
 	suite.Require().Len(pipVersionMatch, 2, "expected pip version to match")
 	suite.Contains(pipVersionMatch[1], "cache", "pip loaded from activestate cache dir")
+
+	// test that PYTHONPATH is preserved in environment (https://www.pivotaltracker.com/story/show/178458102)
+	cp.SendLine(fmt.Sprintf(`%s -c 'import os; print(os.environ["PYTHONPATH"]);'`, pythonExe))
+	cp.Expect("/custom_pythonpath")
 
 	// de-activate shell
 	cp.SendLine("exit")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178458102

Other than "PATH", camel builds do not set any environment variables that could be prepended to an already defined variable.  All use-cases, are usually handled via relocation.  The `PYTHONPATH` that the State Tool sets in `prepare_mac.go`appears to be the only exception to this rule.

For alternative builds, the use case can be properly handled on the build side, via the environment definition files.