### PR TITLE
Use user SID when installing State Tool as admin on Windows.

### DIFF
--- a/internal/runners/prepare/prepare_windows.go
+++ b/internal/runners/prepare/prepare_windows.go
@@ -108,8 +108,8 @@ func setStateProtocol() error {
 		if err != nil {
 			return locale.WrapError(err, "err_prepare_username", "Could not get current username")
 		}
-		protocolKeyPath = fmt.Sprintf(`%s\%s`, user.Gid, protocolKey)
-		protocolCommandKeyPath = fmt.Sprintf(`%s\%s`, user.Gid, protocolCommandKey)
+		protocolKeyPath = fmt.Sprintf(`%s\%s`, user.Uid, protocolKey)
+		protocolCommandKeyPath = fmt.Sprintf(`%s\%s`, user.Uid, protocolCommandKey)
 	}
 
 	protocolKey, _, err := createFunc(protocolKeyPath)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-905" title="DX-905" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-905</a>  _prepare []: prepare error, message: Could not add state protocol, error: Could not create state protocol registry key: The parameter is incorrect.  Stacktrace: D:/a/cli/cli/internal/logging/logging.go:github.com/ActiveState/cli/internal/logging.Error:288
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The group SID does not exist in the registry, but the user SID does.