### PR TITLE
Make non-existant run script error message more visible.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -414,7 +414,7 @@ flag_state_run_list_description:
 error_state_run_undefined_name:
   other: The script name must be provided
 error_state_run_unknown_name:
-  other: The script '[NOTICE]{{.V0}}[/RESET]' is not defined in activestate.yaml.
+  other: "[ERROR]The script [/RESET]'[NOTICE]{{.V0}}[/RESET]' [ERROR]is not defined in activestate.yaml.[/RESET]"
 error_state_run_activate:
   other: Unable to activate a state for running the script in. Try manually running "state activate" first.
 error_state_run_standalone_conflict:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-591" title="DX-591" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-591</a>  The output when trying to state run a nonexistent script should do more to visually indicate that an error occurred
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Input errors by design do not highlight in red because we don't want to be "alarming the user too much." We do want to make this error a bit more obvious though.