### PR TITLE
Added support for listening for config key changes, notifying state-svc, and reacting to them.

### DIFF
--- a/cmd/state-svc/internal/resolver/resolver.go
+++ b/cmd/state-svc/internal/resolver/resolver.go
@@ -166,6 +166,6 @@ func (r *Resolver) RuntimeUsage(ctx context.Context, pid int, exec string, dimen
 }
 
 func (r *Resolver) ConfigChanged(ctx context.Context, key string) (*graph.ConfigChangedResponse, error) {
-	configMediator.NotifyListeners(key)
+	go configMediator.NotifyListeners(key)
 	return &graph.ConfigChangedResponse{Received: true}, nil
 }

--- a/cmd/state-svc/internal/resolver/resolver.go
+++ b/cmd/state-svc/internal/resolver/resolver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/graph"
 	"github.com/ActiveState/cli/internal/logging"
+	configMediator "github.com/ActiveState/cli/internal/mediators/config"
 	"github.com/ActiveState/cli/internal/updater"
 	"github.com/ActiveState/cli/pkg/projectfile"
 	"github.com/patrickmn/go-cache"
@@ -162,4 +163,9 @@ func (r *Resolver) RuntimeUsage(ctx context.Context, pid int, exec string, dimen
 	r.rtwatch.Watch(pid, exec, dims)
 
 	return &graph.RuntimeUsageResponse{Received: true}, nil
+}
+
+func (r *Resolver) ConfigChanged(ctx context.Context, key string) (*graph.ConfigChangedResponse, error) {
+	configMediator.NotifyListeners(key)
+	return &graph.ConfigChangedResponse{Received: true}, nil
 }

--- a/cmd/state-svc/internal/server/generated/generated.go
+++ b/cmd/state-svc/internal/server/generated/generated.go
@@ -54,6 +54,10 @@ type ComplexityRoot struct {
 		Version  func(childComplexity int) int
 	}
 
+	ConfigChangedResponse struct {
+		Received func(childComplexity int) int
+	}
+
 	Project struct {
 		Locations func(childComplexity int) int
 		Namespace func(childComplexity int) int
@@ -62,6 +66,7 @@ type ComplexityRoot struct {
 	Query struct {
 		AnalyticsEvent  func(childComplexity int, category string, action string, label *string, dimensionsJSON string) int
 		AvailableUpdate func(childComplexity int) int
+		ConfigChanged   func(childComplexity int, key string) int
 		Projects        func(childComplexity int) int
 		RuntimeUsage    func(childComplexity int, pid int, exec string, dimensionsJSON string) int
 		Version         func(childComplexity int) int
@@ -90,6 +95,7 @@ type QueryResolver interface {
 	Projects(ctx context.Context) ([]*graph.Project, error)
 	AnalyticsEvent(ctx context.Context, category string, action string, label *string, dimensionsJSON string) (*graph.AnalyticsEventResponse, error)
 	RuntimeUsage(ctx context.Context, pid int, exec string, dimensionsJSON string) (*graph.RuntimeUsageResponse, error)
+	ConfigChanged(ctx context.Context, key string) (*graph.ConfigChangedResponse, error)
 }
 
 type executableSchema struct {
@@ -149,6 +155,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AvailableUpdate.Version(childComplexity), true
 
+	case "ConfigChangedResponse.received":
+		if e.complexity.ConfigChangedResponse.Received == nil {
+			break
+		}
+
+		return e.complexity.ConfigChangedResponse.Received(childComplexity), true
+
 	case "Project.locations":
 		if e.complexity.Project.Locations == nil {
 			break
@@ -181,6 +194,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.AvailableUpdate(childComplexity), true
+
+	case "Query.configChanged":
+		if e.complexity.Query.ConfigChanged == nil {
+			break
+		}
+
+		args, err := ec.field_Query_configChanged_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ConfigChanged(childComplexity, args["key"].(string)), true
 
 	case "Query.projects":
 		if e.complexity.Query.Projects == nil {
@@ -346,8 +371,12 @@ type Query {
   projects: [Project]!
   analyticsEvent(category: String!, action: String!, label: String, dimensionsJson: String!): AnalyticsEventResponse
   runtimeUsage(pid: Int!, exec: String!, dimensionsJson: String!): RuntimeUsageResponse
+  configChanged(key: String!): ConfigChangedResponse
 }
 
+type ConfigChangedResponse {
+  received: Boolean!
+}
 `, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
@@ -410,6 +439,21 @@ func (ec *executionContext) field_Query_analyticsEvent_args(ctx context.Context,
 		}
 	}
 	args["dimensionsJson"] = arg3
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_configChanged_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["key"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["key"] = arg0
 	return args, nil
 }
 
@@ -694,6 +738,41 @@ func (ec *executionContext) _AvailableUpdate_sha256(ctx context.Context, field g
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _ConfigChangedResponse_received(ctx context.Context, field graphql.CollectedField, obj *graph.ConfigChangedResponse) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ConfigChangedResponse",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Received, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Project_namespace(ctx context.Context, field graphql.CollectedField, obj *graph.Project) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -939,6 +1018,45 @@ func (ec *executionContext) _Query_runtimeUsage(ctx context.Context, field graph
 	res := resTmp.(*graph.RuntimeUsageResponse)
 	fc.Result = res
 	return ec.marshalORuntimeUsageResponse2ᚖgithubᚗcomᚋActiveStateᚋcliᚋinternalᚋgraphᚐRuntimeUsageResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_configChanged(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_configChanged_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ConfigChanged(rctx, args["key"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*graph.ConfigChangedResponse)
+	fc.Result = res
+	return ec.marshalOConfigChangedResponse2ᚖgithubᚗcomᚋActiveStateᚋcliᚋinternalᚋgraphᚐConfigChangedResponse(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -2426,6 +2544,33 @@ func (ec *executionContext) _AvailableUpdate(ctx context.Context, sel ast.Select
 	return out
 }
 
+var configChangedResponseImplementors = []string{"ConfigChangedResponse"}
+
+func (ec *executionContext) _ConfigChangedResponse(ctx context.Context, sel ast.SelectionSet, obj *graph.ConfigChangedResponse) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, configChangedResponseImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ConfigChangedResponse")
+		case "received":
+			out.Values[i] = ec._ConfigChangedResponse_received(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var projectImplementors = []string{"Project"}
 
 func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, obj *graph.Project) graphql.Marshaler {
@@ -2529,6 +2674,17 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_runtimeUsage(ctx, field)
+				return res
+			})
+		case "configChanged":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_configChanged(ctx, field)
 				return res
 			})
 		case "__type":
@@ -3279,6 +3435,13 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 		return graphql.Null
 	}
 	return graphql.MarshalBoolean(*v)
+}
+
+func (ec *executionContext) marshalOConfigChangedResponse2ᚖgithubᚗcomᚋActiveStateᚋcliᚋinternalᚋgraphᚐConfigChangedResponse(ctx context.Context, sel ast.SelectionSet, v *graph.ConfigChangedResponse) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ConfigChangedResponse(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOProject2ᚖgithubᚗcomᚋActiveStateᚋcliᚋinternalᚋgraphᚐProject(ctx context.Context, sel ast.SelectionSet, v *graph.Project) graphql.Marshaler {

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -71,9 +71,6 @@ func main() {
 	}
 
 	runErr := run(cfg)
-	if runErr == nil {
-		runErr = cfg.Close()
-	}
 	if runErr != nil {
 		errMsg := errs.Join(runErr, ": ").Error()
 		if locale.IsInputError(runErr) {

--- a/cmd/state-svc/schema/schema.graphqls
+++ b/cmd/state-svc/schema/schema.graphqls
@@ -37,5 +37,9 @@ type Query {
   projects: [Project]!
   analyticsEvent(category: String!, action: String!, label: String, dimensionsJson: String!): AnalyticsEventResponse
   runtimeUsage(pid: Int!, exec: String!, dimensionsJson: String!): RuntimeUsageResponse
+  configChanged(key: String!): ConfigChangedResponse
 }
 
+type ConfigChangedResponse {
+  received: Boolean!
+}

--- a/internal/analytics/client/sync/client.go
+++ b/internal/analytics/client/sync/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ActiveState/cli/internal/instanceid"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/machineid"
+	configMediator "github.com/ActiveState/cli/internal/mediators/config"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/rollbar"
@@ -89,10 +90,8 @@ func New(cfg *config.Instance, auth *authentication.Auth) *Client {
 		a.cfg = cfg
 	}
 
-	if (a.cfg.IsSet(constants.ReportAnalyticsConfig) && !a.cfg.GetBool(constants.ReportAnalyticsConfig)) ||
-		strings.ToLower(os.Getenv(constants.DisableAnalyticsEnvVarName)) == "true" {
-		a.sendReports = false
-	}
+	a.readConfig()
+	configMediator.AddListener(constants.ReportAnalyticsConfig, a.readConfig)
 
 	userID := ""
 	if auth != nil && auth.UserID() != nil {
@@ -130,6 +129,13 @@ func New(cfg *config.Instance, auth *authentication.Auth) *Client {
 	}
 
 	return a
+}
+
+func (a *Client) readConfig() {
+	doNotReport := (!a.cfg.Closed() && a.cfg.IsSet(constants.ReportAnalyticsConfig) && !a.cfg.GetBool(constants.ReportAnalyticsConfig)) ||
+		strings.ToLower(os.Getenv(constants.DisableAnalyticsEnvVarName)) == "true"
+	a.sendReports = !doNotReport
+	logging.Debug("Sending Google Analytics reports? %v", a.sendReports)
 }
 
 func (a *Client) NewReporter(rep Reporter) {

--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -27,3 +27,7 @@ func OnCI() bool {
 func BuiltViaCI() bool {
 	return constants.OnCI == "true"
 }
+
+func InStateSvc() bool {
+	return strings.HasSuffix(os.Args[0], constants.StateSvcCmd)
+}

--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -27,7 +27,3 @@ func OnCI() bool {
 func BuiltViaCI() bool {
 	return constants.OnCI == "true"
 }
-
-func InStateSvc() bool {
-	return strings.HasSuffix(os.Args[0], constants.StateSvcCmd)
-}

--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -14,6 +14,10 @@ type AvailableUpdate struct {
 	Sha256   string `json:"sha256"`
 }
 
+type ConfigChangedResponse struct {
+	Received bool `json:"received"`
+}
+
 type Project struct {
 	Namespace string   `json:"namespace"`
 	Locations []string `json:"locations"`

--- a/internal/mediators/config/listeners.go
+++ b/internal/mediators/config/listeners.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"github.com/ActiveState/cli/internal/logging"
+)
+
+type listener struct {
+	key      string
+	callback func()
+}
+
+var listeners = make([]listener, 0)
+
+// AddListener adds a listener for changes to the given config key that calls the given callback
+// function.
+// Client code is responsible for calling NotifyListeners to signal config changes to listeners.
+func AddListener(key string, callback func()) {
+	logging.Debug("Adding listener for config key: %s", key)
+	listeners = append(listeners, listener{key, callback})
+}
+
+// NotifyListeners notifies listeners that the given config key has changed.
+func NotifyListeners(key string) {
+	for _, listener := range listeners {
+		if listener.key != key {
+			continue
+		}
+		logging.Debug("Invoking callback for config key: %s", key)
+		listener.callback()
+	}
+}

--- a/internal/rollbar/rollbar.go
+++ b/internal/rollbar/rollbar.go
@@ -25,8 +25,18 @@ type config interface {
 	Closed() bool
 }
 
+var currentCfg config
+
+var reportingDisabled bool
+
+func readConfig() {
+	reportingDisabled = currentCfg != nil && !currentCfg.Closed() && currentCfg.IsSet(constants.ReportErrorsConfig) && !currentCfg.GetBool(constants.ReportErrorsConfig)
+	logging.Debug("Sending Rollbar reports? %v", reportingDisabled)
+}
+
 func init() {
 	configMediator.RegisterOption(constants.ReportErrorsConfig, configMediator.Bool, configMediator.EmptyEvent, configMediator.EmptyEvent)
+	configMediator.AddListener(constants.ReportErrorsConfig, readConfig)
 }
 
 // CurrentCmd holds the value of the current command being invoked
@@ -68,10 +78,9 @@ func SetupRollbar(token string) {
 	})
 }
 
-var reportingDisabled bool
-
 func SetConfig(cfg config) {
-	reportingDisabled = cfg != nil && !cfg.Closed() && cfg.IsSet(constants.ReportErrorsConfig) && !cfg.GetBool(constants.ReportErrorsConfig)
+	currentCfg = cfg
+	readConfig()
 }
 
 func UpdateRollbarPerson(userID, username, email string) {

--- a/internal/runners/config/config.go
+++ b/internal/runners/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 type primeable interface {
 	primer.Outputer
 	primer.Configurer
+	primer.SvcModeler
 }
 
 func NewConfig(prime primeable) (*Config, error) {

--- a/internal/runners/config/set.go
+++ b/internal/runners/config/set.go
@@ -61,8 +61,10 @@ func (s *Set) Run(params SetParams) error {
 	configMediator.NotifyListeners(key)
 
 	// Notify state-svc that this key has changed.
-	if err := s.svcModel.ConfigChanged(context.Background(), key); err != nil {
-		logging.Debug("Failed to report config change via state-svc: %s", errs.JoinMessage(err))
+	if s.svcModel != nil {
+		if err := s.svcModel.ConfigChanged(context.Background(), key); err != nil {
+			logging.Debug("Failed to report config change via state-svc: %s", errs.JoinMessage(err))
+		}
 	}
 
 	s.out.Print(locale.Tl("config_set_success", "Successfully set config key: {{.V0}} to {{.V1}}", params.Key.String(), params.Value))

--- a/internal/runners/config/set.go
+++ b/internal/runners/config/set.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
@@ -61,9 +62,9 @@ func (s *Set) Run(params SetParams) error {
 	configMediator.NotifyListeners(key)
 
 	// Notify state-svc that this key has changed.
-	if s.svcModel != nil {
+	if !condition.InStateSvc() && s.svcModel != nil {
 		if err := s.svcModel.ConfigChanged(context.Background(), key); err != nil {
-			logging.Debug("Failed to report config change via state-svc: %s", errs.JoinMessage(err))
+			logging.Error("Failed to report config change via state-svc: %s", errs.JoinMessage(err))
 		}
 	}
 

--- a/internal/runners/config/set.go
+++ b/internal/runners/config/set.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
@@ -62,7 +61,7 @@ func (s *Set) Run(params SetParams) error {
 	configMediator.NotifyListeners(key)
 
 	// Notify state-svc that this key has changed.
-	if !condition.InStateSvc() && s.svcModel != nil {
+	if s.svcModel != nil {
 		if err := s.svcModel.ConfigChanged(context.Background(), key); err != nil {
 			logging.Error("Failed to report config change via state-svc: %s", errs.JoinMessage(err))
 		}

--- a/internal/runners/config/set.go
+++ b/internal/runners/config/set.go
@@ -45,10 +45,15 @@ func (s *Set) Run(params SetParams) error {
 		return locale.WrapError(err, "err_config_set_event", "Could not store config value, if this continues to happen please contact support.")
 	}
 
-	err = s.cfg.Set(params.Key.String(), value)
+	key := params.Key.String()
+
+	err = s.cfg.Set(key, value)
 	if err != nil {
 		return locale.WrapError(err, "err_config_set", fmt.Sprintf("Could not set value %s for key %s", params.Value, params.Key))
 	}
+
+	// Notify listeners that this key has changed.
+	configMediator.NotifyListeners(key)
 
 	s.out.Print(locale.Tl("config_set_success", "Successfully set config key: {{.V0}} to {{.V1}}", params.Key.String(), params.Value))
 	return nil

--- a/internal/runners/config/set_test.go
+++ b/internal/runners/config/set_test.go
@@ -15,7 +15,7 @@ func TestSetUnknownKey(t *testing.T) {
 	cfg.Set("unknown", nil)
 
 	outputer := outputhelper.NewCatcher()
-	set := Set{outputer, cfg}
+	set := Set{outputer, cfg, nil}
 	params := SetParams{"unknown", "true"}
 
 	// Trying to set an unknown config key should error.

--- a/pkg/platform/api/svc/request/configchanged.go
+++ b/pkg/platform/api/svc/request/configchanged.go
@@ -13,7 +13,7 @@ func (e *ConfigChanged) Query() string {
 	    configChanged(key: $key) {
 	      received
 	    }
-  }`
+	}`
 }
 
 func (e *ConfigChanged) Vars() map[string]interface{} {

--- a/pkg/platform/api/svc/request/configchanged.go
+++ b/pkg/platform/api/svc/request/configchanged.go
@@ -1,0 +1,21 @@
+package request
+
+type ConfigChanged struct {
+	key string
+}
+
+func NewConfigChanged(key string) *ConfigChanged {
+	return &ConfigChanged{key}
+}
+
+func (e *ConfigChanged) Query() string {
+	return `query($key: String!) {
+	    configChanged(key: $key) {
+	      received
+	    }
+  }`
+}
+
+func (e *ConfigChanged) Vars() map[string]interface{} {
+	return map[string]interface{}{"key": e.key}
+}

--- a/pkg/platform/model/svc.go
+++ b/pkg/platform/model/svc.go
@@ -96,3 +96,15 @@ func (m *SvcModel) RecordRuntimeUsage(ctx context.Context, pid int, exec string,
 
 	return nil
 }
+
+func (m *SvcModel) ConfigChanged(ctx context.Context, key string) error {
+	defer profile.Measure("svc:RecordRuntimeUsage", time.Now())
+
+	r := request.NewConfigChanged(key)
+	u := graph.ConfigChangedResponse{}
+	if err := m.request(ctx, r, &u); err != nil {
+		return errs.Wrap(err, "Error sending configchanged event via state-svc")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-893" title="DX-893" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-893</a>  state-svc observes report.* changes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The idea is to have subscribers listen for config keys they are interested in and execute a callback function when those keys change. Our pure Go SQLite driver does not have the ability to notify of database changes, so we have to do this manually.

Note that a C-Go SQLite driver (https://pkg.go.dev/github.com/mattn/go-sqlite3#SQLiteConn.RegisterUpdateHook) offers an update hook callback function that would probably be good enough, but we are not using that driver, presumably for cross-platform reasons.