### PR TITLE
`state activate` should source cshrc if it exists from tcshrc.

### DIFF
--- a/internal/assets/contents/shells/tcsh.sh
+++ b/internal/assets/contents/shells/tcsh.sh
@@ -5,6 +5,8 @@
 # `set` variables are not inherited when we spawn the sub shell via exec.  Only
 # `setenv` values are inherited.
 
+if ( -f ~/.cshrc ) source ~/.cshrc
+
 cd "{{.WD}}"
 
 {{- range $K, $V := .Env}}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-889" title="DX-889" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-889</a>  tcsh should check for cshrc
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Otherwise, user cshrc will not be read in an activated environment.