### PR TITLE
Added help description for "state config set".

### DIFF
--- a/cmd/state/internal/cmdtree/config.go
+++ b/cmd/state/internal/cmdtree/config.go
@@ -51,7 +51,7 @@ func newConfigSetCommand(prime *primer.Values) *captain.Command {
 	return captain.NewCommand(
 		"set",
 		locale.Tl("config_set_title", "Set config value"),
-		"",
+		locale.Tl("config_set_description", "Set config values using the terminal"),
 		prime,
 		[]*captain.Flag{},
 		[]*captain.Argument{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-808" title="DX-808" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-808</a>  CLI - CONFIG: "state config" help output missing "set" command description
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is in line with the help description for "state config get," which is "Print config values to the terminal."