### PR TITLE
For `state run` or `state exec`, only interpret "-v" as verbose if it's the first arg.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -226,6 +226,7 @@ func newStateCommand(globals *globalOptions, prime *primer.Values) *captain.Comm
 				Name:        "verbose",
 				Shorthand:   "v",
 				Description: locale.T("flag_state_verbose_description"),
+				Persist:     true,
 				OnUse: func() {
 					if !condition.InUnitTest() {
 						logging.CurrentHandler().SetVerbose(true)

--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -226,7 +226,6 @@ func newStateCommand(globals *globalOptions, prime *primer.Values) *captain.Comm
 				Name:        "verbose",
 				Shorthand:   "v",
 				Description: locale.T("flag_state_verbose_description"),
-				Persist:     true,
 				OnUse: func() {
 					if !condition.InUnitTest() {
 						logging.CurrentHandler().SetVerbose(true)

--- a/cmd/state/internal/cmdtree/exec.go
+++ b/cmd/state/internal/cmdtree/exec.go
@@ -31,6 +31,12 @@ func newExecCommand(prime *primer.Values, args ...string) *captain.Command {
 			if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
 				prime.Output().Print(ccmd.UsageText())
 				return nil
+			} else if len(args) > 0 && (args[0] == "-v" || args[0] == "--verbose") {
+				if len(args) > 1 {
+					args = args[1:]
+				} else {
+					args = []string{}
+				}
 			}
 
 			return runner.Run(params, args...)

--- a/cmd/state/internal/cmdtree/run.go
+++ b/cmd/state/internal/cmdtree/run.go
@@ -29,6 +29,12 @@ func newRunCommand(prime *primer.Values) *captain.Command {
 			if name == "-h" || name == "--help" {
 				prime.Output().Print(ccmd.UsageText())
 				return nil
+			} else if name == "-v" || name == "--verbose" {
+				if len(args) > 1 {
+					name, args = args[1], args[1:]
+				} else {
+					name, args = "", []string{}
+				}
 			}
 
 			if name != "" && len(args) > 0 {

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -260,13 +260,12 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 }
 
 func argsHaveVerbose(args []string) bool {
-	var commandFound, isRunOrExec bool
+	var isRunOrExec bool
 	nextArg := 0
 
 	for i, arg := range args {
-		if i > 0 && !commandFound && !strings.HasPrefix(arg, "-") {
-			commandFound = true
-			isRunOrExec = arg == "run" || arg == "exec"
+		if arg == "run" || arg == "exec" {
+			isRunOrExec = true
 			nextArg = i + 1
 		}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-928" title="DX-928" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-928</a>  argument to scripts -v is interpreted by the state tool
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
