### PR TITLE
Fix TestProjects_Remove automation test

### DIFF
--- a/test/automation/projects_automation_test.go
+++ b/test/automation/projects_automation_test.go
@@ -1,12 +1,14 @@
 package automation
 
 import (
+	"path/filepath"
+	"testing"
+	"time"
+
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/stretchr/testify/suite"
-	"path/filepath"
-	"testing"
 )
 
 type ProjectsAutomationTestSuite struct {
@@ -70,7 +72,7 @@ func (suite *ProjectsAutomationTestSuite) TestProjects_Remote() {
 	ts.LoginAsPersistentUser()
 
 	cp := ts.Spawn("projects", "remote")
-	cp.Expect("Name")
+	cp.Expect("Name", time.Minute)
 	cp.Expect("Organization")
 	cp.Expect("cli-integration-tests")
 	cp.ExpectExitCode(0)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1057" title="DX-1057" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1057</a>  TestProjectsAutomationTestSuite/TestProjects_Remote often fails during nightly tests, but not always
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The expect is failing because of the sheer amount of projects that our integration test user has. I've added some extra time to that expect and also filed a follow-up [here](https://activestatef.atlassian.net/browse/DX-1063). If this continues to be an issue we can add more time or disable the test for the time being until it is addressed properly.