### PR TITLE
Improve `state use`.

### DIFF
--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -18,7 +18,19 @@ func newUseCommand(prime *primer.Values) *captain.Command {
 		"",
 		locale.Tl("use_description", "Use the given project runtime as the default for your system"),
 		prime,
-		[]*captain.Flag{},
+		[]*captain.Flag{
+			{
+				Name:        "path",
+				Shorthand:   "",
+				Description: locale.T("flag_state_use_path_description"),
+				Value:       &params.PreferredPath,
+			},
+			{
+				Name:        "branch",
+				Description: locale.Tl("flag_state_use_branch_description", "Defines the branch to be used"),
+				Value:       &params.Branch,
+			},
+		},
 		[]*captain.Argument{
 			{
 				Name:        locale.T("arg_state_use_namespace"),

--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -10,7 +10,7 @@ import (
 
 func newUseCommand(prime *primer.Values) *captain.Command {
 	params := &use.Params{
-		Namespace: &project.Namespaced{},
+		Namespace: &project.Namespaced{AllowOmitOwner: true},
 	}
 
 	cmd := captain.NewCommand(

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -30,6 +30,9 @@ const ConfigEnvVarName = "ACTIVESTATE_CLI_CONFIGDIR"
 // CacheEnvVarName is the env var used to override the cache dir that the State Tool uses
 const CacheEnvVarName = "ACTIVESTATE_CLI_CACHEDIR"
 
+// ProjectsEnvVarName is the env var used to override the projects dir that `state use` checks out projects to
+const ProjectsEnvVarName = "ACTIVESTATE_CLI_PROJECTSDIR"
+
 // LogEnvVarName is the env var used to override the log file path
 const LogEnvVarName = "ACTIVESTATE_CLI_LOGFILE"
 
@@ -438,3 +441,6 @@ const PipShim = "pip"
 
 // AutoUpdateConfigKey is the config key for storing whether or not autoupdates can be performed
 const AutoUpdateConfigKey = "autoupdate"
+
+// ProjectsDirName is the default name in the user's home directory where `state use` checks out projects to.
+const ProjectsDirName = "Projects"

--- a/internal/installation/storage/storage.go
+++ b/internal/installation/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -141,4 +142,22 @@ func InstallSource() (string, error) {
 	}
 
 	return strings.TrimSpace(string(installFileData)), nil
+}
+
+// ProjectsDir returns the directory used by `state use` to checkout projects to.
+// Note: the returned directory may not yet exist!
+// By default, it is ~/Projects.
+func ProjectsDir() (string, error) {
+	dir, envSet := os.LookupEnv(constants.ProjectsEnvVarName)
+	if envSet {
+		return dir, nil
+	}
+
+	// Note: cannot use fileutils.HomeDir() due to import cycle
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(usr.HomeDir, constants.ProjectsDirName), nil
 }

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -856,6 +856,8 @@ err_activate_create_project:
   other: Could not create new project
 err_invalid_namespace:
   other: "Invalid namespace: [NOTICE]{{.V0}}[/RESET]. Should be in the format of [NOTICE]org/project[/RESET], and can optionally contain a [NOTICE]#COMMIT_ID[/RESET] suffix. Names should be alphanumeric and may contain dashes and periods."
+err_invalid_project_name:
+  other: "Invalid project name: [NOTICE]{{.V0}}[/RESET]. Names should be alphanumeric, may contain dashes and periods, and can optionally contain a [NOTICE]#COMMIT_ID[/RESET] suffix."
 err_could_not_get_commit_behind_count:
   other: Could not obtain commit history properly
 err_must_create_project:
@@ -1868,11 +1870,17 @@ err_update_corrupt_install:
 arg_state_use_namespace:
   other: org/project
 arg_state_use_namespace_description:
-  other: The namespace of the project that you wish to use
-err_checkout_project:
+  other: The namespace of the project that you wish to use. If the project has already been checked out, you can simply use the project's name instead of the entire namespace.
+err_use_cannot_determine_projects_dir:
+  other: Cannot determine where to check out project to
+err_use_checkout_project:
   other: Could not checkout project {{.V0}}
-err_project_frompath:
+err_use_project_frompath:
   other: Could not create project files
+use_checkout_first:
+  other: "Please check it out first with [ACTIONABLE]state use org/{{.V0}}[/RESET]"
+err_use_project_not_checked_out:
+  other: "The project [ACTIONABLE]{{.V0}}[/ACTIONABLE] does not exist at [ACTIONABLE]{{.V1}}[/RESET]."
 err_language_by_commit:
   other: Could not get language from commit ID {{.V0}}
 err_make_language:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1872,7 +1872,7 @@ flag_state_use_path_description:
 arg_state_use_namespace:
   other: org/project
 arg_state_use_namespace_description:
-  other: The namespace of the project that you wish to use. If the project has already been checked out, you can simply use the project's name instead of the entire namespace.
+  other: The org/project namespace of the project that you wish to use. If the project has already been checked out, you can simply use the project's name instead of the entire namespace.
 err_use_cannot_determine_projects_dir:
   other: Cannot determine where to check out project to
 err_use_checkout_project:
@@ -1880,7 +1880,7 @@ err_use_checkout_project:
 err_use_project_frompath:
   other: Could not create project files
 use_checkout_first:
-  other: "Please check it out first with [ACTIONABLE]state use org/{{.V0}}[/RESET]"
+  other: "Please check out the project first with [ACTIONABLE]state use org/{{.V0}}[/RESET] where 'org' is your organization's name"
 err_use_project_not_checked_out:
   other: "The project [ACTIONABLE]{{.V0}}[/RESET] does not exist at [ACTIONABLE]{{.V1}}[/RESET]."
 err_language_by_commit:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1867,6 +1867,8 @@ err_update_corrupt_install:
 
     Uninstallation instructions: {{.V0}}/troubleshooting/uninstall/
     Installation instructions: {{.V0}}/install/
+flag_state_use_path_description:
+  other: Where to install the project. The default location is in your ~/Projects directory
 arg_state_use_namespace:
   other: org/project
 arg_state_use_namespace_description:
@@ -1880,7 +1882,7 @@ err_use_project_frompath:
 use_checkout_first:
   other: "Please check it out first with [ACTIONABLE]state use org/{{.V0}}[/RESET]"
 err_use_project_not_checked_out:
-  other: "The project [ACTIONABLE]{{.V0}}[/ACTIONABLE] does not exist at [ACTIONABLE]{{.V1}}[/RESET]."
+  other: "The project [ACTIONABLE]{{.V0}}[/RESET] does not exist at [ACTIONABLE]{{.V1}}[/RESET]."
 err_language_by_commit:
   other: Could not get language from commit ID {{.V0}}
 err_make_language:

--- a/internal/runners/projects/remote.go
+++ b/internal/runners/projects/remote.go
@@ -44,7 +44,7 @@ func (r *Projects) fetchProjects(onlyLocal bool) (projectWithOrgs, error) {
 		return nil, errs.Wrap(err, "Unknown failure")
 	}
 	var projects projectWithOrgs = []projectWithOrg{}
-	localConfigProjects := r.config.GetStringMapStringSlice(projectfile.LocalProjectsConfigKey)
+	localConfigProjects := projectfile.GetProjectMapping(r.config)
 	for _, org := range orgs.Payload {
 		platformOrgProjects, err := model.FetchOrganizationProjects(org.URLname)
 		if err != nil {

--- a/internal/runners/use/use.go
+++ b/internal/runners/use/use.go
@@ -155,7 +155,7 @@ func (u *Use) getLocalProjectPath(ns *project.Namespaced) string {
 		err := namespaced.Set(namespace)
 		if err != nil {
 			logging.Debug("Cannot parse namespace: %v") // should not happen since this is stored
-			return ""
+			continue
 		}
 		if (!ns.AllowOmitOwner && strings.ToLower(namespaced.String()) == strings.ToLower(ns.String())) ||
 			(ns.AllowOmitOwner && strings.ToLower(namespaced.Project) == strings.ToLower(ns.Project)) {

--- a/pkg/project/namespace_test.go
+++ b/pkg/project/namespace_test.go
@@ -34,6 +34,22 @@ func TestParseNamespace_Invalid(t *testing.T) {
 	assert.Error(t, err, "should get error with valid namespace and invalid commit id (basic hex and dash filter)")
 }
 
+func TestParseProjectNoOwner(t *testing.T) {
+	parsed, err := ParseProjectNoOwner("project")
+	assert.NoError(t, err, "should be able to parse project part of namspace")
+	assert.Empty(t, parsed.Owner)
+	assert.Equal(t, parsed.Project, "project")
+	assert.Empty(t, parsed.CommitID)
+	assert.True(t, parsed.AllowOmitOwner)
+
+	parsed, err = ParseProjectNoOwner("project#a10-b11c12-d13e14-f15")
+	assert.NoError(t, err, "should be able to parse project part of namspace")
+	assert.Empty(t, parsed.Owner)
+	assert.Equal(t, parsed.Project, "project")
+	assert.Equal(t, *parsed.CommitID, strfmt.UUID("a10-b11c12-d13e14-f15"))
+	assert.True(t, parsed.AllowOmitOwner)
+}
+
 func TestParseNamespaceOrConfigfile(t *testing.T) {
 	rootpath, err := environment.GetRootPath()
 	if err != nil {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -265,7 +265,7 @@ func (p *Project) Lock() string { return p.projectfile.Lock }
 // Namespace returns project namespace
 func (p *Project) Namespace() *Namespaced {
 	commitID := strfmt.UUID(p.projectfile.CommitID())
-	return &Namespaced{p.projectfile.Owner(), p.projectfile.Name(), &commitID}
+	return &Namespaced{p.projectfile.Owner(), p.projectfile.Name(), &commitID, false}
 }
 
 // NamespaceString is a convenience function to make interfaces simpler


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1046" title="DX-1046" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1046</a>  As a user I can install a new runtime with state use
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

* All projects are stored in ~/Projects. (Configurable by env var for now.)
* `state use project` may be used if the project is already checked out. (Can omit org.)
* Switching to already checked out project does not re-check it out.
* Support `--path` and `--branch` options, just like `state activate`.

Still waiting on Product for messaging around what to print after running this. Currently we print "Switched to [name] located at [path]".