### PR TITLE
Automation added for `project` command + cleanup for `search` command automation

### DIFF
--- a/test/automation/projects_automation_test.go
+++ b/test/automation/projects_automation_test.go
@@ -1,0 +1,87 @@
+package automation
+
+import (
+	"fmt"
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/stretchr/testify/suite"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type ProjectsAutomationTestSuite struct {
+	tagsuite.Suite
+}
+
+func (suite *ProjectsAutomationTestSuite) TestProjects_NoActProjects() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("projects")
+	cp.ExpectLongString("You have not activated any projects yet")
+	cp.Wait(5 * time.Second)
+	fmt.Println(cp.Snapshot())
+}
+
+func (suite *ProjectsAutomationTestSuite) TestProjects_LocalChkout() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	// Test with PUBLIC project
+	url := "https://platform.activestate.com/qamainorg/public?branch=main&commitID=32e543ee-b6ab-4f59-9b28-ad830ec6980e"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	cp := ts.Spawn("projects")
+	cp.Expect("Organization")
+	cp.Expect("public")
+	cp.Expect("Local Checkout")
+	cp.ExpectExitCode(0)
+
+	// Test with PRIVATE project
+	url = "https://platform.activestate.com/qamainorg/private?branch=main&commitID=92935f87-cc8f-4da3-82d5-13e3e5249452"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	cp = ts.Spawn("projects")
+	cp.Expect("Organization")
+	cp.Expect("private")
+	cp.Expect("Local Checkout")
+	cp.ExpectExitCode(0)
+}
+
+func (suite *ProjectsAutomationTestSuite) TestProjects_NotAuthRemote() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("projects", "remote")
+	cp.Expect("You are not authenticated,")
+	cp.ExpectExitCode(1)
+}
+
+func (suite *ProjectsAutomationTestSuite) TestProjects_Remote() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn(tagsuite.Auth, "--token", e2e.PersistentToken, "-n")
+	cp.Expect("logged in", 40*time.Second)
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("projects", "remote")
+	cp.Expect("Name")
+	cp.Expect("Organization")
+	cp.Expect("cli-integration-tests")
+	cp.ExpectExitCode(0)
+}
+
+func TestProjectsAutomationTestSuite(t *testing.T) {
+	suite.Run(t, new(ProjectsAutomationTestSuite))
+}

--- a/test/automation/search_automation_test.go
+++ b/test/automation/search_automation_test.go
@@ -1,15 +1,12 @@
 package automation
 
 import (
-	"fmt"
-	"path/filepath"
-	"testing"
-	"time"
-
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/stretchr/testify/suite"
+	"path/filepath"
+	"testing"
 )
 
 type SearchAutomationTestSuite struct {
@@ -29,7 +26,6 @@ func (suite *SearchAutomationTestSuite) TestSearch_NoArg() {
 	cp = ts.Spawn("search", "--language", "python")
 	cp.ExpectLongString("The following argument is required:")
 	cp.ExpectExitCode(1)
-
 }
 
 func (suite *SearchAutomationTestSuite) TestSearch_NoLanguageArg() {
@@ -41,7 +37,6 @@ func (suite *SearchAutomationTestSuite) TestSearch_NoLanguageArg() {
 	cp := ts.Spawn("search", "--language")
 	cp.ExpectLongString("flag needs an argument: --language")
 	cp.ExpectExitCode(1)
-
 }
 
 func (suite *SearchAutomationTestSuite) TestSearch_OutProject() {
@@ -51,9 +46,8 @@ func (suite *SearchAutomationTestSuite) TestSearch_OutProject() {
 	defer ts.Close()
 
 	cp := ts.Spawn("search", "flask")
-	cp.ExpectLongString("Language must be provided by flag or by running this command within a project.")
+	cp.ExpectLongString("Language must be provided by flag")
 	cp.ExpectExitCode(1)
-
 }
 
 func (suite *SearchAutomationTestSuite) TestSearch_Flask() {
@@ -69,7 +63,6 @@ func (suite *SearchAutomationTestSuite) TestSearch_Flask() {
 	cp.Expect("flaskcap")
 	cp.Expect("Flask-CDN")
 	cp.ExpectExitCode(0)
-
 }
 
 func (suite *SearchAutomationTestSuite) TestSearch_LanguageFlag() {
@@ -100,14 +93,11 @@ func (suite *SearchAutomationTestSuite) TestSearch_LanguageFlag() {
 	cp.Expect("radar-api")
 	cp.Expect("radar-app")
 	cp.ExpectExitCode(0)
-	cp.Wait(5 * time.Second)
-	fmt.Println(cp.Snapshot())
-
 }
 
 func (suite *SearchAutomationTestSuite) TestSearch_ExactTermFlag() {
 	suite.OnlyRunForTags(tagsuite.Automation)
-	
+
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
@@ -133,7 +123,6 @@ func (suite *SearchAutomationTestSuite) TestSearch_ExactTermFlag() {
 	cp.Expect("Latest Version")
 	cp.Expect("ao")
 	cp.ExpectExitCode(0)
-
 }
 
 func TestSearchAutomationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1025" title="DX-1025" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1025</a>  Automation: `projects` command coverage
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Automation added for `project` command + cleanup for `search` command automation