### PR TITLE
Only keep unique values when merging EnvironmentVariables.

### DIFF
--- a/pkg/platform/runtime/envdef/environment.go
+++ b/pkg/platform/runtime/envdef/environment.go
@@ -242,9 +242,9 @@ func (ev EnvironmentVariable) Merge(other EnvironmentVariable) (*EnvironmentVari
 
 	switch other.Join {
 	case Prepend:
-		res.Values = append(other.Values, ev.Values...)
+		res.Values = filterValuesUniquely(append(other.Values, ev.Values...), true)
 	case Append:
-		res.Values = append(ev.Values, other.Values...)
+		res.Values = filterValuesUniquely(append(ev.Values, other.Values...), false)
 	case Disallowed:
 		if len(ev.Values) != 1 || len(other.Values) != 1 || (ev.Values[0] != other.Values[0]) {
 			sep := string(ev.Separator)

--- a/pkg/platform/runtime/envdef/environment_test.go
+++ b/pkg/platform/runtime/envdef/environment_test.go
@@ -30,14 +30,14 @@ func (suite *EnvironmentTestSuite) TestMergeVariables() {
 	ev2 := envdef.EnvironmentVariable{}
 	err = json.Unmarshal([]byte(`{
 		"env_name": "V",
-		"values": ["c", "d"]
+		"values": ["b", "c"]
 		}`), &ev2)
 	require.NoError(suite.T(), err)
 
 	expected := &envdef.EnvironmentVariable{}
 	err = json.Unmarshal([]byte(`{
 		"env_name": "V",
-		"values": ["c", "d", "a", "b"],
+		"values": ["b", "c", "a"],
 		"join": "prepend"
 		}`), expected)
 	require.NoError(suite.T(), err)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-189" title="DX-189" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-189</a>  runtime store json has duplicate path entries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
