### PR TITLE
Change output.Print() to output.Notice() when printing history notice.

### DIFF
--- a/internal/runners/history/history.go
+++ b/internal/runners/history/history.go
@@ -94,7 +94,7 @@ func (h *History) Run(params *HistoryParams) error {
 		return err
 	}
 
-	h.out.Print(locale.Tl("history_recent_changes", "Here are the most recent changes made to this project.\n"))
+	h.out.Notice(locale.Tl("history_recent_changes", "Here are the most recent changes made to this project.\n"))
 	err = commit.PrintCommits(h.out, commits, orgs, latestRemoteID)
 	if err != nil {
 		return locale.WrapError(err, "err_history_print_commits", "Could not print commit history")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-220" title="DX-220" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-220</a>  JSON formatted history output emits erroneous header
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Otherwise this will affect JSON and other simpler output formats.