### PR TITLE
Enforce separation of installation payload and source.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -234,6 +234,12 @@ func execute(out output.Outputer, cfg *config.Instance, an analytics.Dispatcher,
 		}
 	}
 
+	if condition.OnCI() {
+		if _, err := storage.InstallSource(); err == nil {
+			return errs.New("Cannot run state-installer from an installation directory. Run it from an installer instead.")
+		}
+	}
+
 	// Detect state tool alongside installer executable
 	installerPath := filepath.Dir(osutils.Executable())
 	packagedStateExe := filepath.Join(installerPath, installation.BinDirName, constants.StateCmd+exeutils.Extension)

--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/analytics/client/sync"
 	"github.com/ActiveState/cli/internal/appinfo"
 	"github.com/ActiveState/cli/internal/captain"
+	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -75,7 +75,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallFromLocalSource() {
 
 	// Run installer with source-path flag (ie. install from this local path)
 	cp := ts.SpawnCmdWithOpts(
-		filepath.Join(installerDir, constants.StateInstallerCmd+osutils.ExeExt),
+		filepath.Join(installerDir, constants.ToplevelInstallArchiveDir, constants.StateInstallerCmd+osutils.ExeExt),
 		e2e.WithArgs(target, "--source-path", installerDir),
 		e2e.AppendEnv(constants.DisableUpdates+"=false"))
 

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -45,7 +45,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallFromLocalSource() {
 	defer ts.Close()
 
 	// Determine URL of installer archive.
-	baseUrl := "https://state-tool.s3.amazonaws.com/update/state/"
+	baseUrl := "https://state-tool.s3.amazonaws.com/update/state"
 	archiveExt := "tar.gz"
 	if runtime.GOOS == "windows" {
 		archiveExt = "zip"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-869" title="DX-869" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-869</a>  Separate "installed state tool" from "install payload" in our integration tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The test failures are coming from the inability to run `state-svc stop`. This PR's tests are passing on CI as well as on my local machine.