### PR TITLE
Fix keypair not saving because of stale auth

### DIFF
--- a/internal/keypairs/fetchers.go
+++ b/internal/keypairs/fetchers.go
@@ -16,7 +16,7 @@ type ErrKeypairNotFound struct{ *locale.LocalizedError }
 
 // FetchRaw fetchs the current user keypair or returns a failure.
 func FetchRaw(secretsClient *secretsapi.Client, cfg authentication.Configurable) (*secretModels.Keypair, error) {
-	kpOk, err := secretsClient.Keys.GetKeypair(nil, authentication.New(cfg).ClientAuth())
+	kpOk, err := secretsClient.Keys.GetKeypair(nil, authentication.LegacyGet().ClientAuth())
 	if err != nil {
 		if api.ErrorCode(err) == 404 {
 			return nil, &ErrKeypairNotFound{locale.WrapInputError(err, "keypair_err_not_found")}

--- a/internal/keypairs/keypair.go
+++ b/internal/keypairs/keypair.go
@@ -103,7 +103,7 @@ func SaveEncodedKeypair(cfg Configurable, secretsClient *secretsapi.Client, encK
 		PublicKey:           &encKeypair.EncodedPublicKey,
 	})
 
-	if _, err := secretsClient.Keys.SaveKeypair(params, authentication.New(cfg).ClientAuth()); err != nil {
+	if _, err := secretsClient.Keys.SaveKeypair(params, authentication.LegacyGet().ClientAuth()); err != nil {
 		return locale.WrapError(err, "keypair_err_save")
 	}
 

--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -100,8 +100,6 @@ func New(cfg Configurable) *Auth {
 		cfg: cfg,
 	}
 
-	persist = auth
-
 	return auth
 }
 
@@ -250,6 +248,8 @@ func (s *Auth) updateSession(accessToken *mono_models.JWT) error {
 	s.bearerToken = accessToken.Token
 	clientAuth := httptransport.BearerToken(s.bearerToken)
 	s.clientAuth = &clientAuth
+
+	persist = s
 
 	return nil
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-741" title="DX-741" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-741</a>  Can't auth with `--interactive` due to keypair failure
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
