### PR TITLE
Fixed messaging around inviting without a role non-interactively.

### DIFF
--- a/internal/runners/invite/role.go
+++ b/internal/runners/invite/role.go
@@ -46,9 +46,6 @@ func (r *Role) Set(v string) error {
 		*r = Member
 	default:
 		*r = Unknown
-		if v == "" {
-			return locale.NewInputError("err_invite_unspecified_role", "You must specify a role, should be one of: {{.V0}}", strings.Join(roleNames(), ", "))
-		}
 		return locale.NewInputError("err_invite_invalid_role", "Invalid role: {{.V0}}, should be one of: {{.V1}}", v, strings.Join(roleNames(), ", "))
 	}
 	return nil

--- a/internal/runners/invite/role.go
+++ b/internal/runners/invite/role.go
@@ -42,6 +42,8 @@ func (r *Role) Set(v string) error {
 		*r = Owner
 	case "member":
 		*r = Member
+	case "":
+		*r = Member
 	default:
 		*r = Unknown
 		if v == "" {

--- a/internal/runners/invite/role.go
+++ b/internal/runners/invite/role.go
@@ -44,6 +44,9 @@ func (r *Role) Set(v string) error {
 		*r = Member
 	default:
 		*r = Unknown
+		if v == "" {
+			return locale.NewInputError("err_invite_unspecified_role", "You must specify a role, should be one of: {{.V0}}", strings.Join(roleNames(), ", "))
+		}
 		return locale.NewInputError("err_invite_invalid_role", "Invalid role: {{.V0}}, should be one of: {{.V1}}", v, strings.Join(roleNames(), ", "))
 	}
 	return nil

--- a/test/automation/invite_neg_automation_test.go
+++ b/test/automation/invite_neg_automation_test.go
@@ -120,7 +120,7 @@ func (suite *InviteNegativeAutomationTestSuite) TestInvite_NonExistentArgValues_
 
 	// `-n` flag used
 	cp = ts.Spawn("invite", "qatesting+3@activestate.com", "-n")
-	cp.ExpectLongString("Invalid role: , should be one of: owner, member")
+	cp.ExpectLongString("You must specify a role, should be one of: owner, member")
 	cp.ExpectExitCode(1)
 
 }
@@ -152,7 +152,7 @@ func (suite *InviteNegativeAutomationTestSuite) TestInvite_NonExistentArgValues_
 
 	// `-n` flag used
 	cp = ts.Spawn("invite", "qatesting+3@activestate.com", "-n")
-	cp.ExpectLongString("Invalid role: , should be one of: owner, member")
+	cp.ExpectLongString("You must specify a role, should be one of: owner, member")
 	cp.ExpectExitCode(1)
 }
 

--- a/test/automation/invite_neg_automation_test.go
+++ b/test/automation/invite_neg_automation_test.go
@@ -120,9 +120,8 @@ func (suite *InviteNegativeAutomationTestSuite) TestInvite_NonExistentArgValues_
 
 	// `-n` flag used
 	cp = ts.Spawn("invite", "qatesting+3@activestate.com", "-n")
-	cp.ExpectLongString("You must specify a role, should be one of: owner, member")
 	cp.ExpectExitCode(1)
-
+	suite.Assert().NotContains(cp.TrimmedSnapshot(), "Invalid role") // there is an error, just not this one
 }
 
 func (suite *InviteNegativeAutomationTestSuite) TestInvite_NonExistentArgValues_Private() {
@@ -152,8 +151,8 @@ func (suite *InviteNegativeAutomationTestSuite) TestInvite_NonExistentArgValues_
 
 	// `-n` flag used
 	cp = ts.Spawn("invite", "qatesting+3@activestate.com", "-n")
-	cp.ExpectLongString("You must specify a role, should be one of: owner, member")
 	cp.ExpectExitCode(1)
+	suite.Assert().NotContains(cp.TrimmedSnapshot(), "Invalid role") // there is an error, just not this one
 }
 
 func TestInviteAutomationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1045" title="DX-1045" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1045</a>  INVITE: Wrong message when using `-n` flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
