### PR TITLE
Fixed BuildArtifactCompleted "build bar not initialized" errors.

### DIFF
--- a/internal/runbits/progressbar/progressbar.go
+++ b/internal/runbits/progressbar/progressbar.go
@@ -111,7 +111,8 @@ func (rp *RuntimeProgress) BuildArtifactCompleted(_ artifact.ArtifactID, _ strin
 		return nil
 	}
 	if rp.buildBar == nil {
-		return errs.New("Build bar has not been initialized yet.")
+		logging.Debug("BuildArtifactCompleted: Build bar has not been initialized yet. This can happen if the build artifact was already known to be failing.")
+		return nil
 	}
 
 	rp.buildBar.Increment()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-480" title="DX-480" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-480</a>  Runtime: Build bar has not been initialized yet
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This has already been known to happen for failing builds, so it can happen here too.