### PR TITLE
Added `state update unlock`.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -120,7 +120,9 @@ func New(prime *primer.Values, args ...string) *CmdTree {
 	projectsCmd.AddChildren(newRemoteProjectsCommand(prime))
 
 	updateCmd := newUpdateCommand(prime)
-	updateCmd.AddChildren(newUpdateLockCommand(prime))
+	updateCmd.AddChildren(
+		newUpdateLockCommand(prime),
+		newUpdateUnlockCommand(prime))
 
 	branchCmd := newBranchCommand(prime)
 	branchCmd.AddChildren(

--- a/cmd/state/internal/cmdtree/update.go
+++ b/cmd/state/internal/cmdtree/update.go
@@ -70,3 +70,30 @@ func newUpdateLockCommand(prime *primer.Values) *captain.Command {
 	cmd.SetSkipChecks(true)
 	return cmd
 }
+
+func newUpdateUnlockCommand(prime *primer.Values) *captain.Command {
+	runner := update.NewUnlock(prime)
+	params := update.UnlockParams{}
+
+	cmd := captain.NewCommand(
+		"unlock",
+		locale.Tl("unlock_title", "Unlock the State Tool version"),
+		locale.Tl("unlock_description", "Unlock the State Tool version for the current project."),
+		prime,
+		[]*captain.Flag{
+			{
+				Name: "force",
+				Description: locale.Tl(
+					"flag_update_unlock_force",
+					"Automatically confirm that you would like to remove the lock."),
+				Value: &params.Force,
+			},
+		},
+		[]*captain.Argument{},
+		func(cmd *captain.Command, args []string) error {
+			return runner.Run(&params)
+		},
+	)
+	cmd.SetSkipChecks(true)
+	return cmd
+}

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -71,6 +71,8 @@ updating_to_version:
   other: Updating from [NOTICE]{{.fromVersion}}[/RESET] to [NOTICE]{{.toVersion}}[/RESET]
 confirm_update_locked_version_prompt:
   other: "You ran update from a project directory with a locked State Tool version. This will update the version that your project is locked to. Are you sure you want to do this?"
+confirm_update_unlocked_version_prompt:
+  other: "Are you sure you want to unlock the State Tool version from your project?"
 version_info:
   other: |
     ActiveState CLI by ActiveState Software Inc.

--- a/internal/runners/update/unlock.go
+++ b/internal/runners/update/unlock.go
@@ -1,0 +1,76 @@
+package update
+
+import (
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/multilog"
+	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/internal/prompt"
+	"github.com/ActiveState/cli/internal/updater"
+	"github.com/ActiveState/cli/pkg/project"
+	"github.com/ActiveState/cli/pkg/projectfile"
+)
+
+type UnlockParams struct {
+	Force bool
+}
+
+type Unlock struct {
+	project *project.Project
+	out     output.Outputer
+	prompt  prompt.Prompter
+	cfg     updater.Configurable
+}
+
+func NewUnlock(prime primeable) *Unlock {
+	return &Unlock{
+		prime.Project(),
+		prime.Output(),
+		prime.Prompt(),
+		prime.Config(),
+	}
+}
+
+func (u *Unlock) Run(params *UnlockParams) error {
+	if !u.project.IsLocked() {
+		u.out.Notice(locale.Tl("notice_not_locked", "The State Tool version is not locked for this project."))
+		return nil
+	}
+
+	u.out.Notice(locale.Tl("unlocking_version", "Unlocking State Tool version for current project."))
+
+	if !params.Force {
+		err := confirmUnlock(u.prompt)
+		if err != nil {
+			return locale.WrapError(err, "err_update_unlock_confirm", "Unlock cancelled by user.")
+		}
+	}
+
+	// Invalidate the installer version lock.
+	err := u.cfg.Set(updater.CfgKeyInstallVersion, "")
+	if err != nil {
+		multilog.Error("Failed to invalidate installer version lock on `state update lock` invocation: %v", err)
+	}
+
+	err = projectfile.RemoveLockInfo(u.project.Source().Path())
+	if err != nil {
+		return locale.WrapError(err, "err_update_projectfile", "Could not update projectfile")
+	}
+
+	u.out.Print(locale.Tl("version_unlocked", "State Tool version unlocked"))
+	return nil
+}
+
+func confirmUnlock(prom prompt.Prompter) error {
+	msg := locale.T("confirm_update_unlocked_version_prompt")
+
+	confirmed, err := prom.Confirm(locale.T("confirm"), msg, new(bool))
+	if err != nil {
+		return err
+	}
+
+	if !confirmed {
+		return locale.NewInputError("err_update_lock_noconfirm", "Cancelling by your request.")
+	}
+
+	return nil
+}

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -1130,10 +1130,27 @@ func AddLockInfo(projectFilePath, branch, version string) error {
 	return ioutil.WriteFile(projectFilePath, updated, 0644)
 }
 
+func RemoveLockInfo(projectFilePath string) error {
+	data, err := ioutil.ReadFile(projectFilePath)
+	if err != nil {
+		return locale.WrapError(err, "err_read_projectfile", "", projectFilePath)
+	}
+
+	lockRegex := regexp.MustCompile(`(?m)^lock:.*`)
+	clean := lockRegex.ReplaceAll(data, []byte(""))
+
+	err = ioutil.WriteFile(projectFilePath, clean, 0644)
+	if err != nil {
+		return locale.WrapError(err, "err_write_unlocked_projectfile", "Could not remove lock from projectfile")
+	}
+
+	return nil
+}
+
 func cleanVersionInfo(projectFilePath string) ([]byte, error) {
 	data, err := ioutil.ReadFile(projectFilePath)
 	if err != nil {
-		return nil, locale.WrapError(err, "err_read_projectfile", "Failed to read the activestate.yaml at: %s", projectFilePath)
+		return nil, locale.WrapError(err, "err_read_projectfile", "", projectFilePath)
 	}
 
 	branchRegex := regexp.MustCompile(`(?m:^branch:\s*\w+\n)`)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-810" title="DX-810" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-810</a>  Add `unlock` command for `state update`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is the opposite of `state update lock`.