### PR TITLE
"Fix" intermittent log file error

### DIFF
--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -197,7 +197,7 @@ func init() {
 	for _, file := range files {
 		if strings.HasPrefix(file.Name(), FileNamePrefix()) && strings.HasSuffix(file.Name(), FileNameSuffix) {
 			c = c + 1
-			if c > 9 {
+			if c > 19 {
 				if err := os.Remove(filepath.Join(datadir, file.Name())); err != nil {
 					Error("Could not clean up old log: %s, error: %v", file.Name(), err)
 				}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179382049

This is my best guess.

The easy question to answer was whether this also addresses https://www.pivotaltracker.com/story/show/179275370.  It does!  Due The log file errors in the output we couldn't parse the output as JSON as expected.

I believe that the root issue is that the update is running in the background while we are running `state --version`.  The update is calling a lot of different tools that all create log files themselves, including several `state-svc start` commands.  So, my guess is that we are creating 9 new log files in the background, and hence delete the log file for the `state --version` process.  I would expect a "bad file descriptor" error instead of a "file already closed"-error though. So, it might still not be the issue...