### PR TITLE
Handle multiple e-mail addresses passed as separate command line arguments

### DIFF
--- a/cmd/state/internal/cmdtree/invite.go
+++ b/cmd/state/internal/cmdtree/invite.go
@@ -31,7 +31,7 @@ func newInviteCommand(prime *primer.Values) *captain.Command {
 		},
 		[]*captain.Argument{
 			{
-				Name:        "email1[,email2,..]",
+				Name:        "email1,[email2,..]",
 				Description: locale.Tl("invite_arg_emails", "Email addresses to send the invitations to"),
 				Required:    true,
 				Value:       &params.EmailList,
@@ -40,5 +40,5 @@ func newInviteCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, _ []string) error {
 			return inviteRunner.Run(&params)
 		},
-	).SetGroup(PlatformGroup).SetUnstable(true)
+	).SetGroup(PlatformGroup).SetUnstable(true).SetHasVariableArguments()
 }

--- a/cmd/state/internal/cmdtree/invite.go
+++ b/cmd/state/internal/cmdtree/invite.go
@@ -31,7 +31,7 @@ func newInviteCommand(prime *primer.Values) *captain.Command {
 		},
 		[]*captain.Argument{
 			{
-				Name:        "email1,[email2,..]",
+				Name:        "email1[,email2,..]",
 				Description: locale.Tl("invite_arg_emails", "Email addresses to send the invitations to"),
 				Required:    true,
 				Value:       &params.EmailList,
@@ -40,5 +40,5 @@ func newInviteCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, _ []string) error {
 			return inviteRunner.Run(&params)
 		},
-	).SetGroup(PlatformGroup).SetUnstable(true).SetHasVariableArguments()
+	).SetGroup(PlatformGroup).SetUnstable(true)
 }

--- a/cmd/state/internal/cmdtree/invite.go
+++ b/cmd/state/internal/cmdtree/invite.go
@@ -31,14 +31,14 @@ func newInviteCommand(prime *primer.Values) *captain.Command {
 		},
 		[]*captain.Argument{
 			{
-				Name:        "email1,[email2,..]",
+				Name:        "email1[,email2,..]",
 				Description: locale.Tl("invite_arg_emails", "Email addresses to send the invitations to"),
 				Required:    true,
 				Value:       &params.EmailList,
 			},
 		},
-		func(ccmd *captain.Command, _ []string) error {
-			return inviteRunner.Run(&params)
+		func(ccmd *captain.Command, args []string) error {
+			return inviteRunner.Run(&params, args)
 		},
 	).SetGroup(PlatformGroup).SetUnstable(true).SetHasVariableArguments()
 }

--- a/cmd/state/internal/cmdtree/invite.go
+++ b/cmd/state/internal/cmdtree/invite.go
@@ -1,9 +1,6 @@
 package cmdtree
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/primer"
@@ -34,18 +31,13 @@ func newInviteCommand(prime *primer.Values) *captain.Command {
 		},
 		[]*captain.Argument{
 			{
-				Name:        "email1[,email2,..]",
+				Name:        "email1,[email2,..]",
 				Description: locale.Tl("invite_arg_emails", "Email addresses to send the invitations to"),
 				Required:    true,
 				Value:       &params.EmailList,
 			},
 		},
-		func(ccmd *captain.Command, args []string) error {
-			if len(args) > 1 {
-				// User supplied additional e-mails as arguments instead of a single comma-separated list.
-				// That's fine.
-				params.EmailList = fmt.Sprintf("%s,%s", params.EmailList, strings.Join(args[1:], ","))
-			}
+		func(ccmd *captain.Command, _ []string) error {
 			return inviteRunner.Run(&params)
 		},
 	).SetGroup(PlatformGroup).SetUnstable(true).SetHasVariableArguments()

--- a/cmd/state/internal/cmdtree/invite.go
+++ b/cmd/state/internal/cmdtree/invite.go
@@ -1,6 +1,9 @@
 package cmdtree
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/primer"
@@ -31,13 +34,18 @@ func newInviteCommand(prime *primer.Values) *captain.Command {
 		},
 		[]*captain.Argument{
 			{
-				Name:        "email1,[email2,..]",
+				Name:        "email1[,email2,..]",
 				Description: locale.Tl("invite_arg_emails", "Email addresses to send the invitations to"),
 				Required:    true,
 				Value:       &params.EmailList,
 			},
 		},
-		func(ccmd *captain.Command, _ []string) error {
+		func(ccmd *captain.Command, args []string) error {
+			if len(args) > 1 {
+				// User supplied additional e-mails as arguments instead of a single comma-separated list.
+				// That's fine.
+				params.EmailList = fmt.Sprintf("%s,%s", params.EmailList, strings.Join(args[1:], ","))
+			}
 			return inviteRunner.Run(&params)
 		},
 	).SetGroup(PlatformGroup).SetUnstable(true).SetHasVariableArguments()

--- a/internal/runners/invite/invite.go
+++ b/internal/runners/invite/invite.go
@@ -43,10 +43,21 @@ func New(prime primeable) *invite {
 	}
 }
 
-func (i *invite) Run(params *Params) error {
+func (i *invite) Run(params *Params, args []string) error {
 	if i.project == nil {
 		return locale.NewInputError("err_no_projectfile", "Must be in a project directory.")
 	}
+
+	if len(args) > 1 {
+		for _, arg := range args {
+			if strings.Contains(arg, ",") {
+				return locale.NewInputError(
+					"err_invite_mixed_commas",
+					"Please supply either a comma-separated list of e-mail addresses or a space-separated list of e-mail addresses, not both")
+			}
+		}
+		params.EmailList = strings.Join(args, ",")
+	} // otherwise CSV-separated list of e-mails is already in params.EmailList
 
 	org := params.Org
 	if org.String() == "" {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1134" title="DX-1134" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1134</a>  INVITE: Only first user gets invited
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I chose to handle additional e-mail address arguments instead of raising an error. If we want to force e-mails to be a single CSV argument, we can do that. Let me know.