### PR TITLE
Trial go111module envvar fix for 'go install' use in asy

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -56,6 +56,7 @@ scripts:
   - name: install-deps
     language: bash
     value: |
+      export GO111MODULE=on
       goflags="${GOFLAGS}"; unset GOFLAGS
       if ! type "packr" &> /dev/null; then
         echo "packr was not found on your PATH, installing .."


### PR DESCRIPTION
hotfix for failing deploy job on master
@Naatan I'm not sure this will work, but it's my best guess at the moment.