### PR TITLE
Install path for legacy executables should also be two directory levels higher

### DIFF
--- a/internal/installation/paths.go
+++ b/internal/installation/paths.go
@@ -37,7 +37,7 @@ func InstallPath() (string, error) {
 	stateInfo := appinfo.StateApp()
 	activeStateOwnedPath := strings.Contains(strings.ToLower(stateInfo.Exec()), "activestate")
 	if fileutils.TargetExists(stateInfo.Exec()) {
-		if filepath.Base(filepath.Dir(stateInfo.Exec())) == BinDirName && activeStateOwnedPath {
+		if filepath.Base(filepath.Dir(stateInfo.Exec())) == BinDirName && (activeStateOwnedPath || stateInfo.LegacyExec() != "") {
 			return filepath.Dir(filepath.Dir(stateInfo.Exec())), nil // <return this>/bin/state.exe
 		}
 		return filepath.Dir(stateInfo.Exec()), nil // <return this>/state.exe


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-769" title="DX-769" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-769</a>  `state update` on docker falsely conveys success when it failed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
