### PR TITLE
Fix Installer giving update UX and targeting wrong dir if `-b` passed

### DIFF
--- a/internal/installation/paths.go
+++ b/internal/installation/paths.go
@@ -20,6 +20,10 @@ const CfgTransitionalStateToolPath = "transitional_installation_path"
 
 const BinDirName = "bin"
 
+func DefaultInstallPath() (string, error) {
+	return InstallPathForBranch(constants.BranchName)
+}
+
 func InstallPath() (string, error) {
 	// Facilitate use-case of running executables from the build dir while developing
 	if !condition.BuiltViaCI() && strings.Contains(os.Args[0], "/build/") {
@@ -63,16 +67,13 @@ func BinPathFromInstallPath(installPath string) (string, error) {
 	return installPath, nil
 }
 
-func Installed() (bool, error) {
-	return InstalledOnPath("")
-}
-
-func InstalledOnPath(installPath string) (bool, error) {
+func InstalledOnPath(installPath string) (bool, string, error) {
 	binPath, err := BinPathFromInstallPath(installPath)
 	if err != nil {
-		return false, errs.Wrap(err, "Could not detect binPath from BinPathFromInstallPath")
+		return false, "", errs.Wrap(err, "Could not detect binPath from BinPathFromInstallPath")
 	}
-	return fileutils.TargetExists(appinfo.StateApp(binPath).Exec()), nil
+	path := appinfo.StateApp(binPath).Exec()
+	return fileutils.TargetExists(path), path, nil
 }
 
 func LauncherInstallPath() (string, error) {

--- a/internal/installation/paths_darwin.go
+++ b/internal/installation/paths_darwin.go
@@ -4,19 +4,16 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/mitchellh/go-homedir"
 )
 
-func DefaultInstallPath() (string, error) {
-	// This should actually go to ~/Applications/ActiveStateDesktop.app/Contents/..
-	// but we don't have our app yet
+func InstallPathForBranch(branch string) (string, error) {
 	usr, err := user.Current()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not access info on current user")
 	}
-	return filepath.Join(usr.HomeDir, ".local", "ActiveState", "StateTool", constants.BranchName), nil
+	return filepath.Join(usr.HomeDir, ".local", "ActiveState", "StateTool", branch), nil
 }
 
 func defaultSystemInstallPath() (string, error) {

--- a/internal/installation/paths_linux.go
+++ b/internal/installation/paths_linux.go
@@ -4,17 +4,16 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/mitchellh/go-homedir"
 )
 
-func DefaultInstallPath() (string, error) {
+func InstallPathForBranch(branch string) (string, error) {
 	usr, err := user.Current()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not access info on current user")
 	}
-	return filepath.Join(usr.HomeDir, ".local", "ActiveState", "StateTool", constants.BranchName), nil
+	return filepath.Join(usr.HomeDir, ".local", "ActiveState", "StateTool", branch), nil
 }
 
 func defaultSystemInstallPath() (string, error) {

--- a/internal/installation/paths_windows.go
+++ b/internal/installation/paths_windows.go
@@ -3,12 +3,10 @@ package installation
 import (
 	"os"
 	"path/filepath"
-
-	"github.com/ActiveState/cli/internal/constants"
 )
 
-func DefaultInstallPath() (string, error) {
-	return filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local", "ActiveState", "StateTool", constants.BranchName), nil
+func InstallPathForBranch(branch string) (string, error) {
+	return filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local", "ActiveState", "StateTool", branch), nil
 }
 
 func defaultSystemInstallPath() (string, error) {

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -236,8 +236,6 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_RecursionDetection() {
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 
-	cp.Expect("activated state")
-
 	cp.WaitForInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -264,7 +262,6 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_RecursionDetection() {
 				ts.Dirs.DefaultBin, string(os.PathListSeparator), executor, constants.ExecRecursionLevelEnvVarName)),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false", "VERBOSE=true"),
 	)
-	cp.ExpectLongString("executor recursion detected: parent python")
 	cp.Expect("RECURSION_LVL=1")
 	cp.Wait()
 }

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -236,6 +236,8 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_RecursionDetection() {
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 
+	cp.Expect("activated state")
+
 	cp.WaitForInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -262,6 +264,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_RecursionDetection() {
 				ts.Dirs.DefaultBin, string(os.PathListSeparator), executor, constants.ExecRecursionLevelEnvVarName)),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false", "VERBOSE=true"),
 	)
+	cp.ExpectLongString("executor recursion detected: parent python")
 	cp.Expect("RECURSION_LVL=1")
 	cp.Wait()
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-558" title="DX-558" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />DX-558</a>  Installer always prints "Installing update" even on fresh install
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
