### PR TITLE
Fix rollbar panic

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -64,7 +64,7 @@ func main() {
 		if panics.HandlePanics(recover(), debug.Stack()) {
 			exitCode = 1
 		}
-		if err := events.WaitForEvents(5*time.Second, rollbar.Close, an.Wait); err != nil {
+		if err := events.WaitForEvents(5*time.Second, rollbar.Wait, rollbar.Close, an.Wait); err != nil {
 			logging.Error("state-installer failed to wait for events: %v", err)
 		}
 		os.Exit(exitCode)

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -42,7 +42,7 @@ func main() {
 		if panics.HandlePanics(recover(), debug.Stack()) {
 			exitCode = 1
 		}
-		if err := events.WaitForEvents(5*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(5*time.Second, rollbar.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failing to wait for rollbar to close")
 		}
 		os.Exit(exitCode)
@@ -58,7 +58,7 @@ func main() {
 	if err != nil {
 		errMsg := errs.Join(err, ": ").Error()
 		if locale.IsInputError(err) {
-			logging.Error("state-svc errored out due to input: %s", errMsg)
+			logging.Debug("state-svc errored out due to input: %s", errMsg)
 		} else {
 			logging.Critical("state-svc errored out: %s", errMsg)
 		}

--- a/cmd/state-tray/main.go
+++ b/cmd/state-tray/main.go
@@ -55,7 +55,7 @@ func onReady() {
 			exitCode = 1
 		}
 		logging.Debug("onReady is done with exit code %d", exitCode)
-		if err := events.WaitForEvents(1*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(1*time.Second, rollbar.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failed to wait for rollbar to close")
 		}
 		os.Exit(exitCode)

--- a/cmd/state-update-dialog/main.go
+++ b/cmd/state-update-dialog/main.go
@@ -25,7 +25,7 @@ func main() {
 		if panics.HandlePanics(recover(), debug.Stack()) {
 			exitCode = 1
 		}
-		if err := events.WaitForEvents(1*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(1*time.Second, rollbar.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failed to wait for rollbar to close")
 		}
 		os.Exit(exitCode)

--- a/cmd/state/errors.go
+++ b/cmd/state/errors.go
@@ -104,7 +104,7 @@ func unwrapError(err error) (int, error) {
 	if !locale.IsInputError(err) {
 		logging.Critical("Returning error:\n%s\nCreated at:\n%s", errs.Join(err, "\n").Error(), stack)
 	} else {
-		logging.Error("Returning input error:\n%s\nCreated at:\n%s", errs.Join(err, "\n").Error(), stack)
+		logging.Debug("Returning input error:\n%s\nCreated at:\n%s", errs.Join(err, "\n").Error(), stack)
 	}
 
 	var llerr *config.LocalizedError // workaround type used to avoid circular import in config pkg
@@ -123,7 +123,7 @@ func unwrapError(err error) (int, error) {
 		logging.Error("MUST ADDRESS: Error does not have localization: %s", errs.Join(err, "\n").Error())
 
 		// If this wasn't built via CI then this is a dev workstation, and we should be more aggressive
-		if ! condition.BuiltViaCI() {
+		if !condition.BuiltViaCI() {
 			panic(fmt.Sprintf("Errors must be localized! Please localize: %s, called at: %s\n", errs.JoinMessage(err), stack))
 		}
 	}

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -60,7 +60,7 @@ func main() {
 		}
 
 		// ensure rollbar messages are called
-		if err := events.WaitForEvents(5*time.Second, rollbar.Close, authentication.LegacyClose); err != nil {
+		if err := events.WaitForEvents(5*time.Second, rollbar.Wait, rollbar.Close, authentication.LegacyClose); err != nil {
 			logging.Warning("Failed waiting for events: %v", err)
 		}
 

--- a/internal/logging/rollbar.go
+++ b/internal/logging/rollbar.go
@@ -19,12 +19,12 @@ func (s *RollbarLogger) Printf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-type RollbarErrorLogger struct{
+type RollbarErrorLogger struct {
 	reporter func(string)
 }
 
 func (s *RollbarErrorLogger) Printf(format string, args ...interface{}) {
-	if ! strings.HasPrefix(format, "Rollbar") { // All rollbar errors I observed are prefixed with "Rollbar"
+	if !strings.HasPrefix(format, "Rollbar") { // All rollbar errors I observed are prefixed with "Rollbar"
 		return
 	}
 
@@ -41,6 +41,7 @@ func SetupRollbar(token string) {
 	if _, ok := rollbar.Custom()["UserID"]; !ok {
 		UpdateRollbarPerson("unknown", "unknown", "unknown")
 	}
+	rollbar.SetRetryAttempts(1)
 	rollbar.SetToken(token)
 	rollbar.SetEnvironment(constants.BranchName)
 


### PR DESCRIPTION
When sending a rollbar event fails the default rollbar client will attempt to send it again. This can cause a panic if the underlying transport that the rollbar client uses has already been closed. This PR adds a wait before we close the rollbar client and also sets the number of retries to 1 rather than the default of 3.