### PR TITLE
Remove svc stop from clean config runner

### DIFF
--- a/internal/runners/clean/config.go
+++ b/internal/runners/clean/config.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/ActiveState/cli/internal/constants"
-	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
@@ -60,10 +59,6 @@ func (c *Config) Run(params *ConfigParams) error {
 		if !ok {
 			return nil
 		}
-	}
-
-	if err := stopServices(c.cfg, c.output, c.ipComm, params.Force); err != nil {
-		return errs.Wrap(err, "Failed to stop services.")
 	}
 
 	dir := c.cfg.ConfigPath()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-865" title="DX-865" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-865</a>  state clean config does not work if state-svc could not be stopped
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
