### PR TITLE
Add reporting of cli args of caller that starts svc

### DIFF
--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -103,7 +103,7 @@ func run(cfg *config.Instance) error {
 	if mousetrap.StartedByExplorer() {
 		// Allow starting the svc via a double click
 		captain.DisableMousetrap()
-		return runStart(out, "svc-start mouse")
+		return runStart(out, "svc-start:mouse")
 	}
 
 	p := primer.New(nil, out, nil, nil, nil, nil, cfg, nil, nil, an)
@@ -126,7 +126,7 @@ func run(cfg *config.Instance) error {
 			p, nil, nil,
 			func(ccmd *captain.Command, args []string) error {
 				logging.Debug("Running CmdStart")
-				return runStart(out, "svc-start cli")
+				return runStart(out, "svc-start:cli")
 			},
 		),
 		captain.NewCommand(

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -103,7 +103,7 @@ func run(cfg *config.Instance) error {
 	if mousetrap.StartedByExplorer() {
 		// Allow starting the svc via a double click
 		captain.DisableMousetrap()
-		return runStart(out)
+		return runStart(out, "svc-start mouse")
 	}
 
 	p := primer.New(nil, out, nil, nil, nil, nil, cfg, nil, nil, an)
@@ -116,6 +116,8 @@ func run(cfg *config.Instance) error {
 		},
 	)
 
+	var foregroundArgText string
+
 	cmd.AddChildren(
 		captain.NewCommand(
 			cmdStart,
@@ -124,7 +126,7 @@ func run(cfg *config.Instance) error {
 			p, nil, nil,
 			func(ccmd *captain.Command, args []string) error {
 				logging.Debug("Running CmdStart")
-				return runStart(out)
+				return runStart(out, "svc-start cli")
 			},
 		),
 		captain.NewCommand(
@@ -151,13 +153,20 @@ func run(cfg *config.Instance) error {
 			cmdForeground,
 			"Starting the ActiveState Service",
 			"Start the ActiveState Service (Foreground)",
-			p, nil, nil,
+			p, nil,
+			[]*captain.Argument{
+				{
+					Name:        "Arg text",
+					Description: "Argument text of caller",
+					Value:       &foregroundArgText,
+				},
+			},
 			func(ccmd *captain.Command, args []string) error {
 				logging.Debug("Running CmdForeground")
 				if err := auth.Sync(); err != nil {
 					logging.Warning("Could not sync authenticated state: %s", err.Error())
 				}
-				return runForeground(cfg, an, auth)
+				return runForeground(cfg, an, auth, foregroundArgText)
 			},
 		),
 	)
@@ -165,7 +174,7 @@ func run(cfg *config.Instance) error {
 	return cmd.Execute(args[1:])
 }
 
-func runForeground(cfg *config.Instance, an *anaSync.Client, auth *authentication.Auth) error {
+func runForeground(cfg *config.Instance, an *anaSync.Client, auth *authentication.Auth, argText string) error {
 	logging.Debug("Running in Foreground")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -173,8 +182,12 @@ func runForeground(cfg *config.Instance, an *anaSync.Client, auth *authenticatio
 
 	p := NewService(ctx, cfg, an, auth)
 
+	if argText == "" {
+		argText = "[unknown]"
+	}
+
 	if err := p.Start(); err != nil {
-		return errs.Wrap(err, "Could not start service")
+		return errs.Wrap(err, fmt.Sprintf("Could not start service (invoked by %q)", argText))
 	}
 
 	// Handle sigterm
@@ -215,8 +228,8 @@ func runForeground(cfg *config.Instance, an *anaSync.Client, auth *authenticatio
 	return nil
 }
 
-func runStart(out output.Outputer) error {
-	if _, err := svcctl.EnsureStartedAndLocateHTTP(); err != nil {
+func runStart(out output.Outputer, argText string) error {
+	if _, err := svcctl.EnsureStartedAndLocateHTTP(argText); err != nil {
 		if errors.Is(err, ipc.ErrInUse) {
 			out.Print("A State Service instance is already running in the background.")
 			return nil

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -182,12 +182,12 @@ func runForeground(cfg *config.Instance, an *anaSync.Client, auth *authenticatio
 
 	p := NewService(ctx, cfg, an, auth)
 
-	if argText == "" {
-		argText = "[unknown]"
+	if argText != "" {
+		argText = fmt.Sprintf(" (invoked by %q)", argText)
 	}
 
 	if err := p.Start(); err != nil {
-		return errs.Wrap(err, fmt.Sprintf("Could not start service (invoked by %q)", argText))
+		return errs.Wrap(err, "Could not start service"+argText)
 	}
 
 	// Handle sigterm

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -157,7 +157,7 @@ func run(cfg *config.Instance) error {
 			[]*captain.Argument{
 				{
 					Name:        "Arg text",
-					Description: "Argument text of caller",
+					Description: "Argument text of calling process to be reported if this application is started too often",
 					Value:       &foregroundArgText,
 				},
 			},

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -58,11 +58,10 @@ func (s *service) Start() error {
 	s.ipcSrv = ipc.NewServer(s.ctx, spath, reqHandlers...)
 	err = s.ipcSrv.Start()
 	if err != nil {
-		msg := "Failed to start server"
 		if errors.Is(err, ipc.ErrInUse) {
-			msg += "; An existing server instance appears to be in use"
+			return errs.Wrap(err, "An existing server instance appears to be in use")
 		}
-		return errs.Wrap(err, msg)
+		return errs.Wrap(err, "Failed to start server")
 	}
 
 	return nil

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -58,10 +58,11 @@ func (s *service) Start() error {
 	s.ipcSrv = ipc.NewServer(s.ctx, spath, reqHandlers...)
 	err = s.ipcSrv.Start()
 	if err != nil {
+		msg := "Failed to start server"
 		if errors.Is(err, ipc.ErrInUse) {
-			return errors.New("An existing server instance appears to be in use")
+			msg += "; An existing server instance appears to be in use"
 		}
-		return errs.Wrap(err, "Failed to start server")
+		return errs.Wrap(err, msg)
 	}
 
 	return nil

--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -58,6 +58,9 @@ func (s *service) Start() error {
 	s.ipcSrv = ipc.NewServer(s.ctx, spath, reqHandlers...)
 	err = s.ipcSrv.Start()
 	if err != nil {
+		if errors.Is(err, ipc.ErrInUse) {
+			return errors.New("An existing server instance appears to be in use")
+		}
 		return errs.Wrap(err, "Failed to start server")
 	}
 

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -126,6 +126,10 @@ func (suite *SvcIntegrationTestSuite) TestStartDuplicateErrorOutput() {
 	cp := ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("stop"))
 	cp.ExpectExitCode(0)
 
+	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("status"))
+	cp.Expect("Checking")
+	cp.ExpectExitCode(0)
+
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("start"))
 	cp.Expect("Starting")
 	cp.ExpectExitCode(0)

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -128,7 +128,7 @@ func (suite *SvcIntegrationTestSuite) TestStartDuplicateErrorOutput() {
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("status"))
 	cp.Expect("Checking")
-	cp.ExpectExitCode(0)
+	cp.ExpectNotExitCode(0)
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("start"))
 	cp.Expect("Starting")

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -125,6 +125,7 @@ func (suite *SvcIntegrationTestSuite) TestStartDuplicateErrorOutput() {
 
 	cp := ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("stop"))
 	cp.ExpectExitCode(0)
+	time.Sleep(time.Second * 20)
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("status"))
 	cp.Expect("Checking")

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -121,7 +121,7 @@ func (suite *SvcIntegrationTestSuite) TestSignals() {
 func (suite *SvcIntegrationTestSuite) TestStartDuplicateErrorOutput() {
 	// https://activestatef.atlassian.net/browse/DX-1136
 	suite.OnlyRunForTags(tagsuite.Service)
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS == "windows" {
 		suite.T().Skip("Windows doesn't seem to read from svc at the moment")
 	}
 

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -119,15 +119,17 @@ func (suite *SvcIntegrationTestSuite) TestSignals() {
 }
 
 func (suite *SvcIntegrationTestSuite) TestStartDuplicateErrorOutput() {
+	// https://activestatef.atlassian.net/browse/DX-1136
 	suite.OnlyRunForTags(tagsuite.Service)
+	if runtime.GOOS != "windows" {
+		suite.T().Skip("Windows doesn't seem to read from svc at the moment")
+	}
+
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
 	cp := ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("stop"))
 	cp.ExpectExitCode(0)
-	if runtime.GOOS == "windows" {
-		time.Sleep(time.Second * 20)
-	}
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("status"))
 	cp.Expect("Checking")

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -125,7 +125,9 @@ func (suite *SvcIntegrationTestSuite) TestStartDuplicateErrorOutput() {
 
 	cp := ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("stop"))
 	cp.ExpectExitCode(0)
-	time.Sleep(time.Second * 20)
+	if runtime.GOOS == "windows" {
+		time.Sleep(time.Second * 20)
+	}
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("status"))
 	cp.Expect("Checking")

--- a/cmd/state-tray/main.go
+++ b/cmd/state-tray/main.go
@@ -105,7 +105,7 @@ func run(cfg *config.Instance) (rerr error) {
 
 	systray.SetIcon(iconFile)
 
-	port, err := svcctl.EnsureStartedAndLocateHTTP()
+	port, err := svcctl.EnsureStartedAndLocateHTTP("tray-start")
 	if err != nil && !errors.Is(err, ipc.ErrInUse) {
 		return errs.Wrap(err, "Service failed to start")
 	}

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -141,7 +141,8 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 	}
 
 	ipcClient := svcctl.NewDefaultIPCClient()
-	svcPort, err := svcctl.EnsureExecStartedAndLocateHTTP(ipcClient, svcExec)
+	argText := strings.Join(args, " ")
+	svcPort, err := svcctl.EnsureExecStartedAndLocateHTTP(ipcClient, svcExec, argText)
 	if err != nil {
 		return locale.WrapError(err, "start_svc_failed", "Failed to start state-svc at state tool invocation")
 	}

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -56,7 +56,7 @@ func NewDefaultIPCClient() *ipc.Client {
 	return ipc.NewClient(NewIPCSockPathFromGlobals())
 }
 
-func EnsureExecStartedAndLocateHTTP(ipComm IPCommunicator, exec string) (addr string, err error) {
+func EnsureExecStartedAndLocateHTTP(ipComm IPCommunicator, exec, argText string) (addr string, err error) {
 	defer profile.Measure("svcctl:EnsureExecStartedAndLocateHTTP", time.Now())
 
 	addr, err = LocateHTTP(ipComm)
@@ -70,7 +70,7 @@ func EnsureExecStartedAndLocateHTTP(ipComm IPCommunicator, exec string) (addr st
 		ctx, cancel := context.WithTimeout(context.Background(), commonTimeout)
 		defer cancel()
 
-		if err := startAndWait(ctx, ipComm, exec); err != nil {
+		if err := startAndWait(ctx, ipComm, exec, argText); err != nil {
 			return "", errs.Wrap(err, "Cannot start service at %q", exec)
 		}
 
@@ -83,12 +83,12 @@ func EnsureExecStartedAndLocateHTTP(ipComm IPCommunicator, exec string) (addr st
 	return addr, nil
 }
 
-func EnsureStartedAndLocateHTTP() (addr string, err error) {
+func EnsureStartedAndLocateHTTP(argText string) (addr string, err error) {
 	svcExec, err := installation.ServiceExec()
 	if err != nil {
 		return "", locale.WrapError(err, "err_service_exec")
 	}
-	return EnsureExecStartedAndLocateHTTP(NewDefaultIPCClient(), svcExec)
+	return EnsureExecStartedAndLocateHTTP(NewDefaultIPCClient(), svcExec, argText)
 }
 
 func LocateHTTP(ipComm IPCommunicator) (addr string, err error) {
@@ -137,14 +137,17 @@ func StopServer(ipComm IPCommunicator) error {
 	return nil
 }
 
-func startAndWait(ctx context.Context, ipComm IPCommunicator, exec string) error {
+func startAndWait(ctx context.Context, ipComm IPCommunicator, exec, argText string) error {
 	defer profile.Measure("svcmanager:Start", time.Now())
 
 	if !fileutils.FileExists(exec) {
 		return locale.NewError("svcctl_file_not_found", "Service executable not found")
 	}
 
-	args := []string{"foreground"}
+	args := []string{"foreground", argText}
+	if argText == "" {
+		args = args[:len(args)-1]
+	}
 
 	if _, err := exeutils.ExecuteAndForget(exec, args); err != nil {
 		return locale.WrapError(err, "svcctl_cannot_exec_and_forget", "Cannot execute service in background: {{.V0}}", err.Error())

--- a/test/integration/performance_svc_int_test.go
+++ b/test/integration/performance_svc_int_test.go
@@ -50,7 +50,7 @@ func (suite *PerformanceIntegrationTestSuite) TestSvcPerformance() {
 		suite.Require().NoError(err, errs.JoinMessage(err))
 
 		t := time.Now()
-		svcPort, err = svcctl.EnsureExecStartedAndLocateHTTP(ipcClient, svcExec)
+		svcPort, err = svcctl.EnsureExecStartedAndLocateHTTP(ipcClient, svcExec, "from test")
 		suite.Require().NoError(err, ts.DebugMessage(fmt.Sprintf("Error: %s\nLog Tail:\n%s", errs.JoinMessage(err), logging.ReadTail())))
 		duration := time.Since(t)
 

--- a/test/pseudo/cmd/ipc-shutdown/main.go
+++ b/test/pseudo/cmd/ipc-shutdown/main.go
@@ -17,7 +17,7 @@ func main() {
 		spath := svcctl.NewIPCSockPathFromGlobals()
 		ipcClient := ipc.NewClient(spath)
 
-		addr, err := svcctl.EnsureExecStartedAndLocateHTTP(ipcClient, "../../../../build/state-svc")
+		addr, err := svcctl.EnsureExecStartedAndLocateHTTP(ipcClient, "../../../../build/state-svc", "from test")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ensure and locate: %v\n", errs.JoinMessage(err))
 			os.Exit(1)

--- a/test/pseudo/cmd/tool/main.go
+++ b/test/pseudo/cmd/tool/main.go
@@ -15,7 +15,7 @@ func main() {
 	spath := intsvcctl.NewIPCSockPath()
 	ipcClient := ipc.NewClient(spath)
 
-	addr, err := svcctl.EnsureExecStartedAndLocateHTTP(ipcClient, "../svc/build/svc")
+	addr, err := svcctl.EnsureExecStartedAndLocateHTTP(ipcClient, "../svc/build/svc", "from test")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ensure and locate: %v\n", errs.JoinMessage(err))
 		os.Exit(1)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1030" title="DX-1030" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1030</a>  state-svc foreground []: state-svc errored out: Could not start service: Failed to start server: flisten in use
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
