### PR TITLE
Convert Windows directory separators to '/' when using with bash.exe.

### DIFF
--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -72,7 +72,7 @@ func (suite *PullIntegrationTestSuite) TestPullSetProjectUnrelated() {
 }
 
 func (suite *PullIntegrationTestSuite) TestPull_Merge() {
-	suite.OnlyRunForTags(tagsuite.Push)
+	suite.OnlyRunForTags(tagsuite.Pull)
 	projectLine := "project: https://platform.activestate.com/ActiveState-CLI/cli?branch=main&commitID="
 	unPulledCommit := "882ae76e-fbb7-4989-acc9-9a8b87d49388"
 
@@ -94,10 +94,12 @@ func (suite *PullIntegrationTestSuite) TestPull_Merge() {
 	cp.ExpectLongString("Merging history")
 	cp.ExpectExitCode(0)
 
+	exe := ts.ExecutablePath()
 	if runtime.GOOS == "windows" {
 		wd = filepath.ToSlash(wd)
+		exe = filepath.ToSlash(exe)
 	}
-	cp = ts.SpawnCmd("bash", "-c", fmt.Sprintf("cd %s && %s history | head -n 10", wd, ts.ExecutablePath()))
+	cp = ts.SpawnCmd("bash", "-c", fmt.Sprintf("cd %s && %s history | head -n 10", wd, exe))
 	cp.ExpectLongString("Merged")
 	cp.ExpectExitCode(0)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-542" title="DX-542" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-542</a>  Integration test working directory on Windows is not correct
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also use correct suite tag.

The previous PR did not actually fix this because the suite tag was wrong.