### PR TITLE
Service instances that are not authoritative should die proactively

### DIFF
--- a/cmd/state-svc/internal/rtwatcher/watcher.go
+++ b/cmd/state-svc/internal/rtwatcher/watcher.go
@@ -103,7 +103,7 @@ func (w *Watcher) RecordUsage(e entry) {
 func (w *Watcher) Close() error {
 	logging.Debug("Closing runtime watcher")
 
-	w.stop <- struct{}{}
+	close(w.stop)
 
 	if len(w.watching) > 0 {
 		watchingJson, err := json.Marshal(w.watching)

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -197,7 +197,7 @@ func runForeground(cfg *config.Instance, an *anaSync.Client, auth *authenticatio
 
 		cancel()
 		if err := p.Stop(); err != nil {
-			logging.Debug("Service stop failed: %v", err)
+			multilog.Critical("Service stop failed: %v", errs.JoinMessage(err))
 		}
 	})
 

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -192,6 +192,15 @@ func runForeground(cfg *config.Instance, an *anaSync.Client, auth *authenticatio
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sig)
 
+	p.RunIfNotAuthority(time.Second*3, svcctl.NewDefaultIPCClient(), func(err error) {
+		fmt.Fprintln(os.Stderr, err)
+
+		cancel()
+		if err := p.Stop(); err != nil {
+			logging.Debug("Service stop failed: %v", err)
+		}
+	})
+
 	if err := p.Wait(); err != nil {
 		return errs.Wrap(err, "Failure while waiting for server stop")
 	}

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -104,5 +104,9 @@ func (s *service) RunIfNotAuthority(checkWait time.Duration, ipComm svcctl.IPCom
 }
 
 func portText(srv *server.Server) string {
+	if srv == nil || srv.Port() <= 0 {
+		return ""
+	}
+
 	return ":" + strconv.Itoa(srv.Port())
 }

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/ActiveState/cli/cmd/state-svc/internal/server"
 	anaSvc "github.com/ActiveState/cli/internal/analytics/client/sync"
@@ -50,7 +51,7 @@ func (s *service) Start() error {
 
 	spath := svcctl.NewIPCSockPathFromGlobals()
 	reqHandlers := []ipc.RequestHandler{ // caller-defined handlers to expand ipc capabilities
-		svcctl.HTTPAddrHandler(":" + strconv.Itoa(s.server.Port())),
+		svcctl.HTTPAddrHandler(portText(s.server)),
 		svcctl.LogFileHandler(logging.FileName()),
 	}
 	s.ipcSrv = ipc.NewServer(s.ctx, spath, reqHandlers...)
@@ -81,4 +82,27 @@ func (s *service) Wait() error {
 		return errs.Wrap(err, "IPC server operating failure")
 	}
 	return nil
+}
+
+func (s *service) RunIfNotAuthority(checkWait time.Duration, ipComm svcctl.IPCommunicator, fn func(err error)) {
+	addr := portText(s.server)
+
+	go func() {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(checkWait):
+			checkedAddr, err := svcctl.LocateHTTP(ipComm)
+			if err == nil && (addr == "" || checkedAddr != addr) {
+				err = errs.New("Checked addr %q does not match current addr %q", checkedAddr, addr)
+			}
+			if err != nil {
+				fn(err)
+			}
+		}
+	}()
+}
+
+func portText(srv *server.Server) string {
+	return ":" + strconv.Itoa(srv.Port())
 }

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -124,13 +124,18 @@ func (suite *SvcIntegrationTestSuite) TestSingleSvc() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	oldCount := suite.GetNumStateSvcProcesses() // may be non-zero due to non-test state-svc processes
+	ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("stop"))
+	time.Sleep(2 * time.Second) // allow for some time to stop the existing available process
+
+	oldCount := suite.GetNumStateSvcProcesses() // may be non-zero due to non-test state-svc processes (using different sock file)
 	for i := 1; i <= 10; i++ {
 		go ts.SpawnCmdWithOpts(ts.Exe, e2e.WithArgs("--version"))
 		time.Sleep(50 * time.Millisecond) // do not spam CPU
 	}
 	time.Sleep(2 * time.Second) // allow for some time to spawn the processes
-	for attempts := 10; attempts > 0; attempts-- {
+
+	for attempts := 100; attempts > 0; attempts-- {
+		suite.T().Log("iters left:", attempts, "procs:", suite.GetNumStateSvcProcesses())
 		if suite.GetNumStateSvcProcesses() == oldCount+1 {
 			break
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1003" title="DX-1003" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1003</a>  Non-authoritative service instances stay alive.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
