### PR TITLE
Added synchronization tips when `state import` fails.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1108,6 +1108,10 @@ commit_reqstext_remove_existing_message:
   other: "Remove current packages prior to import from requirements file"
 err_cannot_remove_existing:
   other: "The already configured packages were not able to be overwritten"
+commit_failed_push_tip:
+  other: Ensure any previous changes have been saved by running [ACTIONABLE]state push[/RESET]. Then try running your command again.
+commit_failed_pull_tip:
+  other: Ensure any remote changes have been pulled in by running [ACTIONABLE]state pull[/RESET]. Then try running your command again.
 err_branch_not_bare:
   other: Branch is not bare and is unable to be initialized as such
 err_package_added:

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 
 	"github.com/ActiveState/cli/internal/analytics"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/installation/storage"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -167,7 +168,9 @@ func fetchImportChangeset(cp ChangesetProvider, file string, lang string) (model
 func commitChangeset(project *project.Project, msg string, changeset model.Changeset) (strfmt.UUID, error) {
 	commitID, err := model.CommitChangeset(project.CommitUUID(), msg, changeset)
 	if err != nil {
-		return "", locale.WrapError(err, "err_packages_removed")
+		return "", errs.AddTips(locale.WrapError(err, "err_packages_removed"),
+			locale.T("commit_failed_push_tip"),
+			locale.T("commit_failed_pull_tip"))
 	}
 
 	if err := project.SetCommit(commitID.String()); err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-890" title="DX-890" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-890</a>  CLI - IMPORT: Import `requirments.txt` fails until `state push` is executed.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The error message in the JIRA ticket was returned by the Platform API, so this is a platform error. It doesn't have the local commit created by `state uninstall flask`. The output from that uninstall command does say to run `state push`, so I've added tips to remind the user that that should have been done.

I've also added a tip to run `state pull` in case the user uninstalls flask from the Dashboard and then tries to run `state import`. The error message returned by the Platform API is similar and requires a `state pull` to get that remote commit.