### PR TITLE
Autoupdates respect a user-specified 'autoupdate' config key.

### DIFF
--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -6,10 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ActiveState/cli/internal/osutils"
-	"github.com/ActiveState/cli/internal/profile"
-	"github.com/thoas/go-funk"
-
 	"github.com/ActiveState/cli/internal/appinfo"
 	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/config"
@@ -19,8 +15,11 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/multilog"
+	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/internal/profile"
 	"github.com/ActiveState/cli/internal/updater"
+	"github.com/thoas/go-funk"
 )
 
 const CfgKeyLastCheck = "auto_update_lastcheck"
@@ -54,6 +53,13 @@ func autoUpdate(args []string, cfg *config.Instance, out output.Outputer) (bool,
 	}
 	if up == nil {
 		logging.Debug("No update found")
+		return false, nil
+	}
+
+	if cfg.IsSet(constants.AutoUpdateConfigKey) && !cfg.GetBool(constants.AutoUpdateConfigKey) {
+		logging.Debug("Not performing autoupdates because user turned off autoupdates.")
+		out.Notice(output.Heading(locale.Tl("update_available_header", "Auto Update")))
+		out.Notice(locale.Tr("update_available", constants.VersionNumber, up.Version))
 		return false, nil
 	}
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -406,3 +406,6 @@ const PpmShim = "ppm"
 
 // PipShim is the name of the pip shim
 const PipShim = "pip"
+
+// AutoUpdateConfigKey is the config key for storing whether or not autoupdates can be performed
+const AutoUpdateConfigKey = "autoupdate"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-729" title="DX-729" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-729</a>  Auto-Updating can be disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
If it does not exist or if it is 'true', continue with autoupdates as normal. Otherwise, just print a notice if there is an update available.

The config key has no effect on `state update`, which can always be run.