### PR TITLE
Update default language versions

### DIFF
--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -86,7 +86,7 @@ var lookup = [...]languageData{
 		Executable{"powershell.exe", true},
 	},
 	{
-		"perl", "Perl", ".pl", true, "perl", "5.28.1",
+		"perl", "Perl", ".pl", true, "perl", "5.28.3",
 		Executable{constants.ActivePerlExecutable, false},
 	},
 	{
@@ -94,7 +94,7 @@ var lookup = [...]languageData{
 		Executable{constants.ActivePython2Executable, false},
 	},
 	{
-		"python3", "Python 3", ".py", true, "python", "3.6.6",
+		"python3", "Python 3", ".py", true, "python", "3.8.10",
 		Executable{constants.ActivePython3Executable, false},
 	},
 }


### PR DESCRIPTION
When users don't specify a language version for Perl or Python, default to the latest non-beta version we have.