### PR TITLE
Add tests to ensure we fork off of the correct branch ref

### DIFF
--- a/scripts/internal/workflow-controllers/pr_test.go
+++ b/scripts/internal/workflow-controllers/pr_test.go
@@ -1,0 +1,47 @@
+package wc
+
+import (
+	"testing"
+
+	wh "github.com/ActiveState/cli/scripts/internal/workflow-helpers"
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/require"
+)
+
+type testMeta struct {
+	version           semver.Version
+	jiraVersion       string
+	versionBranchName string
+	versionPRName     string
+}
+
+func (t testMeta) GetVersion() semver.Version {
+	return t.version
+}
+
+func (t testMeta) GetJiraVersion() string {
+	return t.jiraVersion
+}
+
+func (t testMeta) GetVersionBranchName() string {
+	return t.versionBranchName
+}
+
+func (t testMeta) GetVersionPRName() string {
+	return t.versionPRName
+}
+
+func TestDetectBaseRef(t *testing.T) {
+	ghClient := wh.InitGHClient()
+	jiraClient, err := wh.InitJiraClient()
+	require.NoError(t, err)
+	ref, err := DetectBaseRef(ghClient, jiraClient, &testMeta{
+		// This test is using hard coded string values as it's meant to protect against regressions
+		version:           semver.MustParse("0.34.1-RC1"),
+		jiraVersion:       "v0.34.1-RC1",
+		versionBranchName: "version/0-34-1-RC1",
+		versionPRName:     "Version 0.34.1-RC1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "86464907122e34baadeb79f4b989f0f097590174", ref)
+}

--- a/scripts/internal/workflow-helpers/workflow_test.go
+++ b/scripts/internal/workflow-helpers/workflow_test.go
@@ -186,6 +186,28 @@ func Test_issueWithVersionAssert(t *testing.T) {
 			},
 			want: []int{3, 2}, // Should be ordered by closest matching
 		},
+		{
+			name: "Multiple versions sorted DESC",
+			args: args{
+				issues: funk.Shuffle([]*github.Issue{
+					{
+						Title:  github.String(VersionedPRPrefix + "0.34.0-RC2"),
+						Number: github.Int(1),
+					},
+					{
+						Title:  github.String(VersionedPRPrefix + "0.34.0-RC3"),
+						Number: github.Int(2),
+					},
+					{
+						Title:  github.String(VersionedPRPrefix + "0.34.0-RC1"),
+						Number: github.Int(3),
+					},
+				}).([]*github.Issue),
+				assertion:        AssertLT,
+				versionToCompare: semver.MustParse("0.34.1-RC1"),
+			},
+			want: []int{2, 1, 3}, // Should be ordered by closest matching
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1132" title="DX-1132" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1132</a>  CI cannot run integration tests for version/0-34-1-RC1 branch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Turns out the issue we were facing with the 0.34.1-RC1 branch is that it forked off of 0.34.0-RC1 (not RC4). This was in turn because the RC4 PR did not follow the new naming pattern, but RC1 did.

This shouldn't happen again in the future considering this is now automated. I've added some tests that should hopefully help surface regressions if they happen. I've also enabled a branch protection rule for version branch PR's that they have to be up to date with their target branch, which should help surface this issue also (github wasn't telling us the HEAD of beta did not match the forking off point of the PR).