### PR TITLE
Fix potential watcher panic

### DIFF
--- a/cmd/state-svc/internal/rtwatcher/watcher.go
+++ b/cmd/state-svc/internal/rtwatcher/watcher.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ActiveState/cli/internal/analytics/client/sync"
 	anaConst "github.com/ActiveState/cli/internal/analytics/constants"
 	"github.com/ActiveState/cli/internal/analytics/dimensions"
 	"github.com/ActiveState/cli/internal/config"
@@ -23,14 +22,18 @@ const defaultInterval = 1 * time.Minute
 const CfgKey = "runtime-watchers"
 
 type Watcher struct {
-	an       *sync.Client
+	an       analytics
 	cfg      *config.Instance
 	watching []entry
 	stop     chan struct{}
 	interval time.Duration
 }
 
-func New(cfg *config.Instance, an *sync.Client) *Watcher {
+type analytics interface {
+	Event(category string, action string, dim ...*dimensions.Values)
+}
+
+func New(cfg *config.Instance, an analytics) *Watcher {
 	w := &Watcher{an: an, stop: make(chan struct{}, 1), cfg: cfg, interval: defaultInterval}
 
 	if watchersJson := w.cfg.GetString(CfgKey); watchersJson != "" {
@@ -73,6 +76,7 @@ func (w *Watcher) ticker(cb func()) {
 }
 
 func (w *Watcher) check() {
+	watching := w.watching[:0]
 	for i := range w.watching {
 		e := w.watching[i] // Must use index, because we are deleting indexes further down
 		running, err := e.IsRunning()
@@ -82,12 +86,13 @@ func (w *Watcher) check() {
 		}
 		if !running {
 			logging.Debug("Runtime process %d:%s is not running, removing from watcher", e.PID, e.Exec)
-			w.watching = append(w.watching[:i], w.watching[i+1:]...)
 			continue
 		}
+		watching = append(watching, e)
 
 		go w.RecordUsage(e)
 	}
+	w.watching = watching
 }
 
 func (w *Watcher) RecordUsage(e entry) {

--- a/cmd/state-svc/internal/rtwatcher/watcher_test.go
+++ b/cmd/state-svc/internal/rtwatcher/watcher_test.go
@@ -1,9 +1,11 @@
 package rtwatcher
 
 import (
+	"os"
 	"testing"
 	"time"
 
+	"github.com/ActiveState/cli/internal/analytics/client/blackhole"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,4 +20,25 @@ func TestWatcher_ticker(t *testing.T) {
 		calls++
 	})
 	require.Equal(t, 10, calls)
+}
+
+func TestWatcher_check(t *testing.T) {
+	w := &Watcher{an: blackhole.Client{}, stop: make(chan struct{}), interval: (10 * time.Millisecond)}
+	entries := []entry{
+		{
+			PID:  123,
+			Exec: "not-running",
+		},
+		{
+			PID:  os.Getpid(),
+			Exec: os.Args[0],
+		},
+	}
+	w.watching = append(w.watching, entries...)
+	go w.ticker(w.check)
+
+	time.Sleep(10 * time.Millisecond)
+	w.stop <- struct{}{}
+
+	require.Len(t, w.watching, 1, "Not running process should be removed")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-920" title="DX-920" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-920</a>  Service panics (rtwatcher) when hosting activation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
