### PR TITLE
Escape '$' in arguments passed to executors for bash-like shells.

### DIFF
--- a/internal/osutils/shellescape.go
+++ b/internal/osutils/shellescape.go
@@ -16,7 +16,7 @@ type ShellEscape struct {
 func NewBashEscaper() *ShellEscape {
 	return &ShellEscape{
 		regexp.MustCompile(`^[\w]+$`),
-		regexp.MustCompile(`(\\|")`),
+		regexp.MustCompile(`(\\|"|\$)`),
 		`\$1`,
 	}
 }

--- a/internal/osutils/shellescape_test.go
+++ b/internal/osutils/shellescape_test.go
@@ -19,6 +19,7 @@ func (suite *ShellEscaperTestSuite) TestBashEscaper() {
 	suite.Equal(`"quoted\nquote"`, escaper.Quote("quoted\nquote"))
 	suite.Equal(`"quote\\"`, escaper.Quote(`quote\`))
 	suite.Equal(`"quote\"quote"`, escaper.Quote(`quote"quote`))
+	suite.Equal(`"\$FOO"`, escaper.Quote(`$FOO`))
 }
 
 func (suite *ShellEscaperTestSuite) TestBatchEscaper() {

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -296,7 +296,10 @@ func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.WithArgs("activate"),
-		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.AppendEnv(
+			"ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
+			"PERL_VERSION=does_not_exist",
+		),
 	)
 	cp.Expect("Activated")
 	cp.WaitForInput(10 * time.Second)

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -294,7 +294,10 @@ func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
     project: https://platform.activestate.com/ActiveState-CLI/Perl-5.32?commitID=a4762408-def6-41e4-b709-4cb548765005
 	`))
 
-	cp := ts.SpawnWithOpts(e2e.WithArgs("activate"))
+	cp := ts.SpawnWithOpts(
+		e2e.WithArgs("activate"),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
 	cp.Expect("Activated")
 	cp.WaitForInput(10 * time.Second)
 

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -282,10 +282,6 @@ func (suite *RunIntegrationTestSuite) TestRun_BadLanguage() {
 }
 
 func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
-	if runtime.GOOS == "windows" {
-		suite.T().Skip("Testing exec of Perl with variables is not applicable on Windows")
-	}
-
 	suite.OnlyRunForTags(tagsuite.Run)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -282,6 +282,10 @@ func (suite *RunIntegrationTestSuite) TestRun_BadLanguage() {
 }
 
 func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
+	if runtime.GOOS == "windows" {
+		suite.T().Skip("Testing exec of Perl with variables is not applicable on Windows")
+	}
+
 	suite.OnlyRunForTags(tagsuite.Run)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -281,6 +281,29 @@ func (suite *RunIntegrationTestSuite) TestRun_BadLanguage() {
 	cp.Expect("The language for this script is not supported", 5*time.Second)
 }
 
+func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
+	if runtime.GOOS == "windows" {
+		suite.T().Skip("Testing exec of Perl with variables is not applicable on Windows")
+	}
+
+	suite.OnlyRunForTags(tagsuite.Run)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	ts.PrepareActiveStateYAML(strings.TrimSpace(`
+    project: https://platform.activestate.com/ActiveState-CLI/Perl-5.32?commitID=a4762408-def6-41e4-b709-4cb548765005
+	`))
+
+	cp := ts.SpawnWithOpts(e2e.WithArgs("activate"))
+	cp.Expect("Activated")
+	cp.WaitForInput(10 * time.Second)
+
+	cp.SendLine("perl -MEnglish -e 'print $PERL_VERSION'")
+	cp.Expect("v5.32.0")
+	cp.SendLine("exit")
+	cp.ExpectExitCode(0)
+}
+
 func TestRunIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(RunIntegrationTestSuite))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-914" title="DX-914" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-914</a>  Command-line arguments are not double-interpolated in activated projects
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
We double-quote arguments passed to executors before passing to the shell, which interprets special characters like '$'. Those should be escaped.