### PR TITLE
state clean uses --force flag only

### DIFF
--- a/cmd/state/internal/cmdtree/clean.go
+++ b/cmd/state/internal/cmdtree/clean.go
@@ -38,11 +38,6 @@ func newCleanUninstallCommand(prime *primer.Values) *captain.Command {
 				Description: locale.T("flag_state_clean_uninstall_force_description"),
 				Value:       &params.Force,
 			},
-			{
-				Name:        "ignore-errors",
-				Description: locale.T("flag_state_clean_ignore_errors_description"),
-				Value:       &params.IgnoreErrors,
-			},
 		},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {
@@ -71,11 +66,6 @@ func newCleanCacheCommand(prime *primer.Values) *captain.Command {
 				Shorthand:   "f",
 				Description: locale.T("flag_state_clean_cache_force_description"),
 				Value:       &params.Force,
-			},
-			{
-				Name:        "ignore-errors",
-				Description: locale.T("flag_state_clean_ignore_errors_description"),
-				Value:       &params.IgnoreErrors,
 			},
 		},
 		[]*captain.Argument{
@@ -107,11 +97,6 @@ func newCleanConfigCommand(prime *primer.Values) *captain.Command {
 				Shorthand:   "f",
 				Description: locale.T("flag_state_config_cache_force_description"),
 				Value:       &params.Force,
-			},
-			{
-				Name:        "ignore-errors",
-				Description: locale.T("flag_state_clean_ignore_errors_description"),
-				Value:       &params.IgnoreErrors,
 			},
 		},
 		[]*captain.Argument{},

--- a/internal/runners/clean/cache.go
+++ b/internal/runners/clean/cache.go
@@ -20,9 +20,8 @@ type Cache struct {
 }
 
 type CacheParams struct {
-	Force        bool
-	IgnoreErrors bool
-	Project      string
+	Force   bool
+	Project string
 }
 
 func NewCache(prime primeable) *Cache {
@@ -43,7 +42,7 @@ func (c *Cache) Run(params *CacheParams) error {
 		return locale.NewError("err_clean_cache_activated")
 	}
 
-	if err := stopServices(c.config, c.output, params.IgnoreErrors); err != nil {
+	if err := stopServices(c.config, c.output, params.Force); err != nil {
 		return errs.Wrap(err, "Failed to stop services.")
 	}
 

--- a/internal/runners/clean/config.go
+++ b/internal/runners/clean/config.go
@@ -27,8 +27,7 @@ type Config struct {
 }
 
 type ConfigParams struct {
-	Force        bool
-	IgnoreErrors bool
+	Force bool
 }
 
 func NewConfig(prime primeable) *Config {
@@ -58,7 +57,7 @@ func (c *Config) Run(params *ConfigParams) error {
 		}
 	}
 
-	if err := stopServices(c.cfg, c.output, params.IgnoreErrors); err != nil {
+	if err := stopServices(c.cfg, c.output, params.Force); err != nil {
 		return errs.Wrap(err, "Failed to stop services.")
 	}
 

--- a/internal/runners/clean/stop.go
+++ b/internal/runners/clean/stop.go
@@ -11,7 +11,7 @@ import (
 )
 
 func stopServices(cfg configurable, out output.Outputer, ignoreErrors bool) error {
-	cleanForceTip := locale.Tl("clean_force_tip", "You can re-run the command with the [ACTIONABLE]--ignore-errors[/RESET] flag.")
+	cleanForceTip := locale.Tl("clean_force_tip", "You can re-run the command with the [ACTIONABLE]--force[/RESET] flag.")
 
 	// On Windows we need to halt the state tray and the state service before we can remove them
 	svcInfo := appinfo.SvcApp()

--- a/internal/runners/clean/uninstall.go
+++ b/internal/runners/clean/uninstall.go
@@ -21,8 +21,7 @@ type Uninstall struct {
 }
 
 type UninstallParams struct {
-	Force        bool
-	IgnoreErrors bool
+	Force bool
 }
 
 type primeable interface {
@@ -58,7 +57,7 @@ func (u *Uninstall) Run(params *UninstallParams) error {
 		}
 	}
 
-	if err := stopServices(u.cfg, u.out, params.IgnoreErrors); err != nil {
+	if err := stopServices(u.cfg, u.out, params.Force); err != nil {
 		return errs.Wrap(err, "Failed to stop services.")
 	}
 


### PR DESCRIPTION
This is a follow-up story to https://www.pivotaltracker.com/story/show/178564019

We decided to just use the `--force` flag, but the story accidentally got merged with the `--ignore-errors` flag...