### PR TITLE
Fixed `state shell` not activating the default project.

### DIFF
--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/platform/runtime/target"
 	"github.com/ActiveState/cli/pkg/project"
+	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
 type Params struct {
@@ -69,7 +70,11 @@ func (u *Shell) Run(params *Params) error {
 			return locale.WrapError(err, "err_shell_cannot_load_project")
 		}
 	} else {
-		proj, err = project.GetOnce()
+		projectFile, err := projectfile.GetProjectFilePath()
+		if err != nil {
+			return locale.WrapInputError(err, "err_shell_cannot_determine_project", "Cannot determine the project to start a shell/prompt in.")
+		}
+		proj, err = project.FromPath(projectFile)
 		if err != nil {
 			return locale.WrapInputError(err, "err_shell_cannot_load_project")
 		}

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -61,7 +61,7 @@ func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
 	defer ts.Close()
 
 	cp := ts.SpawnWithOpts(
-		e2e.WithArgs("activate", "ActiveState-CLI/Python3", "--default", "--path", ts.Dirs.Work),
+		e2e.WithArgs("activate", "ActiveState-CLI/Python3", "--default", "--path", filepath.Join(ts.Dirs.Work, "foo", "bar", "baz")),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Activated")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1091" title="DX-1091" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1091</a>  `state shell` should work on current dir and global default
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The test was written in such a way to mask the problem. Fixed it too.