### PR TITLE
Attempt to fix rollbar panic happening on beta

### DIFF
--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -107,7 +107,7 @@ func (l *fileHandler) Emit(ctx *MessageContext, message string, args ...interfac
 	filename := filepath.Join(datadir, FileName())
 
 	// only log to rollbar when on release, beta or unstable branch and when built via CI (ie., non-local build)
-	defer func() { // defer so that we can ensure errors are logged to the rollbar even if rollbar panics (which HAS happened!)
+	defer func() { // defer so that we can ensure errors are logged to the logfile even if rollbar panics (which HAS happened!)
 		if ctx.Level == "ERROR" && (constants.BranchName == constants.ReleaseBranch || constants.BranchName == constants.BetaBranch || constants.BranchName == constants.ExperimentalBranch) && rtutils.BuiltViaCI {
 			data := map[string]interface{}{}
 

--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -107,25 +107,27 @@ func (l *fileHandler) Emit(ctx *MessageContext, message string, args ...interfac
 	filename := filepath.Join(datadir, FileName())
 
 	// only log to rollbar when on release, beta or unstable branch and when built via CI (ie., non-local build)
-	if ctx.Level == "ERROR" && (constants.BranchName == constants.ReleaseBranch || constants.BranchName == constants.BetaBranch || constants.BranchName == constants.ExperimentalBranch) && rtutils.BuiltViaCI {
-		data := map[string]interface{}{}
+	defer func() { // defer so that we can ensure errors are logged to the rollbar even if rollbar panics (which HAS happened!)
+		if ctx.Level == "ERROR" && (constants.BranchName == constants.ReleaseBranch || constants.BranchName == constants.BetaBranch || constants.BranchName == constants.ExperimentalBranch) && rtutils.BuiltViaCI {
+			data := map[string]interface{}{}
 
-		if l.file != nil {
-			if err := l.file.Close(); err != nil {
-				data["log_file_close_error"] = err.Error()
-			} else {
-				logData, err := ioutil.ReadFile(filename)
-				if err != nil {
-					data["log_file_read_error"] = err.Error()
+			if l.file != nil {
+				if err := l.file.Close(); err != nil {
+					data["log_file_close_error"] = err.Error()
 				} else {
-					data["log_file_data"] = string(logData)
+					logData, err := ioutil.ReadFile(filename)
+					if err != nil {
+						data["log_file_read_error"] = err.Error()
+					} else {
+						data["log_file_data"] = string(logData)
+					}
 				}
+				l.file = nil // unset so that it is reset later in this func
 			}
-			l.file = nil // unset so that it is reset later in this func
-		}
 
-		rollbar.Error(fmt.Errorf(message, args...), data)
-	}
+			rollbar.Error(fmt.Errorf(message, args...), data)
+		}
+	}()
 
 	message = l.formatter.Format(ctx, message, args...)
 	if l.verbose.value() {

--- a/internal/svcmanager/svcmanager.go
+++ b/internal/svcmanager/svcmanager.go
@@ -49,35 +49,46 @@ func (m *Manager) Start() error {
 }
 
 func (m *Manager) WaitWithContext(ctx context.Context) error {
+	defer profile.Measure("svcmanager:WaitWithContext", time.Now())
+
+	interrupt := false
 	waitDone := make(chan struct{})
 	var err error
+	
 	go func() {
-		err = m.Wait()
-		waitDone <- struct{}{}
+		defer func() { waitDone <- struct{}{} }()
+
+		logging.Debug("Waiting for state-svc")
+		for try := 1; try <= 10; try++ {
+			if interrupt {
+				return
+			}
+
+			logging.Debug("Attempt %d", try)
+			if m.Ready() {
+				return
+			}
+			if try == 10 {
+				err = locale.NewError("err_svcmanager_wait")
+				return
+			}
+
+			time.Sleep(250 * time.Millisecond)
+		}
 	}()
+
 	select {
 	case <-waitDone:
+		break
 	case <-ctx.Done():
+		interrupt = true
 		break
 	}
 	return err
 }
 
 func (m *Manager) Wait() error {
-	defer profile.Measure("svcmanager:Wait", time.Now())
-	logging.Debug("Waiting for state-svc")
-	try := 1
-	for {
-		logging.Debug("Attempt %d", try)
-		if m.Ready() {
-			return nil
-		}
-		if try == 10 {
-			return locale.NewError("err_svcmanager_wait")
-		}
-		time.Sleep(time.Duration(try*100) * time.Millisecond)
-		try = try + 1
-	}
+	return m.WaitWithContext(context.Background())
 }
 
 func (m *Manager) Ready() bool {


### PR DESCRIPTION
Log of the panic this is attempting to fix (can't repro locally, so cannot verify)

```
❯ VERBOSE=true state --version
[DEBUG Jul 23 15:25:10.101201000, main.go:134] ConfigPath: /Users/nathanrijksen/Library/Application Support/activestate/cli-beta
[DEBUG Jul 23 15:25:10.101238000, main.go:135] CachePath: /Users/nathanrijksen/Library/Caches/activestate
[DEBUG Jul 23 15:25:10.126033000, exeutils.go:150] Executing: /Users/nathanrijksen/.local/ActiveState/StateTool/beta/state-svc [start]
[DEBUG Jul 23 15:25:10.133128000, projectfile.go:475] Not merging activestate.windows.yaml because we are on MacOS
[DEBUG Jul 23 15:25:10.133202000, projectfile.go:512] Parsed URL: {ActiveState cli 7a2fb89c-4bf0-4bb8-b45e-88b0d8af10e4 main}
[DEBUG Jul 23 15:25:10.135325000, subshell.go:103] Detected SHELL: zsh
[DEBUG Jul 23 15:25:10.135407000, subshell.go:135] Using binary: /bin/zsh
[DEBUG Jul 23 15:25:10.167884000, projectfile.go:475] Not merging activestate.windows.yaml because we are on MacOS
[DEBUG Jul 23 15:25:10.167964000, projectfile.go:512] Parsed URL: {ActiveState cli 7a2fb89c-4bf0-4bb8-b45e-88b0d8af10e4 main}
[DEBUG Jul 23 15:25:10.169221000, secrets.go:61] secrets-api scheme=https host=platform.activestate.com base_path=/api/secrets/v1
[DEBUG Jul 23 15:25:10.174239000, projectfile.go:475] Not merging activestate.windows.yaml because we are on MacOS
[DEBUG Jul 23 15:25:10.174341000, projectfile.go:512] Parsed URL: {ActiveState cli 7a2fb89c-4bf0-4bb8-b45e-88b0d8af10e4 main}
[DEBUG Jul 23 15:25:10.175454000, secrets.go:61] secrets-api scheme=https host=platform.activestate.com base_path=/api/secrets/v1
[DEBUG Jul 23 15:25:10.177662000, deprecation.go:201] Using cached deprecation information
[DEBUG Jul 23 15:25:10.177933000, analytics.go:279] Sending S3 pixel event with: run-command, ,
[DEBUG Jul 23 15:25:10.177950000, analytics.go:256] Sending Google Analytics event with: run-command, ,
[DEBUG Jul 23 15:25:10.178002000, analytics.go:297] Using S3 pixel URL: https://state-tool.s3.amazonaws.com/pixel?x-action=&x-category=run-command&x-custom10=&x-custom11=&x-custom2=0.29.0-SHAec559e3&x-custom3=beta&x-custom4=7a481c85-5521-4899-82fb-71bae071c486&x-custom5=plain&x-custom6=MacOS&x-custom7=11.4&x-custom8=install.sh&x-custom9=99999999-9999-9999-9999-999999999999&x-label=
[DEBUG Jul 23 15:25:10.178009000, state.go:63] Execute
[DEBUG Jul 23 15:25:10.178221000, svcmanager.go:68] Waiting for state-svc
[DEBUG Jul 23 15:25:10.178261000, svcmanager.go:71] Attempt 1
[DEBUG Jul 23 15:25:10.178561000, gqlclient.go:48] graphqlClient log message: >> variables: map[]
[DEBUG Jul 23 15:25:10.178595000, gqlclient.go:48] graphqlClient log message: >> query: query {
        version {
            state {
                license,
                version,
                branch,
                revision,
                date,
            }
        }
    }
[DEBUG Jul 23 15:25:10.178644000, gqlclient.go:48] graphqlClient log message: >> headers: map[Accept:[application/json; charset=utf-8] Content-Type:[application/json; charset=utf-8] X-Requestor:[D97FA837-C602-5689-8949-D0ABD6F5FED6]]
[DEBUG Jul 23 15:25:10.179353000, svcmanager.go:95] Ping failed, assuming we're not ready: Post "http://127.0.0.1:55609/query": dial tcp 127.0.0.1:55609: connect: connection refused: dial tcp 127.0.0.1:55609: connect: connection refused: connect: connection refused: connection refused
[DEBUG Jul 23 15:25:10.279660000, svcmanager.go:71] Attempt 2
[DEBUG Jul 23 15:25:10.279983000, gqlclient.go:48] graphqlClient log message: >> variables: map[]
[DEBUG Jul 23 15:25:10.280026000, gqlclient.go:48] graphqlClient log message: >> query: query {
        version {
            state {
                license,
                version,
                branch,
                revision,
                date,
            }
        }
    }
[DEBUG Jul 23 15:25:10.280121000, gqlclient.go:48] graphqlClient log message: >> headers: map[Accept:[application/json; charset=utf-8] Content-Type:[application/json; charset=utf-8] X-Requestor:[D97FA837-C602-5689-8949-D0ABD6F5FED6]]
[DEBUG Jul 23 15:25:10.280392000, svcmanager.go:95] Ping failed, assuming we're not ready: Post "http://127.0.0.1:55609/query": dial tcp 127.0.0.1:55609: connect: connection refused: dial tcp 127.0.0.1:55609: connect: connection refused: connect: connection refused: connection refused
[DEBUG Jul 23 15:25:10.484118000, svcmanager.go:71] Attempt 3
[DEBUG Jul 23 15:25:10.484349000, gqlclient.go:48] graphqlClient log message: >> variables: map[]
[DEBUG Jul 23 15:25:10.484375000, gqlclient.go:48] graphqlClient log message: >> query: query {
        version {
            state {
                license,
                version,
                branch,
                revision,
                date,
            }
        }
    }
[DEBUG Jul 23 15:25:10.484405000, gqlclient.go:48] graphqlClient log message: >> headers: map[Accept:[application/json; charset=utf-8] Content-Type:[application/json; charset=utf-8] X-Requestor:[D97FA837-C602-5689-8949-D0ABD6F5FED6]]
[DEBUG Jul 23 15:25:10.484678000, svcmanager.go:95] Ping failed, assuming we're not ready: Post "http://127.0.0.1:55609/query": dial tcp 127.0.0.1:55609: connect: connection refused: dial tcp 127.0.0.1:55609: connect: connection refused: connect: connection refused: connection refused
[DEBUG Jul 23 15:25:10.678510000, gqlclient.go:48] graphqlClient log message: >> variables: map[]
[DEBUG Jul 23 15:25:10.678553000, gqlclient.go:48] graphqlClient log message: >> query: query() {
		availableUpdate() {
			version
			channel
			path
			platform
			sha256
		}
	}
[DEBUG Jul 23 15:25:10.678583000, gqlclient.go:48] graphqlClient log message: >> headers: map[Accept:[application/json; charset=utf-8] Content-Type:[application/json; charset=utf-8] X-Requestor:[D97FA837-C602-5689-8949-D0ABD6F5FED6]]
[ERROR Jul 23 15:25:10.679675000, checker.go:76] Could not check for update when running update notifier, error: Error checking if update is available.: Post "http://127.0.0.1:55609/query": dial tcp 127.0.0.1:55609: connect: connection refused: dial tcp 127.0.0.1:55609: connect: connection refused: connect: connection refused: connection refused

Stacktrace: /Users/runner/work/cli/cli/internal/logging/logging.go:github.com/ActiveState/cli/internal/logging.Error:277
/Users/runner/work/cli/cli/pkg/cmdlets/checker/checker.go:github.com/ActiveState/cli/pkg/cmdlets/checker.RunUpdateNotifier:76
/Users/runner/work/cli/cli/internal/runners/state/state.go:github.com/ActiveState/cli/internal/runners/state.execute:67
/Users/runner/work/cli/cli/internal/runners/state/state.go::51
/Users/runner/work/cli/cli/cmd/state/internal/cmdtree/cmdtree.go:github.com/ActiveState/cli/cmd/state/internal/cmdtree.newStateCommand.func2:270
/Users/runner/work/cli/cli/internal/captain/command.go:github.com/ActiveState/cli/internal/captain.(*Command).runner.func1:537
/Users/runner/work/cli/cli/internal/sighandler/awaiting.go:github.com/ActiveState/cli/internal/sighandler.(*sigHandler).WaitForFunc.func1:46
/Users/runner/hostedtoolcache/go/1.16.6/x64/src/runtime/asm_amd64.s:runtime.goexit:1371

ActiveState CLI by ActiveState Software Inc.
License BSD 3
Version 0.29.0-SHAec559e3
Revision ec559e3059b4c69920c4902f054a5ed93f89fb5c
Branch beta
Built Fri Jul 23 2021 20:17:16 +0000 UTC

[DEBUG Jul 23 15:25:10.680645000, analytics.go:279] Sending S3 pixel event with: command-exit, , 0
[DEBUG Jul 23 15:25:10.680689000, analytics.go:256] Sending Google Analytics event with: command-exit, , 0
[DEBUG Jul 23 15:25:10.680791000, analytics.go:297] Using S3 pixel URL: https://state-tool.s3.amazonaws.com/pixel?x-action=&x-category=command-exit&x-custom10=&x-custom11=&x-custom2=0.29.0-SHAec559e3&x-custom3=beta&x-custom4=7a481c85-5521-4899-82fb-71bae071c486&x-custom5=plain&x-custom6=MacOS&x-custom7=11.4&x-custom8=install.sh&x-custom9=99999999-9999-9999-9999-999999999999&x-label=0
[DEBUG Jul 23 15:25:10.789334000, svcmanager.go:71] Attempt 4
panic: send on closed channel

goroutine 473 [running]:
github.com/rollbar/rollbar-go.(*AsyncTransport).Send(0xc0001103c0, 0xc00041d710, 0x223efad, 0x4)
	/Users/runner/work/cli/cli/vendor/github.com/rollbar/rollbar-go/async_transport.go:91 +0x11a
github.com/rollbar/rollbar-go.(*Client).push(0xc00017e000, 0xc00041d710, 0x20, 0x223eef1)
	/Users/runner/work/cli/cli/vendor/github.com/rollbar/rollbar-go/client.go:550 +0x9e
github.com/rollbar/rollbar-go.(*Client).ErrorWithStackSkipWithExtrasAndContext(0xc00017e000, 0x24c8a98, 0xc000128008, 0x223fe5b, 0x5, 0x24a3f80, 0xc000bf2c30, 0x2, 0xc00041d5f0)
	/Users/runner/work/cli/cli/vendor/github.com/rollbar/rollbar-go/client.go:330 +0x1ce
github.com/rollbar/rollbar-go.Log(0x223fe5b, 0x5, 0xc0008bbc58, 0x2, 0x2)
	/Users/runner/work/cli/cli/vendor/github.com/rollbar/rollbar-go/rollbar.go:368 +0x1ea
github.com/rollbar/rollbar-go.Error(...)
	/Users/runner/work/cli/cli/vendor/github.com/rollbar/rollbar-go/rollbar.go:277
github.com/ActiveState/cli/internal/logging.(*fileHandler).Emit(0xc000114c90, 0xc0000c1140, 0xc0009d3180, 0x36c, 0xc000bf2ae0, 0x1, 0x1, 0x3, 0xc0009d3180)
	/Users/runner/work/cli/cli/internal/logging/defaults.go:127 +0x5fd
github.com/ActiveState/cli/internal/logging.writeMessageDepth(0x4, 0x223f7f3, 0x5, 0xc0009d3180, 0x36c, 0xc000bf2ae0, 0x1, 0x1)
	/Users/runner/work/cli/cli/internal/logging/logging.go:230 +0x191
github.com/ActiveState/cli/internal/logging.writeMessage(...)
	/Users/runner/work/cli/cli/internal/logging/logging.go:212
github.com/ActiveState/cli/internal/logging.Error(0x2266562, 0x1b, 0xc000bf2ae0, 0x1, 0x1)
	/Users/runner/work/cli/cli/internal/logging/logging.go:277 +0x114
github.com/ActiveState/cli/internal/config.(*Instance).get(0xc0008c8f30, 0x22449db, 0x8, 0x1, 0x0)
	/Users/runner/work/cli/cli/internal/config/instance.go:149 +0x18e
github.com/ActiveState/cli/internal/config.(*Instance).GetInt(0xc0008c8f30, 0x22449db, 0x8, 0xc000074d80)
	/Users/runner/work/cli/cli/internal/config/instance.go:174 +0x3f
github.com/ActiveState/cli/internal/svcmanager.(*Manager).Ready(0xc00077a048, 0x223f700)
	/Users/runner/work/cli/cli/internal/svcmanager/svcmanager.go:88 +0x6d
github.com/ActiveState/cli/internal/svcmanager.(*Manager).Wait(0xc00077a048, 0x0, 0x0)
	/Users/runner/work/cli/cli/internal/svcmanager/svcmanager.go:72 +0x13c
github.com/ActiveState/cli/internal/svcmanager.(*Manager).WaitWithContext.func1(0xc00077a048, 0xc000c27ff0, 0xc00070d0e0)
	/Users/runner/work/cli/cli/internal/svcmanager/svcmanager.go:55 +0x2b
created by github.com/ActiveState/cli/internal/svcmanager.(*Manager).WaitWithContext
	/Users/runner/work/cli/cli/internal/svcmanager/svcmanager.go:54 +0x92
```