### PR TITLE
Ensure only one event of the same name is returned

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -3,6 +3,7 @@ package cmdtree
 import (
 	"time"
 
+	"github.com/ActiveState/cli/cmd/state/internal/cmdtree/intercepts/cmdcall"
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/locale"
@@ -269,6 +270,10 @@ func newStateCommand(globals *globalOptions, prime *primer.Values) *captain.Comm
 			return runner.Run(ccmd.Usage)
 		},
 	)
+
+	cmdCall := cmdcall.New(prime)
+
+	cmd.SetInterceptChain(cmdCall.InterceptExec)
 
 	return cmd
 }

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -226,6 +226,10 @@ func SetupProjectRcFile(prj *project.Project, templateName, ext string, env map[
 	activatedKey := fmt.Sprintf("activated_%s", prj.Namespace().String())
 	for _, eventType := range project.ActivateEvents() {
 		event := prj.EventByName(eventType.String())
+		if event == nil {
+			continue
+		}
+
 		v, err := event.Value()
 		if err != nil {
 			return nil, errs.Wrap(err, "Could not get event value")

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -224,16 +224,18 @@ func SetupProjectRcFile(prj *project.Project, templateName, ext string, env map[
 
 	// Yes this is awkward, issue here - https://www.pivotaltracker.com/story/show/175619373
 	activatedKey := fmt.Sprintf("activated_%s", prj.Namespace().String())
-	for _, event := range prj.Events() {
+	for _, eventType := range project.ActivateEvents() {
+		event := prj.EventByName(eventType.String())
 		v, err := event.Value()
 		if err != nil {
-			return nil, errs.Wrap(err, "Misc failure")
+			return nil, errs.Wrap(err, "Could not get event value")
 		}
 
-		if strings.ToLower(event.Name()) == "first-activate" && !cfg.GetBool(activatedKey) {
+		if strings.ToLower(event.Name()) == project.FirstActivate.String() && !cfg.GetBool(activatedKey) {
 			userScripts = v + "\n" + userScripts
 		}
-		if strings.ToLower(event.Name()) == "activate" {
+
+		if strings.ToLower(event.Name()) == project.Activate.String() {
 			userScripts = userScripts + "\n" + v
 		}
 	}

--- a/pkg/project/events.go
+++ b/pkg/project/events.go
@@ -3,6 +3,19 @@ package project
 type EventType string
 
 const (
-	BeforeCmd EventType = "before-command"
-	AfterCmd  EventType = "after-command"
+	BeforeCmd     EventType = "before-command"
+	AfterCmd      EventType = "after-command"
+	Activate      EventType = "activate"
+	FirstActivate EventType = "first-activate"
 )
+
+func (e EventType) String() string {
+	return string(e)
+}
+
+func ActivateEvents() []EventType {
+	return []EventType{
+		Activate,
+		FirstActivate,
+	}
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -160,7 +160,7 @@ func (p *Project) Events() []*Event {
 // EventByName returns a reference to a projectfile.Script with a given name.
 func (p *Project) EventByName(name string) *Event {
 	for _, event := range p.Events() {
-		if event.Name() == name {
+		if strings.ToLower(event.Name()) == strings.ToLower(name) {
 			return event
 		}
 	}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -151,15 +151,20 @@ func (p *Project) Events() []*Event {
 
 	es := projectfile.MakeEventsFromConstrainedEntities(constrained)
 	events := make([]*Event, 0, len(es))
-	addedEvents := make(map[string]struct{})
 	for _, e := range es {
-		if _, ok := addedEvents[e.Name]; ok {
-			continue
-		}
-		addedEvents[e.Name] = struct{}{}
 		events = append(events, &Event{e, p})
 	}
 	return events
+}
+
+// EventByName returns a reference to a projectfile.Script with a given name.
+func (p *Project) EventByName(name string) *Event {
+	for _, event := range p.Events() {
+		if event.Name() == name {
+			return event
+		}
+	}
+	return nil
 }
 
 // Scripts returns a reference to projectfile.Scripts

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -148,9 +148,15 @@ func (p *Project) Events() []*Event {
 	if err != nil {
 		logging.Warning("Could not filter unconstrained events: %v", err)
 	}
+
 	es := projectfile.MakeEventsFromConstrainedEntities(constrained)
 	events := make([]*Event, 0, len(es))
+	addedEvents := make(map[string]struct{})
 	for _, e := range es {
+		if _, ok := addedEvents[e.Name]; ok {
+			continue
+		}
+		addedEvents[e.Name] = struct{}{}
 		events = append(events, &Event{e, p})
 	}
 	return events

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/config"
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/pkg/projectfile"
 
@@ -130,16 +129,22 @@ func (suite *ProjectTestSuite) TestEvents() {
 	}
 }
 
-func (suite *ProjectTestSuite) TestEvents_Duplicates() {
-	project, err := project.Parse(filepath.Join(suite.testdataDir, "events", constants.ConfigFileName))
-	suite.NoError(err)
+func (suite *ProjectTestSuite) TestEventByName() {
+	var name string
+	switch runtime.GOOS {
+	case "linux":
+		name = "foo"
+	case "windows":
+		name = "bar"
+	case "darwin":
+		name = "baz"
+	}
 
-	events := project.Events()
-	suite.Equal(1, len(events), "Events do not contain duplicates")
+	event := suite.project.EventByName(name)
+	suite.Equal(name, event.Name())
 
-	value, err := events[0].Value()
-	suite.NoError(err)
-	suite.Equal("first-event", value, "Value of event should be first event in file")
+	event = suite.project.EventByName("not-there")
+	suite.Nil(event)
 }
 
 func (suite *ProjectTestSuite) TestLanguages() {

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/pkg/projectfile"
 
@@ -127,6 +128,18 @@ func (suite *ProjectTestSuite) TestEvents() {
 		suite.Equal("baz", name, "Names should match (OSX)")
 		suite.Equal("baz OSX", value, "Value should match (OSX)")
 	}
+}
+
+func (suite *ProjectTestSuite) TestEvents_Duplicates() {
+	project, err := project.Parse(filepath.Join(suite.testdataDir, "events", constants.ConfigFileName))
+	suite.NoError(err)
+
+	events := project.Events()
+	suite.Equal(1, len(events), "Events do not contain duplicates")
+
+	value, err := events[0].Value()
+	suite.NoError(err)
+	suite.Equal("first-event", value, "Value of event should be first event in file")
 }
 
 func (suite *ProjectTestSuite) TestLanguages() {

--- a/pkg/project/testdata/events/activestate.yaml
+++ b/pkg/project/testdata/events/activestate.yaml
@@ -1,0 +1,6 @@
+project: https://platform.activestate.com/ActiveState/project?branch=main&commitID=00010001-0001-0001-0001-000100010001
+events:
+  - name: bar
+    value: first-event
+  - name: bar
+    value: second-event

--- a/pkg/project/testdata/events/activestate.yaml
+++ b/pkg/project/testdata/events/activestate.yaml
@@ -1,6 +1,0 @@
-project: https://platform.activestate.com/ActiveState/project?branch=main&commitID=00010001-0001-0001-0001-000100010001
-events:
-  - name: bar
-    value: first-event
-  - name: bar
-    value: second-event

--- a/test/integration/events_int_test.go
+++ b/test/integration/events_int_test.go
@@ -33,6 +33,8 @@ events:
     value: echo "First activate event"
   - name: activate
     value: echo "Activate event"
+  - name: activate
+    value: echo "Activate event duplicate"
   - name: before-command
     scope: ["activate"]
     value: before
@@ -42,6 +44,7 @@ events:
 `))
 
 	cp := ts.Spawn("activate")
+	cp.Send("")
 	cp.Expect("before-script")
 	cp.Expect("First activate event")
 	cp.Expect("Activate event")
@@ -58,6 +61,9 @@ events:
 	output := cp.TrimmedSnapshot()
 	if strings.Contains(output, "First activate event") {
 		suite.T().Fatal("Output from second activate event should not contain first-activate output")
+	}
+	if strings.Contains(output, "Activate event duplicate") {
+		suite.T().Fatal("Output should not contain output from duplicate activate event")
 	}
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179541727

This logic could be in a few places. Specifically where it is in this PR or in the `sscommon` package when we are building the project RC file. If we don't want to support multiple events with the same name we could also error when parsing the config, but that will be more involved when taking the constraints into account. Also the AC states it should use the _first_ event it encounters with a name.