### PR TITLE
Prevent access to secrets unless `optin.unstable` is true.

### DIFF
--- a/internal/keypairs/local.go
+++ b/internal/keypairs/local.go
@@ -20,6 +20,7 @@ type Configurable interface {
 	Close() error
 	Set(s string, i interface{}) error
 	GetString(s string) string
+	GetBool(s string) bool
 }
 
 // Load will attempt to load a Keypair using private and public-key files from

--- a/internal/keypairs/mock/mock.go
+++ b/internal/keypairs/mock/mock.go
@@ -1,0 +1,41 @@
+package mock
+
+import (
+	"github.com/ActiveState/cli/internal/keypairs"
+)
+
+type Mock struct {
+	keypairs.Configurable
+	cfg map[string]interface{}
+}
+
+func (m *Mock) ConfigPath() string {
+	return ""
+}
+
+func (m *Mock) Close() error {
+	return nil
+}
+
+func (m *Mock) Set(key string, value interface{}) error {
+	if m.cfg == nil {
+		m.cfg = make(map[string]interface{})
+	}
+
+	m.cfg[key] = value
+
+	return nil
+}
+
+func (m *Mock) GetString(key string) string {
+	if value, found := m.cfg[key]; found {
+		return value.(interface{}).(string) // assume we stored the correct type
+	} else {
+		return ""
+	}
+}
+
+func (m *Mock) GetBool(key string) bool {
+	value, found := m.cfg[key]
+	return found && value.(interface{}).(bool) // assume we stored the correct type
+}

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1848,6 +1848,11 @@ unstable_command_warning:
     This feature [ACTIONABLE]state {{.V0}}[/RESET] is still in beta. If you want to opt-in to unstable features, run the following command:
 
     [ACTIONABLE]state config set optin.unstable true[/RESET]
+secrets_unstable_warning:
+  other: |
+    The use of secrets is still in beta. If you want to opt-in to unstable features, run the following command:
+
+    [ACTIONABLE]state config set optin.unstable true[/RESET]
 err_update_corrupt_install:
   other: |
     Unfortunately your current installation appears to have been corrupted. Please reinstall the State Tool by first

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1850,7 +1850,7 @@ unstable_command_warning:
     [ACTIONABLE]state config set optin.unstable true[/RESET]
 secrets_unstable_warning:
   other: |
-    The use of secrets is still in beta. If you want to opt-in to unstable features, run the following command:
+    The secrets feature is currently unstable and not ready for production use. If you want to opt-in to unstable features, run the following command:
 
     [ACTIONABLE]state config set optin.unstable true[/RESET]
 err_update_corrupt_install:

--- a/internal/testhelpers/config_test/config.go
+++ b/internal/testhelpers/config_test/config.go
@@ -1,4 +1,4 @@
-package mock
+package config_test
 
 import (
 	"github.com/ActiveState/cli/internal/keypairs"

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
-	configMock "github.com/ActiveState/cli/internal/keypairs/mock"
+	configMock "github.com/ActiveState/cli/internal/testhelpers/config_test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
+	configMock "github.com/ActiveState/cli/internal/keypairs/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,16 +30,6 @@ func newMock(t *testing.T, channel, version, tag string) *httpGetMock {
 	b, err := json.Marshal(up)
 	require.NoError(t, err)
 	return &httpGetMock{MockedResponse: b}
-}
-
-type configMock struct{}
-
-func (cm *configMock) GetString(string) string {
-	return ""
-}
-
-func (cm *configMock) Set(string, interface{}) error {
-	return nil
 }
 
 func TestCheckerCheckFor(t *testing.T) {
@@ -86,7 +77,7 @@ func TestCheckerCheckFor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			m := newMock(t, tt.MockChannel, tt.MockVersion, tt.MockTag)
-			check := NewChecker(&configMock{}, constants.APIUpdateInfoURL, constants.APIUpdateURL, "master", "1.2.3", m)
+			check := NewChecker(&configMock.Mock{}, constants.APIUpdateInfoURL, constants.APIUpdateURL, "master", "1.2.3", m)
 			res, err := check.CheckFor(tt.CheckChannel, tt.CheckVersion)
 			require.NoError(t, err)
 			if res != nil {

--- a/pkg/project/prompting_expander_test.go
+++ b/pkg/project/prompting_expander_test.go
@@ -66,6 +66,7 @@ func (suite *VarPromptingExpanderTestSuite) BeforeTest(suiteName, testName strin
 	suite.graphMock.ProjectByOrgAndName(mock.NoOptions)
 
 	suite.cfg, err = config.New()
+	suite.cfg.Set(constants.UnstableConfig, true)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/project/prompting_expander_test.go
+++ b/pkg/project/prompting_expander_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/keypairs"
+	configMock "github.com/ActiveState/cli/internal/keypairs/mock"
 	"github.com/ActiveState/cli/internal/locale"
 	promptMock "github.com/ActiveState/cli/internal/prompt/mock"
 	"github.com/ActiveState/cli/internal/testhelpers/httpmock"
@@ -65,9 +65,8 @@ func (suite *VarPromptingExpanderTestSuite) BeforeTest(suiteName, testName strin
 	suite.graphMock = mock.Init()
 	suite.graphMock.ProjectByOrgAndName(mock.NoOptions)
 
-	suite.cfg, err = config.New()
+	suite.cfg = &configMock.Mock{}
 	suite.cfg.Set(constants.UnstableConfig, true)
-	suite.Require().NoError(err)
 }
 
 func (suite *VarPromptingExpanderTestSuite) AfterTest(suiteName, testName string) {

--- a/pkg/project/prompting_expander_test.go
+++ b/pkg/project/prompting_expander_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/keypairs"
-	configMock "github.com/ActiveState/cli/internal/keypairs/mock"
 	"github.com/ActiveState/cli/internal/locale"
 	promptMock "github.com/ActiveState/cli/internal/prompt/mock"
+	configMock "github.com/ActiveState/cli/internal/testhelpers/config_test"
 	"github.com/ActiveState/cli/internal/testhelpers/httpmock"
 	"github.com/ActiveState/cli/internal/testhelpers/osutil"
 	"github.com/ActiveState/cli/internal/testhelpers/outputhelper"

--- a/pkg/project/secrets.go
+++ b/pkg/project/secrets.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 
 	"github.com/ActiveState/cli/internal/access"
+	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
@@ -245,7 +246,7 @@ var ErrSecretNotFound = errors.New("secret not found")
 
 // Expand will expand a variable to a secret value, if no secret exists it will return an empty string
 func (e *SecretExpander) Expand(_ string, category string, name string, isFunction bool, project *Project) (string, error) {
-	if !e.cfg.GetBool(constants.UnstableConfig) {
+	if !e.cfg.GetBool(constants.UnstableConfig) && !condition.InUnitTest() {
 		return "", locale.NewError("secrets_unstable_warning")
 	}
 
@@ -288,7 +289,7 @@ func (e *SecretExpander) Expand(_ string, category string, name string, isFuncti
 
 // ExpandWithPrompt will expand a variable to a secret value, if no secret exists the user will be prompted
 func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string, isFunction bool, project *Project) (string, error) {
-	if !e.cfg.GetBool(constants.UnstableConfig) {
+	if !e.cfg.GetBool(constants.UnstableConfig) && !condition.InUnitTest() {
 		return "", locale.NewError("secrets_unstable_warning")
 	}
 

--- a/pkg/project/secrets.go
+++ b/pkg/project/secrets.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 
 	"github.com/ActiveState/cli/internal/access"
-	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
@@ -246,7 +245,7 @@ var ErrSecretNotFound = errors.New("secret not found")
 
 // Expand will expand a variable to a secret value, if no secret exists it will return an empty string
 func (e *SecretExpander) Expand(_ string, category string, name string, isFunction bool, project *Project) (string, error) {
-	if !e.cfg.GetBool(constants.UnstableConfig) && !condition.InUnitTest() {
+	if !e.cfg.GetBool(constants.UnstableConfig) {
 		return "", locale.NewError("secrets_unstable_warning")
 	}
 
@@ -289,7 +288,7 @@ func (e *SecretExpander) Expand(_ string, category string, name string, isFuncti
 
 // ExpandWithPrompt will expand a variable to a secret value, if no secret exists the user will be prompted
 func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string, isFunction bool, project *Project) (string, error) {
-	if !e.cfg.GetBool(constants.UnstableConfig) && !condition.InUnitTest() {
+	if !e.cfg.GetBool(constants.UnstableConfig) {
 		return "", locale.NewError("secrets_unstable_warning")
 	}
 

--- a/pkg/project/secrets.go
+++ b/pkg/project/secrets.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 
 	"github.com/ActiveState/cli/internal/access"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/prompt"
@@ -244,6 +245,10 @@ var ErrSecretNotFound = errors.New("secret not found")
 
 // Expand will expand a variable to a secret value, if no secret exists it will return an empty string
 func (e *SecretExpander) Expand(_ string, category string, name string, isFunction bool, project *Project) (string, error) {
+	if !e.cfg.GetBool(constants.UnstableConfig) {
+		return "", locale.NewError("secrets_unstable_warning")
+	}
+
 	isUser := category == UserCategory
 
 	if e.project == nil {
@@ -283,6 +288,10 @@ func (e *SecretExpander) Expand(_ string, category string, name string, isFuncti
 
 // ExpandWithPrompt will expand a variable to a secret value, if no secret exists the user will be prompted
 func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string, isFunction bool, project *Project) (string, error) {
+	if !e.cfg.GetBool(constants.UnstableConfig) {
+		return "", locale.NewError("secrets_unstable_warning")
+	}
+
 	isUser := category == UserCategory
 
 	if knownValue, exists := e.cachedSecrets[category+name]; exists {

--- a/pkg/project/secrets_test.go
+++ b/pkg/project/secrets_test.go
@@ -77,6 +77,7 @@ func (suite *SecretsExpanderTestSuite) BeforeTest(suiteName, testName string) {
 	suite.graphMock.ProjectByOrgAndName(mock.NoOptions)
 
 	suite.cfg, err = config.New()
+	suite.cfg.Set(constants.UnstableConfig, true)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/project/secrets_test.go
+++ b/pkg/project/secrets_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v2"
 
-	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/keypairs"
+	configMock "github.com/ActiveState/cli/internal/keypairs/mock"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/testhelpers/httpmock"
 	"github.com/ActiveState/cli/internal/testhelpers/osutil"
@@ -76,9 +76,8 @@ func (suite *SecretsExpanderTestSuite) BeforeTest(suiteName, testName string) {
 	suite.graphMock = mock.Init()
 	suite.graphMock.ProjectByOrgAndName(mock.NoOptions)
 
-	suite.cfg, err = config.New()
+	suite.cfg = &configMock.Mock{}
 	suite.cfg.Set(constants.UnstableConfig, true)
-	suite.Require().NoError(err)
 }
 
 func (suite *SecretsExpanderTestSuite) AfterTest(suiteName, testName string) {

--- a/pkg/project/secrets_test.go
+++ b/pkg/project/secrets_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/keypairs"
-	configMock "github.com/ActiveState/cli/internal/keypairs/mock"
 	"github.com/ActiveState/cli/internal/locale"
+	configMock "github.com/ActiveState/cli/internal/testhelpers/config_test"
 	"github.com/ActiveState/cli/internal/testhelpers/httpmock"
 	"github.com/ActiveState/cli/internal/testhelpers/osutil"
 	"github.com/ActiveState/cli/internal/testhelpers/secretsapi_test"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-909" title="DX-909" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-909</a>  Secrets are unstable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
