### PR TITLE
Do not emit unstable command warnings for editor.v0 output type.

### DIFF
--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -525,7 +525,7 @@ func (c *Command) subCommandNames() []string {
 func (c *Command) runner(cobraCmd *cobra.Command, args []string) error {
 	defer profile.Measure("captain:runner", time.Now())
 
-	if c.unstable {
+	if c.unstable && c.out.Type() != output.EditorV0FormatName {
 		if !c.cfg.GetBool(constants.UnstableConfig) {
 			c.out.Print(locale.Tr("unstable_command_warning", c.Name()))
 			return nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-853" title="DX-853" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-853</a>  Komodo is bugged due to `state organizations` being unstable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Editors do not process this kind of unstructured output. Simply allow all unstable commands to run without any notice.