### PR TITLE
Print state tool update version during an update to the latest version.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -739,6 +739,8 @@ update_available:
      You can update by running [ACTIONABLE]`state update`[/RESET]
 update_none_found:
   other: No new update available.
+updating_version:
+  other: Updating State Tool to version {{.V0}}
 runtime_update_notice_known_count:
   other: "Your activestate.yaml is [NOTICE]{{.V0}}[/RESET] commits behind."
 runtime_update_notice_unknown_count:

--- a/internal/runners/update/update.go
+++ b/internal/runners/update/update.go
@@ -64,6 +64,10 @@ func (u *Update) Run(params *Params) error {
 		return nil
 	}
 
+	if params.Version == "" {
+		u.out.Notice(locale.Tl("updating_version", "Updating State Tool to version {{.V0}}", up.Version))
+	}
+
 	// Handle switching channels
 	var installPath string
 	if params.Channel != "" && params.Channel != constants.BranchName {

--- a/internal/runners/update/update.go
+++ b/internal/runners/update/update.go
@@ -46,12 +46,6 @@ func New(prime primeable) *Update {
 }
 
 func (u *Update) Run(params *Params) error {
-	if params.Version == "" {
-		u.out.Notice(locale.Tl("updating_latest", "Updating State Tool to latest version available."))
-	} else {
-		u.out.Notice(locale.Tl("updating_version", "Updating State Tool to version {{.V0}}", params.Version))
-	}
-
 	// Check for available update
 	checker := updater.NewDefaultChecker(u.cfg)
 	up, err := checker.CheckFor(params.Channel, params.Version)
@@ -60,12 +54,18 @@ func (u *Update) Run(params *Params) error {
 	}
 	if up == nil {
 		logging.Debug("No update found")
-		u.out.Notice(locale.T("update_none_found"))
+		if params.Version == "" {
+			u.out.Notice(locale.T("update_none_found"))
+		} else {
+			u.out.Notice(locale.Tl("update_to_version_not_found", "No update to version {{.V0}} available", params.Version))
+		}
 		return nil
 	}
 
 	if params.Version == "" {
-		u.out.Notice(locale.Tl("updating_version", "Updating State Tool to version {{.V0}}", up.Version))
+		u.out.Notice(locale.Tr("updating_version", up.Version))
+	} else {
+		u.out.Notice(locale.Tr("updating_version", params.Version))
 	}
 
 	// Handle switching channels

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -141,7 +141,7 @@ func (suite *UpdateIntegrationTestSuite) testUpdate(ts *e2e.Session, baseDir str
 
 	cp := ts.SpawnCmdWithOpts(stateExec, spawnOpts...)
 	cp.Expect("Updating State Tool to latest version available")
-	cp.Expect("Updating State Tool version")
+	cp.Expect("Updating State Tool to version")
 	cp.Expect("Installing Update")
 }
 

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -140,7 +140,7 @@ func (suite *UpdateIntegrationTestSuite) testUpdate(ts *e2e.Session, baseDir str
 	suite.NoError(err)
 
 	cp := ts.SpawnCmdWithOpts(stateExec, spawnOpts...)
-	cp.Expect("Updating State Tool to latest version available")
+	cp.Expect("Updating State Tool to")
 	cp.Expect("Installing Update")
 }
 
@@ -170,7 +170,7 @@ func (suite *UpdateIntegrationTestSuite) TestUpdate_Repair() {
 	}
 
 	cp := ts.SpawnCmdWithOpts(stateExePath, spawnOpts...)
-	cp.Expect("Updating State Tool to latest version available")
+	cp.Expect("Updating State Tool to version")
 	cp.Expect("Installing Update", time.Minute)
 	cp.ExpectExitCode(0)
 

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -141,7 +141,6 @@ func (suite *UpdateIntegrationTestSuite) testUpdate(ts *e2e.Session, baseDir str
 
 	cp := ts.SpawnCmdWithOpts(stateExec, spawnOpts...)
 	cp.Expect("Updating State Tool to latest version available")
-	cp.Expect("Updating State Tool to version")
 	cp.Expect("Installing Update")
 }
 

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -141,6 +141,7 @@ func (suite *UpdateIntegrationTestSuite) testUpdate(ts *e2e.Session, baseDir str
 
 	cp := ts.SpawnCmdWithOpts(stateExec, spawnOpts...)
 	cp.Expect("Updating State Tool to latest version available")
+	cp.Expect("Updating State Tool version")
 	cp.Expect("Installing Update")
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1099" title="DX-1099" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1099</a>  UPDATE: When run `state update` no version number provided like it done in install flow.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
