### PR TITLE
Implemented `state reset <commitID>`

### DIFF
--- a/cmd/state/internal/cmdtree/reset.go
+++ b/cmd/state/internal/cmdtree/reset.go
@@ -13,11 +13,17 @@ func newResetCommand(prime *primer.Values, globals *globalOptions) *captain.Comm
 
 	return captain.NewCommand(
 		"reset",
-		locale.Tl("reset_title", "Reset to Same Commit as Platform Project"),
-		locale.Tl("reset_description", "Reset local checkout to be equal to the project on the platform."),
+		locale.Tl("reset_title", "Reset to a Commit"),
+		locale.Tl("reset_description", "Reset local checkout to a particular commit."),
 		prime,
 		[]*captain.Flag{},
-		[]*captain.Argument{},
+		[]*captain.Argument{
+			{
+				Name:        locale.Tl("arg_state_reset_commitid", "CommitID"),
+				Description: locale.Tl("arg_state_reset_commitid_description", "Reset to the given commit. If not specified, resets local checkout to be equal to the project on the platform"),
+				Value:       &params.CommitID,
+			},
+		},
 		func(ccmd *captain.Command, args []string) error {
 			params.Force = globals.NonInteractive
 			return runner.Run(params)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1147" title="DX-1147" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1147</a>  `state reset` supports commitID parameter
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I tried to write integration tests for this command, but I need to use `state install`, which will likely result in sporadic failures and timeouts that are out of our control.