### PR TITLE
Added zig-cache to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ obj/
 bin/
 installers/msi-language/Product.wxs
 node_modules
+zig-cache
+


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1116" title="DX-1116" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1116</a>  Add zig-cache to gitignore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I'm targetting it for v0.34.1 even though the executors are in v0.35 because these files will not disappear when switching between branches.