### PR TITLE
Debug shorcut permission problem

### DIFF
--- a/internal/osutils/shortcut/shortcut_linux.go
+++ b/internal/osutils/shortcut/shortcut_linux.go
@@ -71,7 +71,7 @@ func Save(target, path string, opts SaveOpts) (file string, err error) {
 	if err != nil {
 		logging.Errorf(
 			"Could not set desktop file as trusted: %v (stdout: %s; stderr: %s)",
-			err, stdoutText, stderrText,
+			errs.JoinMessage(err), stdoutText, stderrText,
 		)
 	}
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179381982

I checked that we are already setting the executable flag for the shortcut.  So, it remains unclear why the command fails.

This PR modifies the log messages such that it includes the full error message.  My suspicion is that it fails when `gio` cannot be found, for example when the State Tool is installed in a simple docker container.  But that will need to be investigated.