### PR TITLE
Added more helpful message on what to do if update fails in original subshell from installation.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1763,7 +1763,7 @@ update_permission_err:
     Error received: {{.V1}}
 err_update_in_progress:
   other: |
-    A State Tool update appears to already be running.
+    A State Tool update already appears to be running.
     Please close any open shells, open a new one, and then try this command again.
     If this issue persists please manually delete [ACTIONABLE]{{.V0}}[/RESET].
 auto_update_to_version:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1764,6 +1764,7 @@ update_permission_err:
 err_update_in_progress:
   other: |
     A State Tool update appears to already be running.
+    Please close any open shells, open a new one, and then try this command again.
     If this issue persists please manually delete [ACTIONABLE]{{.V0}}[/RESET].
 auto_update_to_version:
   other: Updating State Tool from [NOTICE]{{.V0}}[/RESET] to [NOTICE]{{.V1}}[/RESET].


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-879" title="DX-879" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-879</a>  CLI - UPDATE: Update prevented with `A State Tool update appears to already be running.`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
