### PR TITLE
Updated deploy integration test to not find PPM.

### DIFF
--- a/test/integration/deploy_int_test.go
+++ b/test/integration/deploy_int_test.go
@@ -121,11 +121,14 @@ func (suite *DeployIntegrationTestSuite) TestDeployPerl() {
 	cp.SendLine("ptar -h")
 	cp.Expect("a tar-like program written in perl")
 
-	// Disabled for the moment: https://activestatef.atlassian.net/browse/DX-943
-	// cp.SendLine("ppm --version")
-	// cp.Expect("not found")
-	// cp.SendLine(errorLevel)
-	// cp.Expect("0")
+	// Check that PPM no longer exists.
+	// The state tool ppm shim should be used instead, but that does not exist for deployed runtimes.
+	cp.SendLine("ppm --version")
+	if runtime.GOOS == "windows" {
+		cp.Expect("not recognized")
+	} else {
+		cp.Expect("not found")
+	}
 
 	cp.SendLine("exit 0")
 	cp.ExpectExitCode(0)

--- a/test/integration/deploy_int_test.go
+++ b/test/integration/deploy_int_test.go
@@ -121,15 +121,6 @@ func (suite *DeployIntegrationTestSuite) TestDeployPerl() {
 	cp.SendLine("ptar -h")
 	cp.Expect("a tar-like program written in perl")
 
-	// Check that PPM no longer exists.
-	// The state tool ppm shim should be used instead, but that does not exist for deployed runtimes.
-	cp.SendLine("ppm --version")
-	if runtime.GOOS == "windows" {
-		cp.Expect("not recognized")
-	} else {
-		cp.Expect("not found")
-	}
-
 	cp.SendLine("exit 0")
 	cp.ExpectExitCode(0)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-943" title="DX-943" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-943</a>  Find out what to do about ppm tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


On Windows, Strawberry Perl provides `ppm`, which the test was picking up. We have removed PPM in favor of using `state install`, and provide a shim for activated states. For deployments, this shim does not exist, so there's no reason to test that it's not there. Also, BE asserts that PPM isn't provided by the runtime, so we should trust them.