### PR TITLE
Debugging: remove symbol stripping from compiled exes.

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -1,7 +1,7 @@
 project: https://platform.activestate.com/ActiveState/cli?branch=main&commitID=7a2fb89c-4bf0-4bb8-b45e-88b0d8af10e4
 constants:
   - name: CLI_BUILDFLAGS
-    value: -ldflags="-s -w"
+    value: -ldflags=""
   - name: CLI_PKGS
     value: ./cmd/state
   - name: SYSTRAY_PKGS


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1096" title="DX-1096" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1096</a>  Running installer should update if installed state tool is older
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
