### PR TITLE
Updated installation scripts to allow installing specific versions via '-v' option.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -42,7 +42,6 @@ type Params struct {
 	updateTag       string
 	branch          string
 	command         string
-	version         string
 	force           bool
 	activate        *project.Namespaced
 	activateDefault *project.Namespaced
@@ -105,6 +104,7 @@ func main() {
 	}
 
 	var garbageBool bool
+	var garbageString string
 
 	// We have old install one liners around that use `-activate` instead of `--activate`
 	processedArgs := os.Args
@@ -154,12 +154,6 @@ func main() {
 				Value:       params.activateDefault,
 			},
 			{
-				Name:        "version",
-				Shorthand:   "v",
-				Description: "The version of the State Tool to install",
-				Value:       &params.version,
-			},
-			{
 				Name:        "force",
 				Shorthand:   "f",
 				Description: "Force the installation, overwriting any version of the State Tool already installed",
@@ -183,6 +177,7 @@ func main() {
 			},
 			// The remaining flags are for backwards compatibility (ie. we don't want to error out when they're provided)
 			{Name: "nnn", Shorthand: "n", Hidden: true, Value: &garbageBool}, // don't prompt; useless cause we don't prompt anyway
+			{Name: "vvv", Shorthand: "v", Hidden: true, Value: &garbageString},
 		},
 		[]*captain.Argument{
 			{

--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -139,7 +139,7 @@ catch [System.Exception]
     progress_fail
     Write-Error "Could not download $zipURL to $zipPath."
     Write-Error $_.Exception.Message
-    return 1
+    exit 1
 }
 
 # Verify checksum if possible.
@@ -150,7 +150,7 @@ if ($checksum -and $hash -ne $checksum)
     Write-Warning "Expected: $checksum"
     Write-Warning "Received: $hash"
     Write-Warning "Aborting installation"
-    return 1
+    exit 1
 }
 
 # Extract it.
@@ -162,7 +162,7 @@ catch
 {
     progress_fail
     Write-Error $_.Exception.Message
-    return 1
+    exit 1
 }
 progress_done
 

--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -66,12 +66,12 @@ function download([string] $url, [string] $out)
         {
             if ($Retrycount -gt 5)
             {
-                Write-Error "Could not Download after 5 retries."
+                Write-Error "Could not download after 5 retries."
                 throw $_
             }
             else
             {
-                Write-Host "Could not Download, retrying..."
+                Write-Host "Could not download, retrying..."
                 Write-Host $_
                 $Retrycount = $Retrycount + 1
             }

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -130,11 +130,7 @@ fi
 progress "Preparing Installer for State Tool Package Manager version $VERSION"
 STATEURL="$BASE_FILE_URL/$RELURL"
 ARCHIVE="$OS-amd64$DOWNLOADEXT"
-if ! $FETCH $TMPDIR/$ARCHIVE $STATEURL ; then
-  progress_fail
-  error "Could not fetch the State Tool installer at $STATEURL. Please try again."
-  exit 1
-fi
+$FETCH $TMPDIR/$ARCHIVE $STATEURL
 
 # Verify checksum if possible.
 if [ ! -z "$SUM" -a  "`$SHA256SUM -b $TMPDIR/$ARCHIVE | cut -d ' ' -f1`" != "$SUM" ]; then
@@ -151,8 +147,14 @@ if [ $OS = "windows" ]; then
   TMPDIRW=$(echo $(cd $TMPDIR && pwd -W) | sed 's|/|\\|g')
   powershell -command "& {&'Expand-Archive' -Force '$TMPDIRW\\$ARCHIVVE' '$TMPDIRW'}"
 else
-  tar -xzf $TMPDIR/$ARCHIVE -C $TMPDIR || exit 1
+  tar -xzf $TMPDIR/$ARCHIVE -C $TMPDIR
 fi
+if [ $? -ne 0 ]; then
+  progress_fail
+  error "Could not download the State Tool installer at $STATEURL. Please try again."
+  exit 1
+fi
+
 chmod +x $TMPDIR/$INSTALLERNAME$BINARYEXT
 progress_done
 echo ""

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -131,6 +131,11 @@ progress "Preparing Installer for State Tool Package Manager version $VERSION"
 STATEURL="$BASE_FILE_URL/$RELURL"
 ARCHIVE="$OS-amd64$DOWNLOADEXT"
 $FETCH $TMPDIR/$ARCHIVE $STATEURL
+# wget and curl differ on how to handle AWS' "Forbidden" result for unknown versions.
+# wget will exit with nonzero status. curl simply creates an XML file with the forbidden error.
+# If curl was used, make sure the file downloaded is of type 'data', according to the UNIX `file`
+# command. (The XML error will be reported as a 'text' type.)
+# If wget returned an error or curl fetched a "forbidden" response, raise an error and exit.
 if [ $? -ne 0 -o \( "`echo $FETCH | grep -o 'curl'`" == "curl" -a -z "`file -b $TMPDIR/$ARCHIVE | grep -o 'data'`" \) ]; then
   rm -f $TMPDIR/$ARCHIVE
   progress_fail

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -155,7 +155,6 @@ if [ $OS = "windows" ]; then
 else
   tar -xzf $TMPDIR/$ARCHIVE -C $TMPDIR || exit 1
 fi
-
 chmod +x $TMPDIR/$INSTALLERNAME$BINARYEXT
 progress_done
 echo ""

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -152,6 +152,31 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall_NonEmptyTarget() {
 	cp.ExpectExitCode(1)
 }
 
+func (suite *InstallScriptsIntegrationTestSuite) TestInstall_VersionDoesNotExist() {
+	suite.OnlyRunForTags(tagsuite.InstallScripts)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	script := scriptPath(suite.T(), ts.Dirs.Work)
+	args := []string{script, "-t", ts.Dirs.Work}
+	args = append(args, "-v", "does-not-exist")
+	var cp *termtest.ConsoleProcess
+	if runtime.GOOS != "windows" {
+		cp = ts.SpawnCmdWithOpts(
+			"bash", e2e.WithArgs(args...),
+			e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		)
+	} else {
+		cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(args...),
+			e2e.AppendEnv("SHELL="),
+			e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		)
+	}
+	cp.Expect("Could not download")
+	cp.ExpectLongString("does-not-exist")
+	cp.ExpectExitCode(1)
+}
+
 // scriptPath returns the path to an installation script copied to targetDir, if useTestUrl is true, the install script is modified to download from the local test server instead
 func scriptPath(t *testing.T, targetDir string) string {
 	ext := ".ps1"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-916" title="DX-916" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-916</a>  CLI - install.sh: `-v` flag is not working.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
