### PR TITLE
Remove vestigial code.

### DIFF
--- a/cmd/state/main_test.go
+++ b/cmd/state/main_test.go
@@ -15,17 +15,6 @@ type MainTestSuite struct {
 	suite.Suite
 }
 
-func (suite *MainTestSuite) cleanDeprecationFile() {
-	cfg, err := config.New()
-	suite.Require().NoError(err)
-	defer func() { suite.Require().NoError(cfg.Close()) }()
-	// force fetching of deprecation info
-	err = os.Remove(filepath.Join(cfg.ConfigPath(), "deprecation.json"))
-	if err != nil && !os.IsNotExist(err) {
-		suite.T().Logf("Could not remove deprecation file")
-	}
-}
-
 func (suite *MainTestSuite) TestOutputer() {
 	{
 		outputer, err := initOutput(outputFlags{"", false, false, false}, "")

--- a/cmd/state/main_test.go
+++ b/cmd/state/main_test.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/stretchr/testify/suite"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-883" title="DX-883" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-883</a>  deprecation.json is downloaded to config dir
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

It was never called and doesn't appear to be necessary anywhere, as `deprecation.json` is not written by any code in our codebase.

The only other occurrence if the JSON file is in `deprecation.go`, but its contents remain in memory and are not written anywhere.

It appears that in the first half of April we had code that would write `deprecation.json`, but that it has since been removed (https://github.com/ActiveState/cli/commit/aae8f21af62073e76700ad0b24f06ee15118d6e5#diff-b91c6a3bcd0445227c5cd98ff4105aed8db4f2bda97a32a75fccd84a6b778933L201)