### PR TITLE
Fixed os-specific yaml files overriding settings in main yaml.

### DIFF
--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -479,8 +479,48 @@ func Parse(configFilepath string) (_ *Project, rerr error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := mergo.Merge(project, *secondaryProject, mergo.WithAppendSlice); err != nil {
+		if err := mergo.Merge(project, *secondaryProject, mergo.WithAppendSlice, mergo.WithOverride); err != nil {
 			return nil, errs.Wrap(err, "Could not merge %s into your activestate.yaml", file.Name())
+		}
+
+		// Now reverse all arrays such that any members that were redefined show up first. (The array
+		// will still have two copies.)
+		if list := project.Platforms; len(secondaryProject.Platforms) > 0 {
+			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+				list[i], list[j] = list[j], list[i]
+			}
+		}
+		if list := project.Languages; len(secondaryProject.Languages) > 0 {
+			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+				list[i], list[j] = list[j], list[i]
+			}
+		}
+		if list := project.Constants; len(secondaryProject.Constants) > 0 {
+			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+				list[i], list[j] = list[j], list[i]
+			}
+		}
+		if secondaryProject.Secrets != nil {
+			if list := project.Secrets.User; len(secondaryProject.Secrets.User) > 0 {
+				for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+					list[i], list[j] = list[j], list[i]
+				}
+			}
+			if list := project.Secrets.Project; len(secondaryProject.Secrets.Project) > 0 {
+				for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+					list[i], list[j] = list[j], list[i]
+				}
+			}
+		}
+		if list := project.Events; len(secondaryProject.Events) > 0 {
+			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+				list[i], list[j] = list[j], list[i]
+			}
+		}
+		if list := project.Jobs; len(secondaryProject.Jobs) > 0 {
+			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+				list[i], list[j] = list[j], list[i]
+			}
 		}
 	}
 

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -479,49 +479,11 @@ func Parse(configFilepath string) (_ *Project, rerr error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := mergo.Merge(project, *secondaryProject, mergo.WithAppendSlice, mergo.WithOverride); err != nil {
+		if err := mergo.Merge(secondaryProject, *project, mergo.WithAppendSlice); err != nil {
 			return nil, errs.Wrap(err, "Could not merge %s into your activestate.yaml", file.Name())
 		}
-
-		// Now reverse all arrays such that any members that were redefined show up first. (The array
-		// will still have two copies.)
-		if list := project.Platforms; len(secondaryProject.Platforms) > 0 {
-			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-				list[i], list[j] = list[j], list[i]
-			}
-		}
-		if list := project.Languages; len(secondaryProject.Languages) > 0 {
-			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-				list[i], list[j] = list[j], list[i]
-			}
-		}
-		if list := project.Constants; len(secondaryProject.Constants) > 0 {
-			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-				list[i], list[j] = list[j], list[i]
-			}
-		}
-		if secondaryProject.Secrets != nil {
-			if list := project.Secrets.User; len(secondaryProject.Secrets.User) > 0 {
-				for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-					list[i], list[j] = list[j], list[i]
-				}
-			}
-			if list := project.Secrets.Project; len(secondaryProject.Secrets.Project) > 0 {
-				for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-					list[i], list[j] = list[j], list[i]
-				}
-			}
-		}
-		if list := project.Events; len(secondaryProject.Events) > 0 {
-			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-				list[i], list[j] = list[j], list[i]
-			}
-		}
-		if list := project.Jobs; len(secondaryProject.Jobs) > 0 {
-			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-				list[i], list[j] = list[j], list[i]
-			}
-		}
+		secondaryProject.path = project.path // keep original project path, not secondary path
+		project = secondaryProject
 	}
 
 	if err = project.Init(); err != nil {

--- a/pkg/projectfile/projectfile_darwin_test.go
+++ b/pkg/projectfile/projectfile_darwin_test.go
@@ -1,0 +1,43 @@
+package projectfile
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ActiveState/cli/internal/environment"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYamlMerge(t *testing.T) {
+	rootpath, err := environment.GetRootPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project, err := Parse(filepath.Join(rootpath, "pkg", "projectfile", "testdata", "activestate.yaml"))
+	assert.NoError(t, err, "Should not throw an error")
+
+	assert.Equal(t, "dev", project.Environments) // should be overridden
+
+	debugConstantsSeen := 0
+	macOSConstantSeen := true
+	assert.True(t, len(project.Constants) > 2) // these constants should not override the others
+	for _, constant := range project.Constants {
+		switch constant.Name {
+		case "DEBUG":
+			// We are merging with mergo's WithAppendSlice, so there will be two variables with this name.
+			// However, we expect the one from activestate.macos.yaml to show up first.
+			if debugConstantsSeen == 0 {
+				assert.Equal(t, "false", constant.Value) // from activestate.macos.yaml
+			} else {
+				assert.Equal(t, "true", constant.Value) // from activestate.yaml
+			}
+			debugConstantsSeen++
+		case "macOS":
+			assert.Equal(t, "true", constant.Value) // should be added
+			macOSConstantSeen = true
+		}
+	}
+	assert.Equal(t, 2, debugConstantsSeen)
+	assert.True(t, macOSConstantSeen)
+}

--- a/pkg/projectfile/projectfile_linux_test.go
+++ b/pkg/projectfile/projectfile_linux_test.go
@@ -17,7 +17,7 @@ func TestYamlMerge(t *testing.T) {
 	project, err := Parse(filepath.Join(rootpath, "pkg", "projectfile", "testdata", "activestate.yaml"))
 	assert.NoError(t, err, "Should not throw an error")
 
-	assert.Equal(t, "dev,qa,prod", project.Environment) // should not be overridden by macOS's environment
+	assert.Equal(t, "dev,qa,prod", project.Environments) // should not be overridden by macOS's environment
 
 	assert.True(t, len(project.Constants) > 2) // should not be overridden by macOS's constants
 	for _, constant := range project.Constants {

--- a/pkg/projectfile/projectfile_linux_test.go
+++ b/pkg/projectfile/projectfile_linux_test.go
@@ -1,0 +1,33 @@
+package projectfile
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ActiveState/cli/internal/environment"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYamlMerge(t *testing.T) {
+	rootpath, err := environment.GetRootPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project, err := Parse(filepath.Join(rootpath, "pkg", "projectfile", "testdata", "activestate.yaml"))
+	assert.NoError(t, err, "Should not throw an error")
+
+	assert.Equal(t, "dev,qa,prod", project.Environment) // should not be overridden by macOS's environment
+
+	assert.True(t, len(project.Constants) > 2) // should not be overridden by macOS's constants
+	for _, constant := range project.Constants {
+		switch constant.Name {
+		case "DEBUG":
+			assert.Equal(t, "true", constant.Value) // should not be overridden by macOS's 'false' value
+		case "PYTHONPATH":
+			assert.NotEmpty(t, constant.Value)
+		case "macOS":
+			assert.Fail(t, "macOS constant should not have been merged from activestate.macos.yaml")
+		}
+	}
+}

--- a/pkg/projectfile/testdata/activestate.macos.yaml
+++ b/pkg/projectfile/testdata/activestate.macos.yaml
@@ -1,0 +1,6 @@
+environments: dev
+constants:
+  - name: macOS
+    value: true
+  - name: DEBUG
+    value: false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-522" title="DX-522" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-522</a>  Merged as.yaml don't override main yaml
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
For example, settings and constants defined in activestate.macos.yaml should override the same settings in activestate.yaml on macOS.
Also added tests.