### PR TITLE
Re-enable error tips in an activated state setup by one-line installer command.

### DIFF
--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -143,11 +143,12 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 
 	cp := ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.WithArgs(target),
+		e2e.WithArgs(target, "--activate", "ActiveState-CLI/Python3"),
 		e2e.AppendEnv(constants.DisableUpdates+"=true"),
 	)
 
-	cp.SendLine("state activate ActiveState/DoesNotExist")
+	cp.WaitForInput()
+	cp.SendLine("state command-does-not-exist")
 	cp.WaitForInput()
 	cp.SendLine("exit")
 	cp.Wait()

--- a/internal/runners/activate/activation.go
+++ b/internal/runners/activate/activation.go
@@ -6,7 +6,8 @@ import (
 	"path/filepath"
 	rt "runtime"
 
-	"github.com/ActiveState/cli/internal/analytics/constants"
+	anaConst "github.com/ActiveState/cli/internal/analytics/constants"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileevents"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -29,6 +30,12 @@ func (r *Activate) activateAndWait(proj *project.Project, venv *virtualenvironme
 	ve, err := venv.GetEnv(false, true, filepath.Dir(projectfile.Get().Path()))
 	if err != nil {
 		return locale.WrapError(err, "error_could_not_activate_venv", "Could not retrieve environment information.")
+	}
+
+	if _, exists := os.LookupEnv(constants.DisableErrorTipsEnvVarName); exists {
+		// If this exists, it came from the installer. It should not exist in an activated environment
+		// otherwise.
+		ve[constants.DisableErrorTipsEnvVarName] = "false"
 	}
 
 	// If we're not using plain output then we should just dump the environment information
@@ -68,7 +75,7 @@ func (r *Activate) activateAndWait(proj *project.Project, venv *virtualenvironme
 	}
 	defer fe.Close()
 
-	r.analytics.Event(constants.CatActivationFlow, "before-subshell")
+	r.analytics.Event(anaConst.CatActivationFlow, "before-subshell")
 
 	err = <-r.subshell.Errors()
 	if err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1052" title="DX-1052" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1052</a>  Error tips are not displayed in the state shell created immediately after install
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The previous attempt failed to consider the `-c 'state activate org/namespace'` bit from a one-line installer command. this PR rectifies that and updates the integration test accordingly.