### PR TITLE
Revert IPv4 vs IPv6 preference for OAuth.

### DIFF
--- a/pkg/platform/api/api.go
+++ b/pkg/platform/api/api.go
@@ -16,15 +16,13 @@ import (
 )
 
 // RoundTripper is an implementation of http.RoundTripper that adds additional request information
-type RoundTripper struct {
-	transport http.RoundTripper
-}
+type RoundTripper struct{}
 
 // RoundTrip executes a single HTTP transaction, returning a Response for the provided Request.
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", r.UserAgent())
 	req.Header.Set("X-Requestor", machineid.UniqID())
-	return r.transport.RoundTrip(req)
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 // UserAgent returns the user agent used by the State Tool
@@ -60,12 +58,7 @@ func (r *RoundTripper) UserAgent() string {
 
 // NewRoundTripper creates a new instance of RoundTripper
 func NewRoundTripper() http.RoundTripper {
-	return NewRoundTripperWithTransport(http.DefaultTransport)
-}
-
-// NewRoundTripperWithTransport creates a new instance of RoundTripper with the specified transport.
-func NewRoundTripperWithTransport(transport http.RoundTripper) http.RoundTripper {
-	return &RoundTripper{transport}
+	return &RoundTripper{}
 }
 
 // ErrorCode tries to retrieve the code associated with an API error

--- a/pkg/platform/api/mono/mono.go
+++ b/pkg/platform/api/mono/mono.go
@@ -1,9 +1,6 @@
 package mono
 
 import (
-	"context"
-	"net"
-	"net/http"
 	"net/url"
 
 	"github.com/go-openapi/runtime"
@@ -37,26 +34,7 @@ func Init(serviceURL *url.URL, auth *runtime.ClientAuthInfoWriter) *mono_client.
 	if auth != nil {
 		transportRuntime.DefaultAuthentication = *auth
 	}
-	client := mono_client.New(transportRuntime, strfmt.Default)
-
-	// For the Oauth client, prefer use of IPv4. This is needed particularly for device
-	// authorization, which compares the IP address of the State Tool request and the IP address of
-	// the web client request. If there's a mismatch, authorization fails. When this happens, it's
-	// often because the State Tool connects to the Platform via IPv6, but the browser does via IPv4
-	// (browsers apparently prefer IPv4 for now).
-	ipv4PreferredTransportRuntime := httptransport.New(serviceURL.Host, serviceURL.Path, []string{serviceURL.Scheme})
-	ipv4PreferredTransport := http.DefaultTransport.(*http.Transport).Clone()
-	ipv4PreferredTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		dialer := &net.Dialer{}
-		if conn, err := dialer.DialContext(ctx, "tcp4", addr); conn != nil {
-			return conn, err
-		}
-		return dialer.DialContext(ctx, "tcp", addr) // fallback to default ipv6/ipv4 dialer
-	}
-	ipv4PreferredTransportRuntime.Transport = api.NewRoundTripperWithTransport(ipv4PreferredTransport)
-	client.Oauth.SetTransport(ipv4PreferredTransportRuntime)
-
-	return client
+	return mono_client.New(transportRuntime, strfmt.Default)
 }
 
 // Get returns a cached version of the default api client

--- a/pkg/project/prompting_expander_test.go
+++ b/pkg/project/prompting_expander_test.go
@@ -1,0 +1,152 @@
+package project_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/keypairs"
+	"github.com/ActiveState/cli/internal/locale"
+	promptMock "github.com/ActiveState/cli/internal/prompt/mock"
+	"github.com/ActiveState/cli/internal/testhelpers/httpmock"
+	"github.com/ActiveState/cli/internal/testhelpers/osutil"
+	"github.com/ActiveState/cli/internal/testhelpers/outputhelper"
+	"github.com/ActiveState/cli/internal/testhelpers/secretsapi_test"
+	"github.com/ActiveState/cli/pkg/platform/api"
+	"github.com/ActiveState/cli/pkg/platform/api/graphql/request/mock"
+	secretsapi "github.com/ActiveState/cli/pkg/platform/api/secrets"
+	secretsModels "github.com/ActiveState/cli/pkg/platform/api/secrets/secrets_models"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/project"
+	"github.com/ActiveState/cli/pkg/projectfile"
+)
+
+type VarPromptingExpanderTestSuite struct {
+	suite.Suite
+
+	projectFile   *projectfile.Project
+	project       *project.Project
+	promptMock    *promptMock.Mock
+	secretsClient *secretsapi.Client
+	secretsMock   *httpmock.HTTPMock
+	platformMock  *httpmock.HTTPMock
+	graphMock     *mock.Mock
+	cfg           keypairs.Configurable
+}
+
+func (suite *VarPromptingExpanderTestSuite) BeforeTest(suiteName, testName string) {
+	locale.Set("en-US")
+
+	suite.promptMock = promptMock.Init()
+	pjFile, err := loadSecretsProject()
+	suite.Require().Nil(err, "Unmarshalled project YAML")
+	pjFile.Persist()
+	suite.projectFile = pjFile
+	suite.project, err = project.New(pjFile, outputhelper.NewCatcher())
+	suite.NoError(err, "no failure should occur when loading project")
+
+	secretsClient := secretsapi_test.NewDefaultTestClient("bearing123")
+	suite.Require().NotNil(secretsClient)
+	suite.secretsClient = secretsClient
+
+	suite.secretsMock = httpmock.Activate(secretsClient.BaseURI)
+	suite.platformMock = httpmock.Activate(api.GetServiceURL(api.ServiceMono).String())
+
+	suite.platformMock.Register("POST", "/login")
+	suite.platformMock.Register("GET", "/organizations/SecretOrg/members")
+	authentication.LegacyGet().AuthenticateWithToken("")
+
+	suite.graphMock = mock.Init()
+	suite.graphMock.ProjectByOrgAndName(mock.NoOptions)
+
+	suite.cfg, err = config.New()
+	suite.Require().NoError(err)
+}
+
+func (suite *VarPromptingExpanderTestSuite) AfterTest(suiteName, testName string) {
+	httpmock.DeActivate()
+	projectfile.Reset()
+	osutil.RemoveConfigFile(suite.cfg.ConfigPath(), constants.KeypairLocalFileName+".key")
+	suite.graphMock.Close()
+	suite.Require().NoError(suite.cfg.Close())
+}
+
+func (suite *VarPromptingExpanderTestSuite) prepareWorkingExpander() project.ExpanderFunc {
+	suite.platformMock.RegisterWithCode("GET", "/organizations/SecretOrg", 200)
+
+	osutil.CopyTestFileToConfigDir(suite.cfg.ConfigPath(), "self-private.key", constants.KeypairLocalFileName+".key", 0600)
+
+	suite.secretsMock.RegisterWithResponder("GET", "/organizations/00010001-0001-0001-0001-000100010002/user_secrets", func(req *http.Request) (int, string) {
+		return 200, "user_secrets-empty"
+	})
+	return project.NewSecretPromptingExpander(suite.secretsClient, suite.promptMock, suite.cfg)
+}
+
+func (suite *VarPromptingExpanderTestSuite) assertExpansionSaveFailure(secretName, expectedValue string) {
+	suite.secretsMock.RegisterWithResponder("PATCH", "/organizations/00010001-0001-0001-0001-000100010002/user_secrets", func(req *http.Request) (int, string) {
+		return 400, "something-happened"
+	})
+	suite.secretsMock.RegisterWithResponseBody("GET", "/definitions/00010001-0001-0001-0001-000100010001", 200, "[]")
+
+	suite.promptMock.OnMethod("InputSecret").Once().Return(expectedValue, nil)
+	expanderFn := suite.prepareWorkingExpander()
+	expandedValue, err := expanderFn("", project.ProjectCategory, secretName, false, suite.project)
+
+	suite.Require().NotNil(err)
+	suite.Zero(expandedValue)
+}
+
+func (suite *VarPromptingExpanderTestSuite) assertExpansionSaveSuccess(secretName string, category string, expectedValue string) {
+	var userChanges []*secretsModels.UserSecretChange
+	var bodyErr error
+	suite.secretsMock.RegisterWithResponder("PATCH", "/organizations/00010001-0001-0001-0001-000100010002/user_secrets", func(req *http.Request) (int, string) {
+		reqBody, _ := ioutil.ReadAll(req.Body)
+		bodyErr = json.Unmarshal(reqBody, &userChanges)
+		return 204, "empty-response"
+	})
+	suite.secretsMock.RegisterWithResponseBody("GET", "/definitions/00010001-0001-0001-0001-000100010001", 200, "[]")
+
+	suite.promptMock.OnMethod("InputSecret").Once().Return(expectedValue, nil)
+	expanderFn := suite.prepareWorkingExpander()
+	expandedValue, err := expanderFn("", category, secretName, false, suite.project)
+
+	suite.Require().NoError(bodyErr)
+	suite.Require().Nil(err)
+	suite.Equal(expectedValue, expandedValue)
+
+	_, err = expanderFn("", category, secretName, false, suite.project)
+	suite.Require().Nil(err, "Should not prompt again because it should have stored/cached the secret")
+
+	suite.Require().Len(userChanges, 1)
+
+	change := userChanges[0]
+	suite.Equal(secretName, *change.Name)
+
+	if category == project.ProjectCategory {
+		suite.Equal(false, *change.IsUser)
+	} else {
+		suite.Equal(true, *change.IsUser)
+	}
+
+	suite.Equal(strfmt.UUID("00010001-0001-0001-0001-000100010001"), change.ProjectID)
+
+	kp, _ := keypairs.LoadWithDefaults(suite.cfg)
+	decryptedBytes, err := kp.DecodeAndDecrypt(*change.Value)
+	suite.Require().Nil(err)
+	suite.Equal(expectedValue, string(decryptedBytes))
+}
+
+func (suite *VarPromptingExpanderTestSuite) TestSavesSecret() {
+	suite.assertExpansionSaveSuccess("proj-secret", project.ProjectCategory, "more amazing")
+	suite.assertExpansionSaveSuccess("user-secret", project.UserCategory, "more amazing")
+}
+
+func Test_SecretsPromptingExpander_TestSuite(t *testing.T) {
+	suite.Run(t, new(VarPromptingExpanderTestSuite))
+}

--- a/pkg/project/secrets_test.go
+++ b/pkg/project/secrets_test.go
@@ -1,0 +1,133 @@
+package project_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v2"
+
+	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/keypairs"
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/testhelpers/httpmock"
+	"github.com/ActiveState/cli/internal/testhelpers/osutil"
+	"github.com/ActiveState/cli/internal/testhelpers/secretsapi_test"
+	"github.com/ActiveState/cli/pkg/platform/api"
+	"github.com/ActiveState/cli/pkg/platform/api/graphql/request/mock"
+	secretsapi "github.com/ActiveState/cli/pkg/platform/api/secrets"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/project"
+	"github.com/ActiveState/cli/pkg/projectfile"
+)
+
+type SecretsExpanderTestSuite struct {
+	suite.Suite
+
+	projectFile *projectfile.Project
+	project     *project.Project
+	cfg         keypairs.Configurable
+
+	secretsClient *secretsapi.Client
+	secretsMock   *httpmock.HTTPMock
+	platformMock  *httpmock.HTTPMock
+	graphMock     *mock.Mock
+}
+
+func loadSecretsProject() (*projectfile.Project, error) {
+	pjfile := &projectfile.Project{}
+	contents := strings.TrimSpace(`
+project: "https://platform.activestate.com/SecretOrg/SecretProject?commitID=00010001-0001-0001-0001-000100010001"
+`)
+
+	err := yaml.Unmarshal([]byte(contents), pjfile)
+	if err != nil {
+		return nil, err
+	}
+	err = pjfile.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	return pjfile, nil
+}
+
+func (suite *SecretsExpanderTestSuite) BeforeTest(suiteName, testName string) {
+	locale.Set("en-US")
+
+	projectFile, err := loadSecretsProject()
+	suite.Require().Nil(err, "Unmarshalled project YAML")
+	projectFile.Persist()
+	suite.projectFile = projectFile
+	suite.project = project.Get()
+
+	secretsClient := secretsapi_test.NewDefaultTestClient("bearing123")
+	suite.Require().NotNil(secretsClient)
+	suite.secretsClient = secretsClient
+
+	suite.secretsMock = httpmock.Activate(secretsClient.BaseURI)
+	suite.platformMock = httpmock.Activate(api.GetServiceURL(api.ServiceMono).String())
+
+	suite.platformMock.Register("POST", "/login")
+	suite.platformMock.Register("GET", "/organizations/SecretOrg/members")
+	authentication.LegacyGet().AuthenticateWithToken("")
+
+	suite.graphMock = mock.Init()
+	suite.graphMock.ProjectByOrgAndName(mock.NoOptions)
+
+	suite.cfg, err = config.New()
+	suite.Require().NoError(err)
+}
+
+func (suite *SecretsExpanderTestSuite) AfterTest(suiteName, testName string) {
+	httpmock.DeActivate()
+	projectfile.Reset()
+	osutil.RemoveConfigFile(suite.cfg.ConfigPath(), constants.KeypairLocalFileName+".key")
+	suite.graphMock.Close()
+	suite.Require().NoError(suite.cfg.Close())
+}
+
+func (suite *SecretsExpanderTestSuite) prepareWorkingExpander() project.ExpanderFunc {
+	suite.platformMock.RegisterWithCode("GET", "/organizations/SecretOrg", 200)
+
+	osutil.CopyTestFileToConfigDir(suite.cfg.ConfigPath(), "self-private.key", constants.KeypairLocalFileName+".key", 0600)
+
+	suite.secretsMock.RegisterWithCode("GET", "/organizations/00010001-0001-0001-0001-000100010002/user_secrets", 200)
+	return project.NewSecretQuietExpander(suite.secretsClient, suite.cfg)
+}
+
+func (suite *SecretsExpanderTestSuite) assertExpansionFailure(secretName string) {
+	value, err := suite.prepareWorkingExpander()("", project.ProjectCategory, secretName, false, suite.project)
+	suite.Require().Error(err)
+	suite.Zero(value)
+}
+
+func (suite *SecretsExpanderTestSuite) assertExpansionSuccess(secretName string, expectedExpansionValue string, isUser bool) {
+	category := project.ProjectCategory
+	if isUser {
+		category = project.UserCategory
+	}
+	value, err := suite.prepareWorkingExpander()("", category, secretName, false, suite.project)
+	suite.Equal(expectedExpansionValue, value)
+	suite.Nil(err)
+}
+
+func (suite *SecretsExpanderTestSuite) TestKeypairNotFound() {
+	expanderFn := project.NewSecretQuietExpander(suite.secretsClient, suite.cfg)
+	value, err := expanderFn("", project.ProjectCategory, "undefined-secret", false, suite.project)
+	suite.Error(err)
+	suite.Zero(value)
+}
+
+func (suite *SecretsExpanderTestSuite) TestProjectSecret() {
+	suite.assertExpansionSuccess("proj-secret", "proj-value", false)
+}
+
+func (suite *SecretsExpanderTestSuite) TestUserSecret() {
+	suite.assertExpansionSuccess("user-proj-secret", "user-proj-value", true)
+}
+
+func Test_SecretsExpander_TestSuite(t *testing.T) {
+	suite.Run(t, new(SecretsExpanderTestSuite))
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-757" title="DX-757" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-757</a>  `state auth` ip verification doesn't break on ipv4 vs ipv6
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The Platform no longer performs IP-checking of client and browser. It only IP-checks the client.

This reverts commit 4ae88a43a7de06223407acf6c0040cbe87f7b889, reversing
changes made to a1b8db930c40f70502e966d70e3efd7a71137bd1.