### PR TITLE
Don't bother trying to uninstall deployment in cwd on Windows.

### DIFF
--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -56,7 +56,6 @@ func (u *Uninstall) Run(params *Params) error {
 		if runtime.GOOS == "windows" {
 			if err != nil {
 				return locale.NewInputError(
-					err,
 					"err_deploy_uninstall_cannot_chdir",
 					"Cannot remove deployment in current working directory. Please cd elsewhere and then supply `--path` argument")
 			}

--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -2,7 +2,6 @@ package uninstall
 
 import (
 	"os"
-	"path/filepath"
 	"runtime"
 
 	"github.com/ActiveState/cli/internal/config"
@@ -54,6 +53,14 @@ func (u *Uninstall) Run(params *Params) error {
 
 	path := params.Path
 	if path == "" {
+		if runtime.GOOS == "windows" {
+			if err != nil {
+				return locale.NewInputError(
+					err,
+					"err_deploy_uninstall_cannot_chdir",
+					"Cannot remove deployment in current working directory. Please cd elsewhere and then supply `--path` argument")
+			}
+		}
 		cwd, err := os.Getwd()
 		if err != nil {
 			return locale.WrapInputError(
@@ -62,15 +69,6 @@ func (u *Uninstall) Run(params *Params) error {
 				"Cannot determine current working directory. Please supply `--path` argument")
 		}
 		path = cwd
-		if runtime.GOOS == "windows" {
-			err = os.Chdir(filepath.Dir(path)) // cannot os.RemoveAll() in current working directory, so leave it
-			if err != nil {
-				return locale.WrapInputError(
-					err,
-					"err_deploy_uninstall_cannot_chdir",
-					"Cannot switch away from current working directory. Please supply `--path` argument")
-			}
-		}
 	}
 
 	logging.Debug("Attempting to uninstall deployment at %s", path)

--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -54,11 +54,9 @@ func (u *Uninstall) Run(params *Params) error {
 	path := params.Path
 	if path == "" {
 		if runtime.GOOS == "windows" {
-			if err != nil {
-				return locale.NewInputError(
-					"err_deploy_uninstall_cannot_chdir",
-					"Cannot remove deployment in current working directory. Please cd elsewhere and then supply `--path` argument")
-			}
+			return locale.NewInputError(
+				"err_deploy_uninstall_cannot_chdir",
+				"Cannot remove deployment in current working directory. Please cd elsewhere and then supply `--path` argument")
 		}
 		cwd, err := os.Getwd()
 		if err != nil {

--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -56,7 +56,7 @@ func (u *Uninstall) Run(params *Params) error {
 		if runtime.GOOS == "windows" {
 			return locale.NewInputError(
 				"err_deploy_uninstall_cannot_chdir",
-				"Cannot remove deployment in current working directory. Please cd elsewhere and then supply `--path` argument")
+				"Cannot remove deployment in current working directory. Please cd elsewhere and run this command again with the '--path' flag.")
 		}
 		cwd, err := os.Getwd()
 		if err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-848" title="DX-848" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-848</a>  We can revert `state deploy` with `state deploy uninstall`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Just tell the user to cd elsewhere and supply a path argument.

The `os.Chdir()` method worked in git bash, but did not work in cmd.exe. No matter what I try, a directory cannot be removed out from under cmd.exe.