### PR TITLE
v0.34.0-RC4

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -197,7 +197,9 @@ func main() {
 
 		exitCode = errs.UnwrapExitCode(err)
 		an.EventWithLabel(AnalyticsFunnelCat, "fail", err.Error())
-		out.Error(err.Error())
+		if !errs.IsSilent(err) {
+			out.Error(err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
https://activestatef.atlassian.net/jira/software/c/projects/DX/issues/?jql=project+%3D+%22DX%22+AND+fixVersion%3Dv0.34.0-RC4+ORDER+BY+created+DESC\n* [When activating a private project with the one-liner the error message from the forwarded state tool command is not printed in red and is not the last message printed to a user’s console. See output below.

 

{noformat}dev@76a7ad31ab67:~$ sh <(curl -q https://platform.activestate.com/dl/cli/w19880l01/install.sh) --activate ActiveState/TheHomeRepot
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2677    0  2677    0     0   5806      0 --:--:-- --:--:-- --:--:--  5819
• Preparing Installer for State Tool Package Manager... ✔ Done

█ Installing State Tool Package Manager

The State Tool lets you install and manage your language runtimes.

ActiveState collects usage statistics and diagnostic data about failures.
By using the State Tool Package Manager you agree to the terms of ActiveState’s Privacy Policy,
available at: https://www.activestate.com/company/privacy-policy

• Downloading State Tool version 0.33.0-SHA7b42690... ✔ Done
• Installing State Tool to /home/dev/.local/ActiveState/StateTool/release... ✔ Done

█ State Tool Package Manager Installation Complete

State Tool Package Manager has been successfully installed.

Running `state activate ActiveState/TheHomeRepot`

█ Creating a Virtual Environment for your Project's Packages


The requested project ActiveState/TheHomeRepot could not be found. If this is a private project you may need to authenticate with 'state auth'.

Need More Help?
───────────────
 • Run → `state activate --help` for general help
 • Ask For Help → https://community.activestate.com/c/state-tool/
Could not activate ActiveState/TheHomeRepot, error returned: exit status 1
Could not run installer{noformat}](https://activestatef.atlassian.net/browse/DX-931)