### PR TITLE
Fixed multi-add of the same bin path in ENV["PATH"] when more than one exclusion path is present.

### DIFF
--- a/pkg/platform/runtime/envdef/environment.go
+++ b/pkg/platform/runtime/envdef/environment.go
@@ -369,10 +369,14 @@ func FilterPATH(env map[string]string, excludes ...string) {
 	paths := strings.Split(PATH, string(os.PathListSeparator))
 	for _, p := range paths {
 		pc := filepath.Clean(p)
+		include_path := true
 		for _, exclude := range excludes {
 			if pc == filepath.Clean(exclude) {
-				continue
+				include_path = false
+				break
 			}
+		}
+		if include_path {
 			newPaths = append(newPaths, p)
 		}
 	}

--- a/pkg/platform/runtime/envdef/environment.go
+++ b/pkg/platform/runtime/envdef/environment.go
@@ -370,6 +370,7 @@ func FilterPATH(env map[string]string, excludes ...string) {
 	for _, p := range paths {
 		pc := filepath.Clean(p)
 		includePath := true
+
 		for _, exclude := range excludes {
 			if pc == filepath.Clean(exclude) {
 				includePath = false

--- a/pkg/platform/runtime/envdef/environment.go
+++ b/pkg/platform/runtime/envdef/environment.go
@@ -369,14 +369,14 @@ func FilterPATH(env map[string]string, excludes ...string) {
 	paths := strings.Split(PATH, string(os.PathListSeparator))
 	for _, p := range paths {
 		pc := filepath.Clean(p)
-		include_path := true
+		includePath := true
 		for _, exclude := range excludes {
 			if pc == filepath.Clean(exclude) {
-				include_path = false
+				includePath = false
 				break
 			}
 		}
-		if include_path {
+		if includePath {
 			newPaths = append(newPaths, p)
 		}
 	}

--- a/pkg/platform/runtime/envdef/environment.go
+++ b/pkg/platform/runtime/envdef/environment.go
@@ -370,7 +370,6 @@ func FilterPATH(env map[string]string, excludes ...string) {
 	for _, p := range paths {
 		pc := filepath.Clean(p)
 		includePath := true
-
 		for _, exclude := range excludes {
 			if pc == filepath.Clean(exclude) {
 				includePath = false

--- a/pkg/platform/runtime/envdef/environment_test.go
+++ b/pkg/platform/runtime/envdef/environment_test.go
@@ -237,6 +237,14 @@ func TestFilterPATH(t *testing.T) {
 			},
 			"/path//to/key1" + s + "/path/to//key3",
 		},
+		{
+			"Does not filter any paths",
+			args{
+				map[string]string{"PATH": "/path/to/key1"},
+				[]string{"/path/to/key2", "/path/to/key3"},
+			},
+			"/path/to/key1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-798" title="DX-798" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-798</a>  CLI - Deploy: Binary directories provided same path twice and added twice to the PATH env variable.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

.