### PR TITLE
Check for authorization success and do not return an error in that case.

### DIFF
--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -222,7 +222,9 @@ func (s *Auth) AuthenticateWithDevice(deviceCode strfmt.UUID, interval time.Dura
 func (s *Auth) AuthenticateWithDevicePolling(deviceCode strfmt.UUID, interval time.Duration) error {
 	for start := time.Now(); time.Since(start) < 5*time.Minute; {
 		err := s.AuthenticateWithDevice(deviceCode, interval)
-		if !errors.Is(err, errNotYetGranted) {
+		if err == nil {
+			return nil
+		} else if !errors.Is(err, errNotYetGranted) {
 			return errs.Wrap(err, "Device authentication failed")
 		}
 		time.Sleep(interval) // then try again


### PR DESCRIPTION
There's a bug where `state auth` will always report a failure. It doesn't check for the case where device authorization succeeds. It always assumes that the server is waiting.