### PR TITLE
Allow mixed use of commas and spaces as e-mail address separators for…

### DIFF
--- a/internal/runners/invite/invite.go
+++ b/internal/runners/invite/invite.go
@@ -50,13 +50,6 @@ func (i *invite) Run(params *Params, args []string) error {
 	}
 
 	if len(args) > 1 {
-		for _, arg := range args {
-			if strings.Contains(arg, ",") {
-				return locale.NewInputError(
-					"err_invite_mixed_commas",
-					"Please supply either a comma-separated list of e-mail addresses or a space-separated list of e-mail addresses, not both")
-			}
-		}
 		params.EmailList = strings.Join(args, ",")
 	} // otherwise CSV-separated list of e-mails is already in params.EmailList
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1134" title="DX-1134" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1134</a>  INVITE: Only first user gets invited
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
… `state invite`