### PR TITLE
Check if we are trying to overwrite read-only files

### DIFF
--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -492,7 +492,7 @@ func MoveAllFilesRecursively(fromPath, toPath string, cb MoveAllFilesCallback) e
 				// On Windows, the following renaming step can otherwise fail if subToPath is read-only (file removal is allowed)
 				err = os.Remove(subToPath)
 				if err != nil {
-					logging.Error("Failed to remove destination file %s: %v", subToPath, err)
+					logging.Error("Failed to remove file scheduled to be overwritten: %s (file mode: %#o): %v", subToPath, toInfo.Mode(), err)
 				}
 			}
 		}
@@ -526,7 +526,7 @@ func MoveAllFilesRecursively(fromPath, toPath string, cb MoveAllFilesCallback) e
 
 		err = os.Rename(subFromPath, subToPath)
 		if err != nil {
-			return errs.Wrap(err, "os.Rename %s:%s failed", subFromPath, subToPath)
+			return errs.Wrap(err, "os.Rename %s:%s failed (file mode: %#o)", subFromPath, subToPath, toInfo.Mode())
 		}
 		cb(subFromPath, subToPath)
 	}


### PR DESCRIPTION
https://activestatef.atlassian.net/browse/ST-261

As discussed: I added debug information that would reveal if we are possibly trying to overwrite read-only files.  But we are definitely not running into race-conditions due to parallel writes.  Everything is moved to the final target directory in the same thread.