### PR TITLE
Added script that stops running state tool processes

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -269,6 +269,7 @@ scripts:
       else
         cp installers/install${constants.SCRIPT_EXT} $INSTALLERS_DIR/install${constants.SCRIPT_EXT}
       fi
+      cp installers/stop${constants.SCRIPT_EXT} $INSTALLERS_DIR/stop${constants.SCRIPT_EXT}
   - name: deploy-installers
     language: bash
     description: Deploys update files to S3. This steps is automated by CI and should never be ran manually unless you KNOW WHAT YOU'RE DOING.

--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright 2019-2021 ActiveState Software Inc. All rights reserved.
+﻿# Copyright 2019-2022 ActiveState Software Inc. All rights reserved.
 <#
 .EXAMPLE
 install.ps1 -b branchToInstall

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Copyright 2021 ActiveState Software Inc. All rights reserved.
+# Copyright 2022 ActiveState Software Inc. All rights reserved.
 
 # URL to fetch installer archive from
 BASE_FILE_URL="https://state-tool.s3.amazonaws.com/update/state"

--- a/installers/stop.ps1
+++ b/installers/stop.ps1
@@ -1,0 +1,30 @@
+# Copyright 2022-2022 ActiveState Software Inc. All rights reserved.
+
+Set-StrictMode -Off
+
+$currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+if (!$currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
+{
+    Write-Error "Please run this script as administrator. This is required to ensure any existing State Tool processes are terminated."
+    Exit 1
+}
+
+$continue = Read-Host "You are about to kill all State Tool processes, continue? (y/n)"
+if ($continue -ne 'y')
+{
+    Write-Host "Cancelled"
+    Exit 1
+}
+
+Write-Host "Stopping running State Tool processes"
+
+$pss = Get-Process | Where {$_.Name -eq "state-svc" -or $_.Name -eq "state" -or $_.Name -eq "state-installer"} 
+
+foreach ($ps in $pss) {
+    if ($ps.Path.ToLower().Contains('activestate') -or $ps.Name -eq "state-installer") {
+        Write-Host "Stopping $($ps.Name) at $($ps.Path)"
+        Stop-Process -Id $ps.Id
+    }
+}
+
+Write-Host "Done"

--- a/installers/stop.sh
+++ b/installers/stop.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Copyright 2022 ActiveState Software Inc. All rights reserved.
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run this script as administrator. This is required to ensure any existing State Tool processes are terminated."
+  exit 1
+fi
+
+read -r -p "You are about to kill all State Tool processes, continue? (y/n)" response
+if ! [ "$response" != "${response#[Yy]}" ] ;then
+    echo "Cancelled"
+    exit 1
+fi
+
+echo "Stopping running State Tool processes"
+ps ax | grep -i "state-installer\|activestate.*state" | awk '{ print $1;}' | xargs kill -9
+
+echo "Done"

--- a/installers/stop.sh
+++ b/installers/stop.sh
@@ -13,6 +13,17 @@ if ! [ "$response" != "${response#[Yy]}" ] ;then
 fi
 
 echo "Stopping running State Tool processes"
-ps ax | grep -i "state-installer\|activestate.*state" | awk '{ print $1;}' | xargs kill -9
+# Because POSIX doesn't always give the executable path of a process we have to get a little creative with lsof here.
+# Which isn't as reliable as checking the executable path because it gives all files in use by the process.
+# Therefore we also check that the en-us.yaml is in use, which helps build confidence that we are killing the right process.
+for PID in `ps ax | grep -i "state-installer\|state" | grep -v "grep" | awk '{ print $1;}'`; do
+  LSOUT=`lsof -p $PID`
+  if [ "`echo $LSOUT | grep -i "activestate"`" != "" ]; then
+    if [ "`basename $(ps -p $PID -o comm=)`" == "state" ] && [ "`echo $LSOUT | grep -i "en-us.yaml"`" == "" ]; then
+      continue
+    fi
+    kill -9 $PID
+  fi
+done
 
 echo "Done"


### PR DESCRIPTION
These are to help with deprecation and documentation, such that we can direct people at these scripts to stop any running state tool processes and get them out of a corrupt state prior to doing a new install.