### PR TITLE
Fix executors breaking when encountering a dir

### DIFF
--- a/internal/exeutils/find.go
+++ b/internal/exeutils/find.go
@@ -42,7 +42,7 @@ func findExes(executable string, PATH string, exts []string, fileExists func(str
 	for _, p := range candidates {
 		for _, ext := range exts {
 			fp := filepath.Clean(filepath.Join(p, executable+ext))
-			if fileExists(fp) && (filter == nil || filter(fp)) {
+			if fileExists(fp) && !fileutils.IsDir(fp) && (filter == nil || filter(fp)) {
 				result = append(result, fp)
 			}
 		}

--- a/pkg/platform/runtime/executor/executor.go
+++ b/pkg/platform/runtime/executor/executor.go
@@ -170,6 +170,10 @@ func (f *Executor) createExecutor(exe string) error {
 }
 
 func IsExecutor(filePath string) (bool, error) {
+	if fileutils.IsDir(filePath) {
+		return false, nil
+	}
+	
 	b, err := fileutils.ReadFile(filePath)
 	if err != nil {
 		return false, locale.WrapError(err, "err_cleanexecutor_noread", "Could not read potential executor file: {{.V0}}.", filePath)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-719" title="DX-719" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-719</a>  Executors created with invalid path
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
