### PR TITLE
Do not remain in activated subshell upon install.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -347,6 +347,7 @@ func installOrUpdateFromLocalSource(out output.Outputer, cfg *config.Instance, a
 		out.Print("")
 		out.Print(output.Title("State Tool Package Manager Installation Complete"))
 		out.Print("State Tool Package Manager has been successfully installed.")
+		out.Print("Please restart your shell or open a new one in order to start using the [ACTIONABLE]state[/RESET] command.")
 	}
 
 	return nil
@@ -403,6 +404,9 @@ func postInstallEvents(out output.Outputer, cfg *config.Instance, an analytics.D
 		}
 		if err = <-ss.Errors(); err != nil {
 			return errs.Wrap(err, "Subshell execution; error returned: %s", errs.JoinMessage(err))
+		}
+		if err := ss.Deactivate(); err != nil {
+			return errs.Wrap(err, "Subshell exit; error returned: %s", errs.JoinMessage(err))
 		}
 	}
 

--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -346,7 +346,8 @@ func installOrUpdateFromLocalSource(out output.Outputer, cfg *config.Instance, a
 		out.Print("")
 		out.Print(output.Title("State Tool Package Manager Installation Complete"))
 		out.Print("State Tool Package Manager has been successfully installed.")
-		out.Print("Please restart your shell or open a new one in order to start using the [ACTIONABLE]state[/RESET] command.")
+		out.Print("")
+		out.Print("[ACTIONABLE]Please restart your shell or open a new one to start using the[/RESET] state [ACTIONABLE]command.[/RESET]")
 	}
 
 	return nil

--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -397,17 +397,6 @@ func postInstallEvents(out output.Outputer, cfg *config.Instance, an analytics.D
 			an.EventWithLabel(AnalyticsFunnelCat, "forward-activate-default-err", err.Error())
 			return errs.Wrap(err, "Could not activate %s, error returned: %s", params.activateDefault.String(), errs.JoinMessage(err))
 		}
-	case !isUpdate:
-		ss := subshell.New(cfg)
-		if err := ss.Activate(nil, cfg, out); err != nil {
-			return errs.Wrap(err, "Subshell setup; error returned: %s", errs.JoinMessage(err))
-		}
-		if err = <-ss.Errors(); err != nil {
-			return errs.Wrap(err, "Subshell execution; error returned: %s", errs.JoinMessage(err))
-		}
-		if err := ss.Deactivate(); err != nil {
-			return errs.Wrap(err, "Subshell exit; error returned: %s", errs.JoinMessage(err))
-		}
 	}
 
 	return nil

--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/rollbar"
 	"github.com/ActiveState/cli/internal/runbits/panics"
-	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/pkg/project"
 )
 

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -76,14 +76,22 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 					"bash", e2e.WithArgs(argsWithActive...),
 					e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 				)
+				expectStateToolInstallation(cp)
+				cp.ExpectExitCode(0)
+
+				// Start a new shell session with `state` in $PATH.
+				cp = ts.SpawnCmdWithOpts("bash", e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
 			} else {
 				cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(argsWithActive...),
 					e2e.AppendEnv("SHELL="),
 					e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 				)
-			}
+				expectStateToolInstallation(cp)
+				cp.ExpectExitCode(0)
 
-			expectStateToolInstallation(cp)
+				// Start a new shell session with `state` in %PATH%.
+				cp = ts.SpawnCmdWithOpts("cmd.exe", e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
+			}
 
 			if tt.Activate != "" || tt.ActivateByCommand != "" {
 				cp.Expect("Creating a Virtual Environment")

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -76,22 +76,14 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 					"bash", e2e.WithArgs(argsWithActive...),
 					e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 				)
-				expectStateToolInstallation(cp)
-				cp.ExpectExitCode(0)
-
-				// Start a new shell session with `state` in $PATH.
-				cp = ts.SpawnCmdWithOpts("bash", e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
 			} else {
 				cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(argsWithActive...),
 					e2e.AppendEnv("SHELL="),
 					e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 				)
-				expectStateToolInstallation(cp)
-				cp.ExpectExitCode(0)
-
-				// Start a new shell session with `state` in %PATH%.
-				cp = ts.SpawnCmdWithOpts("cmd.exe", e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
 			}
+
+			expectStateToolInstallation(cp)
 
 			if tt.Activate != "" || tt.ActivateByCommand != "" {
 				cp.Expect("Creating a Virtual Environment")
@@ -101,6 +93,15 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 
 				cp.SendLine("python3 -c \"import sys; print(sys.copyright)\"")
 				cp.Expect("ActiveState Software Inc.")
+			} else {
+				cp.ExpectExitCode(0)
+				if runtime.GOOS != "windows" {
+					// Start a new shell session with `state` in $PATH.
+					cp = ts.SpawnCmdWithOpts("bash", e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
+				} else {
+					// Start a new shell session with `state` in %PATH%.
+					cp = ts.SpawnCmdWithOpts("cmd.exe", e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
+				}
 			}
 
 			cp.SendLine("state --version")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-879" title="DX-879" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-879</a>  CLI - UPDATE: Update prevented with `A State Tool update appears to already be running.`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Attempting to update will fail since the installer is still "running". Be a good shell citizen by asking the user to start a new shell to use the `state` command.