### PR TITLE
Automation added for revert command

### DIFF
--- a/test/automation/projects_automation_test.go
+++ b/test/automation/projects_automation_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 type ProjectsAutomationTestSuite struct {
@@ -31,7 +30,7 @@ func (suite *ProjectsAutomationTestSuite) TestProjects_LocalChkout() {
 	defer ts.Close()
 
 	// Test with PUBLIC project
-	url := "https://platform.activestate.com/qamainorg/public?branch=main&commitID=32e543ee-b6ab-4f59-9b28-ad830ec6980e"
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-public?branch=main&commitID=e78d3564-2de5-4d63-aa4f-ddc5e0a43511"
 	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
 
 	cp := ts.Spawn("projects")
@@ -41,7 +40,7 @@ func (suite *ProjectsAutomationTestSuite) TestProjects_LocalChkout() {
 	cp.ExpectExitCode(0)
 
 	// Test with PRIVATE project
-	url = "https://platform.activestate.com/qamainorg/private?branch=main&commitID=92935f87-cc8f-4da3-82d5-13e3e5249452"
+	url = "https://platform.activestate.com/ActiveState-CLI/qa-private?branch=main&commitID=c276db93-a585-4341-950c-24d8f9638cb0"
 	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
 
 	cp = ts.Spawn("projects")
@@ -68,11 +67,9 @@ func (suite *ProjectsAutomationTestSuite) TestProjects_Remote() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("auth", "--token", e2e.PersistentToken, "-n")
-	cp.Expect("logged in", 40*time.Second)
-	cp.ExpectExitCode(0)
+	ts.LoginAsPersistentUser()
 
-	cp = ts.Spawn("projects", "remote")
+	cp := ts.Spawn("projects", "remote")
 	cp.Expect("Name")
 	cp.Expect("Organization")
 	cp.Expect("cli-integration-tests")

--- a/test/automation/reset_automation_test.go
+++ b/test/automation/reset_automation_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 type ResetAutomationTestSuite struct {
@@ -32,14 +31,14 @@ func (suite *ResetAutomationTestSuite) TestReset_PublicProject() {
 	defer ts.Close()
 
 	// Test with PUBLIC project
-	url := "https://platform.activestate.com/qamainorg/public?branch=main&commitID=32e543ee-b6ab-4f59-9b28-ad830ec6980e"
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-public?branch=main&commitID=e78d3564-2de5-4d63-aa4f-ddc5e0a43511"
 	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
 
 	// Testing if user choose NO to the reset
 	cp := ts.Spawn("reset")
 	cp.SendLine("n")
 	cp.Expect("Reset aborted by user")
-	cp.ExpectNotExitCode(0)
+	cp.ExpectExitCode(1)
 
 	// Testing if user choose YES for reset and reset have been successful
 	cp = ts.Spawn("reset")
@@ -61,7 +60,7 @@ func (suite *ResetAutomationTestSuite) TestReset_NoAuthPrivateProject() {
 	defer ts.Close()
 
 	// Test with PRIVATE project
-	url := "https://platform.activestate.com/ActiveState-CLI/qa-private?branch=main&commitID=d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2"
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-private?branch=main&commitID=c276db93-a585-4341-950c-24d8f9638cb0"
 	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
 
 	cp := ts.Spawn("reset")
@@ -76,19 +75,17 @@ func (suite *ResetAutomationTestSuite) TestReset_PrivateProject() {
 	defer ts.Close()
 
 	// Authentication
-	cp := ts.Spawn(tagsuite.Auth, "--token", e2e.PersistentToken, "-n")
-	cp.Expect("logged in", 40*time.Second)
-	cp.ExpectExitCode(0)
+	ts.LoginAsPersistentUser()
 
 	// Test with PRIVATE project
 	url := "https://platform.activestate.com/ActiveState-CLI/qa-private?branch=main&commitID=d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2"
 	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
 
 	// Testing if user choose NO to the reset
-	cp = ts.Spawn("reset")
+	cp := ts.Spawn("reset")
 	cp.SendLine("n")
 	cp.Expect("Reset aborted by user")
-	cp.ExpectNotExitCode(0)
+	cp.ExpectExitCode(1)
 
 	// Testing if user choose YES for reset and reset have been successful
 	cp = ts.Spawn("reset")

--- a/test/automation/revert_automation_test.go
+++ b/test/automation/revert_automation_test.go
@@ -1,0 +1,162 @@
+package automation
+
+import (
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/stretchr/testify/suite"
+	"path/filepath"
+	"testing"
+)
+
+type RevertAutomationTestSuite struct {
+	tagsuite.Suite
+}
+
+func (suite *RevertAutomationTestSuite) TestRevert_MissingArg() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("revert")
+	cp.ExpectLongString("The following argument is required")
+	cp.ExpectLongString("Name: commit-id")
+	cp.ExpectLongString("Description: The commit ID to revert to")
+	cp.ExpectExitCode(1)
+}
+
+func (suite *RevertAutomationTestSuite) TestRevert_NotInProjects() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("revert", "111")
+	cp.ExpectLongString("you need to be in an existing project")
+	cp.ExpectExitCode(1)
+}
+
+func (suite *RevertAutomationTestSuite) TestRevert_NotAuthPublic() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	// Test with PUBLIC project
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-public?branch=main&commitID=e78d3564-2de5-4d63-aa4f-ddc5e0a43511"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	cp := ts.Spawn("revert", "111")
+	cp.ExpectLongString("You are not authenticated")
+	cp.ExpectExitCode(1)
+}
+
+func (suite *RevertAutomationTestSuite) TestRevert_NotAuthPrivate() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	// Test with PUBLIC project
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-private?branch=main&commitID=c276db93-a585-4341-950c-24d8f9638cb0"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	cp := ts.Spawn("revert", "111")
+	cp.ExpectLongString("You are not authenticated")
+	cp.ExpectExitCode(1)
+}
+
+func (suite *RevertAutomationTestSuite) TestRevert_NonexistentCommitPublic() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	// Authentication
+	ts.LoginAsPersistentUser()
+
+	// Test with PUBLIC project
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-public?branch=main&commitID=e78d3564-2de5-4d63-aa4f-ddc5e0a43511"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	cp := ts.Spawn("revert", "111")
+	cp.ExpectLongString("Could not fetch commit details for commit with ID: 111")
+	cp.ExpectLongString("Could not get commit from ID: 111")
+	cp.ExpectExitCode(1)
+}
+
+func (suite *RevertAutomationTestSuite) TestRevert_NonexistentCommitPrivate() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	// Authentication
+	ts.LoginAsPersistentUser()
+
+	// Test with PRIVATE project
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-private?branch=main&commitID=c276db93-a585-4341-950c-24d8f9638cb0"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	cp := ts.Spawn("revert", "111")
+	cp.ExpectLongString("Could not fetch commit details for commit with ID: 111")
+	cp.ExpectLongString("Could not get commit from ID: 111")
+	cp.ExpectExitCode(1)
+}
+
+func (suite *RevertAutomationTestSuite) TestRevert_PublicProject() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	// Authentication
+	ts.LoginAsPersistentUser()
+
+	// Test with PUBLIC project
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-public?branch=main&commitID=e78d3564-2de5-4d63-aa4f-ddc5e0a43511"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	// Testing if user choose NO to the reset
+	cp := ts.Spawn("revert", "66e5a9ba-6762-4027-a001-6e9c54437dde")
+	cp.SendLine("n")
+	//cp.Expect("Revert aborted by the user") // Not implemented and currently just close the session.
+	cp.ExpectExitCode(0)
+
+	// Testing if user choose YES for reset and reset have been successful
+	cp = ts.Spawn("revert", "66e5a9ba-6762-4027-a001-6e9c54437dde")
+	cp.SendLine("y")
+	cp.ExpectLongString("Sucessfully reverted to commit: 66e5a9ba-6762-4027-a001-6e9c54437dde")
+	cp.ExpectExitCode(0)
+}
+
+func (suite *RevertAutomationTestSuite) TestRevert_PrivateProject() {
+	suite.OnlyRunForTags(tagsuite.Automation)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	// Authentication
+	ts.LoginAsPersistentUser()
+
+	// Test with PRIVATE project
+	url := "https://platform.activestate.com/ActiveState-CLI/qa-private?branch=main&commitID=c276db93-a585-4341-950c-24d8f9638cb0"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	// Testing if user choose NO to the reset
+	cp := ts.Spawn("revert", "d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
+	cp.SendLine("n")
+	//cp.Expect("Reset aborted by user") // Not implemented and currently just close the session.
+	cp.ExpectExitCode(0)
+
+	// Testing if user choose YES for reset and reset have been successful
+	cp = ts.Spawn("revert", "d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
+	cp.SendLine("y")
+	cp.ExpectLongString("Sucessfully reverted to commit: d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
+	cp.ExpectExitCode(0)
+}
+
+func TestRevertAutomationTestSuite(t *testing.T) {
+	suite.Run(t, new(RevertAutomationTestSuite))
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1034" title="DX-1034" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1034</a>  Automation: `revert` command coverage
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
`Revert` command automation coverage added.
Cleanup and fixes for `Projects` and `Reset` command done.