### PR TITLE
Flag `state init` unstable.

### DIFF
--- a/cmd/state/internal/cmdtree/init.go
+++ b/cmd/state/internal/cmdtree/init.go
@@ -65,5 +65,5 @@ func newInitCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, _ []string) error {
 			return initRunner.Run(&params)
 		},
-	).SetGroup(EnvironmentGroup)
+	).SetGroup(EnvironmentGroup).SetUnstable(true)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-908" title="DX-908" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-908</a>  Remove `state init` from stable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
