### PR TITLE
Include the full command in the help message

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -217,7 +217,7 @@ func run(args []string, isInteractive bool, out output.Outputer) error {
 	if err != nil {
 		cmdName := ""
 		if childCmd != nil {
-			cmdName = childCmd.Use() + " "
+			cmdName = childCmd.UseFull() + " "
 		}
 		err = errs.AddTips(err, locale.Tl("err_tip_run_help", "Run → [ACTIONABLE]`state {{.V0}}--help`[/RESET] for general help", cmdName))
 	}


### PR DESCRIPTION
https://app.asana.com/0/1200234825028451/1200539827060441

So that the help message for `state export new-api-key` changes from
"Run → `state new-api-key --help` for general help" to
"Run → `state export new-api-key --help` for general help"

Test:
1. Run `state run build` to build a new version
2. Run `build/state export new-api-key` to verify the help message is as expected:
    ```
    build/state export new-api-key
    
    Something Went Wrong
    ────────────────────
     x The following argument is required:
      Name: name
      Description: API key name
    
    Need More Help?
    ───────────────
     • Run → `state export new-api-key --help` for general help
     • Visit the Forum → https://community.activestate.com/c/state-tool/
    ```