### PR TITLE
Fixed potential segfault in secrets get with no project file present.

### DIFF
--- a/internal/runners/secrets/secrets.go
+++ b/internal/runners/secrets/secrets.go
@@ -60,7 +60,7 @@ func NewList(client *secretsapi.Client, p listPrimeable) *List {
 
 // Run executes the list behavior.
 func (l *List) Run(params ListRunParams) error {
-	if l.proj == nil || l.proj.Source() == nil {
+	if l.proj == nil {
 		return locale.NewInputError("err_no_project")
 	}
 	if err := checkSecretsAccess(l.proj); err != nil {
@@ -115,6 +115,9 @@ func (l *listOutput) MarshalOutput(format output.Format) interface{} {
 // checkSecretsAccess is reusable "runner-level" logic and provides a directly
 // usable localized error.
 func checkSecretsAccess(proj *project.Project) error {
+	if proj == nil {
+		return locale.NewInputError("err_no_project")
+	}
 	allowed, err := access.Secrets(proj.Owner())
 	if err != nil {
 		return locale.WrapError(err, "secrets_err_access")

--- a/internal/runners/secrets/secrets.go
+++ b/internal/runners/secrets/secrets.go
@@ -60,7 +60,7 @@ func NewList(client *secretsapi.Client, p listPrimeable) *List {
 
 // Run executes the list behavior.
 func (l *List) Run(params ListRunParams) error {
-	if l.proj == nil {
+	if l.proj == nil || l.proj.Source() == nil {
 		return locale.NewInputError("err_no_project")
 	}
 	if err := checkSecretsAccess(l.proj); err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-921" title="DX-921" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-921</a>  CLI - SECRETS: Panic runtime error when executing `state secrets get project.FOO` not from the project folder.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
