### PR TITLE
Handle browser error in state learn

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1785,8 +1785,6 @@ err_ping_version_mismatch:
     The installed version of the State Tool Service does not match that of the client.
     Please stop the service with [ACTIONABLE]state-svc stop[/RESET] and try your command again.
     If this issue persists please reinstall the State Tool.
-err_learn_open:
-  other: "Could not open cheat sheet in browser"
 err_get_wd:
   other: Unable to get appropriate parent directory for project, please ensure you have write permissions in your current directory.
 err_directory_in_use:

--- a/internal/runners/learn/learn.go
+++ b/internal/runners/learn/learn.go
@@ -3,6 +3,7 @@ package learn
 import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/skratchdot/open-golang/open"
@@ -25,7 +26,8 @@ func (l *Learn) Run() error {
 
 	err := open.Run(constants.CheatSheetURL)
 	if err != nil {
-		return locale.WrapError(err, "err_learn_open", constants.CheatSheetURL)
+		logging.Warning("Could not open browser: %v", err)
+		l.out.Notice(locale.Tr("err_browser_open", constants.CheatSheetURL))
 	}
 
 	return nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-880" title="DX-880" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-880</a>  CLI - LEARN: Linux with no GUI trying opening the link have `Something Went Wrong` message.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
