### PR TITLE
Display deactivated notice after exiting `state shell`.

### DIFF
--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -80,5 +80,11 @@ func (u *Shell) Run(params *Params) error {
 		return locale.WrapError(err, "err_shell_wait", "Could not start runtime shell/prompt.")
 	}
 
+	if proj.IsHeadless() {
+		u.out.Notice(locale.T("info_deactivated_by_commit"))
+	} else {
+		u.out.Notice(locale.T("info_deactivated", proj))
+	}
+
 	return nil
 }

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -36,6 +36,7 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 		cp.SendLine("python3 --version")
 		cp.Expect("Python 3.6.6")
 		cp.SendLine("exit")
+		cp.Expect("Deactivated")
 		cp.ExpectExitCode(0)
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1092" title="DX-1092" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1092</a>  SHELL/PROMPT: When deactivating the project activated by `state shell` no message provided to user like it did if `state activate` command used.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
