### PR TITLE
Fix execDir using wrong state executables when encountering old path

### DIFF
--- a/internal/appinfo/appinfo.go
+++ b/internal/appinfo/appinfo.go
@@ -17,14 +17,19 @@ type AppInfo struct {
 	executable string
 }
 
-func execDir(baseDir ...string) string {
-	if len(baseDir) > 0 {
-		binDir := filepath.Join(baseDir[0], "bin")
+func execDir(baseDir ...string) (resultPath string) {
+	defer func() {
+		// Account for legacy use-case that wasn't using the correct bin dir
+		binDir := filepath.Join(resultPath, "bin")
 		if fileutils.DirExists(binDir) {
-			return binDir
+			resultPath = binDir
 		}
+	}()
+
+	if len(baseDir) > 0 {
 		return baseDir[0]
 	}
+
 	if condition.InUnitTest() {
 		// Work around tests creating a temp file, but we need the original (ie. the one from the build dir)
 		rootPath := environment.GetRootPathUnsafe()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-534" title="DX-534" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />DX-534</a>  state-svc sometimes trying to start with wrong path
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
