### PR TITLE
Do not report an error attempting to reset executors for a runtime that has not been set up.

### DIFF
--- a/internal/runners/prepare/prepare.go
+++ b/internal/runners/prepare/prepare.go
@@ -75,7 +75,7 @@ func (r *Prepare) resetExecutors() error {
 
 	run, err := rt.New(target.NewCustomTarget(proj.Owner(), proj.Name(), proj.CommitUUID(), defaultTargetDir, target.TriggerResetExec, proj.IsHeadless()), r.analytics, r.svcModel)
 	if err != nil {
-		if runtime.IsNeedsUpdateError(err) {
+		if rt.IsNeedsUpdateError(err) {
 			return nil // project was never set up, so no executors to reset
 		}
 		return errs.Wrap(err, "Could not initialize runtime for global default project.")

--- a/internal/runners/prepare/prepare.go
+++ b/internal/runners/prepare/prepare.go
@@ -75,6 +75,9 @@ func (r *Prepare) resetExecutors() error {
 
 	run, err := rt.New(target.NewCustomTarget(proj.Owner(), proj.Name(), proj.CommitUUID(), defaultTargetDir, target.TriggerResetExec, proj.IsHeadless()), r.analytics, r.svcModel)
 	if err != nil {
+		if runtime.IsNeedsUpdateError(err) {
+			return nil // project was never set up, so no executors to reset
+		}
 		return errs.Wrap(err, "Could not initialize runtime for global default project.")
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-906" title="DX-906" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-906</a>  _prepare []: prepare error, message: Could not reset global executors, error received: Could not initialize runtime for global default project.: Runtime requires setup., error: Could not initialize runtime for global default project.: Runtime requires set
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
