### PR TITLE
Fix state tool not on PATH after install

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -387,6 +387,7 @@ func postInstallEvents(out output.Outputer, cfg *config.Instance, an analytics.D
 		}
 	case !isUpdate:
 		ss := subshell.New(cfg)
+		ss.SetEnv(envMap(binPath))
 		if err := ss.Activate(nil, cfg, out); err != nil {
 			return errs.Wrap(err, "Subshell setup; error returned: %s", errs.JoinMessage(err))
 		}
@@ -402,6 +403,13 @@ func envSlice(binPath string) []string {
 	return []string{
 		"PATH=" + binPath + string(os.PathListSeparator) + os.Getenv("PATH"),
 		constants.DisableErrorTipsEnvVarName + "=true",
+	}
+}
+
+func envMap(binPath string) map[string]string {
+	return map[string]string{
+		"PATH": binPath + string(os.PathListSeparator) + os.Getenv("PATH"),
+		constants.DisableErrorTipsEnvVarName: "true",
 	}
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-986" title="DX-986" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-986</a>  State tool not found after fresh installation on Windows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
