### PR TITLE
Recognise and utilise languages.Unset constant

### DIFF
--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -119,6 +119,10 @@ func MakeByShell(shell string) Language {
 
 // MakeByName will retrieve a language by a given name after lower-casing.
 func MakeByName(name string) Language {
+	if len(name) == 0 {
+		return Unset
+	}
+
 	nameParts := strings.Split(name, "@")
 	for i, data := range lookup {
 		if strings.ToLower(nameParts[0]) == data.name {

--- a/internal/runners/activate/checkout.go
+++ b/internal/runners/activate/checkout.go
@@ -84,7 +84,7 @@ func (r *Checkout) Run(ns *project.Namespaced, branchName, targetPath string) er
 			CommitID:   commitID,
 			BranchName: branchName,
 			Directory:  targetPath,
-			Language:   language,
+			Language:   language.String(),
 		})
 		if err != nil {
 			return err
@@ -94,15 +94,15 @@ func (r *Checkout) Run(ns *project.Namespaced, branchName, targetPath string) er
 	return nil
 }
 
-func getLanguage(commitID strfmt.UUID) (string, error) {
+func getLanguage(commitID strfmt.UUID) (language.Language, error) {
 	modelLanguage, err := model.LanguageByCommit(commitID)
 	if err != nil {
-		return "", err
+		return language.Unset, err
 	}
 
 	lang, err := language.MakeByNameAndVersion(modelLanguage.Name, modelLanguage.Version)
 	if err != nil {
-		return "", err
+		return language.Unset, err
 	}
-	return lang.String(), nil
+	return lang, nil
 }

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -1005,7 +1005,7 @@ func createCustom(params *CreateParams, lang language.Language) (*Project, error
 	}
 
 	content := params.Content
-	if content == "" && lang.String() != "" {
+	if content == "" && lang != language.Unset && lang != language.Unknown {
 		tplName := "activestate.yaml." + strings.TrimRight(lang.String(), "23") + ".tpl"
 		template, err := assets.ReadFileBytes(tplName)
 		if err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-654" title="DX-654" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-654</a>  Language specific activestate.yaml template name not resolving
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
There is precedent for referring to unset or unknown languages: https://github.com/ActiveState/cli/blob/47cac62ced45ea30afa7b7470a3f7bdab624569c/internal/runners/tutorial/tutorial.go#L74

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

