### PR TITLE
Use PID for logfile in foreground

### DIFF
--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -236,7 +236,7 @@ func runStatus(out output.Outputer) error {
 
 	out.Print(fmt.Sprintf("Port: %s", port))
 	out.Print(fmt.Sprintf("Dashboard: http://127.0.0.1%s", port))
-	out.Print(fmt.Sprintf("Log: %s\n", logging.FilePathFor(logfile)))
+	out.Print(fmt.Sprintf("Log: %s", logging.FilePathFor(logfile)))
 
 	return nil
 }

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -229,7 +229,7 @@ func runStatus(out output.Outputer) error {
 		return errs.Wrap(err, "Service cannot be reached")
 	}
 
-	logfile, err := svcctl.LocateLogFile(ipcClient)
+	logfile, err := svcctl.LogFileName(ipcClient)
 	if err != nil {
 		return errs.Wrap(err, "Service could not locate log file")
 	}

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -139,7 +139,7 @@ func run(cfg *config.Instance) error {
 			p, nil, nil,
 			func(ccmd *captain.Command, args []string) error {
 				logging.Debug("Running CmdStatus")
-				return runStatus(out, cfg)
+				return runStatus(out)
 			},
 		),
 		captain.NewCommand(
@@ -221,7 +221,7 @@ func runStop() error {
 	return nil
 }
 
-func runStatus(out output.Outputer, cfg *config.Instance) error {
+func runStatus(out output.Outputer) error {
 	ipcClient := svcctl.NewDefaultIPCClient()
 	// Don't run in background if we're already running
 	port, err := svcctl.LocateHTTP(ipcClient)
@@ -229,9 +229,14 @@ func runStatus(out output.Outputer, cfg *config.Instance) error {
 		return errs.Wrap(err, "Service cannot be reached")
 	}
 
+	logfile, err := svcctl.LocateLogFile(ipcClient)
+	if err != nil {
+		return errs.Wrap(err, "Service could not locate log file")
+	}
+
 	out.Print(fmt.Sprintf("Port: %s", port))
 	out.Print(fmt.Sprintf("Dashboard: http://127.0.0.1%s", port))
-	out.Print(fmt.Sprintf("Log: %s\n", cfg.GetString(constants.SvcLogConfig)))
+	out.Print(fmt.Sprintf("Log: %s\n", logging.FilePathFor(logfile)))
 
 	return nil
 }

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -139,7 +139,7 @@ func run(cfg *config.Instance) error {
 			p, nil, nil,
 			func(ccmd *captain.Command, args []string) error {
 				logging.Debug("Running CmdStatus")
-				return runStatus(out)
+				return runStatus(out, cfg)
 			},
 		),
 		captain.NewCommand(
@@ -221,7 +221,7 @@ func runStop() error {
 	return nil
 }
 
-func runStatus(out output.Outputer) error {
+func runStatus(out output.Outputer, cfg *config.Instance) error {
 	ipcClient := svcctl.NewDefaultIPCClient()
 	// Don't run in background if we're already running
 	port, err := svcctl.LocateHTTP(ipcClient)
@@ -231,7 +231,7 @@ func runStatus(out output.Outputer) error {
 
 	out.Print(fmt.Sprintf("Port: %s", port))
 	out.Print(fmt.Sprintf("Dashboard: http://127.0.0.1%s", port))
-	out.Print(fmt.Sprintf("Log: %s\n", logging.FilePathFor(logging.FileNameFor(os.Getpid()))))
+	out.Print(fmt.Sprintf("Log: %s\n", cfg.GetString(constants.SvcLogConfig)))
 
 	return nil
 }

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -231,7 +231,7 @@ func runStatus(out output.Outputer) error {
 
 	out.Print(fmt.Sprintf("Port: %s", port))
 	out.Print(fmt.Sprintf("Dashboard: http://127.0.0.1%s", port))
-	//fmt.Printf("Log: %s\n", logging.FilePathFor(logging.FileNameFor(*pid)))
+	out.Print(fmt.Sprintf("Log: %s\n", logging.FilePathFor(logging.FileNameFor(os.Getpid()))))
 
 	return nil
 }

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -51,7 +51,7 @@ func (s *service) Start() error {
 	spath := svcctl.NewIPCSockPathFromGlobals()
 	reqHandlers := []ipc.RequestHandler{ // caller-defined handlers to expand ipc capabilities
 		svcctl.HTTPAddrHandler(":" + strconv.Itoa(s.server.Port())),
-		svcctl.LogFileHandler(":" + strconv.Itoa(s.server.Port())),
+		svcctl.LogFileHandler(logging.FileName()),
 	}
 	s.ipcSrv = ipc.NewServer(s.ctx, spath, reqHandlers...)
 	err = s.ipcSrv.Start()

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/ActiveState/cli/cmd/state-svc/internal/server"
 	anaSvc "github.com/ActiveState/cli/internal/analytics/client/sync"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/ipc"
 	"github.com/ActiveState/cli/internal/logging"
@@ -56,6 +58,11 @@ func (s *service) Start() error {
 	err = s.ipcSrv.Start()
 	if err != nil {
 		return errs.Wrap(err, "Failed to start server")
+	}
+
+	err = s.cfg.Set(constants.SvcLogConfig, logging.FilePathFor(logging.FileNameFor(os.Getpid())))
+	if err != nil {
+		return errs.Wrap(err, "Failed to set log file path in config")
 	}
 
 	return nil

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/ActiveState/cli/cmd/state-svc/internal/server"
 	anaSvc "github.com/ActiveState/cli/internal/analytics/client/sync"
 	"github.com/ActiveState/cli/internal/config"
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/ipc"
 	"github.com/ActiveState/cli/internal/logging"
@@ -53,16 +51,12 @@ func (s *service) Start() error {
 	spath := svcctl.NewIPCSockPathFromGlobals()
 	reqHandlers := []ipc.RequestHandler{ // caller-defined handlers to expand ipc capabilities
 		svcctl.HTTPAddrHandler(":" + strconv.Itoa(s.server.Port())),
+		svcctl.LogFileHandler(":" + strconv.Itoa(s.server.Port())),
 	}
 	s.ipcSrv = ipc.NewServer(s.ctx, spath, reqHandlers...)
 	err = s.ipcSrv.Start()
 	if err != nil {
 		return errs.Wrap(err, "Failed to start server")
-	}
-
-	err = s.cfg.Set(constants.SvcLogConfig, logging.FilePathFor(logging.FileNameFor(os.Getpid())))
-	if err != nil {
-		return errs.Wrap(err, "Failed to set log file path in config")
 	}
 
 	return nil

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -352,12 +352,6 @@ const GlobalDefaultPrefname = "projects.active.path"
 // DefaultBranchName is the default branch name used on platform projects
 const DefaultBranchName = "main"
 
-// SvcConfigPort is the config key used for storing the svc port
-const SvcConfigPort = "svc-port"
-
-// SvcConfigPid is the config key used for storing the svc pid
-const SvcConfigPid = "svc-pid"
-
 // UnstableConfig is the config key used to determine if a command is unstable
 const UnstableConfig = "optin.unstable"
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -352,9 +352,6 @@ const GlobalDefaultPrefname = "projects.active.path"
 // DefaultBranchName is the default branch name used on platform projects
 const DefaultBranchName = "main"
 
-// SvcLogConfig is the config key for the state service log file
-const SvcLogConfig = "svc.log"
-
 // UnstableConfig is the config key used to determine if a command is unstable
 const UnstableConfig = "optin.unstable"
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -352,6 +352,9 @@ const GlobalDefaultPrefname = "projects.active.path"
 // DefaultBranchName is the default branch name used on platform projects
 const DefaultBranchName = "main"
 
+// SvcLogConfig is the config key for the state service log file
+const SvcLogConfig = "svc.log"
+
 // UnstableConfig is the config key used to determine if a command is unstable
 const UnstableConfig = "optin.unstable"
 

--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -1,3 +1,4 @@
+//go:build !test
 // +build !test
 
 package logging

--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -1,4 +1,3 @@
-//go:build !test
 // +build !test
 
 package logging

--- a/internal/svcctl/comm.go
+++ b/internal/svcctl/comm.go
@@ -49,6 +49,6 @@ func (c *Comm) GetHTTPAddr(ctx context.Context) (string, error) {
 	return c.req.Request(ctx, KeyHTTPAddr)
 }
 
-func (c *Comm) GetLogFile(ctx context.Context) (string, error) {
+func (c *Comm) GetLogFileName(ctx context.Context) (string, error) {
 	return c.req.Request(ctx, KeyLogFile)
 }

--- a/internal/svcctl/comm.go
+++ b/internal/svcctl/comm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/ActiveState/cli/internal/ipc"
-	"github.com/ActiveState/cli/internal/logging"
 )
 
 var (
@@ -39,7 +38,7 @@ func HTTPAddrHandler(addr string) ipc.RequestHandler {
 func LogFileHandler(logFile string) ipc.RequestHandler {
 	return func(input string) (string, bool) {
 		if input == KeyLogFile {
-			return logging.FileName(), true
+			return logFile, true
 		}
 		return "", false
 	}

--- a/internal/svcctl/comm.go
+++ b/internal/svcctl/comm.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/ActiveState/cli/internal/ipc"
+	"github.com/ActiveState/cli/internal/logging"
 )
 
 var (
 	KeyHTTPAddr = "http-addr"
+	KeyLogFile  = "log-file"
 )
 
 type Requester interface {
@@ -34,6 +36,19 @@ func HTTPAddrHandler(addr string) ipc.RequestHandler {
 	}
 }
 
+func LogFileHandler(logFile string) ipc.RequestHandler {
+	return func(input string) (string, bool) {
+		if input == KeyLogFile {
+			return logging.FileName(), true
+		}
+		return "", false
+	}
+}
+
 func (c *Comm) GetHTTPAddr(ctx context.Context) (string, error) {
 	return c.req.Request(ctx, KeyHTTPAddr)
+}
+
+func (c *Comm) GetLogFile(ctx context.Context) (string, error) {
+	return c.req.Request(ctx, KeyLogFile)
 }

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -90,6 +90,22 @@ func LocateHTTP(ipComm IPCommunicator) (addr string, err error) {
 	return addr, nil
 }
 
+func LocateLogFile(ipComm IPCommunicator) (string, error) {
+	comm := NewComm(ipComm)
+
+	ctx, cancel := context.WithTimeout(context.Background(), commonTimeout)
+	defer cancel()
+
+	logfile, err := comm.GetLogFile(ctx)
+	if err != nil {
+		return "", errs.Wrap(err, "Log file request failed")
+	}
+
+	logging.Debug("Located log file at %s", logfile)
+
+	return logfile, nil
+}
+
 func StopServer(ipComm IPCommunicator) error {
 	ctx, cancel := context.WithTimeout(context.Background(), commonTimeout)
 	defer cancel()

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -101,7 +101,7 @@ func LogFileName(ipComm IPCommunicator) (string, error) {
 		return "", errs.Wrap(err, "Log file request failed")
 	}
 
-	logging.Debug("Located log file at %s", logfile)
+	logging.Debug("Log file name %s", logfile)
 
 	return logfile, nil
 }

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -101,7 +101,7 @@ func LogFileName(ipComm IPCommunicator) (string, error) {
 		return "", errs.Wrap(err, "Log file request failed")
 	}
 
-	logging.Debug("Log file name %s", logfile)
+	logging.Debug("Service returned log file: %s", logfile)
 
 	return logfile, nil
 }

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -90,13 +90,13 @@ func LocateHTTP(ipComm IPCommunicator) (addr string, err error) {
 	return addr, nil
 }
 
-func LocateLogFile(ipComm IPCommunicator) (string, error) {
+func LogFileName(ipComm IPCommunicator) (string, error) {
 	comm := NewComm(ipComm)
 
 	ctx, cancel := context.WithTimeout(context.Background(), commonTimeout)
 	defer cancel()
 
-	logfile, err := comm.GetLogFile(ctx)
+	logfile, err := comm.GetLogFileName(ctx)
 	if err != nil {
 		return "", errs.Wrap(err, "Log file request failed")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-830" title="DX-830" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-830</a>  Drop the PID mechanic from the state-svc
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It doesn't appear that the PID is used for the state service. This just adds a line to the `status` command for the log file and removes some constants.