### PR TITLE
"Could not find a project" should be an input error.

### DIFF
--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -108,7 +108,7 @@ func (s *Exec) Run(params *Params, args ...string) error {
 			}
 		}
 		if s.proj == nil {
-			return locale.NewError("exec_no_project_found", "Could not find a project.  You need to be in a project directory or specify a global default project via `state activate --default`")
+			return locale.NewInputError("exec_no_project_found", "Could not find a project.  You need to be in a project directory or specify a global default project via `state activate --default`")
 		}
 		projectDir = filepath.Dir(proj.Source().Path())
 		rtTarget = target.NewProjectTarget(proj, storage.CachePath(), nil, trigger)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1163" title="DX-1163" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1163</a>  "Could not find a project" should be input error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
We don't want it logged to rollbar.