### PR TITLE
Update push branch check

### DIFF
--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -164,12 +164,14 @@ func (r *Push) Run(params PushParams) error {
 	// Detect the target branch
 	var branch *mono_models.Branch
 	branch, err = model.BranchForProjectByName(targetPjm, r.project.BranchName())
-	if err != nil {
-		logging.Error("Could not fetch branch: %s", errs.JoinMessage(err))
+	if errs.Matches(err, &model.ErrBranchNotFound{}) {
 		branch, err = model.DefaultBranchForProject(targetPjm)
 		if err != nil {
 			return locale.NewInputError("err_no_default_branch")
 		}
+	}
+	if err != nil {
+		return locale.WrapError(err, "err_fetch_branch", "", r.project.BranchName())
 	}
 
 	// Check if branch is already up to date

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -164,6 +164,7 @@ func (r *Push) Run(params PushParams) error {
 	// Detect the target branch
 	var branch *mono_models.Branch
 	if projectCreated || r.project.BranchName() == "" {
+		// If we have created an empty project the only existing branch will be the default one
 		branch, err = model.DefaultBranchForProject(targetPjm)
 		if err != nil {
 			return locale.NewInputError("err_no_default_branch")

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -164,6 +164,7 @@ func (r *Push) Run(params PushParams) error {
 	// Detect the target branch
 	var branch *mono_models.Branch
 	if projectCreated || r.project.BranchName() == "" {
+		// https://www.pivotaltracker.com/story/show/176806415
 		// If we have created an empty project the only existing branch will be the default one
 		branch, err = model.DefaultBranchForProject(targetPjm)
 		if err != nil {

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -163,16 +163,12 @@ func (r *Push) Run(params PushParams) error {
 
 	// Detect the target branch
 	var branch *mono_models.Branch
-	if r.project.BranchName() == "" {
-		// https://www.pivotaltracker.com/story/show/176806415
+	branch, err = model.BranchForProjectByName(targetPjm, r.project.BranchName())
+	if err != nil {
+		logging.Error("Could not fetch branch: %s", errs.JoinMessage(err))
 		branch, err = model.DefaultBranchForProject(targetPjm)
 		if err != nil {
 			return locale.NewInputError("err_no_default_branch")
-		}
-	} else {
-		branch, err = model.BranchForProjectByName(targetPjm, r.project.BranchName())
-		if err != nil {
-			return locale.WrapError(err, "err_fetch_branch", "", r.project.BranchName())
 		}
 	}
 

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -163,15 +163,16 @@ func (r *Push) Run(params PushParams) error {
 
 	// Detect the target branch
 	var branch *mono_models.Branch
-	branch, err = model.BranchForProjectByName(targetPjm, r.project.BranchName())
-	if errs.Matches(err, &model.ErrBranchNotFound{}) {
+	if projectCreated || r.project.BranchName() == "" {
 		branch, err = model.DefaultBranchForProject(targetPjm)
 		if err != nil {
 			return locale.NewInputError("err_no_default_branch")
 		}
-	}
-	if err != nil {
-		return locale.WrapError(err, "err_fetch_branch", "", r.project.BranchName())
+	} else {
+		branch, err = model.BranchForProjectByName(targetPjm, r.project.BranchName())
+		if err != nil {
+			return locale.WrapError(err, "err_fetch_branch", "", r.project.BranchName())
+		}
 	}
 
 	// Check if branch is already up to date

--- a/pkg/platform/model/projects.go
+++ b/pkg/platform/model/projects.go
@@ -25,8 +25,6 @@ type ErrProjectNameConflict struct{ *locale.LocalizedError }
 
 type ErrProjectNotFound struct{ *locale.LocalizedError }
 
-type ErrBranchNotFound struct{ *locale.LocalizedError }
-
 // FetchProjectByName fetches a project for an organization.
 func FetchProjectByName(orgName string, projectName string) (*mono_models.Project, error) {
 	logging.Debug("fetching project (%s) in organization (%s)", projectName, orgName)
@@ -141,11 +139,11 @@ func BranchForProjectByName(pj *mono_models.Project, name string) (*mono_models.
 		}
 	}
 
-	return nil, &ErrBranchNotFound{locale.NewInputError(
+	return nil, locale.NewInputError(
 		"err_no_matching_branch_label",
 		"This project has no branch with label matching [NOTICE]{{.V0}}[/RESET].",
 		name,
-	)}
+	)
 }
 
 // CreateEmptyProject will create the project on the platform

--- a/pkg/platform/model/projects.go
+++ b/pkg/platform/model/projects.go
@@ -25,6 +25,8 @@ type ErrProjectNameConflict struct{ *locale.LocalizedError }
 
 type ErrProjectNotFound struct{ *locale.LocalizedError }
 
+type ErrBranchNotFound struct{ *locale.LocalizedError }
+
 // FetchProjectByName fetches a project for an organization.
 func FetchProjectByName(orgName string, projectName string) (*mono_models.Project, error) {
 	logging.Debug("fetching project (%s) in organization (%s)", projectName, orgName)
@@ -139,11 +141,11 @@ func BranchForProjectByName(pj *mono_models.Project, name string) (*mono_models.
 		}
 	}
 
-	return nil, locale.NewInputError(
+	return nil, &ErrBranchNotFound{locale.NewInputError(
 		"err_no_matching_branch_label",
 		"This project has no branch with label matching [NOTICE]{{.V0}}[/RESET].",
 		name,
-	)
+	)}
 }
 
 // CreateEmptyProject will create the project on the platform

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -81,7 +81,7 @@ func (suite *PullIntegrationTestSuite) TestPull_Merge() {
 	ts.LoginAsPersistentUser()
 
 	cp := ts.SpawnWithOpts(e2e.WithArgs("push"), e2e.WithWorkDirectory(wd))
-	cp.ExpectLongString("Your project has new commits available")
+	cp.ExpectLongString("Your project has new changes available")
 	cp.ExpectExitCode(1)
 
 	cp = ts.SpawnWithOpts(e2e.WithArgs("pull"), e2e.WithWorkDirectory(wd))

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -65,6 +66,10 @@ func (suite *PullIntegrationTestSuite) TestPullSetProjectUnrelated() {
 }
 
 func (suite *PullIntegrationTestSuite) TestPull_Merge() {
+	// https://activestatef.atlassian.net/browse/DX-542
+	if runtime.GOOS == "windows" {
+		suite.T().Skip("Working directory is not working correctly on Windows")
+	}
 	suite.OnlyRunForTags(tagsuite.Push)
 	projectLine := "project: https://platform.activestate.com/ActiveState-CLI/cli?branch=main&commitID="
 	unPulledCommit := "882ae76e-fbb7-4989-acc9-9a8b87d49388"

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
-	"github.com/ActiveState/cli/internal/locale"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -89,7 +88,7 @@ func (suite *PullIntegrationTestSuite) TestPull_Merge() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnCmd("bash", "-c", fmt.Sprintf("cd %s && %s history | head -n 10", wd, ts.ExecutablePath()))
-	cp.ExpectLongString(locale.T("pull_merge_commit"))
+	cp.ExpectLongString("Merged")
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(e2e.WithArgs("push"), e2e.WithWorkDirectory(wd))

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -90,10 +90,6 @@ func (suite *PullIntegrationTestSuite) TestPull_Merge() {
 	cp = ts.SpawnCmd("bash", "-c", fmt.Sprintf("cd %s && %s history | head -n 10", wd, ts.ExecutablePath()))
 	cp.ExpectLongString("Merged")
 	cp.ExpectExitCode(0)
-
-	cp = ts.SpawnWithOpts(e2e.WithArgs("push"), e2e.WithWorkDirectory(wd))
-	cp.ExpectLongString("You do not have permission") // This tells us the history is valid, we don't need an actual successful push
-	cp.ExpectExitCode(1)
 }
 
 func TestPullIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-260" title="DX-260" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />DX-260</a>  Creating fork with `state push` fails when source is custom branch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Judging from the ticket I think this is the behaviour we want.

1. User is on a non-default branch of a project
2. `state push <new/namespace>`
3. state push creates a new project. The new project's default branch has the latest commit from (1)