### PR TITLE
Do not error attempting to write completions script.

### DIFF
--- a/internal/subshell/bash/bash.go
+++ b/internal/subshell/bash/bash.go
@@ -93,7 +93,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	logging.Debug("Writing to %s: %s", fpath, completionScript)
 	err := fileutils.WriteFile(fpath, []byte(completionScript))
 	if err != nil {
-		return errs.Wrap(err, "Could not write completions script")
+		logging.Debug("Could not write completions script '%s', likely due to non-admin privileges", fpath)
 	}
 
 	return nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-904" title="DX-904" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-904</a>  _prepare []: prepare error, message: Could not generate completions script, error received: Writing completion data failed., error: Writing completion data failed: Could not write completions script: os.OpenFile /etc/bash_completion.d/state failed: access
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It's likely because we don't have admin privileges. This is a minor thing and not worth reporting an error over, especially to Rollbar.