### PR TITLE
Removed logging of error wrapping and creation.

### DIFF
--- a/cmd/state/errors.go
+++ b/cmd/state/errors.go
@@ -101,13 +101,6 @@ func unwrapError(err error) (int, error) {
 		return code, nil
 	}
 
-	// Log error if this isn't a user input error
-	if !locale.IsInputError(err) {
-		multilog.Critical("Returning error:\n%s\nCreated at:\n%s", errs.Join(err, "\n").Error(), stack)
-	} else {
-		logging.Debug("Returning input error:\n%s\nCreated at:\n%s", errs.Join(err, "\n").Error(), stack)
-	}
-
 	var llerr *config.LocalizedError // workaround type used to avoid circular import in config pkg
 	if errors.As(err, &llerr) {
 		key, base := llerr.Localization()

--- a/cmd/state/errors.go
+++ b/cmd/state/errors.go
@@ -101,6 +101,13 @@ func unwrapError(err error) (int, error) {
 		return code, nil
 	}
 
+	// Log error if this isn't a user input error
+	if !locale.IsInputError(err) {
+		multilog.Critical("Returning error:\n%s\nCreated at:\n%s", errs.Join(err, "\n").Error(), stack)
+	} else {
+		logging.Debug("Returning input error:\n%s\nCreated at:\n%s", errs.Join(err, "\n").Error(), stack)
+	}
+
 	var llerr *config.LocalizedError // workaround type used to avoid circular import in config pkg
 	if errors.As(err, &llerr) {
 		key, base := llerr.Localization()

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils/stacktrace"
 	"github.com/ActiveState/cli/internal/rtutils"
 )
@@ -71,7 +70,6 @@ func New(message string, args ...interface{}) *WrapperError {
 // Wrap creates a new error that wraps the given error
 func Wrap(wrapTarget error, message string, args ...interface{}) *WrapperError {
 	msg := fmt.Sprintf(message, args...)
-	logging.Debug("Wrapped error: %v -- with: %v", wrapTarget, msg)
 	return newError(msg, wrapTarget)
 }
 

--- a/internal/locale/errors.go
+++ b/internal/locale/errors.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils/stacktrace"
 	"github.com/ActiveState/cli/internal/rtutils"
 )
@@ -83,8 +82,6 @@ func WrapError(err error, id string, args ...string) *LocalizedError {
 	l.localized = translation
 	l.stack = stacktrace.GetWithSkip([]string{rtutils.CurrentFile()})
 
-	logging.Debug("Wrapped localized error: %v -- with: %v", err, translation)
-
 	return l
 }
 
@@ -109,8 +106,6 @@ func WrapInputError(err error, id string, args ...string) *LocalizedError {
 	l.wrapped = err
 	l.localized = translation
 	l.stack = stacktrace.GetWithSkip([]string{rtutils.CurrentFile()})
-
-	logging.Debug("Wrapped input error: %v -- with: %v", err, translation)
 
 	return l
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-878" title="DX-878" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-878</a>  Stop reporting "error created" and "wrapped error" logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It's cluttering up the log file. These errors will ultimately be reported anyway.