### PR TITLE
Don't repeat messaging on update

### DIFF
--- a/cmd/state-transition-update/main.go
+++ b/cmd/state-transition-update/main.go
@@ -83,7 +83,6 @@ func run() error {
 			return err
 		}
 
-		fmt.Println("Please start a new shell to continue using the State Tool.")
 		return nil
 	}
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178939100

The updater will check if the installation path is on the current `PATH`. If not it will print a message about starting a new shell. This will cover updates involving the transitional state tool