### PR TITLE
DX-745 Adds a fallback mechanism for opening URIs on linux

### DIFF
--- a/internal/osutils/openuri.go
+++ b/internal/osutils/openuri.go
@@ -1,0 +1,18 @@
+// +build !windows,!darwin
+
+package osutils
+
+import (
+	"github.com/ActiveState/cli/internal/logging"
+	"github.com/skratchdot/open-golang/open"
+)
+
+func OpenURI(input string) error {
+	err := open.Run(input)
+
+	if err != nil {
+		logging.Warning("open.Run failed, attempting alternative method to open browser. Error received: %v", err)
+		err = open.RunWith(input, "x-www-browser")
+	}
+	return err
+}

--- a/internal/osutils/openuri_darwin.go
+++ b/internal/osutils/openuri_darwin.go
@@ -1,0 +1,11 @@
+// +build darwin
+
+package osutils
+
+import (
+	"github.com/skratchdot/open-golang/open"
+)
+
+func OpenURI(input string) error {
+	return open.Run(input)
+}

--- a/internal/osutils/openuri_windows.go
+++ b/internal/osutils/openuri_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package osutils
+
+import (
+	"github.com/skratchdot/open-golang/open"
+)
+
+func OpenURI(input string) error {
+	return open.Run(input)
+}

--- a/pkg/cmdlets/auth/login.go
+++ b/pkg/cmdlets/auth/login.go
@@ -3,9 +3,9 @@ package auth
 import (
 	"time"
 
+	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/rtutils/p"
 	"github.com/go-openapi/strfmt"
-	"github.com/skratchdot/open-golang/open"
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/keypairs"
@@ -21,9 +21,9 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/model/auth"
 )
 
-// OpenURI aliases to open.Run which opens the given URI in your browser. This is being exposed so that it can be
+// OpenURI aliases to exeutils.OpenURI which opens the given URI in your browser. This is being exposed so that it can be
 // overwritten in tests
-var OpenURI = open.Run
+var OpenURI = osutils.OpenURI
 
 // Authenticate will prompt the user for authentication
 func Authenticate(cfg keypairs.Configurable, out output.Outputer, prompt prompt.Prompter, auth *authentication.Auth) error {


### PR DESCRIPTION
On linux distributions with no display or otherwise running without a
native display manager (e.g. if they're running under WSL) there is no
`xdg-open` executable for generally opening files in a graphical
context.  They may however, still be able to open URIs in an
alternative way.  The open-golang package we're currently using only
knows about using `xdg-open` so this commit adds a fallback to try
using `x-www-browser` as provided by the alternatives mechanism on
linux systems where `xdg-open` fails