### PR TITLE
Remove any deployed runtime environment config on uninstall.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1353,7 +1353,10 @@ clean_cache_artifact_confirm:
 clean_config_confirm:
   other: You are about the remove the State Tool config directory. Continue?
 clean_success_message:
-  other: "Successfully removed State Tool and related files\n"
+  other: |
+    Successfully removed State Tool and related files.
+
+    [ACTIONABLE]Please restart your terminal or start a new terminal session in order to clear any residual Runtime Environment variables and settings.[/RESET]
 clean_message_windows:
   other: |
     Deletion of State Tool has been scheduled.

--- a/internal/runners/clean/run.go
+++ b/internal/runners/clean/run.go
@@ -45,11 +45,14 @@ func removeEnvPaths(cfg configurable) error {
 	// remove shell file additions
 	s := subshell.New(cfg)
 	if err := s.CleanUserEnv(cfg, sscommon.InstallID, isAdmin); err != nil {
-		return errs.Wrap(err, "Failed to State Tool installation PATH")
+		return errs.Wrap(err, "Failed to remove State Tool installation PATH")
 	}
 	// Default projects will stop working, so we return them from the PATH as well
 	if err := s.CleanUserEnv(cfg, sscommon.DefaultID, isAdmin); err != nil {
 		return errs.Wrap(err, "Failed to remove default directory from PATH")
+	}
+	if err := s.CleanUserEnv(cfg, sscommon.DeployID, isAdmin); err != nil {
+		return errs.Wrap(err, "Failed to remove deploy directory from PATH")
 	}
 
 	if err := s.RemoveLegacyInstallPath(cfg); err != nil {

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -92,20 +92,6 @@ func WriteRcFile(rcTemplateName string, path string, data RcIdentification, env 
 	return fileutils.AppendToFile(path, []byte(fileutils.LineEnd+out.String()))
 }
 
-func WriteRcData(data string, path string, identification RcIdentification) error {
-	if err := fileutils.Touch(path); err != nil {
-		return err
-	}
-
-	if err := CleanRcFile(path, identification); err != nil {
-		return err
-	}
-
-	data = identification.Start + fileutils.LineEnd + data + fileutils.LineEnd + identification.Stop
-	logging.Debug("Writing to %s:\n%s", path, data)
-	return fileutils.AppendToFile(path, []byte(fileutils.LineEnd+data))
-}
-
 // RemoveLegacyInstallPath removes the PATH modification statement added to the shell-rc file by the legacy install script
 func RemoveLegacyInstallPath(path string) error {
 	if err := fileutils.Touch(path); err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-800" title="DX-800" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-800</a>  CLI - Install: Installation failed if before that "state deploy" executed on this system
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Residual environment variables like SSL_CERT_FILE can interfere with other programs.

Also notify the user to restart their shell/terminal to remove residual environment variables.