### PR TITLE
Implement `state shell --cd`

### DIFF
--- a/cmd/state/internal/cmdtree/shell.go
+++ b/cmd/state/internal/cmdtree/shell.go
@@ -22,7 +22,14 @@ func newShellCommand(prime *primer.Values) *captain.Command {
 		"",
 		locale.Tl("shell_description", "Starts a shell/prompt for the given project runtime"),
 		prime,
-		[]*captain.Flag{},
+		[]*captain.Flag{
+			{
+				Name:        "cd",
+				Shorthand:   "",
+				Description: locale.Tl("flag_state_shell_cd_description", "Change to the project directory after starting shell/prompt"),
+				Value:       &params.ChangeDirectory,
+			},
+		},
 		[]*captain.Argument{
 			{
 				Name:        locale.T("arg_state_activate_namespace"),

--- a/internal/runbits/activation/activation.go
+++ b/internal/runbits/activation/activation.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/virtualenvironment"
 	"github.com/ActiveState/cli/pkg/project"
-	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
 func ActivateAndWait(
@@ -28,16 +27,20 @@ func ActivateAndWait(
 	out output.Outputer,
 	ss subshell.SubShell,
 	cfg *config.Instance,
-	an analytics.Dispatcher) error {
+	an analytics.Dispatcher,
+	changeDirectory bool) error {
 
 	logging.Debug("Activating and waiting")
 
-	err := os.Chdir(filepath.Dir(proj.Source().Path()))
-	if err != nil {
-		return err
+	projectDir := filepath.Dir(proj.Source().Path())
+	if changeDirectory {
+		err := os.Chdir(projectDir)
+		if err != nil {
+			return err
+		}
 	}
 
-	ve, err := venv.GetEnv(false, true, filepath.Dir(projectfile.Get().Path()))
+	ve, err := venv.GetEnv(false, true, projectDir)
 	if err != nil {
 		return locale.WrapError(err, "error_could_not_activate_venv", "Could not retrieve environment information.")
 	}

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -209,7 +209,7 @@ func (r *Activate) run(params *ActivateParams) error {
 		return errs.AddTips(err, "Run → [ACTIONABLE]state push[/RESET] to create your project")
 	}
 
-	if err := activation.ActivateAndWait(proj, venv, r.out, r.subshell, r.config, r.analytics); err != nil {
+	if err := activation.ActivateAndWait(proj, venv, r.out, r.subshell, r.config, r.analytics, true); err != nil {
 		return locale.WrapError(err, "err_activate_wait", "Could not activate runtime environment.")
 	}
 

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -21,7 +21,8 @@ import (
 )
 
 type Params struct {
-	Namespace *project.Namespaced
+	Namespace       *project.Namespaced
+	ChangeDirectory bool
 }
 
 type primeable interface {
@@ -91,7 +92,7 @@ func (u *Shell) Run(params *Params) error {
 
 	venv := virtualenvironment.New(rti)
 
-	err = activation.ActivateAndWait(proj, venv, u.out, u.subshell, u.config, u.analytics)
+	err = activation.ActivateAndWait(proj, venv, u.out, u.subshell, u.config, u.analytics, params.ChangeDirectory)
 	if err != nil {
 		return locale.WrapError(err, "err_shell_wait", "Could not start runtime shell/prompt.")
 	}

--- a/pkg/project/expander.go
+++ b/pkg/project/expander.go
@@ -82,11 +82,6 @@ func (ctx *Expansion) ApplyWithMaxDepth(s string, depth int) (string, error) {
 	return expanded, err
 }
 
-// Expand will detect the active project and invoke ExpandFromProject with the given string
-func Expand(s string) (string, error) {
-	return ExpandFromProject(s, Get())
-}
-
 // ExpandFromProject searches for $category.name-style variables in the given
 // string and substitutes them with their contents, derived from the given
 // project, and subject to the given constraints (if any).
@@ -95,7 +90,7 @@ func ExpandFromProject(s string, p *Project) (string, error) {
 }
 
 func ExpandFromScript(s string, script *Script) (string, error) {
-	expansion := &Expansion{Project: Get(), Script: script}
+	expansion := &Expansion{Project: script.project, Script: script}
 	return expansion.ApplyWithMaxDepth(s, 0)
 }
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -371,27 +371,27 @@ func (p *Platform) Name() string { return p.platform.Name }
 
 // Os returned with all secrets evaluated
 func (p *Platform) Os() (string, error) {
-	return Expand(p.platform.Os)
+	return ExpandFromProject(p.platform.Os, p.project)
 }
 
 // Version returned with all secrets evaluated
 func (p *Platform) Version() (string, error) {
-	return Expand(p.platform.Version)
+	return ExpandFromProject(p.platform.Version, p.project)
 }
 
 // Architecture with all secrets evaluated
 func (p *Platform) Architecture() (string, error) {
-	return Expand(p.platform.Architecture)
+	return ExpandFromProject(p.platform.Architecture, p.project)
 }
 
 // Libc returned are constrained and all secrets evaluated
 func (p *Platform) Libc() (string, error) {
-	return Expand(p.platform.Libc)
+	return ExpandFromProject(p.platform.Libc, p.project)
 }
 
 // Compiler returned are constrained and all secrets evaluated
 func (p *Platform) Compiler() (string, error) {
-	return Expand(p.platform.Compiler)
+	return ExpandFromProject(p.platform.Compiler, p.project)
 }
 
 // Language covers the language structure
@@ -418,7 +418,7 @@ func (l *Language) ID() string {
 func (l *Language) Build() (*Build, error) {
 	build := Build{}
 	for key, val := range l.language.Build {
-		newVal, err := Expand(val)
+		newVal, err := ExpandFromProject(val, l.project)
 		if err != nil {
 			return nil, err
 		}
@@ -460,7 +460,7 @@ func (p *Package) Version() string { return p.pkg.Version }
 func (p *Package) Build() (*Build, error) {
 	build := Build{}
 	for key, val := range p.pkg.Build {
-		newVal, err := Expand(val)
+		newVal, err := ExpandFromProject(val, p.project)
 		if err != nil {
 			return nil, err
 		}
@@ -480,7 +480,7 @@ func (c *Constant) Name() string { return c.constant.Name }
 
 // Value returns constant value
 func (c *Constant) Value() (string, error) {
-	return Expand(c.constant.Value)
+	return ExpandFromProject(c.constant.Value, c.project)
 }
 
 // SecretScope defines the scope of a secret
@@ -592,14 +592,14 @@ func (e *Event) Name() string { return e.event.Name }
 
 // Value returned with all secrets evaluated
 func (e *Event) Value() (string, error) {
-	return Expand(e.event.Value)
+	return ExpandFromProject(e.event.Value, e.project)
 }
 
 // Scope returns the scope property of the event
 func (e *Event) Scope() ([]string, error) {
 	result := []string{}
 	for _, s := range e.event.Scope {
-		v, err := Expand(s)
+		v, err := ExpandFromProject(s, e.project)
 		if err != nil {
 			return result, err
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1143" title="DX-1143" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1143</a>  state shell has a --cd parameter
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Without `--cd`, stay in the current working directory.
Since there may not be an activestate.yaml file in the new shell's cwd, the variable expansion routines need to make use of their project references rather than obtaining new ones.