### PR TITLE
Fixed error tips showing in shell created by installer.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -402,7 +402,6 @@ func envSlice(binPath string) []string {
 func envMap(binPath string) map[string]string {
 	return map[string]string{
 		"PATH": binPath + string(os.PathListSeparator) + os.Getenv("PATH"),
-		constants.DisableErrorTipsEnvVarName: "true",
 	}
 }
 

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -148,7 +148,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 	)
 
 	cp.Send("state activate ActiveState/DoesNotExist")
-	cp.Send("exit")
+	cp.SendLine("exit")
 	cp.ExpectExitCode(1)
 	suite.Assert().Contains(cp.TrimmedSnapshot(), "Need More Help?", "error tips should be displayed in shell created by installer")
 }

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -147,7 +147,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 		e2e.AppendEnv(constants.DisableUpdates+"=true"),
 	)
 
-	cp.Send("state activate ActiveState/DoesNotExist")
+	cp.SendLine("state activate ActiveState/DoesNotExist")
 	cp.WaitForInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -113,6 +113,46 @@ func (suite *InstallerIntegrationTestSuite) TestInstallIncompatible() {
 	cp.ExpectExitCode(1)
 }
 
+func (suite *InstallerIntegrationTestSuite) TestInstallNoErrorTips() {
+	suite.OnlyRunForTags(tagsuite.Installer, tagsuite.Critical)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	suite.setupTest(ts)
+
+	target := filepath.Join(ts.Dirs.Work, "installation")
+
+	cp := ts.SpawnCmdWithOpts(
+		suite.installerExe,
+		e2e.WithArgs(target, "--activate", "ActiveState/DoesNotExist"),
+		e2e.AppendEnv(constants.DisableUpdates+"=true"),
+	)
+
+	cp.ExpectExitCode(1)
+	suite.Assert().NotContains(cp.TrimmedSnapshot(), "Need More Help?", "error tips should not be displayed when invoking installer")
+}
+
+func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
+	suite.OnlyRunForTags(tagsuite.Installer, tagsuite.Critical)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	suite.setupTest(ts)
+
+	target := filepath.Join(ts.Dirs.Work, "installation")
+
+	cp := ts.SpawnCmdWithOpts(
+		suite.installerExe,
+		e2e.WithArgs(target),
+		e2e.AppendEnv(constants.DisableUpdates+"=true"),
+	)
+
+	cp.Send("state activate ActiveState/DoesNotExist")
+	cp.Send("exit")
+	cp.ExpectExitCode(1)
+	suite.Assert().Contains(cp.TrimmedSnapshot(), "Need More Help?", "error tips should be displayed in shell created by installer")
+}
+
 func (suite *InstallerIntegrationTestSuite) AssertConfig(ts *e2e.Session) {
 	if runtime.GOOS != "windows" {
 		// Test bashrc

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -150,7 +150,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 	cp.Send("state activate ActiveState/DoesNotExist")
 	cp.WaitForInput()
 	cp.SendLine("exit")
-	cp.ExpectExitCode(1)
+	cp.ExpectExitCode(0)
 	suite.Assert().Contains(cp.TrimmedSnapshot(), "Need More Help?", "error tips should be displayed in shell created by installer")
 }
 

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -148,6 +148,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 	)
 
 	cp.Send("state activate ActiveState/DoesNotExist")
+	cp.WaitForInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(1)
 	suite.Assert().Contains(cp.TrimmedSnapshot(), "Need More Help?", "error tips should be displayed in shell created by installer")

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -150,7 +150,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 	cp.SendLine("state activate ActiveState/DoesNotExist")
 	cp.WaitForInput()
 	cp.SendLine("exit")
-	cp.ExpectExitCode(0)
+	cp.Wait()
 	suite.Assert().Contains(cp.TrimmedSnapshot(), "Need More Help?", "error tips should be displayed in shell created by installer")
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1052" title="DX-1052" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1052</a>  Error tips are not displayed in the state shell created immediately after install
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Added unit tests for when to display error tips vs. when not to.