### PR TITLE
Initial attempt to autostart state-svc in a Linux server environment.

### DIFF
--- a/internal/osutils/autostart/autostart_linux.go
+++ b/internal/osutils/autostart/autostart_linux.go
@@ -1,6 +1,8 @@
 package autostart
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -8,12 +10,15 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/osutils/shortcut"
+	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/mitchellh/go-homedir"
 )
 
 const (
-	autostartDir = ".config/autostart"
+	autostartDir  = ".config/autostart"
+	autostartFile = ".profile"
 )
 
 func (a *app) enable() error {
@@ -25,6 +30,19 @@ func (a *app) enable() error {
 		return nil
 	}
 
+	if a.onDesktop() {
+		// The user is installing while in a desktop environment. Install an autostart shortcut file.
+		return a.enableOnDesktop()
+	}
+	// Probably in a server environment. Install to the user's ~/.profile.
+	return a.enableOnServer()
+}
+
+func (a *app) onDesktop() bool {
+	return os.Getenv("WAYLAND_DISPLAY") || os.Getenv("DISPLAY")
+}
+
+func (a *app) enableOnDesktop() error {
 	dir, err := prependHomeDir(autostartDir)
 	if err != nil {
 		return errs.Wrap(err, "Could not find autostart directory")
@@ -57,14 +75,36 @@ func (a *app) enable() error {
 	return nil
 }
 
-func (a *app) Path() (string, error) {
+func (a *app) enableOnServer() error {
+	profile, err := prependHomeDir(autostartFile)
+	if err != nil {
+		return errs.Wrap(err, "Could not find ~/.profile")
+	}
+
+	esc := osutils.NewBashEscaper()
+	exec = esc.Quote(a.Exec)
+	for _, arg := range a.Args {
+		exec += " " + esc.Quote(arg)
+	}
+
+	return sscommon.WriteRcData(exec, profile, sscommon.InstallID, true)
+}
+
+// Path returns the path to the installed autostart shortcut file.
+// The installer keeps track of this file for later removal on uninstall.
+func (a *app) InstallPath() (string, error) {
 	dir, err := prependHomeDir(autostartDir)
 	if err != nil {
 		return "", errs.Wrap(err, "Could not find autostart directory")
 	}
 	path := filepath.Join(dir, a.options.LaunchFileName)
 
-	return path, nil
+	if fileutils.FileExists(path) {
+		return path, nil
+	}
+
+	// If on server, do not report ~/.profile as installed, as it would be removed on uninstall.
+	return "", nil
 }
 
 func (a *app) disable() error {
@@ -76,22 +116,56 @@ func (a *app) disable() error {
 		return nil
 	}
 
-	path, err := a.Path()
+	path, err := a.InstallPath()
 	if err != nil {
 		return err
 	}
 
-	return os.Remove(path)
+	// Remove the desktop autostart shortcut file if it's there.
+	if fileutils.FileExists(path) {
+		err := os.Remove(path)
+		if err != nil {
+			return errs.Wrap(err, "Could not remove autostart shortcut")
+		}
+	}
+
+	// Remove the ~/.profile modification if it's there.
+	profile, err := prependHomeDir(autostartFile)
+	if err != nil {
+		return errs.Wrap(err, "Could not find ~/.profile")
+	}
+	if fileutils.FileExists(profile) {
+		return sscommon.CleanRcFile(profile, sscommon.InstallID)
+	}
+
+	return nil
 }
 
 func (a *app) IsEnabled() (bool, error) {
+	// Check for desktop autostart shortcut file.
 	dir, err := prependHomeDir(autostartDir)
 	if err != nil {
 		return false, errs.Wrap(err, "Could not find autostart directory")
 	}
 	path := filepath.Join(dir, a.options.LaunchFileName)
+	if fileutils.FileExists(path) {
+		return true, nil
+	}
 
-	return fileutils.FileExists(path), nil
+	// Or check for ~/.profile modification.
+	profile, err := prependHomeDir(autostartFile)
+	if err != nil {
+		return errs.Wrap(err, "Could not find ~/.profile")
+	}
+	if fileutils.FileExists(profile) {
+		data, err := fileutils.ReadFile(profile)
+		if err != nil {
+			return false, errs.Wrap(err, "Could not read ~/.profile")
+		}
+		return bytes.Contains(data, []byte{a.Exec}), nil
+	}
+
+	return false, nil
 }
 
 func prependHomeDir(path string) (string, error) {

--- a/internal/osutils/autostart/autostart_mac.go
+++ b/internal/osutils/autostart/autostart_mac.go
@@ -31,7 +31,7 @@ func (a *app) enable() error {
 		return nil
 	}
 
-	path, err := a.Path()
+	path, err := a.InstallPath()
 	if err != nil {
 		return errs.Wrap(err, "Could not get launch file")
 	}
@@ -63,7 +63,7 @@ func (a *app) disable() error {
 	if !enabled {
 		return nil
 	}
-	path, err := a.Path()
+	path, err := a.InstallPath()
 	if err != nil {
 		return errs.Wrap(err, "Could not get launch file")
 	}
@@ -71,14 +71,14 @@ func (a *app) disable() error {
 }
 
 func (a *app) IsEnabled() (bool, error) {
-	path, err := a.Path()
+	path, err := a.InstallPath()
 	if err != nil {
 		return false, errs.Wrap(err, "Could not get launch file")
 	}
 	return fileutils.FileExists(path), nil
 }
 
-func (a *app) Path() (string, error) {
+func (a *app) InstallPath() (string, error) {
 	dir, err := homedir.Dir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")

--- a/internal/osutils/autostart/autostart_windows.go
+++ b/internal/osutils/autostart/autostart_windows.go
@@ -62,7 +62,7 @@ func (a *app) IsEnabled() (bool, error) {
 	return fileutils.FileExists(a.shortcutFilename()), nil
 }
 
-func (a *app) Path() (string, error) {
+func (a *app) InstallPath() (string, error) {
 	return a.shortcutFilename(), nil
 }
 

--- a/internal/runners/clean/run.go
+++ b/internal/runners/clean/run.go
@@ -21,6 +21,11 @@ func removeCache(cachePath string) error {
 }
 
 func undoPrepare(cfg configurable) error {
+	err := prepare.CleanOS(cfg)
+	if err != nil {
+		return locale.WrapError(err, "err_prepare_clean", "Could not perform OS-specific cleanup")
+	}
+
 	toRemove, err := prepare.InstalledPreparedFiles(cfg)
 	if err != nil {
 		return locale.WrapError(err, "err_prepared_files", "Could not determine files to remove")

--- a/internal/runners/prepare/prepare.go
+++ b/internal/runners/prepare/prepare.go
@@ -166,7 +166,7 @@ func InstalledPreparedFiles(cfg autostart.Configurable) ([]string, error) {
 		return nil, locale.WrapError(err, "err_autostart_app")
 	}
 
-	path, err := trayShortcut.Path()
+	path, err := trayShortcut.InstallPath()
 	if err != nil {
 		multilog.Error("Failed to determine shortcut path for removal: %v", err)
 	} else if path != "" {
@@ -178,12 +178,12 @@ func InstalledPreparedFiles(cfg autostart.Configurable) ([]string, error) {
 		return nil, locale.WrapError(err, "err_svc_exec")
 	}
 
-	svcShortuct, err := autostart.New(svcAutostart.App, svcExec, []string{"start"}, svcAutostart.Options, cfg)
+	svcShortcut, err := autostart.New(svcAutostart.App, svcExec, []string{"start"}, svcAutostart.Options, cfg)
 	if err != nil {
 		return nil, locale.WrapError(err, "err_autostart_app")
 	}
 
-	path, err = svcShortuct.Path()
+	path, err = svcShortcut.InstallPath()
 	if err != nil {
 		multilog.Error("Failed to determine shortcut path for removal: %v", err)
 	} else if path != "" {
@@ -198,4 +198,9 @@ func InstalledPreparedFiles(cfg autostart.Configurable) ([]string, error) {
 	files = append(files, osSpecificFiles...)
 
 	return files, nil
+}
+
+// CleanOS performs any OS-specific cleanup that is needed other than deleting installed files.
+func CleanOS(cfg autostart.Configurable) error {
+	return cleanOS(cfg)
 }

--- a/internal/runners/prepare/prepare_darwin.go
+++ b/internal/runners/prepare/prepare_darwin.go
@@ -36,3 +36,7 @@ func (r *Prepare) prepareOS() error {
 func installedPreparedFiles(cfg autostart.Configurable) ([]string, error) {
 	return nil, nil
 }
+
+func cleanOS(cfg autostart.Configurable) error {
+	return nil
+}

--- a/internal/runners/prepare/prepare_linux.go
+++ b/internal/runners/prepare/prepare_linux.go
@@ -87,3 +87,11 @@ func installedPreparedFiles(cfg autostart.Configurable) ([]string, error) {
 
 	return files, nil
 }
+
+func cleanOS(cfg autostart.Configurable) error {
+	svcShortcut, err := autostart.New(svcAutostart.App, svcExec, nil, svcAutostart.Options, cfg)
+	if err != nil {
+		return locale.WrapError(err, "Could not get svc autostart shortcut")
+	}
+	return svcShortcut.Disable() // cleans ~/.profile if necessary
+}

--- a/internal/runners/prepare/prepare_linux.go
+++ b/internal/runners/prepare/prepare_linux.go
@@ -89,6 +89,10 @@ func installedPreparedFiles(cfg autostart.Configurable) ([]string, error) {
 }
 
 func cleanOS(cfg autostart.Configurable) error {
+	svcExec, err := installation.ServiceExec()
+	if err != nil {
+		return locale.WrapError(err, "Could not get state-svc location")
+	}
 	svcShortcut, err := autostart.New(svcAutostart.App, svcExec, nil, svcAutostart.Options, cfg)
 	if err != nil {
 		return locale.WrapError(err, "Could not get svc autostart shortcut")

--- a/internal/runners/prepare/prepare_windows.go
+++ b/internal/runners/prepare/prepare_windows.go
@@ -155,3 +155,7 @@ func installedPreparedFiles(cfg autostart.Configurable) ([]string, error) {
 
 	return files, nil
 }
+
+func cleanOS(cfg autostart.Configurable) error {
+	return nil
+}

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -65,7 +65,8 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 		homeDir, err := homedir.Dir()
 		suite.Require().NoError(err)
 		profile := filepath.Join(homeDir, ".profile")
-		suite.Contains(string(fileutils.ReadFileUnsafe(profile)), as.Exec, "autostart should be configured for Linux server environment")
+		profileContents := fileutils.ReadFileUnsafe(profile)
+		suite.Contains(string(profileContents), as.Exec, "autostart should be configured for Linux server environment")
 	}
 
 	// Verify autostart can be disabled.
@@ -80,7 +81,8 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 		homeDir, err := homedir.Dir()
 		suite.Require().NoError(err)
 		profile := filepath.Join(homeDir, ".profile")
-		suite.NotContains(string(fileutils.ReadFileUnsafe(profile)), as.Exec, "autostart should not be configured for Linux server environment anymore")
+		profileContents := fileutils.ReadFileUnsafe(profile)
+		suite.NotContains(string(profileContents), as.Exec, "autostart should not be configured for Linux server environment anymore")
 	}
 }
 

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -57,7 +57,7 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 	suite.Require().NoError(err)
 	cfg, err := config.New()
 	suite.Require().NoError(err)
-	as, err := autostart.New(svcAutostart.App, svcExec, []string{"start"}, svcAutostart.Options, cfg)
+	as, err := autostart.New(svcAutostart.App, svcExec, nil, svcAutostart.Options, cfg)
 	suite.Require().NoError(err)
 	enabled, err := as.IsEnabled()
 	suite.Require().NoError(err)

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
-	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/osutils/autostart"
 	"github.com/ActiveState/cli/internal/rtutils/singlethread"
@@ -53,11 +52,9 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 	suite.AssertConfig(filepath.Join(ts.Dirs.Cache, "bin"))
 
 	// Verify autostart was enabled.
-	svcExec, err := installation.ServiceExec()
-	suite.Require().NoError(err)
 	cfg, err := config.New()
 	suite.Require().NoError(err)
-	as, err := autostart.New(svcAutostart.App, svcExec, nil, svcAutostart.Options, cfg)
+	as, err := autostart.New(svcAutostart.App, ts.SvcExe, nil, svcAutostart.Options, cfg)
 	suite.Require().NoError(err)
 	enabled, err := as.IsEnabled()
 	suite.Require().NoError(err)
@@ -71,6 +68,7 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 		suite.Contains(string(fileutils.ReadFileUnsafe(profile)), as.Exec, "autostart should be configured for Linux server environment")
 	}
 
+	// Verify autostart can be disabled.
 	err = as.Disable()
 	suite.Require().NoError(err)
 	enabled, err = as.IsEnabled()

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -82,7 +82,7 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 		suite.Require().NoError(err)
 		profile := filepath.Join(homeDir, ".profile")
 		profileContents := fileutils.ReadFileUnsafe(profile)
-		suite.NotContains(string(profileContents), as.Exec, "autostart should not be configured for Linux server environment anymore")
+		suite.NotContains(profileContents, as.Exec, "autostart should not be configured for Linux server environment anymore")
 	}
 }
 

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -65,8 +65,8 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 		homeDir, err := homedir.Dir()
 		suite.Require().NoError(err)
 		profile := filepath.Join(homeDir, ".profile")
-		profileContents := fileutils.ReadFileUnsafe(profile)
-		suite.Contains(string(profileContents), as.Exec, "autostart should be configured for Linux server environment")
+		profileContents := string(fileutils.ReadFileUnsafe(profile))
+		suite.Contains(profileContents, as.Exec, "autostart should be configured for Linux server environment")
 	}
 
 	// Verify autostart can be disabled.

--- a/test/integration/uninstall_int_test.go
+++ b/test/integration/uninstall_int_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -65,6 +66,14 @@ func (suite *UninstallIntegrationTestSuite) TestUninstall() {
 
 	if fileutils.FileExists(ts.TrayExe) {
 		suite.Fail("State tray executable should not exist after uninstall")
+	}
+
+	if runtime.GOOS == "linux" {
+		// When installed in a non-desktop environment (i.e. on a server), verify the user's ~/.profile was reverted.
+		homeDir, err := homedir.Dir()
+		suite.Require().NoError(err)
+		profile := filepath.Join(homeDir, ".profile")
+		suite.NotContains(string(fileutils.ReadFileUnsafe(profile)), ts.SvcExe, "autostart should not be configured for Linux server environment anymore")
 	}
 
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1067" title="DX-1067" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1067</a>  We can autostart programs on Linux systems without a desktop environment
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Modify ~/.profile if a desktop environment is not detected upon prepare/install.
When undoing prepare/uninstalling, remove any ~/.profile modifications.