### PR TITLE
Do not print silent errors on install error.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -196,7 +196,9 @@ func main() {
 
 		exitCode = errs.UnwrapExitCode(err)
 		an.EventWithLabel(AnalyticsFunnelCat, "fail", err.Error())
-		out.Error(err.Error())
+		if !errs.IsSilent(err) {
+			out.Error(err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-931" title="DX-931" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-931</a>  Our installer conveys errors from forwarded state tool activation more prominently
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
For example, when attempting to activate a private repo when not authenticated, slim down error output.