### PR TITLE
Make non-interactive only act when it needs to with `state auth`

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -880,6 +880,8 @@ err_deprecation:
     Please update by running [ACTIONABLE]`state update`[/RESET].
 err_auth_required:
   other: Authentication is required, please authenticate by running 'state auth'
+err_auth_needinput:
+  other: You are logged out, in order to log in either run this command in interactive mode or provide your credentials via flags (see '[ACTIONABLE]state auth --help[/RESET]').
 auth_required_activate:
   other: You need to be authenticated to activate an ActiveState Platform project
 prompt_login_or_signup:

--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -61,10 +61,6 @@ type SignupParams struct {
 // Run runs our command
 func (a *Auth) Run(params *AuthParams) error {
 	if !a.Authenticated() {
-		if params.NonInteractive {
-			return locale.NewInputError("err_auth_loggedout", "You are logged out.")
-		}
-
 		if err := params.verify(); err != nil {
 			return locale.WrapInputError(err, "err_auth_params", "Invalid authentication params")
 		}
@@ -95,11 +91,15 @@ func (a *Auth) Run(params *AuthParams) error {
 
 func (a *Auth) authenticate(params *AuthParams) error {
 	if params.Prompt || params.Username != "" {
-		return authlet.AuthenticateWithInput(params.Username, params.Password, params.Totp, a.Cfg, a.Outputer, a.Prompter, a.Auth)
+		return authlet.AuthenticateWithInput(params.Username, params.Password, params.Totp, params.NonInteractive, a.Cfg, a.Outputer, a.Prompter, a.Auth)
 	}
 
 	if params.Token != "" {
 		return authlet.AuthenticateWithToken(params.Token, a.Auth)
+	}
+
+	if params.NonInteractive {
+		return locale.NewInputError("err_auth_needinput")
 	}
 
 	return authlet.AuthenticateWithBrowser(a.Outputer, a.Auth, a.Prompter)

--- a/test/integration/auth_int_test.go
+++ b/test/integration/auth_int_test.go
@@ -46,7 +46,7 @@ func (suite *AuthIntegrationTestSuite) TestAuthToken() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn(tagsuite.Auth, "--token", e2e.PersistentToken)
+	cp := ts.Spawn(tagsuite.Auth, "--token", e2e.PersistentToken, "-n")
 	cp.Expect("logged in", 40*time.Second)
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-770" title="DX-770" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-770</a>  `state auth -n` is too aggressive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
