### PR TITLE
Raise an error for invalid boolean or integer config values.

### DIFF
--- a/internal/runners/config/set.go
+++ b/internal/runners/config/set.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
@@ -11,7 +12,6 @@ import (
 	configMediator "github.com/ActiveState/cli/internal/mediators/config"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/pkg/platform/model"
-	"github.com/spf13/cast"
 )
 
 type Set struct {
@@ -38,9 +38,17 @@ func (s *Set) Run(params SetParams) error {
 	}
 	switch option.Type {
 	case configMediator.Bool:
-		value = cast.ToBool(params.Value)
+		var err error
+		value, err = strconv.ParseBool(params.Value)
+		if err != nil {
+			return locale.WrapInputError(err, "Invalid boolean value")
+		}
 	case configMediator.Int:
-		value = cast.ToInt(params.Value)
+		var err error
+		value, err = strconv.ParseInt(params.Value, 0, 0)
+		if err != nil {
+			return locale.WrapInputError(err, "Invalid integer value")
+		}
 	default:
 		value = params.Value
 	}

--- a/test/integration/config_int_test.go
+++ b/test/integration/config_int_test.go
@@ -35,6 +35,9 @@ func (suite *ConfigIntegrationTestSuite) TestConfig() {
 
 	cp = ts.Spawn("config", "get", constants.UnstableConfig)
 	cp.Expect("false")
+
+	cp = ts.Spawn("config", "set", constants.UnstableConfig, "oops")
+	cp.Expect("Invalid boolean value")
 }
 
 func TestConfigIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1151" title="DX-1151" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1151</a>  `state config set` accepts invalid value
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Do not silently default to "false" or 0.