### PR TITLE
Fixed display of commit history despite committers having been deleted by their orgs

### DIFF
--- a/pkg/cmdlets/commit/commit.go
+++ b/pkg/cmdlets/commit/commit.go
@@ -16,10 +16,6 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/model"
 )
 
-// AuthorDeleted is the placeholder username to use if an author has since been deleted from an
-// organization and their username can no longer be obtained.
-const AuthorDeleted = "<deleted>"
-
 type commitData struct {
 	Hash    string   `locale:"hash,[HEADING]Commit[/RESET]"`
 	Author  string   `locale:"author,[HEADING]Author[/RESET]"`
@@ -78,8 +74,7 @@ func commitDataFromCommit(commit *mono_models.Commit, orgs []gmodel.Organization
 	if commit.Author != nil && orgs != nil {
 		username, err = usernameForID(*commit.Author, orgs)
 		if err != nil {
-			logging.Debug("Could not determine username for commit author '%s'. Using placeholder value '%s'.", *commit.Author, AuthorDeleted)
-			username = AuthorDeleted
+			return commitData{}, locale.WrapError(err, "err_commit_print_username", "Could not determine username for commit author")
 		}
 	}
 
@@ -173,5 +168,7 @@ func usernameForID(id strfmt.UUID, orgs []gmodel.Organization) (string, error) {
 		}
 	}
 
-	return "", locale.NewError("err_user_not_found", id.String())
+	placeholder := locale.Tl("deleted_username", "<deleted>")
+	logging.Debug("Could not determine username for commit author '%s'. Using placeholder value '%s'.", id, placeholder)
+	return placeholder, nil
 }

--- a/pkg/cmdlets/commit/commit.go
+++ b/pkg/cmdlets/commit/commit.go
@@ -8,12 +8,17 @@ import (
 	"github.com/go-openapi/strfmt"
 
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/output"
 	gmodel "github.com/ActiveState/cli/pkg/platform/api/graphql/model"
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	"github.com/ActiveState/cli/pkg/platform/model"
 )
+
+// AuthorDeleted is the placeholder username to use if an author has since been deleted from an
+// organization and their username can no longer be obtained.
+const AuthorDeleted = "<deleted>"
 
 type commitData struct {
 	Hash    string   `locale:"hash,[HEADING]Commit[/RESET]"`
@@ -73,7 +78,8 @@ func commitDataFromCommit(commit *mono_models.Commit, orgs []gmodel.Organization
 	if commit.Author != nil && orgs != nil {
 		username, err = usernameForID(*commit.Author, orgs)
 		if err != nil {
-			return commitData{}, locale.WrapError(err, "err_commit_print_username", "Could not determine username for commit author")
+			logging.Debug("Could not determine username for commit author '%s'. Using placeholder value '%s'.", *commit.Author, AuthorDeleted)
+			username = AuthorDeleted
 		}
 	}
 

--- a/pkg/cmdlets/commit/commit.go
+++ b/pkg/cmdlets/commit/commit.go
@@ -72,10 +72,7 @@ func commitDataFromCommit(commit *mono_models.Commit, orgs []gmodel.Organization
 	var username string
 	var err error
 	if commit.Author != nil && orgs != nil {
-		username, err = usernameForID(*commit.Author, orgs)
-		if err != nil {
-			return commitData{}, locale.WrapError(err, "err_commit_print_username", "Could not determine username for commit author")
-		}
+		username = usernameForID(*commit.Author, orgs)
 	}
 
 	commitData := commitData{
@@ -158,17 +155,17 @@ func formatConstraints(constraints []*mono_models.Constraint) string {
 	return strings.Join(result, ",")
 }
 
-func usernameForID(id strfmt.UUID, orgs []gmodel.Organization) (string, error) {
+func usernameForID(id strfmt.UUID, orgs []gmodel.Organization) string {
 	for _, org := range orgs {
 		if org.ID == id {
 			if org.DisplayName != "" {
-				return org.DisplayName, nil
+				return org.DisplayName
 			}
-			return org.URLName, nil
+			return org.URLName
 		}
 	}
 
 	placeholder := locale.Tl("deleted_username", "<deleted>")
 	logging.Debug("Could not determine username for commit author '%s'. Using placeholder value '%s'.", id, placeholder)
-	return placeholder, nil
+	return placeholder
 }

--- a/pkg/platform/model/organizations.go
+++ b/pkg/platform/model/organizations.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/pkg/platform/api"
 	"github.com/ActiveState/cli/pkg/platform/api/graphql"
 	"github.com/ActiveState/cli/pkg/platform/api/graphql/model"
@@ -117,7 +118,7 @@ func FetchOrganizationsByIDs(ids []strfmt.UUID) ([]model.Organization, error) {
 	}
 
 	if len(response.Organizations) != len(ids) {
-		return nil, locale.NewError("err_orgs_length")
+		logging.Debug("Organization membership mismatch: %d members returned for %d members requested. Caller must account for this.", len(response.Organizations), len(ids))
 	}
 
 	return response.Organizations, nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-713" title="DX-713" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-713</a>  `state history` breaks if org members are deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Show a placeholder username instead of erroring out.

For example:
```
  Commit     218dd5ee-cba7-43ca-a926-536610daf0dc                       
  Author     <deleted>                                                  
  Date       25 Apr 20 00:29 UTC                                        
  Message    Manual update by ActiveState support.
```

I also forked ActiveState/cli and reverted to Aleks' commit, which did not error:

```
█ Reverting Commit

You are about to revert to the following commit:
  Commit     218dd5ee-cba7-43ca-a926-536610daf0dc   
  Author     <deleted>                              
  Date       25 Apr 20 00:29 UTC                    
  Message    Manual update by ActiveState support.  

[...]

Sucessfully reverted to commit: 218dd5ee-cba7-43ca-a926-536610daf0dc
```