### PR TITLE
Ensure project dimension is accurate

### DIFF
--- a/internal/runners/prepare/prepare.go
+++ b/internal/runners/prepare/prepare.go
@@ -61,7 +61,7 @@ func (r *Prepare) resetExecutors() error {
 		return errs.Wrap(err, "Could not get project from default project directory")
 	}
 
-	run, err := rt.New(rt.NewCustomTarget("", "", "", defaultTargetDir, rt.TriggerDefault, proj.IsHeadless()), r.analytics)
+	run, err := rt.New(rt.NewCustomTarget(proj.Owner(), proj.Name(), proj.CommitUUID(), defaultTargetDir, rt.TriggerDefault, proj.IsHeadless()), r.analytics)
 	if err != nil {
 		return errs.Wrap(err, "Could not initialize runtime for global default project.")
 	}

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
 	"github.com/ActiveState/cli/pkg/platform/runtime/setup/events"
 	"github.com/ActiveState/cli/pkg/platform/runtime/store"
+	"github.com/ActiveState/cli/pkg/project"
 )
 
 type Runtime struct {
@@ -65,9 +66,10 @@ func New(target setup.Targeter, an analytics.Dispatcher) (*Runtime, error) {
 		return DisabledRuntime, nil
 	}
 	an.Event(anaConsts.CatRuntime, anaConsts.ActRuntimeStart, &dimensions.Values{
-		Trigger:  p.StrP(target.Trigger()),
-		Headless: p.StrP(strconv.FormatBool(target.Headless())),
-		CommitID: p.StrP(target.CommitUUID().String()),
+		Trigger:          p.StrP(target.Trigger()),
+		Headless:         p.StrP(strconv.FormatBool(target.Headless())),
+		CommitID:         p.StrP(target.CommitUUID().String()),
+		ProjectNameSpace: p.StrP(project.NewNamespace(target.Owner(), target.Name(), target.CommitUUID().String()).String()),
 	})
 
 	r, err := newRuntime(target, an)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-468" title="DX-468" target="_blank"><img alt="Sub-task" src="https://activestatef.atlassian.net/secure/viewavatar?size=medium&avatarId=10316&avatarType=issuetype" />DX-468</a>  Ensure project is always accurate with runtime events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I _think_ this covers the AC in the ticket. There is one instance where we create a custom target where we do not have the project information. Other than that, including the project namespace in the `runtime-start`  event should be accurate.