### PR TITLE
Update watcher executable verification

### DIFF
--- a/cmd/state-svc/internal/rtwatcher/entry.go
+++ b/cmd/state-svc/internal/rtwatcher/entry.go
@@ -37,7 +37,7 @@ func (e entry) IsRunning() (bool, error) {
 		return false, errs.New("Process args are empty: %d", e.PID)
 	}
 
-	if filepath.Clean(args[0]) == filepath.Clean(e.Exec) {
+	if filepath.Base(args[0]) == filepath.Base(e.Exec) {
 		logging.Debug("Process %d matched", e.PID)
 		return true, nil
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-684" title="DX-684" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-684</a>  Watcher does not match process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
While this is niche the executable path from `args` and `e.Exec` can be different. This updates the check to just check the base.