### PR TITLE
Do not show command group headers if all children are hidden.

### DIFF
--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -768,7 +768,7 @@ func childCommands(cmd *Command) string {
 	var group string
 	table := table.New([]string{"", ""})
 	table.HideHeaders = true
-	for _, child := range cmd.Children() {
+	for _, child := range cmd.AvailableChildren() {
 		if group != child.Group().String() && child.Group().String() != "" {
 			group = child.Group().String()
 			table.AddRow([]string{""})


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-847" title="DX-847" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-847</a>  CLI - HELP: Section with no `STABLE` commands still part of the help menu
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
