### PR TITLE
Fixed locale message ids.

### DIFF
--- a/internal/runners/packages/info.go
+++ b/internal/runners/packages/info.go
@@ -54,8 +54,8 @@ func (i *Info) Run(params InfoRunParams, nstype model.NamespaceType) error {
 	if len(packages) == 0 {
 		return errs.AddTips(
 			locale.NewInputError("err_package_info_no_packages", "", params.Package.String()),
-			locale.T("info_try_search"),
-			locale.T("info_request"),
+			locale.T("package_try_search"),
+			locale.T("package_info_request"),
 		)
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-973" title="DX-973" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-973</a>  CLI - INFO: Help is providing localization message ID instead of the help message.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
