### PR TITLE
Shorten ipc sock path string

### DIFF
--- a/internal/ipc/sockpath/sockpath.go
+++ b/internal/ipc/sockpath/sockpath.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	sockpathExtension = "sock"
+	maxChannelLength  = 12
 )
 
 type SockPath struct {
@@ -17,12 +18,14 @@ type SockPath struct {
 }
 
 func (n *SockPath) String() string {
-	filename := fmt.Sprintf(
-		"%s-%s.%s",
-		n.AppName,
-		strings.ReplaceAll(n.AppChannel, "/", "--"),
-		sockpathExtension,
-	)
+	appChannel := strings.ReplaceAll(n.AppChannel, "/", "_")
+	cStart := len(appChannel) - maxChannelLength
+	if cStart < 0 {
+		cStart = 0
+	}
+	appChannel = appChannel[cStart:]
+
+	filename := fmt.Sprintf("%s-%s.%s", n.AppName, appChannel, sockpathExtension)
 
 	return filepath.Join(n.RootDir, filename)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1066" title="DX-1066" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1066</a>  Sock filepath length exceeds Mac limit
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
