### PR TITLE
Recognize '-h' and '--help' for `state exec`.

### DIFF
--- a/cmd/state/internal/cmdtree/exec.go
+++ b/cmd/state/internal/cmdtree/exec.go
@@ -28,6 +28,11 @@ func newExecCommand(prime *primer.Values, args ...string) *captain.Command {
 		},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {
+			if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
+				prime.Output().Print(ccmd.UsageText())
+				return nil
+			}
+
 			return runner.Run(params, args...)
 		},
 	)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-197" title="DX-197" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-197</a>  state exec help text is wrong
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Similar to `state run`, which has the same argument structure.