### PR TITLE
Multiple language listing fix

### DIFF
--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -56,24 +56,13 @@ func FetchLanguagesForCommit(commitID strfmt.UUID) ([]Language, error) {
 		return nil, err
 	}
 
-	languageMap := map[string]interface{}{}
 	languages := []Language{}
 	for _, requirement := range checkpoint {
 		if NamespaceMatch(requirement.Namespace, NamespaceLanguageMatch) {
-			languageMap[requirement.Requirement] = struct{}{}
 			languages = append(languages, Language{
 				Name:    requirement.Requirement,
 				Version: requirement.VersionConstraint,
 			})
-			continue
-		}
-		if NamespaceMatch(requirement.Namespace, NamespacePackageMatch) || NamespaceMatch(requirement.Namespace, NamespaceBundlesMatch) {
-			language := LanguageFromNamespace(requirement.Namespace)
-			if _, exists := languageMap[language]; exists || language == "" {
-				continue
-			}
-			languageMap[requirement.Requirement] = struct{}{}
-			languages = append(languages, Language{Name: language})
 		}
 	}
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179567826

This code was first introduced when we implemented `state install` without a project. Since then our sourcing of the language for that use case has changed.