### PR TITLE
Handle panics in analytics and logging/rollbar

### DIFF
--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -37,7 +37,7 @@ func main() {
 		if panics.HandlePanics(recover(), debug.Stack()) {
 			exitCode = 1
 		}
-		if err := events.WaitForEvents(1*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(1*time.Second, analytics.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failed to wait for rollbar to close: %v", err)
 		}
 		os.Exit(exitCode)

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -40,7 +40,7 @@ func main() {
 		if panics.HandlePanics(recover(), debug.Stack()) {
 			exitCode = 1
 		}
-		if err := events.WaitForEvents(1*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(1*time.Second, analytics.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failing to wait for rollbar to close")
 		}
 		os.Exit(exitCode)

--- a/cmd/state-transition-update/main.go
+++ b/cmd/state-transition-update/main.go
@@ -32,7 +32,7 @@ func main() {
 		if panics.HandlePanics(recover(), debug.Stack()) {
 			exitCode = 1
 		}
-		if err := events.WaitForEvents(1*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(1*time.Second, analytics.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failed waiting to close rollbar")
 		}
 		os.Exit(exitCode)

--- a/cmd/state-tray/main.go
+++ b/cmd/state-tray/main.go
@@ -56,7 +56,7 @@ func onReady() {
 			exitCode = 1
 		}
 		logging.Debug("onReady is done with exit code %d", exitCode)
-		if err := events.WaitForEvents(1*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(1*time.Second, analytics.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failed to wait for rollbar to close")
 		}
 		os.Exit(exitCode)

--- a/cmd/state-update-dialog/main.go
+++ b/cmd/state-update-dialog/main.go
@@ -26,7 +26,7 @@ func main() {
 		if panics.HandlePanics(recover(), debug.Stack()) {
 			exitCode = 1
 		}
-		if err := events.WaitForEvents(1*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(1*time.Second, analytics.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failed to wait for rollbar to close")
 		}
 		os.Exit(exitCode)

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -53,7 +53,7 @@ func main() {
 		}
 
 		// ensure rollbar messages are called
-		if err := events.WaitForEvents(time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(time.Second, analytics.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failed waiting for events: %v", err)
 		}
 

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -221,9 +221,9 @@ func Configure(cfg configurable) {
 
 // Event logs an event to google analytics
 func Event(category string, action string) {
-	defer handlePanics(recover(), debug.Stack())
 	eventWaitGroup.Add(1)
 	go func() {
+		defer handlePanics(recover(), debug.Stack())
 		defer eventWaitGroup.Done()
 		event(category, action)
 	}()
@@ -238,6 +238,7 @@ func EventWithLabel(category string, action string, label string) {
 	defer handlePanics(recover(), debug.Stack())
 	eventWaitGroup.Add(1)
 	go func() {
+		defer handlePanics(recover(), debug.Stack())
 		defer eventWaitGroup.Done()
 		eventWithLabel(category, action, label)
 	}()
@@ -271,6 +272,7 @@ func sendEvent(category, action, label string, dimensions map[string]string) err
 }
 
 func sendGAEvent(category, action, label string, dimensions map[string]string) {
+	defer handlePanics(recover(), debug.Stack())
 	defer eventWaitGroup.Done()
 	logging.Debug("Sending Google Analytics event with: %s, %s, %s", category, action, label)
 
@@ -294,6 +296,7 @@ func sendGAEvent(category, action, label string, dimensions map[string]string) {
 }
 
 func sendS3Pixel(category, action, label string, dimensions map[string]string) {
+	defer handlePanics(recover(), debug.Stack())
 	defer eventWaitGroup.Done()
 	logging.Debug("Sending S3 pixel event with: %s, %s, %s", category, action, label)
 	pixelURL, err := url.Parse("https://state-tool.s3.amazonaws.com/pixel")

--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -105,6 +105,7 @@ func FilePathForCmd(cmd string, pid int) string {
 const FileNameSuffix = ".log"
 
 func (l *fileHandler) Emit(ctx *MessageContext, message string, args ...interface{}) error {
+	defer handlePanics(recover())
 	// In this function we close and open the file handle to the log file. In
 	// order to ensure this is safe to be called across threads, we just
 	// synchronize the entire function
@@ -169,6 +170,7 @@ func (l *fileHandler) Printf(msg string, args ...interface{}) {
 }
 
 func init() {
+	defer handlePanics(recover())
 	timestamp = time.Now().UnixNano()
 	handler := &fileHandler{DefaultFormatter, nil, sync.Mutex{}, safeBool{}}
 	SetHandler(handler)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -357,5 +357,5 @@ func handlePanics(err interface{}) {
 	if err == nil {
 		return
 	}
-	fmt.Fprintf(os.Stderr, "Panic occurred in logging module: %v\n", err)
+	fmt.Fprintf(os.Stderr, "Failed to log error. Please report this on the forums if it keeps happening. Error: %v\n", err)
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -351,5 +351,11 @@ func BridgeStdLog(level int) {
 			log.SetOutput(b)
 		}
 	}
+}
 
+func handlePanics(err interface{}) {
+	if err == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Panic occurred in logging module: %v\n", err)
 }

--- a/internal/logging/rollbar.go
+++ b/internal/logging/rollbar.go
@@ -14,6 +14,7 @@ import (
 )
 
 func SetupRollbar(token string) {
+	defer handlePanics(recover())
 	// set user to unknown (if it has not been set yet)
 	if _, ok := rollbar.Custom()["UserID"]; !ok {
 		UpdateRollbarPerson("unknown", "unknown", "unknown")
@@ -51,6 +52,7 @@ func SetupRollbar(token string) {
 }
 
 func UpdateRollbarPerson(userID, username, email string) {
+	defer handlePanics(recover())
 	rollbar.SetPerson(uniqid.Text(), username, email)
 
 	custom := rollbar.Custom()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179457181

Note, that the story actually shows the regular panic message, so it was not even handled by our `main()` function panic handler.
I figured out that this panic handlers only handle panics in the go-routine that their running in: 
https://play.golang.org/p/iXAnMonq4tE

Which means, that other functions that are running go-routines are also not handled by our panic-handlers!
Follow-up story is here: https://www.pivotaltracker.com/story/show/179501830
