### PR TITLE
Fixed inability to run `state deploy uninstall` from cwd on Windows.

### DIFF
--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -2,6 +2,7 @@ package uninstall
 
 import (
 	"os"
+	"path"
 	"runtime"
 
 	"github.com/ActiveState/cli/internal/config"
@@ -61,6 +62,15 @@ func (u *Uninstall) Run(params *Params) error {
 				"Cannot determine current working directory. Please supply `--path` argument")
 		}
 		path = cwd
+		if runtime.GOOS == "windows" {
+			err = os.Chdir(filepath.Dir(path)) // cannot os.RemoveAll() in current working directory, so leave it
+			if err != nil {
+				return locale.WrapInputError(
+					err,
+					"err_deploy_uninstall_cannot_chdir",
+					"Cannot switch away from current working directory. Please supply `--path` argument")
+			}
+		}
 	}
 
 	logging.Debug("Attempting to uninstall deployment at %s", path)

--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -2,7 +2,7 @@ package uninstall
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/ActiveState/cli/internal/config"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-848" title="DX-848" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-848</a>  We can revert `state deploy` with `state deploy uninstall`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Windows doesn't let you remove the dir as its currently "in use" by the shell/prompt.