### PR TITLE
Fixed `state use reset --non-interactive`.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -140,7 +140,7 @@ func New(prime *primer.Values, args ...string) *CmdTree {
 	checkoutCmd := newCheckoutCommand(prime)
 
 	useCmd := newUseCommand(prime)
-	useCmd.AddChildren(newUseResetCommand(prime))
+	useCmd.AddChildren(newUseResetCommand(prime, globals))
 
 	shellCmd := newShellCommand(prime)
 

--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -34,7 +34,7 @@ func newUseCommand(prime *primer.Values) *captain.Command {
 	return cmd
 }
 
-func newUseResetCommand(prime *primer.Values) *captain.Command {
+func newUseResetCommand(prime *primer.Values, globals *globalOptions) *captain.Command {
 	params := &use.ResetParams{}
 
 	return captain.NewCommand(
@@ -42,16 +42,10 @@ func newUseResetCommand(prime *primer.Values) *captain.Command {
 		"",
 		locale.Tl("reset_description", "Reset your default project runtime"),
 		prime,
-		[]*captain.Flag{
-			{
-				Name:        "force",
-				Shorthand:   "f",
-				Description: locale.Tl("flag_state_use_reset_force_description", "Reset without prompts"),
-				Value:       &params.Force,
-			},
-		},
+		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(_ *captain.Command, _ []string) error {
+			params.Force = globals.NonInteractive
 			return use.NewReset(prime).Run(params)
 		},
 	)

--- a/internal/runners/use/reset.go
+++ b/internal/runners/use/reset.go
@@ -42,7 +42,7 @@ func (u *Reset) Run(params *ResetParams) error {
 		return err
 	}
 	if !ok {
-		return locale.NewInputError("err_resert_aborted", "Reset aborted by user")
+		return locale.NewInputError("err_reset_aborted", "Reset aborted by user")
 	}
 
 	reset, err := globaldefault.ResetDefaultActivation(u.subshell, u.config)

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -132,14 +132,18 @@ func (suite *UseIntegrationTestSuite) TestReset() {
 
 	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "reset"))
 	cp.Expect("Continue?")
-	cp.SendLine("y")
+	cp.SendLine("n")
+	cp.Expect("Reset aborted by user")
+	cp.ExpectExitCode(1)
+
+	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "reset", "--non-interactive"))
 	cp.Expect("Reset default project runtime")
 	cp.Expect("Note you may need to")
 	cp.ExpectExitCode(0)
 
 	suite.False(fileutils.TargetExists(python3Exe), python3Exe+" still exists")
 
-	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "reset", "-f"))
+	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "reset", "-n"))
 	cp.Expect("No global default project to reset")
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1082" title="DX-1082" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1082</a>  USE command: `state use reset -n` not resetting the default project + non message to user printed.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also removed redundant `--force` argument.

Nathan confirmed we can remove the `--force` argument.