### PR TITLE
Attempt to fix randomly hanging integration test on Windows CI.

### DIFF
--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -71,7 +71,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutWithFlags() {
 		e2e.WithArgs("checkout", "ActiveState-CLI/Python3#6d9280e7-75eb-401a-9e71-0d99759fbad3", "--path", python3Dir),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.ExpectExitCode(0)
+	cp.Expect("Checked out")
 
 	suite.Require().True(fileutils.DirExists(python3Dir), "state checkout should have created "+python3Dir)
 	asy := filepath.Join(python3Dir, constants.ConfigFileName)

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -72,6 +72,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutWithFlags() {
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Checked out")
+	cp.ExpectExitCode(0)
 
 	suite.Require().True(fileutils.DirExists(python3Dir), "state checkout should have created "+python3Dir)
 	asy := filepath.Join(python3Dir, constants.ConfigFileName)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1083" title="DX-1083" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1083</a>  Nightly integration tests: Checkout randomly times out on Windows.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
