### PR TITLE
Remove checkout from `state use` and `storage.ProjectsDir()`

### DIFF
--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -2,7 +2,6 @@ package cmdtree
 
 import (
 	"github.com/ActiveState/cli/internal/captain"
-	"github.com/ActiveState/cli/internal/installation/storage"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/runners/use"
@@ -14,29 +13,12 @@ func newUseCommand(prime *primer.Values) *captain.Command {
 		Namespace: &project.Namespaced{AllowOmitOwner: true},
 	}
 
-	projectsDir, err := storage.ProjectsDir(prime.Config())
-	if err != nil {
-		projectsDir = "Projects"
-	}
-
 	cmd := captain.NewCommand(
 		"use",
 		"",
 		locale.Tl("use_description", "Use the given project runtime as the default for your system"),
 		prime,
-		[]*captain.Flag{
-			{
-				Name:        "path",
-				Shorthand:   "",
-				Description: locale.Tl("flag_state_use_path_description", "", projectsDir),
-				Value:       &params.PreferredPath,
-			},
-			{
-				Name:        "branch",
-				Description: locale.Tl("flag_state_use_branch_description", "Defines the branch to be used"),
-				Value:       &params.Branch,
-			},
-		},
+		[]*captain.Flag{},
 		[]*captain.Argument{
 			{
 				Name:        locale.T("arg_state_use_namespace"),

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -30,9 +30,6 @@ const ConfigEnvVarName = "ACTIVESTATE_CLI_CONFIGDIR"
 // CacheEnvVarName is the env var used to override the cache dir that the State Tool uses
 const CacheEnvVarName = "ACTIVESTATE_CLI_CACHEDIR"
 
-// ProjectsEnvVarName is the env var used to override the projects dir that `state use` checks out projects to
-const ProjectsEnvVarName = "ACTIVESTATE_CLI_PROJECTSDIR"
-
 // LogEnvVarName is the env var used to override the log file path
 const LogEnvVarName = "ACTIVESTATE_CLI_LOGFILE"
 
@@ -441,10 +438,3 @@ const PipShim = "pip"
 
 // AutoUpdateConfigKey is the config key for storing whether or not autoupdates can be performed
 const AutoUpdateConfigKey = "autoupdate"
-
-// ProjectsDirName is the default name in the user's home directory where `state use` checks out projects to.
-const ProjectsDirName = "Projects"
-
-// ProjectsDirConfigKey is the config key for where `state use` checks out projects to.
-// If this is unset, the default directory is ~/<ProjectsDirName> (see above).
-const ProjectsDirConfigKey = "projects.directory"

--- a/internal/installation/storage/storage.go
+++ b/internal/installation/storage/storage.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -148,26 +147,4 @@ func InstallSource() (string, error) {
 type configReader interface {
 	IsSet(string) bool
 	GetString(string) string
-}
-
-// ProjectsDir returns the directory used by `state use` to checkout projects to.
-// Note: the returned directory may not yet exist!
-// By default, it is ~/Projects.
-func ProjectsDir(cfg configReader) (string, error) {
-	dir, envSet := os.LookupEnv(constants.ProjectsEnvVarName)
-	if envSet {
-		return dir, nil
-	}
-
-	if cfg != nil && cfg.IsSet(constants.ProjectsDirConfigKey) {
-		return cfg.GetString(constants.ProjectsDirConfigKey), nil
-	}
-
-	// Note: cannot use fileutils.HomeDir() due to import cycle
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(usr.HomeDir, constants.ProjectsDirName), nil
 }

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1871,8 +1871,6 @@ err_update_corrupt_install:
 
     Uninstallation instructions: {{.V0}}/troubleshooting/uninstall/
     Installation instructions: {{.V0}}/install/
-flag_state_use_path_description:
-  other: Where to install the project. The default location is in the {{.V0}} directory, and it can be configured by running [ACTIONABLE]state config set projects.directory <path>[/RESET]
 arg_state_use_namespace:
   other: org/project
 arg_state_use_namespace_description:
@@ -1884,7 +1882,7 @@ err_use_checkout_project:
 err_use_project_frompath:
   other: Could not create project files
 err_local_project_not_checked_out:
-  other: "The project [ACTIONABLE]{{.V0}}[/RESET] does not exist at [ACTIONABLE]{{.V1}}[/RESET]."
+  other: "The project [ACTIONABLE]{{.V0}}[/RESET] is not checked out. Please check it out using [ACTIONABLE]`state checkout`[/RESET]"
 arg_state_shell_use_namespace_description:
   other: The namespace of the project you wish to start a shell/prompt for, or just the project name if previously used
 err_language_by_commit:

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/constraints"
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/ActiveState/cli/internal/installation/storage"
 	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/language"
 	"github.com/ActiveState/cli/internal/locale"
@@ -387,13 +385,8 @@ func FromNamespaceLocal(ns *Namespaced, cfg projectfile.ConfigGetter) (*Project,
 		}
 	}
 
-	projectsDir, err := storage.ProjectsDir(cfg)
-	if err != nil {
-		return nil, locale.WrapError(err, "err_cannot_determine_projects_dir")
-	}
-	projectDir := filepath.Join(projectsDir, ns.Project)
 	return nil, &LocalProjectDoesNotExist{
-		locale.NewInputError("err_local_project_not_checked_out", "", ns.Project, projectDir),
+		locale.NewInputError("err_local_project_not_checked_out", "", ns.Project),
 	}
 }
 

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -19,23 +18,17 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	projectsDir := filepath.Join(ts.Dirs.Base, "projects")
-
 	cp := ts.SpawnWithOpts(
-		e2e.WithArgs("use", "ActiveState-CLI/Python3"),
-		e2e.AppendEnv(
-			"ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
-			"ACTIVESTATE_CLI_PROJECTSDIR="+projectsDir),
+		e2e.WithArgs("checkout", "ActiveState-CLI/Python3"),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to Python3")
+	cp.ExpectExitCode(0)
 
 	args := []string{"Python3", "ActiveState-CLI/Python3"}
 	for _, arg := range args {
 		cp := ts.SpawnWithOpts(
 			e2e.WithArgs("shell", arg),
-			e2e.AppendEnv(
-				"ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
-				"ACTIVESTATE_CLI_PROJECTSDIR="+projectsDir),
+			e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 		)
 		cp.Expect("Activated")
 		cp.WaitForInput()
@@ -51,11 +44,9 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 	for _, arg := range args {
 		cp := ts.SpawnWithOpts(
 			e2e.WithArgs("shell", arg),
-			e2e.AppendEnv(
-				"ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
-				"ACTIVESTATE_CLI_PROJECTSDIR="+projectsDir),
+			e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 		)
-		cp.Expect("The project Python-3.9 does not exist")
+		cp.Expect("The project Python-3.9 is not checked out")
 		cp.ExpectExitCode(1)
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1074" title="DX-1074" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1074</a>  Remove checkout logic from `state use`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
`state use` and `state shell` depend on projects checked out via `state checkout`.