### PR TITLE
Renamed config.SetWithLock() to config.GetThenSet()

### DIFF
--- a/cmd/state-svc/manager.go
+++ b/cmd/state-svc/manager.go
@@ -35,8 +35,8 @@ func NewServiceManager(cfg *config.Instance) *serviceManager {
 
 func (s *serviceManager) Start(args ...string) error {
 	var proc *os.Process
-	err := s.cfg.SetWithLock(constants.SvcConfigPid, func(oldPidI interface{}) (interface{}, error) {
-		oldPid := cast.ToInt(oldPidI)
+	err := s.cfg.GetThenSet(constants.SvcConfigPid, func(currentValue interface{}) (interface{}, error) {
+		oldPid := cast.ToInt(currentValue)
 		curPid, err := s.CheckPid(oldPid)
 		if err == nil && curPid != nil {
 			return nil, ErrSvcAlreadyRunning

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -60,8 +60,8 @@ func (s *service) Stop() error {
 		return errs.Wrap(err, "Failed to stop server")
 	}
 
-	err := s.cfg.SetWithLock(constants.SvcConfigPid, func(setPidI interface{}) (interface{}, error) {
-		setPid := cast.ToInt(setPidI)
+	err := s.cfg.GetThenSet(constants.SvcConfigPid, func(currentValue interface{}) (interface{}, error) {
+		setPid := cast.ToInt(currentValue)
 		if setPid != os.Getpid() {
 			logging.Warning("PID in configuration file does not match PID of server shutting down")
 		}

--- a/cmd/state-tray/main.go
+++ b/cmd/state-tray/main.go
@@ -257,8 +257,8 @@ func onExit() {
 			logging.Error("Failed to close config after exiting systray: %w", err)
 		}
 	}()
-	err = cfg.SetWithLock(installation.ConfigKeyTrayPid, func(setPidI interface{}) (interface{}, error) {
-		setPid := cast.ToInt(setPidI)
+	err = cfg.GetThenSet(installation.ConfigKeyTrayPid, func(currentValue interface{}) (interface{}, error) {
+		setPid := cast.ToInt(currentValue)
 		if setPid != os.Getpid() {
 			return nil, errs.New("PID in configuration file does not match PID of Systray shutting down")
 		}

--- a/internal/runners/clean/cache_test.go
+++ b/internal/runners/clean/cache_test.go
@@ -56,7 +56,7 @@ func (c *configMock) GetStringMapStringSlice(key string) map[string][]string {
 	return map[string][]string{}
 }
 
-func (c *configMock) SetWithLock(_ string, fn func(interface{}) (interface{}, error)) error {
+func (c *configMock) GetThenSet(_ string, fn func(interface{}) (interface{}, error)) error {
 	_, err := fn(nil)
 	return err
 }

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -1169,7 +1169,7 @@ type ConfigGetter interface {
 	AllKeys() []string
 	GetStringSlice(string) []string
 	Set(string, interface{}) error
-	SetWithLock(string, func(interface{}) (interface{}, error)) error
+	GetThenSet(string, func(interface{}) (interface{}, error)) error
 	Close() error
 }
 
@@ -1229,7 +1229,7 @@ func GetCachedProjectNameForPath(config ConfigGetter, projectPath string) string
 func addDeprecatedProjectMappings(cfg ConfigGetter) {
 	var unsets []string
 
-	err := cfg.SetWithLock(
+	err := cfg.GetThenSet(
 		LocalProjectsConfigKey,
 		func(v interface{}) (interface{}, error) {
 			projects, err := cast.ToStringMapStringSliceE(v)
@@ -1281,7 +1281,7 @@ func GetProjectPaths(cfg ConfigGetter, namespace string) []string {
 // StoreProjectMapping associates the namespace with the project
 // path in the config
 func StoreProjectMapping(cfg ConfigGetter, namespace, projectPath string) {
-	err := cfg.SetWithLock(
+	err := cfg.GetThenSet(
 		LocalProjectsConfigKey,
 		func(v interface{}) (interface{}, error) {
 			projects, err := cast.ToStringMapStringSliceE(v)
@@ -1335,7 +1335,7 @@ func StoreProjectMapping(cfg ConfigGetter, namespace, projectPath string) {
 // CleanProjectMapping removes projects that no longer exist
 // on a user's filesystem from the projects config entry
 func CleanProjectMapping(cfg ConfigGetter) {
-	err := cfg.SetWithLock(
+	err := cfg.GetThenSet(
 		LocalProjectsConfigKey,
 		func(v interface{}) (interface{}, error) {
 			projects, err := cast.ToStringMapStringSliceE(v)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-48" title="DX-48" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-48</a>  Get rid of `config.SetWithLock()`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This better captures what is going on.

I created a separate [JIRA ticket](https://activestatef.atlassian.net/jira/software/c/projects/DX/issues/DX-651) on improving concurrency so we can use something more generic like `config.WithLock()` and pass a function that calls `config.Get()` and then `config.Set()`. Until then, this at least limits confusion with `config.Set()`.

 Note: `config.Set()` is already thread-safe.