### PR TITLE
Fix auth locale entries

### DIFF
--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -162,9 +162,9 @@ func (s *Auth) AuthenticateWithModel(credentials *mono_models.Credentials) error
 	loginOK, err := mono.Get().Authentication.PostLogin(params)
 	if err != nil {
 		tips := []string{
-			locale.T("relog_tip", "If you're having trouble authenticating try logging out and logging back in again."),
-			locale.T("logout_tip", "Logout with [ACTIONABLE]`state auth logout`[/RESET]."),
-			locale.T("logout_tip", "Login with [ACTIONABLE]`state auth`[/RESET]."),
+			locale.Tl("relog_tip", "If you're having trouble authenticating try logging out and logging back in again."),
+			locale.Tl("logout_tip", "Logout with [ACTIONABLE]`state auth logout`[/RESET]."),
+			locale.Tl("logout_tip", "Login with [ACTIONABLE]`state auth`[/RESET]."),
 		}
 
 		switch err.(type) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-420" title="DX-420" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />DX-420</a>  Failed `state auth` has missing locale entries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
