### PR TITLE
Use .bash_profile on Mac

### DIFF
--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -162,6 +162,9 @@ func (suite *InstallerIntegrationTestSuite) AssertConfig(ts *e2e.Session) {
 		suite.Require().NoError(err)
 
 		fname := ".bashrc"
+		if runtime.GOOS == "darwin" {
+			fname = ".bash_profile"
+		}
 		if strings.Contains(os.Getenv("SHELL"), "zsh") {
 			fname = ".zshrc"
 		}

--- a/internal/subshell/bash/bash.go
+++ b/internal/subshell/bash/bash.go
@@ -22,6 +22,9 @@ var rcFileName = ".bashrc"
 
 func init() {
 	escaper = osutils.NewBashEscaper()
+	if runtime.GOOS == "darwin" {
+		rcFileName = ".bash_profile"
+	}
 }
 
 // SubShell covers the subshell.SubShell interface, reference that for documentation

--- a/internal/subshell/bash/bash.go
+++ b/internal/subshell/bash/bash.go
@@ -22,6 +22,9 @@ var rcFileName = ".bashrc"
 
 func init() {
 	escaper = osutils.NewBashEscaper()
+
+	// On macOS all terminal windows run login shells, this means that
+	// .bashrc can be ignored so we instead use .bash_profile
 	if runtime.GOOS == "darwin" {
 		rcFileName = ".bash_profile"
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1054" title="DX-1054" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1054</a>  state not available in path when using bash as default shell on Mac with terminal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
