### PR TITLE
Auth requires both --username and --password flags

### DIFF
--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -49,7 +49,7 @@ func (p AuthParams) verify() error {
 	}
 
 	if p.Totp != "" && (p.Username == "" || p.Password == "") {
-		return locale.WrapInputError("err_auth_invalid_totp_param", "[ACTIONABLE]--totp[/RESET] flag requires both [ACTIONABLE]--username[/RESET] and [ACTIONABLE]--password[/RESET] flags", args ...string)
+		return locale.NewInputError("err_auth_invalid_totp_param", "[ACTIONABLE]--totp[/RESET] flag requires both [ACTIONABLE]--username[/RESET] and [ACTIONABLE]--password[/RESET] flags")
 	}
 
 	return nil

--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -41,11 +41,15 @@ type AuthParams struct {
 
 func (p AuthParams) verify() error {
 	if p.Username != "" && p.Password == "" {
-		return locale.NewInputError("err_auth_invalid_username_flag", "[ACTIONABLE]--username[/RESET] flag requires [ACTIONABLE]--password[/RESET] flag")
+		return locale.NewInputError("err_auth_invalid_username_param", "[ACTIONABLE]--username[/RESET] flag requires [ACTIONABLE]--password[/RESET] flag")
 	}
 
 	if p.Username == "" && p.Password != "" {
 		return locale.NewInputError("err_auth_invalid_password_param", "[ACTIONABLLE]--password[/RESET] flag requires [ACTIONABLE]--username[/RESET] flag")
+	}
+
+	if p.Totp != "" && (p.Username == "" || p.Password == "") {
+		return locale.WrapInputError("err_auth_invalid_totp_param", "[ACTIONABLE]--totp[/RESET] flag requires both [ACTIONABLE]--username[/RESET] and [ACTIONABLE]--password[/RESET] flags", args ...string)
 	}
 
 	return nil
@@ -88,7 +92,7 @@ func (a *Auth) Run(params *AuthParams) error {
 }
 
 func (a *Auth) authenticate(params *AuthParams) error {
-	if params.Interactive || params.Username != "" || params.Totp != "" {
+	if params.Interactive || params.Username != "" {
 		return authlet.AuthenticateWithInput(params.Username, params.Password, params.Totp, a.Cfg, a.Outputer, a.Prompter, a.Auth)
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-735" title="DX-735" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-735</a>  CLI - AUTH: Using only the "--password" flag does not generate an error message and starts auth by authorization via the web browser.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
