### PR TITLE
Fixed help description for "state pull --set-project"

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -161,7 +161,7 @@ func New(prime *primer.Values, args ...string) *CmdTree {
 		deployCmd,
 		scriptsCmd,
 		eventsCmd,
-		newPullCommand(prime),
+		newPullCommand(prime, globals),
 		updateCmd,
 		newForkCommand(prime),
 		newPpmCommand(prime),

--- a/cmd/state/internal/cmdtree/pull.go
+++ b/cmd/state/internal/cmdtree/pull.go
@@ -11,7 +11,6 @@ func newPullCommand(prime *primer.Values, globals *globalOptions) *captain.Comma
 	runner := pull.New(prime)
 
 	params := &pull.PullParams{}
-	params.Force = globals.NonInteractive
 
 	return captain.NewCommand(
 		"pull",
@@ -28,6 +27,7 @@ func newPullCommand(prime *primer.Values, globals *globalOptions) *captain.Comma
 		},
 		[]*captain.Argument{},
 		func(cmd *captain.Command, args []string) error {
+			params.Force = globals.NonInteractive
 			return runner.Run(params)
 		}).SetGroup(VCSGroup)
 }

--- a/cmd/state/internal/cmdtree/pull.go
+++ b/cmd/state/internal/cmdtree/pull.go
@@ -21,13 +21,13 @@ func newPullCommand(prime *primer.Values) *captain.Command {
 			{
 				Name:        "force",
 				Shorthand:   "",
-				Description: locale.Tl("flag_state_pull_force_description", "Force pulling specified project even if it is unrelated to checked out one"),
+				Description: locale.Tl("flag_state_pull_force_description", "Force pulling the specified project even if it is unrelated to the checked out one"),
 				Value:       &params.Force,
 			},
 			{
 				Name:        "set-project",
 				Shorthand:   "",
-				Description: locale.Tl("flag_state_pull_set_project_description", "project even if it is unrelated to checked out one"),
+				Description: locale.Tl("flag_state_pull_set_project_description", "Pull from the specified project instead of the checked out one"),
 				Value:       &params.SetProject,
 			},
 		},

--- a/cmd/state/internal/cmdtree/pull.go
+++ b/cmd/state/internal/cmdtree/pull.go
@@ -7,10 +7,11 @@ import (
 	"github.com/ActiveState/cli/internal/runners/pull"
 )
 
-func newPullCommand(prime *primer.Values) *captain.Command {
+func newPullCommand(prime *primer.Values, globals *globalOptions) *captain.Command {
 	runner := pull.New(prime)
 
 	params := &pull.PullParams{}
+	params.Force = globals.NonInteractive
 
 	return captain.NewCommand(
 		"pull",
@@ -18,12 +19,6 @@ func newPullCommand(prime *primer.Values) *captain.Command {
 		locale.Tl("pull_description", "Pull in the latest version of your project from the ActiveState Platform"),
 		prime,
 		[]*captain.Flag{
-			{
-				Name:        "force",
-				Shorthand:   "",
-				Description: locale.Tl("flag_state_pull_force_description", "Force pulling the specified project even if it is unrelated to the checked out one"),
-				Value:       &params.Force,
-			},
 			{
 				Name:        "set-project",
 				Shorthand:   "",

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -43,6 +43,12 @@ func (suite *PullIntegrationTestSuite) TestPullSetProject() {
 
 	// update to related project
 	cp := ts.Spawn("pull", "--set-project", "ActiveState-CLI/small-python-fork")
+	cp.ExpectLongString("you may lose changes to your project")
+	cp.SendLine("n")
+	cp.Expect("Pull aborted by user")
+	cp.ExpectNotExitCode(0)
+
+	cp = ts.Spawn("pull", "--non-interactive", "--set-project", "ActiveState-CLI/small-python-fork")
 	cp.Expect("activestate.yaml has been updated")
 	cp.ExpectExitCode(0)
 }
@@ -60,9 +66,9 @@ func (suite *PullIntegrationTestSuite) TestPullSetProjectUnrelated() {
 	cp.Expect("Pull aborted by user")
 	cp.ExpectNotExitCode(0)
 
-	cp = ts.Spawn("pull", "--force", "--set-project", "ActiveState-CLI/Python3")
-	cp.Expect("activestate.yaml has been updated")
-	cp.ExpectExitCode(0)
+	cp = ts.Spawn("pull", "--non-interactive", "--set-project", "ActiveState-CLI/Python3")
+	cp.Expect("could not detect common parent")
+	cp.ExpectExitCode(1)
 }
 
 func (suite *PullIntegrationTestSuite) TestPull_Merge() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-813" title="DX-813" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-813</a>  CLI - PULL: Help output has descriptions starting with NON capitalized letters and part of the descriptions looked off.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Also replace `state pull --force` with `state pull --non-interactive`. Force was changed 9 months ago to be simply a non-interactive type of option. A merge is still required, and if the target project is completely unrelated, the pull can still fail.

This PR will also address https://activestatef.atlassian.net/browse/DX-817

I also went through all of our "*_description" localization strings and they all appear to be capitalized properly. This looks like the only one.