### PR TITLE
Use an expander context for expanding ASY values.

### DIFF
--- a/pkg/project/expander.go
+++ b/pkg/project/expander.go
@@ -162,9 +162,18 @@ func ScriptExpander(_ string, name string, meta string, isFunction bool, ctx *Ex
 		if err != nil {
 			return "", err
 		}
-		if posixPath := meta == "path._posix" || (runtime.GOOS == "windows" && ctx.Script != nil && ctx.Script.LanguageSafe()[0] == language.Sh); posixPath {
+
+		if meta == "path._posix" {
 			return osutils.BashifyPath(path)
 		}
+
+		if runtime.GOOS == "windows" && ctx.Script != nil {
+			lang := ctx.Script.LanguageSafe()[0]
+			if lang == language.Bash || lang == language.Sh {
+				return osutils.BashifyPath(path)
+			}
+		}
+
 		return path, nil
 	}
 

--- a/pkg/project/expander_test.go
+++ b/pkg/project/expander_test.go
@@ -156,7 +156,7 @@ func TestExpandProjectConstant(t *testing.T) {
 func TestExpandProjectSecret(t *testing.T) {
 	pj := loadProject(t)
 
-	project.RegisterExpander("secrets", func(_ string, category string, meta string, isFunction bool, ctx *project.ExpanderContext) (string, error) {
+	project.RegisterExpander("secrets", func(_ string, category string, meta string, isFunction bool, ctx *project.Expansion) (string, error) {
 		if category == project.ProjectCategory {
 			return "proj-value", nil
 		}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -558,7 +558,7 @@ func (s *Secret) ValueOrNil() (*string, error) {
 		category = UserCategory
 	}
 
-	value, err := secretsExpander.Expand("", category, s.secret.Name, false, s.project)
+	value, err := secretsExpander.Expand("", category, s.secret.Name, false, NewExpanderContext(s.project))
 	if err != nil {
 		if errors.Is(err, ErrSecretNotFound) {
 			return nil, nil
@@ -667,7 +667,7 @@ func (script *Script) Description() string { return script.script.Description }
 
 // Value returned with all secrets evaluated
 func (script *Script) Value() (string, error) {
-	return Expand(script.script.Value)
+	return ExpandFromScript(script.script.Value, script)
 }
 
 // Raw returns the script value with no secrets or constants expanded

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -558,7 +558,7 @@ func (s *Secret) ValueOrNil() (*string, error) {
 		category = UserCategory
 	}
 
-	value, err := secretsExpander.Expand("", category, s.secret.Name, false, NewExpanderContext(s.project))
+	value, err := secretsExpander.Expand("", category, s.secret.Name, false, NewExpansion(s.project))
 	if err != nil {
 		if errors.Is(err, ErrSecretNotFound) {
 			return nil, nil

--- a/pkg/project/prompting_expander_test.go
+++ b/pkg/project/prompting_expander_test.go
@@ -96,7 +96,7 @@ func (suite *VarPromptingExpanderTestSuite) assertExpansionSaveFailure(secretNam
 
 	suite.promptMock.OnMethod("InputSecret").Once().Return(expectedValue, nil)
 	expanderFn := suite.prepareWorkingExpander()
-	expandedValue, err := expanderFn("", project.ProjectCategory, secretName, false, project.NewExpanderContext(suite.project))
+	expandedValue, err := expanderFn("", project.ProjectCategory, secretName, false, project.NewExpansion(suite.project))
 
 	suite.Require().NotNil(err)
 	suite.Zero(expandedValue)
@@ -114,13 +114,13 @@ func (suite *VarPromptingExpanderTestSuite) assertExpansionSaveSuccess(secretNam
 
 	suite.promptMock.OnMethod("InputSecret").Once().Return(expectedValue, nil)
 	expanderFn := suite.prepareWorkingExpander()
-	expandedValue, err := expanderFn("", category, secretName, false, project.NewExpanderContext(suite.project))
+	expandedValue, err := expanderFn("", category, secretName, false, project.NewExpansion(suite.project))
 
 	suite.Require().NoError(bodyErr)
 	suite.Require().Nil(err)
 	suite.Equal(expectedValue, expandedValue)
 
-	_, err = expanderFn("", category, secretName, false, project.NewExpanderContext(suite.project))
+	_, err = expanderFn("", category, secretName, false, project.NewExpansion(suite.project))
 	suite.Require().Nil(err, "Should not prompt again because it should have stored/cached the secret")
 
 	suite.Require().Len(userChanges, 1)

--- a/pkg/project/prompting_expander_test.go
+++ b/pkg/project/prompting_expander_test.go
@@ -96,7 +96,7 @@ func (suite *VarPromptingExpanderTestSuite) assertExpansionSaveFailure(secretNam
 
 	suite.promptMock.OnMethod("InputSecret").Once().Return(expectedValue, nil)
 	expanderFn := suite.prepareWorkingExpander()
-	expandedValue, err := expanderFn("", project.ProjectCategory, secretName, false, suite.project)
+	expandedValue, err := expanderFn("", project.ProjectCategory, secretName, false, project.NewExpanderContext(suite.project))
 
 	suite.Require().NotNil(err)
 	suite.Zero(expandedValue)
@@ -114,13 +114,13 @@ func (suite *VarPromptingExpanderTestSuite) assertExpansionSaveSuccess(secretNam
 
 	suite.promptMock.OnMethod("InputSecret").Once().Return(expectedValue, nil)
 	expanderFn := suite.prepareWorkingExpander()
-	expandedValue, err := expanderFn("", category, secretName, false, suite.project)
+	expandedValue, err := expanderFn("", category, secretName, false, project.NewExpanderContext(suite.project))
 
 	suite.Require().NoError(bodyErr)
 	suite.Require().Nil(err)
 	suite.Equal(expectedValue, expandedValue)
 
-	_, err = expanderFn("", category, secretName, false, suite.project)
+	_, err = expanderFn("", category, secretName, false, project.NewExpanderContext(suite.project))
 	suite.Require().Nil(err, "Should not prompt again because it should have stored/cached the secret")
 
 	suite.Require().Len(userChanges, 1)

--- a/pkg/project/registry_test.go
+++ b/pkg/project/registry_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestRegisterExpander_RequiresNonBlankName(t *testing.T) {
-	err := project.RegisterExpander("", func(_ string, n string, _ string, _ bool, ctx *project.ExpanderContext) (string, error) {
+	err := project.RegisterExpander("", func(_ string, n string, _ string, _ bool, ctx *project.Expansion) (string, error) {
 		return "", nil
 	})
 	assert.ErrorIs(t, err, project.ErrExpandBadName)
 	assert.False(t, project.IsRegistered(""))
 
-	err = project.RegisterExpander(" \n \t\f ", func(_ string, n string, _ string, _ bool, ctx *project.ExpanderContext) (string, error) {
+	err = project.RegisterExpander(" \n \t\f ", func(_ string, n string, _ string, _ bool, ctx *project.Expansion) (string, error) {
 		return "", nil
 	})
 	assert.ErrorIs(t, err, project.ErrExpandBadName)
@@ -30,7 +30,7 @@ func TestRegisterExpander_FuncCannotBeNil(t *testing.T) {
 
 func TestRegisterExpander(t *testing.T) {
 	assert.False(t, project.IsRegistered("lobsters"))
-	err := project.RegisterExpander("lobsters", func(_ string, n string, _ string, _ bool, ctx *project.ExpanderContext) (string, error) {
+	err := project.RegisterExpander("lobsters", func(_ string, n string, _ string, _ bool, ctx *project.Expansion) (string, error) {
 		return "", nil
 	})
 	assert.Nil(t, err)

--- a/pkg/project/registry_test.go
+++ b/pkg/project/registry_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestRegisterExpander_RequiresNonBlankName(t *testing.T) {
-	err := project.RegisterExpander("", func(_ string, n string, _ string, _ bool, p *project.Project) (string, error) {
+	err := project.RegisterExpander("", func(_ string, n string, _ string, _ bool, ctx *project.ExpanderContext) (string, error) {
 		return "", nil
 	})
 	assert.ErrorIs(t, err, project.ErrExpandBadName)
 	assert.False(t, project.IsRegistered(""))
 
-	err = project.RegisterExpander(" \n \t\f ", func(_ string, n string, _ string, _ bool, p *project.Project) (string, error) {
+	err = project.RegisterExpander(" \n \t\f ", func(_ string, n string, _ string, _ bool, ctx *project.ExpanderContext) (string, error) {
 		return "", nil
 	})
 	assert.ErrorIs(t, err, project.ErrExpandBadName)
@@ -30,7 +30,7 @@ func TestRegisterExpander_FuncCannotBeNil(t *testing.T) {
 
 func TestRegisterExpander(t *testing.T) {
 	assert.False(t, project.IsRegistered("lobsters"))
-	err := project.RegisterExpander("lobsters", func(_ string, n string, _ string, _ bool, p *project.Project) (string, error) {
+	err := project.RegisterExpander("lobsters", func(_ string, n string, _ string, _ bool, ctx *project.ExpanderContext) (string, error) {
 		return "", nil
 	})
 	assert.Nil(t, err)

--- a/pkg/project/secrets.go
+++ b/pkg/project/secrets.go
@@ -244,7 +244,7 @@ type SecretFunc func(name string, project *Project) (string, error)
 var ErrSecretNotFound = errors.New("secret not found")
 
 // Expand will expand a variable to a secret value, if no secret exists it will return an empty string
-func (e *SecretExpander) Expand(_ string, category string, name string, isFunction bool, ctx *ExpanderContext) (string, error) {
+func (e *SecretExpander) Expand(_ string, category string, name string, isFunction bool, ctx *Expansion) (string, error) {
 	if !condition.OptInUnstable(e.cfg) {
 		return "", locale.NewError("secrets_unstable_warning")
 	}
@@ -287,7 +287,7 @@ func (e *SecretExpander) Expand(_ string, category string, name string, isFuncti
 }
 
 // ExpandWithPrompt will expand a variable to a secret value, if no secret exists the user will be prompted
-func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string, isFunction bool, ctx *ExpanderContext) (string, error) {
+func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string, isFunction bool, ctx *Expansion) (string, error) {
 	if !condition.OptInUnstable(e.cfg) {
 		return "", locale.NewError("secrets_unstable_warning")
 	}

--- a/pkg/project/secrets.go
+++ b/pkg/project/secrets.go
@@ -244,7 +244,7 @@ type SecretFunc func(name string, project *Project) (string, error)
 var ErrSecretNotFound = errors.New("secret not found")
 
 // Expand will expand a variable to a secret value, if no secret exists it will return an empty string
-func (e *SecretExpander) Expand(_ string, category string, name string, isFunction bool, project *Project) (string, error) {
+func (e *SecretExpander) Expand(_ string, category string, name string, isFunction bool, ctx *ExpanderContext) (string, error) {
 	if !condition.OptInUnstable(e.cfg) {
 		return "", locale.NewError("secrets_unstable_warning")
 	}
@@ -252,10 +252,10 @@ func (e *SecretExpander) Expand(_ string, category string, name string, isFuncti
 	isUser := category == UserCategory
 
 	if e.project == nil {
-		e.project = project
+		e.project = ctx.Project
 	}
 	if e.projectFile == nil {
-		e.projectFile = project.Source()
+		e.projectFile = ctx.Project.Source()
 	}
 
 	keypair, err := e.KeyPair()
@@ -287,7 +287,7 @@ func (e *SecretExpander) Expand(_ string, category string, name string, isFuncti
 }
 
 // ExpandWithPrompt will expand a variable to a secret value, if no secret exists the user will be prompted
-func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string, isFunction bool, project *Project) (string, error) {
+func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string, isFunction bool, ctx *ExpanderContext) (string, error) {
 	if !condition.OptInUnstable(e.cfg) {
 		return "", locale.NewError("secrets_unstable_warning")
 	}
@@ -299,10 +299,10 @@ func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string
 	}
 
 	if e.project == nil {
-		e.project = project
+		e.project = ctx.Project
 	}
 	if e.projectFile == nil {
-		e.projectFile = project.Source()
+		e.projectFile = ctx.Project.Source()
 	}
 
 	keypair, err := e.KeyPair()
@@ -333,7 +333,7 @@ func (e *SecretExpander) ExpandWithPrompt(_ string, category string, name string
 		description = def.Description
 	}
 
-	project.Outputer.Notice(locale.Tr("secret_value_prompt_summary", name, description, scope, locale.T("secret_prompt_"+scope)))
+	ctx.Project.Outputer.Notice(locale.Tr("secret_value_prompt_summary", name, description, scope, locale.T("secret_prompt_"+scope)))
 	if value, err = e.prompt.InputSecret(locale.Tl("secret_expand", "Secret Expansion"), locale.Tr("secret_value_prompt", name)); err != nil {
 		return "", locale.NewInputError("secrets_err_value_prompt", "The provided secret value is invalid.")
 	}

--- a/pkg/project/secrets_test.go
+++ b/pkg/project/secrets_test.go
@@ -98,7 +98,7 @@ func (suite *SecretsExpanderTestSuite) prepareWorkingExpander() project.Expander
 }
 
 func (suite *SecretsExpanderTestSuite) assertExpansionFailure(secretName string) {
-	value, err := suite.prepareWorkingExpander()("", project.ProjectCategory, secretName, false, project.NewExpanderContext(suite.project))
+	value, err := suite.prepareWorkingExpander()("", project.ProjectCategory, secretName, false, project.NewExpansion(suite.project))
 	suite.Require().Error(err)
 	suite.Zero(value)
 }
@@ -108,14 +108,14 @@ func (suite *SecretsExpanderTestSuite) assertExpansionSuccess(secretName string,
 	if isUser {
 		category = project.UserCategory
 	}
-	value, err := suite.prepareWorkingExpander()("", category, secretName, false, project.NewExpanderContext(suite.project))
+	value, err := suite.prepareWorkingExpander()("", category, secretName, false, project.NewExpansion(suite.project))
 	suite.Equal(expectedExpansionValue, value)
 	suite.Nil(err)
 }
 
 func (suite *SecretsExpanderTestSuite) TestKeypairNotFound() {
 	expanderFn := project.NewSecretQuietExpander(suite.secretsClient, suite.cfg)
-	value, err := expanderFn("", project.ProjectCategory, "undefined-secret", false, project.NewExpanderContext(suite.project))
+	value, err := expanderFn("", project.ProjectCategory, "undefined-secret", false, project.NewExpansion(suite.project))
 	suite.Error(err)
 	suite.Zero(value)
 }

--- a/pkg/project/secrets_test.go
+++ b/pkg/project/secrets_test.go
@@ -98,7 +98,7 @@ func (suite *SecretsExpanderTestSuite) prepareWorkingExpander() project.Expander
 }
 
 func (suite *SecretsExpanderTestSuite) assertExpansionFailure(secretName string) {
-	value, err := suite.prepareWorkingExpander()("", project.ProjectCategory, secretName, false, suite.project)
+	value, err := suite.prepareWorkingExpander()("", project.ProjectCategory, secretName, false, project.NewExpanderContext(suite.project))
 	suite.Require().Error(err)
 	suite.Zero(value)
 }
@@ -108,14 +108,14 @@ func (suite *SecretsExpanderTestSuite) assertExpansionSuccess(secretName string,
 	if isUser {
 		category = project.UserCategory
 	}
-	value, err := suite.prepareWorkingExpander()("", category, secretName, false, suite.project)
+	value, err := suite.prepareWorkingExpander()("", category, secretName, false, project.NewExpanderContext(suite.project))
 	suite.Equal(expectedExpansionValue, value)
 	suite.Nil(err)
 }
 
 func (suite *SecretsExpanderTestSuite) TestKeypairNotFound() {
 	expanderFn := project.NewSecretQuietExpander(suite.secretsClient, suite.cfg)
-	value, err := expanderFn("", project.ProjectCategory, "undefined-secret", false, suite.project)
+	value, err := expanderFn("", project.ProjectCategory, "undefined-secret", false, project.NewExpanderContext(suite.project))
 	suite.Error(err)
 	suite.Zero(value)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-300" title="DX-300" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-300</a>  ASY scripts expansion considers language during path acquisition
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This allows for expanding based on more than just project context.

Add in a script context to fix a bug with Windows-style paths showing up in a bash script on Windows.