### PR TITLE
When extracting artifactID name from artifact filename, do so using basename, not the full filename

### DIFF
--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -714,12 +714,12 @@ func (s *Setup) fetchAndInstallArtifactsFromDir(installFunc artifactInstaller) (
 		for i, a := range artifacts {
 			// Each artifact is of the form artifactID.tar.gz, so extract the artifactID from the name.
 			filename := a.Path()
-			extIndex := strings.Index(filename, ".")
+			basename := filepath.Base(filename)
+			extIndex := strings.Index(basename, ".")
 			if extIndex == -1 {
-				extIndex = len(filename)
+				extIndex = len(basename)
 			}
-			filenameNoExt := filepath.Base(filename[0:extIndex])
-			artifactID := artifact.ArtifactID(filenameNoExt)
+			artifactID := artifact.ArtifactID(basename[0:extIndex])
 			installedArtifacts[i] = artifactID
 
 			// Submit the artifact for setup and install.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1021" title="DX-1021" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1021</a>  Offline Installer will fail if path to artifacts contains a '.' in it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Otherwise any artifact path with a parent directory that contains a '.' will cause problems.