### PR TITLE
Add powershell files & partial subshell code

### DIFF
--- a/assets/shells/powershell.ps1
+++ b/assets/shells/powershell.ps1
@@ -1,0 +1,44 @@
+{{if ne .Owner ""}}
+#https://stackoverflow.com/questions/5725888/windows-powershell-changing-the-command-prompt
+function Global:prompt {
+    $currentDirectory = $(Get-Location)
+    $UncRoot = $currentDirectory.Drive.DisplayRoot
+    write-host " $UncRoot" -ForegroundColor Gray
+    # Convert-Path needed for pure UNC-locations
+    write-host "[{{.Owner}}/{{.Name}}] PS $(Convert-Path $currentDirectory)>" -NoNewline -ForegroundColor Yellow
+    return " "
+}
+{{end}}
+
+{{- range $K, $V := .Env}}
+{{- if eq $K "PATH"}}
+$env:{{$K}}="{{$V}}:$env:PATH"
+{{- else}}
+$env:{{$K}}="{{$V}}"
+{{- end}}
+{{- end}}
+
+{{$execCmd := .ExecName}}
+
+{{ if .ExecAlias }}
+Set-Alias  {{.ExecName}} {{.ExecAlias}}
+{{ end }}
+
+{{range $K, $CMD := .Scripts}}
+DOSKEY {{$K}}="{{$execCmd}}" run "{{$CMD}}" $*
+{{end}}
+
+{{range $K, $CMD := .Scripts}}
+function {{$K}} {
+    {{$.ExecName}} {{$CMD}} $args
+}
+export -f {{$K}}
+{{end}}
+
+cd {{.WD}}
+
+{{range $line := splitLines .ActivatedMessage}}
+    {{if eq $line ""}}write-host .{{else}}write-host {{$line}}{{end}}
+{{end}}
+
+{{.UserScripts}}

--- a/assets/shells/powershell_global.ps1
+++ b/assets/shells/powershell_global.ps1
@@ -1,0 +1,9 @@
+# {{.Start}}
+{{- range $K, $V := .Env}}
+{{- if eq $K "PATH"}}
+$env:{{$K}}="{{$V}}:$env:PATH"
+{{- else}}
+$env:{{$K}}="{{$V}}"
+{{- end}}
+{{- end}}
+# {{.Stop}}

--- a/internal/subshell/powershell/env.go
+++ b/internal/subshell/powershell/env.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/osutils"
+)
+
+type OpenKeyFn func(path string) (osutils.RegistryKey, error)
+
+type CmdEnv struct {
+	openKeyFn OpenKeyFn
+	// whether this updates the system environment
+	userScope bool
+}
+
+func NewCmdEnv(userScope bool) *CmdEnv {
+	openKeyFn := osutils.OpenSystemKey
+	if userScope {
+		openKeyFn = osutils.OpenUserKey
+	}
+	return &CmdEnv{
+		openKeyFn: openKeyFn,
+		userScope: userScope,
+	}
+}
+
+func getEnvironmentPath(userScope bool) string {
+	if userScope {
+		return "Environment"
+	}
+	return `SYSTEM\ControlSet001\Control\Session Manager\Environment`
+}
+
+// unsetUserEnv clears a state cool configured environment variable
+// It only does this if the value equals the expected value (meaning if we can verify that state tool was in fact
+// responsible for setting it)
+func (c *CmdEnv) unset(name, ifValueEquals string) error {
+	key, err := c.openKeyFn(getEnvironmentPath(c.userScope))
+	if err != nil {
+		return locale.WrapError(err, "err_windows_registry")
+	}
+	defer key.Close()
+
+	v, _, err := key.GetStringValue(name)
+	if err != nil {
+		if osutils.IsNotExistError(err) {
+			return nil
+		}
+		return locale.WrapError(err, "err_windows_registry")
+	}
+
+	// Check if we are responsible for the value
+	if v != ifValueEquals {
+		return nil
+	}
+
+	// Delete value
+	return key.DeleteValue(name)
+}
+
+// setUserEnv sets a variable in the user environment and saves the original as a backup
+func (c *CmdEnv) set(name, newValue string) error {
+	key, err := c.openKeyFn(getEnvironmentPath(c.userScope))
+	if err != nil {
+		return locale.WrapError(err, "err_windows_registry")
+	}
+	defer key.Close()
+
+	// Check if we're going to be overriding
+	_, valType, err := key.GetStringValue(name)
+	if err != nil && !osutils.IsNotExistError(err) {
+		return locale.WrapError(err, "err_windows_registry")
+	}
+
+	return osutils.SetStringValue(key, name, valType, newValue)
+}
+
+// Get retrieves a variable from the user environment, this prioritizes a backup if it exists
+func (c *CmdEnv) Get(name string) (string, error) {
+	key, err := c.openKeyFn(getEnvironmentPath(c.userScope))
+	if err != nil {
+		return "", locale.WrapError(err, "err_windows_registry")
+	}
+	defer key.Close()
+
+	v, _, err := key.GetStringValue(name)
+	if err != nil && !osutils.IsNotExistError(err) {
+		return v, locale.WrapError(err, "err_windows_registry")
+	}
+	return v, nil
+}
+
+// GetUnsafe is an alias for `get` intended for use by tests/integration tests, don't use for anything else!
+func (c *CmdEnv) GetUnsafe(name string) string {
+	r, f := c.Get(name)
+	if f != nil {
+		log.Fatalf("GetUnsafe failed with: %s", f.Error())
+	}
+	return r
+}

--- a/internal/subshell/powershell/env_test.go
+++ b/internal/subshell/powershell/env_test.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/thoas/go-funk"
+	"github.com/ActiveState/cli/internal/osutils"
+)
+
+type RegistryKeyMock struct {
+	getCalls       []string
+	setCalls       []string
+	setExpandCalls []string
+	delCalls       []string
+
+	getResults map[string]RegistryValue
+	setResults map[string]error
+	delResults map[string]error
+}
+
+type RegistryValue struct {
+	Value string
+	Error error
+}
+
+func (r *RegistryKeyMock) GetStringValue(name string) (string, uint32, error) {
+	r.getCalls = append(r.getCalls, name)
+	if v, ok := r.getResults[name]; ok {
+		return v.Value, 0, v.Error
+	}
+	return "", 0, osutils.NotExistError()
+}
+
+func (r *RegistryKeyMock) SetStringValue(name, value string) error {
+	r.setCalls = append(r.setCalls, name+"="+value)
+	if v, ok := r.setResults[name]; ok {
+		return v
+	}
+	return nil
+}
+
+func (r *RegistryKeyMock) SetExpandStringValue(name, value string) error {
+	r.setExpandCalls = append(r.setExpandCalls, name+"="+value)
+	if v, ok := r.setResults[name]; ok {
+		return v
+	}
+	return nil
+}
+
+func (r *RegistryKeyMock) DeleteValue(name string) error {
+	r.delCalls = append(r.getCalls, name)
+	if v, ok := r.delResults[name]; ok {
+		return v
+	}
+	return nil
+}
+
+func (r *RegistryKeyMock) Close() error {
+	return nil
+}
+
+func openKeyMock(path string) (osutils.RegistryKey, error) {
+	return &RegistryKeyMock{}, nil
+}
+
+func TestCmdEnv_unset(t *testing.T) {
+	type fields struct {
+		registryMock *RegistryKeyMock
+		openKeyErr   error
+	}
+	type args struct {
+		name          string
+		ifValueEquals string
+	}
+	type want struct {
+		returnValue      error
+		registryGetCalls *[]string // nil means it should have no calls
+		registrySetCalls *[]string
+		registryDelCalls *[]string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   want
+	}{
+		{
+			"unset, value not equals",
+			fields{&RegistryKeyMock{}, nil},
+			args{
+				"key",
+				"value_not_equal",
+			},
+			want{
+				nil,
+				&[]string{},
+				nil,
+				nil,
+			},
+		},
+		{
+			"unset, value equals",
+			fields{&RegistryKeyMock{
+				getResults: map[string]RegistryValue{
+					"key": RegistryValue{"value_equals", nil},
+				},
+			}, nil},
+			args{
+				"key",
+				"value_equals",
+			},
+			want{
+				nil,
+				&[]string{},
+				nil,
+				&[]string{"key"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CmdEnv{
+				openKeyFn: func(path string) (osutils.RegistryKey, error) {
+					return tt.fields.registryMock, tt.fields.openKeyErr
+				},
+			}
+			if got := c.unset(tt.args.name, tt.args.ifValueEquals); !reflect.DeepEqual(got, tt.want.returnValue) {
+				t.Errorf("unset() = %v, want %v", got, tt.want)
+			}
+			rm := tt.fields.registryMock
+
+			registryValidator(t, rm.getCalls, tt.want.registryGetCalls, "GET")
+			registryValidator(t, rm.setCalls, tt.want.registrySetCalls, "SET")
+			registryValidator(t, rm.setExpandCalls, &[]string{}, "EXPAND")
+			registryValidator(t, rm.delCalls, tt.want.registryDelCalls, "DEL")
+		})
+	}
+}
+
+func TestCmdEnv_set(t *testing.T) {
+	type fields struct {
+		registryMock *RegistryKeyMock
+		openKeyErr   error
+	}
+	type args struct {
+		name  string
+		value string
+	}
+	type want struct {
+		returnValue      error
+		registryGetCalls *[]string // nil means it should have no calls
+		registrySetCalls *[]string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   want
+	}{
+		{
+			"set",
+			fields{&RegistryKeyMock{}, nil},
+			args{
+				"key",
+				"value",
+			},
+			want{
+				nil,
+				&[]string{},
+				&[]string{"key=value", "!key_original"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CmdEnv{
+				openKeyFn: func(path string) (osutils.RegistryKey, error) {
+					return tt.fields.registryMock, tt.fields.openKeyErr
+				},
+			}
+			if got := c.set(tt.args.name, tt.args.value); !reflect.DeepEqual(got, tt.want.returnValue) {
+				t.Errorf("set() = %v, want %v", got, tt.want)
+			}
+			rm := tt.fields.registryMock
+
+			registryValidator(t, rm.getCalls, tt.want.registryGetCalls, "GET")
+			registryValidator(t, rm.setCalls, tt.want.registrySetCalls, "SET")
+		})
+	}
+}
+
+func TestCmdEnv_get(t *testing.T) {
+	type fields struct {
+		registryMock *RegistryKeyMock
+		openKeyErr   error
+	}
+	type args struct {
+		name string
+	}
+	type want struct {
+		returnValue      string
+		returnFailure    error
+		registryGetCalls *[]string // nil means it should have no calls
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   want
+	}{
+		{
+			"get nonexist",
+			fields{&RegistryKeyMock{}, nil},
+			args{
+				"key",
+			},
+			want{
+				"",
+				nil,
+				&[]string{"key"},
+			},
+		},
+		{
+			"get existing",
+			fields{&RegistryKeyMock{
+				getResults: map[string]RegistryValue{
+					"key": RegistryValue{"value", nil},
+				},
+			}, nil},
+			args{
+				"key",
+			},
+			want{
+				"value",
+				nil,
+				&[]string{"key"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CmdEnv{
+				openKeyFn: func(path string) (osutils.RegistryKey, error) {
+					return tt.fields.registryMock, tt.fields.openKeyErr
+				},
+			}
+			got, gotFail := c.Get(tt.args.name)
+			if !reflect.DeepEqual(got, tt.want.returnValue) {
+				t.Errorf("get() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(gotFail, tt.want.returnFailure) {
+				t.Errorf("get() err = %v, want %v", gotFail, tt.want)
+			}
+
+			rm := tt.fields.registryMock
+			registryValidator(t, rm.getCalls, tt.want.registryGetCalls, "GET")
+		})
+	}
+}
+
+func registryValidator(t *testing.T, got []string, want *[]string, name string) {
+	if want == nil && len(got) > 0 {
+		t.Errorf("%s: registry should have no calls but got: %v", name, got)
+		t.FailNow()
+	}
+
+	if want != nil {
+		for _, v := range *want {
+			exclude := strings.HasPrefix(v, "!")
+			if exclude {
+				v = strings.TrimPrefix(v, "!")
+			}
+			contains := funk.Contains(got, v)
+			if exclude && contains {
+				t.Errorf("%s: should not contain: %s, calls: %v", name, v, got)
+			}
+			if !exclude && !contains {
+				t.Errorf("%s: should have contained: %s, calls: %v", name, v, got)
+			}
+		}
+	}
+}

--- a/internal/subshell/powershell/powershell.go
+++ b/internal/subshell/powershell/powershell.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/internal/subshell/sscommon"
+	"github.com/ActiveState/cli/pkg/project"
+)
+
+var escaper *osutils.ShellEscape
+
+func init() {
+	escaper = osutils.NewBatchEscaper()
+}
+
+// SubShell covers the subshell.SubShell interface, reference that for documentation
+type SubShell struct {
+	binary          string
+	rcFile          *os.File
+	cmd             *exec.Cmd
+	env             map[string]string
+	errs            chan error
+	activateCommand *string
+}
+
+const Name string = "powershell"
+
+// https://www.improvescripting.com/how-to-create-powershell-profile-step-by-step-with-examples/
+const rcFileName = "Microsoft.PowerShell_profile.ps1"
+
+// Shell - see subshell.SubShell
+func (v *SubShell) Shell() string {
+	return Name
+}
+
+// Binary - see subshell.SubShell
+func (v *SubShell) Binary() string {
+	return v.binary
+}
+
+// SetBinary - see subshell.SubShell
+func (v *SubShell) SetBinary(binary string) {
+	v.binary = binary
+}
+
+// WriteUserEnv - see subshell.SubShell
+func (v *SubShell) WriteUserEnv(cfg sscommon.Configurable, env map[string]string, envType sscommon.RcIdentification, userScope bool) error {
+	cmdEnv := NewCmdEnv(userScope)
+
+	// Clean up old entries
+	oldEnv := cfg.GetStringMap(envType.Key)
+	for k, v := range oldEnv {
+		if err := cmdEnv.unset(k, v.(string)); err != nil {
+			return err
+		}
+	}
+
+	// Store new entries
+	err := cfg.Set(envType.Key, env)
+	if err != nil {
+		return errs.Wrap(err, "Could not set env infomation in config")
+	}
+
+	for k, v := range env {
+		value := v
+		if k == "PATH" {
+			path, err := cmdEnv.Get("PATH")
+			if err != nil {
+				return err
+			}
+			if path != "" {
+				path = ";" + path
+			}
+
+			value = v + path
+		}
+
+		// Set key/value in the user environment
+		err := cmdEnv.set(k, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := osutils.PropagateEnv(); err != nil {
+		return errs.Wrap(err, "Sending OS signal to update environment failed.")
+	}
+	return nil
+}
+
+func (v *SubShell) CleanUserEnv(cfg sscommon.Configurable, envType sscommon.RcIdentification, userScope bool) error {
+	cmdEnv := NewCmdEnv(userScope)
+
+	// Clean up old entries
+	oldEnv := cfg.GetStringMap(envType.Key)
+	for k, v := range oldEnv {
+		if err := cmdEnv.unset(k, v.(string)); err != nil {
+			return err
+		}
+	}
+
+	if err := osutils.PropagateEnv(); err != nil {
+		return errs.Wrap(err, "Sending OS signal to update environment failed.")
+	}
+	return nil
+}
+
+func (v *SubShell) RemoveLegacyInstallPath(_ sscommon.Configurable) error {
+	return nil
+}
+
+func (v *SubShell) WriteCompletionScript(completionScript string) error {
+	return locale.NewError("err_writecompletions_notsupported", "{{.V0}} does not support completions.", v.Shell())
+}
+
+func (v *SubShell) RcFile() (string, error) {
+	homeDir, err := fileutils.HomeDir()
+	if err != nil {
+		return "", errs.Wrap(err, "IO failure")
+	}
+
+	rcFilePath := filepath.Join(homeDir, "Documents", rcFileName)
+	// Ensure the .bashrc file exists. On some platforms it is not created by default
+	if !fileutils.TargetExists(rcFilePath) {
+		err = fileutils.Touch(rcFilePath)
+		if err != nil {
+			return "", errs.Wrap(err, "Failed to create RCFile at %s", rcFilePath)
+		}
+	}
+
+	return rcFilePath, nil
+}
+
+// SetupShellRcFile - subshell.SubShell
+func (v *SubShell) SetupShellRcFile(targetDir string, env map[string]string, namespace project.Namespaced) error {
+	env = sscommon.EscapeEnv(env)
+	return sscommon.SetupShellRcFile(filepath.Join(targetDir, "shell.ps1"), "powershell_global.bat", env, namespace)
+}
+
+// SetEnv - see subshell.SetEnv
+func (v *SubShell) SetEnv(env map[string]string) {
+	v.env = env
+}
+
+// SetActivateCommand - see subshell.SetActivateCommand
+func (v *SubShell) SetActivateCommand(cmd string) {
+	v.activateCommand = &cmd
+}
+
+// Quote - see subshell.Quote
+func (v *SubShell) Quote(value string) string {
+	return escaper.Quote(value)
+}
+
+// Activate - see subshell.SubShell
+func (v *SubShell) Activate(prj *project.Project, cfg sscommon.Configurable, out output.Outputer) error {
+	env := sscommon.EscapeEnv(v.env)
+	var err error
+	if v.rcFile, err = sscommon.SetupProjectRcFile(prj, "powershell.ps1", ".ps1", env, out, cfg); err != nil {
+		return err
+	}
+
+	shellArgs := []string{"/K", v.rcFile.Name()}
+	if v.activateCommand != nil {
+		if err := fileutils.AppendToFile(v.rcFile.Name(), []byte("\r\n"+*v.activateCommand+"\r\nexit")); err != nil {
+			return err
+		}
+	}
+
+	cmd := exec.Command("powershell.exe", shellArgs...)
+
+	v.errs = sscommon.Start(cmd)
+	v.cmd = cmd
+	return nil
+}
+
+// Errors returns a channel for receiving errors related to active behavior
+func (v *SubShell) Errors() <-chan error {
+	return v.errs
+}
+
+// Deactivate - see subshell.SubShell
+func (v *SubShell) Deactivate() error {
+	if !v.IsActive() {
+		return nil
+	}
+
+	if err := sscommon.Stop(v.cmd); err != nil {
+		return err
+	}
+
+	v.cmd = nil
+	return nil
+}
+
+// Run - see subshell.SubShell
+func (v *SubShell) Run(filename string, args ...string) error {
+	return sscommon.RunFuncByBinary(v.Binary())(osutils.EnvMapToSlice(v.env), filename, args...)
+}
+
+// IsActive - see subshell.SubShell
+func (v *SubShell) IsActive() bool {
+	return v.cmd != nil && (v.cmd.ProcessState == nil || !v.cmd.ProcessState.Exited())
+}

--- a/internal/subshell/powershell/powershell_test.go
+++ b/internal/subshell/powershell/powershell_test.go
@@ -1,0 +1,3 @@
+package cmd
+
+// Tested in ../subshell_test.go

--- a/internal/subshell/subshell.go
+++ b/internal/subshell/subshell.go
@@ -119,11 +119,13 @@ func New(cfg sscommon.Configurable) SubShell {
 		subs = &fish.SubShell{}
 	case "cmd":
 		subs = &cmd.SubShell{}
+	case "powershell":
+		subs = &powershell.SubShell{}
 	default:
 		logging.Debug("Unsupported shell: %s, defaulting to OS default.", name)
 		switch runtime.GOOS {
 		case "windows":
-			return &cmd.SubShell{}
+			return &powershell.SubShell{}
 		case "darwin":
 			return &zsh.SubShell{}
 		default:
@@ -162,8 +164,12 @@ func DetectShellBinary(cfg sscommon.Configurable) (binary string) {
 
 	if runtime.GOOS == "windows" {
 		binary = os.Getenv("ComSpec")
+		powershell = os.Getenv("PSModulePath")
 		if binary != "" {
 			return binary
+		}
+		if powershell != "" {
+			return "powershell.exe"
 		}
 	}
 


### PR DESCRIPTION
This is an attempt (admittedly failed) at adding Powershell support in the state tool.  

I think there's an opportunity to make this a little more user friendly where a user provide the correct templated "rcFile" and completes the interface for subshell and they can add whatever shell they want.  I THINK that's basically there already but once I hit the `sscommon` code it got a little confusing, espcially with Powershell as I think I can use the Unix sscommon. 



Notes:
Dev:
- Nothing is tested.  I wasn't even able to get it to build due to the confusing noted in the *Contributing to the code* section below
- RCFILE: Helpful post about where Powershell "rcFiles" live (also noted in the powershell.go subshell file): https://www.improvescripting.com/how-to-create-powershell-profile-step-by-step-with-examples/
   - It looks like you could use `Profile.ps1` as the rcFile name instead 
- Detecting Powershell: There doesn't seem to be an obvious way to detect that you're in a Powershell terminal.  I'm using `PSModulePath` which is the only Powershell specific envvar I could find in a vanilla shell
   - Another option would be to execute Powershell specific cmd and you're in that shell if it doesn't fail
- For powershell, I THINK you will be able to do the same thing as you do with BASH rcfiles with the `cleanRCfile` function and appending to it.  One point there though is that it looks like Windows does NOT populate the user specific `Microsoft.PowerShell_profile.ps1` file so you'll most likely need to create it (or just always handle the file maybe not being there...which maybe you do already)


Contributing to the code:
- There is an install cmd for Powershell in the README that should go.  
- The `activestate-windows.yaml` is misleading.  I thought I could use at least CMD but ALL scripts in the as.yaml are bash scripts so  it doesn't actually support Windows at all.  For a company backed open source project, we really should put some effort in support Windows in the contribution process.
-  Navigating the code page is daunting to say the least.  There's no documentation or information of how the project is laid or supposed to be implemented.  The only way you can add to it it seems like is modifying an existing feature.  I wouldn't know where to begin to add new features.

To whomever picks this up, if they do:
- I'm not sure the powershell/env[-test].go files are needed but they may be because Powershell can be weird about how you access variables.
-  