### PR TITLE
Fix executable name returning full path on Windows

### DIFF
--- a/internal/osutils/osutils.go
+++ b/internal/osutils/osutils.go
@@ -135,7 +135,7 @@ func Executable() string {
 // ExecutableName returns the name of the executable called with the extension
 // removed and falls back to the command used to call the executable.
 func ExecutableName() string {
-	name := path.Base(Executable())
+	name := filepath.Base(Executable())
 	name = strings.TrimSuffix(name, path.Ext(name))
 	return name
 }

--- a/internal/osutils/osutils_test.go
+++ b/internal/osutils/osutils_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
@@ -117,5 +118,12 @@ func TestEnvMapToSlice(t *testing.T) {
 				t.Errorf("EnvMapToSlice() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExecutableName(t *testing.T) {
+	name := ExecutableName()
+	if fileutils.TargetExists(name) {
+		t.Fatalf("Executable name should return a filename, not a filepath. Returned: %s", name)
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-483" title="DX-483" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />DX-483</a>  Analytics events have the full path of the exe in them
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
