### PR TITLE
Always use go get in install-deps script

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -56,7 +56,7 @@ scripts:
   - name: install-deps
     language: bash
     value: |
-      tmpdir="$(mktemp --directory --tmpdir="${PWD}")"
+      tmpdir="$(mktemp --directory "${PWD}/tmp.XXXXXXX")"
       cleanup() { rm -rf "${tmpdir}"; }
       pushd "${tmpdir}" && trap "cleanup" EXIT
       go mod init deps

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -56,16 +56,20 @@ scripts:
   - name: install-deps
     language: bash
     value: |
-      export GO111MODULE=on
+      tmpdir="$(mktemp --directory --tmpdir="${PWD}")"
+      cleanup() { rm -rf "${tmpdir}"; }
+      pushd "${tmpdir}" && trap "cleanup" EXIT
+      go mod init deps
       goflags="${GOFLAGS}"; unset GOFLAGS
       if ! type "packr" &> /dev/null; then
         echo "packr was not found on your PATH, installing .."
-        go install github.com/gobuffalo/packr/packr@v1.30.1
+        go get github.com/gobuffalo/packr/packr@v1.30.1
       fi
       if ! type "golangci-lint" &> /dev/null; then
         echo "golangci-lint was not found on your PATH, installing .."
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+        go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
       fi
+      popd
       GOFLAGS="${goflags}"
       $scripts.install-deps-os
   - name: install-deps-os

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -56,7 +56,7 @@ scripts:
   - name: install-deps
     language: bash
     value: |
-      tmpdir="$(mktemp --directory "${PWD}/tmp.XXXXXXX")"
+      tmpdir="$(mktemp -d "${PWD}/tmp.XXXXXXX")"
       cleanup() { rm -rf "${tmpdir}"; }
       pushd "${tmpdir}" && trap "cleanup" EXIT
       go mod init deps


### PR DESCRIPTION
@Naatan The temporary directory juggling here is due to how `go get` works with modules and alters the go.mod and go.sum files.

As of go1.16, `go install` is the recommended way to build and install commands. That would remove the need for this change. See: https://activestatef.atlassian.net/browse/DX-596