### PR TITLE
Improve error messaging around inability to find local projects.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1884,7 +1884,7 @@ err_checkout_project:
 err_project_frompath:
   other: Could not create project files
 err_local_project_not_checked_out:
-  other: "The project [ACTIONABLE]{{.V0}}[/RESET] is not checked out. Please check it out using [ACTIONABLE]`state checkout`[/RESET]"
+  other: "Cannot find the [ACTIONABLE]{{.V0}}[/RESET] project. Please either check it out using [ACTIONABLE]`state checkout`[/RESET] or reactivate it using [ACTIONABLE]`state activate`[/RESET]"
 arg_state_shell_namespace_description:
   other: The namespace of the project you wish to start a shell/prompt for, or just the project name if previously used
 err_language_by_commit:

--- a/internal/runners/use/use.go
+++ b/internal/runners/use/use.go
@@ -72,7 +72,7 @@ func (u *Use) Run(params *Params) error {
 		if !runbitsProject.IsLocalProjectDoesNotExistError(err) {
 			return locale.WrapError(err, "err_use", "Unable to use project")
 		}
-		return locale.WrapInputError(err, "err_use_project_does_not_exist", "Local project does not exist.")
+		return locale.WrapInputError(err, "err_use_cannot_find_local_project", "Local project cannot be found.")
 	}
 
 	if cid := params.Namespace.CommitID; cid != nil && *cid != proj.CommitUUID() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1080" title="DX-1080" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1080</a>  USE command: After reinstall, `state use <project>` can't find any previously checked out projects.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This would happen after uninstalling the state tool (which clears the project cache), reinstalling it, and then attempting to run something like `state use project`.