### PR TITLE
Raise errors for unrecognized/unnecessary/extra command line arguments.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -325,6 +325,7 @@ func (a *addCmdAs) deprecatedAlias(aliased *captain.Command, name string) {
 	)
 
 	cmd.SetHidden(true)
+	cmd.SetHasVariableArguments()
 
 	a.parent.AddChildren(cmd)
 }

--- a/cmd/state/internal/cmdtree/exec.go
+++ b/cmd/state/internal/cmdtree/exec.go
@@ -54,6 +54,7 @@ func newExecCommand(prime *primer.Values, args ...string) *captain.Command {
 	}
 
 	cmd.SetGroup(EnvironmentGroup)
+	cmd.SetHasVariableArguments()
 
 	return cmd
 }

--- a/cmd/state/internal/cmdtree/invite.go
+++ b/cmd/state/internal/cmdtree/invite.go
@@ -40,5 +40,5 @@ func newInviteCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, _ []string) error {
 			return inviteRunner.Run(&params)
 		},
-	).SetGroup(PlatformGroup).SetUnstable(true)
+	).SetGroup(PlatformGroup).SetUnstable(true).SetHasVariableArguments()
 }

--- a/cmd/state/internal/cmdtree/run.go
+++ b/cmd/state/internal/cmdtree/run.go
@@ -47,6 +47,7 @@ func newRunCommand(prime *primer.Values) *captain.Command {
 
 	cmd.SetGroup(EnvironmentGroup)
 	cmd.SetDisableFlagParsing(true)
+	cmd.SetHasVariableArguments()
 
 	return cmd
 }

--- a/test/integration/platforms_int_test.go
+++ b/test/integration/platforms_int_test.go
@@ -43,9 +43,12 @@ func (suite *PlatformsIntegrationTestSuite) TestPlatforms_listSimple() {
 
 	suite.PrepareActiveStateYAML(ts)
 
-	cmds := []string{"", "search"}
+	cmds := [][]string{
+		[]string{"platforms"},
+		[]string{"platforms", "search"},
+	}
 	for _, cmd := range cmds {
-		cp := ts.Spawn("platforms", cmd)
+		cp := ts.Spawn(cmd...)
 		expectations := []string{
 			"Linux",
 			"4.15.0",
@@ -88,7 +91,7 @@ func (suite *PlatformsIntegrationTestSuite) TestPlatforms_addRemove() {
 		cp.Expect(expectation)
 	}
 
-	cp = ts.Spawn("platforms", "remove", platform, version)
+	cp = ts.Spawn("platforms", "remove", fmt.Sprintf("%s@%s", platform, version))
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("platforms")
@@ -129,7 +132,7 @@ func (suite *PlatformsIntegrationTestSuite) TestPlatforms_addRemoveLatest() {
 		cp.Expect(expectation)
 	}
 
-	cp = ts.Spawn("platforms", "remove", platform, version)
+	cp = ts.Spawn("platforms", "remove", fmt.Sprintf("%s@%s", platform, version))
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("platforms")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-899" title="DX-899" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-899</a>  CLI: Executing commands with additional unsupported characters/words/caption is still executable and not generating any errors.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This restriction is on by default. Commands like `state run` and `state exec` must opt-out to accept a variable number of command line arguments.