### PR TITLE
Ask installed state tool for its version in order to check if update flow should be performed.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -477,6 +477,9 @@ func noArgs() bool {
 	return len(os.Args[1:]) == 0
 }
 
+var branchRegex = regexp.MustCompile("Branch (\\S+)")
+var versionRegex = regexp.MustCompile("Version (\\S+)")
+
 func shouldUpdateInstalledStateTool() bool {
 	logging.Debug("Checking if installed state tool is an older version.")
 
@@ -489,7 +492,6 @@ func shouldUpdateInstalledStateTool() bool {
 		return true // probably corrupted install
 	}
 
-	branchRegex := regexp.MustCompile("Branch (\\S+)")
 	branchMatch := branchRegex.FindSubmatch(output)
 	if len(branchMatch) == 0 {
 		logging.Debug("Could not read state tool branch.")
@@ -500,7 +502,6 @@ func shouldUpdateInstalledStateTool() bool {
 		return false // do not update, require --force
 	}
 
-	versionRegex := regexp.MustCompile("Version (\\S+)")
 	versionMatch := versionRegex.FindSubmatch(output)
 	if len(versionMatch) == 0 {
 		logging.Debug("Could not read state tool version.")

--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -476,11 +476,6 @@ func noArgs() bool {
 	return len(os.Args[1:]) == 0
 }
 
-type stateToolVersionOutput struct {
-	Branch  string `json:"branch"`
-	Version string `json:"version"`
-}
-
 func shouldUpdateInstalledStateTool(stateExePath string) bool {
 	logging.Debug("Checking if installed state tool is an older version.")
 
@@ -489,21 +484,21 @@ func shouldUpdateInstalledStateTool(stateExePath string) bool {
 		logging.Debug("Could not determine state tool version.")
 		return true // probably corrupted install
 	}
-	stdout = strings.ReplaceAll(stdout, "\x00", "") // TODO: DX-328
+	stdout = strings.Split(stdout, "\x00")[0] // TODO: DX-328
 
-	versionInfo := stateToolVersionOutput{}
-	err = json.Unmarshal([]byte(stdout), &versionInfo)
+	versionData := installation.VersionData{}
+	err = json.Unmarshal([]byte(stdout), &versionData)
 	if err != nil {
 		logging.Debug("Could not read state tool version output")
 		return true
 	}
 
-	if versionInfo.Branch != constants.BranchName {
+	if versionData.Branch != constants.BranchName {
 		logging.Debug("State tool branch is different from installer.")
 		return false // do not update, require --force
 	}
 
-	if versionInfo.Version != constants.Version {
+	if versionData.Version != constants.Version {
 		logging.Debug("State tool version is different from installer.")
 		return true
 	}

--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -210,9 +210,9 @@ func isStateExecutable(name string) bool {
 	return false
 }
 
-func installedOnPath(installRoot, branch string) (bool, string, error) {
+func installedOnPath(installRoot, branch string) (bool, string, string, error) {
 	if !fileutils.DirExists(installRoot) {
-		return false, "", nil
+		return false, "", "", nil
 	}
 
 	// This is not using appinfo on purpose because we want to deal with legacy installation formats, which appinfo does not
@@ -228,9 +228,9 @@ func installedOnPath(installRoot, branch string) (bool, string, error) {
 	}
 	for _, candidate := range candidates {
 		if fileutils.TargetExists(candidate) {
-			return true, installRoot, nil
+			return true, installRoot, candidate, nil
 		}
 	}
 
-	return false, installRoot, nil
+	return false, installRoot, stateCmd, nil
 }

--- a/internal/installation/versiondata.go
+++ b/internal/installation/versiondata.go
@@ -1,0 +1,10 @@
+package installation
+
+type VersionData struct {
+	License    string `json:"license"`
+	Version    string `json:"version"`
+	Branch     string `json:"branch"`
+	Revision   string `json:"revision"`
+	Date       string `json:"date"`
+	BuiltViaCI bool   `json:"builtViaCI"`
+}

--- a/internal/runners/state/state.go
+++ b/internal/runners/state/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/profile"
+	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/pkg/cmdlets/checker"
 	"github.com/ActiveState/cli/pkg/platform/model"
 )
@@ -51,22 +52,13 @@ func (s *State) Run(usageFunc func() error) error {
 	return execute(s.opts, usageFunc, s.cfg, s.svcMdl, s.out)
 }
 
-type versionData struct {
-	License    string `json:"license"`
-	Version    string `json:"version"`
-	Branch     string `json:"branch"`
-	Revision   string `json:"revision"`
-	Date       string `json:"date"`
-	BuiltViaCI bool   `json:"builtViaCI"`
-}
-
 func execute(opts *Options, usageFunc func() error, cfg *config.Instance, svcModel *model.SvcModel, out output.Outputer) error {
 	logging.Debug("Execute")
 	defer profile.Measure("runners:state:execute", time.Now())
 
 	if opts.Version {
 		checker.RunUpdateNotifier(svcModel, out)
-		vd := versionData{
+		vd := installation.VersionData{
 			constants.LibraryLicense,
 			constants.Version,
 			constants.BranchName,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1096" title="DX-1096" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1096</a>  Running installer should update if installed state tool is older
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Calling the updater routine was only doing so for the currently running installer (which is up to date), not the install state tool.