### PR TITLE
A user trying to export a non-existant private key should be an input error.

### DIFF
--- a/internal/runners/export/privkey.go
+++ b/internal/runners/export/privkey.go
@@ -33,7 +33,7 @@ func (p *PrivateKey) Run(params *PrivateKeyParams) error {
 
 	filepath := keypairs.LocalKeyFilename(p.cfg.ConfigPath(), constants.KeypairLocalFileName)
 	if !fileutils.FileExists(filepath) {
-		return locale.NewError("err_privkey_nofile",
+		return locale.NewInputError("err_privkey_nofile",
 			"No private key file exists. Please make sure you have authenticated with your password. Authenticating with an API key is not sufficient.")
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1161" title="DX-1161" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1161</a>  "No private key file exists" should be input error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It should not be logged to rollbar.