### PR TITLE
Do not do any arg parsing for unstable commands if the user has not opted into using them.

### DIFF
--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -561,7 +561,13 @@ func (c *Command) runner(cobraCmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Run OnUse functions for non-persistent flags
+  warnUnstableCommand := c.unstable && (c.out.Type() != output.EditorV0FormatName && c.out.Type() != output.EditorFormatName)
+	if warnUnstableCommand && !condition.OptInUnstable(c.cfg) {
+	  c.out.Notice(locale.Tr("unstable_command_warning", c.Name()))
+	  return nil
+	}
+
+  // Run OnUse functions for non-persistent flags
 	c.runFlags(false)
 
 	for idx, arg := range c.arguments {
@@ -594,11 +600,7 @@ func (c *Command) runner(cobraCmd *cobra.Command, args []string) error {
 		c.out.Notice(output.Title(c.title + suffix))
 	}
 
-	if c.unstable && (c.out.Type() != output.EditorV0FormatName && c.out.Type() != output.EditorFormatName) {
-		if !condition.OptInUnstable(c.cfg) {
-			c.out.Notice(locale.Tr("unstable_command_warning", c.Name()))
-			return nil
-		}
+	if warnUnstableCommand {
 		c.out.Notice(locale.T("unstable_feature_banner"))
 	}
 

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -561,13 +561,13 @@ func (c *Command) runner(cobraCmd *cobra.Command, args []string) error {
 		}
 	}
 
-  warnUnstableCommand := c.unstable && (c.out.Type() != output.EditorV0FormatName && c.out.Type() != output.EditorFormatName)
+	warnUnstableCommand := c.unstable && (c.out.Type() != output.EditorV0FormatName && c.out.Type() != output.EditorFormatName)
 	if warnUnstableCommand && !condition.OptInUnstable(c.cfg) {
-	  c.out.Notice(locale.Tr("unstable_command_warning", c.Name()))
-	  return nil
+		c.out.Notice(locale.Tr("unstable_command_warning", c.Name()))
+		return nil
 	}
 
-  // Run OnUse functions for non-persistent flags
+	// Run OnUse functions for non-persistent flags
 	c.runFlags(false)
 
 	for idx, arg := range c.arguments {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1000" title="DX-1000" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1000</a>  CLI - UNSUPPORTED COMMANDS: Executing `unsupported` commands with wrong/not full syntax showing help/suggestion for the command instead of a message that it is still beta.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Otherwise they'll get the unstable warning later after satisfying the arg parser.