### PR TITLE
Notify user an existing API token is preventing a complete logout.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -219,6 +219,8 @@ logout_description:
   other: Logout
 logged_out:
   other: You have been logged out
+logout_still_have_api_token:
+  other: You still have an API token configured. You will not be completely logged out until you remove it.
 signup_success:
   other: Your account has been registered and a confirmation email has been sent to [NOTICE]{{.Email}}[/RESET], your account will have limited permissions until you confirm it.
 signup_failure:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -220,7 +220,7 @@ logout_description:
 logged_out:
   other: You have been logged out
 logout_still_have_api_token:
-  other: You still have an API token configured (environment variable or Google Cloud). You will not be completely logged out until you remove it.
+  other: Logout is incomplete because you have authenticated with an environment variable. To complete logout please unset the '[ACTIONABLE]ACTIVESTATE_API_KEY[/RESET]' environment variable.
 signup_success:
   other: Your account has been registered and a confirmation email has been sent to [NOTICE]{{.Email}}[/RESET], your account will have limited permissions until you confirm it.
 signup_failure:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -220,7 +220,7 @@ logout_description:
 logged_out:
   other: You have been logged out
 logout_still_have_api_token:
-  other: You still have an API token configured. You will not be completely logged out until you remove it.
+  other: You still have an API token configured (environment variable or Google Cloud). You will not be completely logged out until you remove it.
 signup_success:
   other: Your account has been registered and a confirmation email has been sent to [NOTICE]{{.Email}}[/RESET], your account will have limited permissions until you confirm it.
 signup_failure:

--- a/internal/runners/auth/logout.go
+++ b/internal/runners/auth/logout.go
@@ -24,6 +24,10 @@ func (l *Logout) Run() error {
 		return locale.WrapError(err, "err_auth_logout", "Failed to delete authentication key")
 	}
 	l.Outputer.Notice(output.Heading(locale.Tl("authentication_title", "Authentication")))
-	l.Outputer.Notice(locale.T("logged_out"))
+	if l.Auth.AvailableAPIToken() == "" {
+		l.Outputer.Notice(locale.T("logged_out"))
+	} else {
+		l.Outputer.Notice(locale.T("logout_still_have_api_token"))
+	}
 	return nil
 }

--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -103,7 +103,7 @@ func New(cfg Configurable) *Auth {
 		cfg: cfg,
 	}
 
-	if availableAPIToken(cfg) != "" {
+	if auth.AvailableAPIToken() != "" {
 		logging.Debug("Authenticating with stored API token")
 		auth.Authenticate()
 	}
@@ -151,7 +151,7 @@ func (s *Auth) Authenticate() error {
 		return nil
 	}
 
-	apiToken := availableAPIToken(s.cfg)
+	apiToken := s.AvailableAPIToken()
 	if apiToken == "" {
 		return locale.NewInputError("err_no_credentials")
 	}
@@ -392,7 +392,7 @@ func (s *Auth) NewAPIKey(name string) (string, error) {
 	return tokenOK.Payload.Token, nil
 }
 
-func availableAPIToken(cfg Configurable) string {
+func (s *Auth) AvailableAPIToken() string {
 	tkn, err := gcloud.GetSecret(constants.APIKeyEnvVarName)
 	if err != nil && !errors.Is(err, gcloud.ErrNotAvailable{}) {
 		logging.Error("Could not retrieve gcloud secret: %v", err)
@@ -406,5 +406,5 @@ func availableAPIToken(cfg Configurable) string {
 		logging.Debug("Using API token passed via env var")
 		return tkn
 	}
-	return cfg.GetString(ApiTokenConfigKey)
+	return s.cfg.GetString(ApiTokenConfigKey)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-697" title="DX-697" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-697</a>  User can still state activate a new private project after they have state auth logout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I was not able to activate a private repository after logging out from the following cases:
* Log in using web authentication
* Log in using interactive authentication

I was able to activate a private repository after logging out from the following case:
* Log in using an API token (passwordless login)

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

