### PR TITLE
Fix state export env panic

### DIFF
--- a/internal/runners/export/env.go
+++ b/internal/runners/export/env.go
@@ -30,6 +30,10 @@ func NewEnv(prime primeable) *Env {
 }
 
 func (e *Env) Run() error {
+	if e.project == nil {
+		return locale.NewInputError("err_env_no_project", "No project found.")
+	}
+
 	rt, _, err := runtime.NewFromProject(e.project, target.TriggerActivate, e.analytics, e.svcModel, e.out, e.auth)
 	if err != nil {
 		return locale.WrapError(err, "err_export_new_runtime", "Could not initialize runtime")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1148" title="DX-1148" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1148</a>  There is a command to easily export the location of my python interpreter (eg. state export env)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
