### PR TITLE
Fixed handling of `--path` to `state exec`.

### DIFF
--- a/cmd/state/internal/cmdtree/exec.go
+++ b/cmd/state/internal/cmdtree/exec.go
@@ -1,8 +1,6 @@
 package cmdtree
 
 import (
-	"strings"
-
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/primer"
@@ -31,7 +29,7 @@ func newExecCommand(prime *primer.Values, args ...string) *captain.Command {
 			if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
 				prime.Output().Print(ccmd.UsageText())
 				return nil
-			} else if len(args) > 0 && (args[0] == "-v" || args[0] == "--verbose") {
+			} else if len(args) > 0 && (args[0] == "-v" || args[0] == "--verbose" || args[0] == "--") {
 				if len(args) > 1 {
 					args = args[1:]
 				} else {
@@ -44,14 +42,6 @@ func newExecCommand(prime *primer.Values, args ...string) *captain.Command {
 	)
 	cmd.SetSkipChecks(true)
 	cmd.SetDeferAnalytics(true)
-
-	// Cobra will handle the `--` delimiter if flag parsing is enabled.
-	// If the delimeter is not present we have to disable flag parsing
-	// to ensure flags are passed to the command rather than
-	// parsed as a flag for `state exec`
-	if !strings.Contains(strings.Join(args, " "), " -- ") {
-		cmd.SetDisableFlagParsing(true)
-	}
 
 	cmd.SetGroup(EnvironmentGroup)
 	cmd.SetHasVariableArguments()

--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -107,7 +107,7 @@ func (s *Exec) Run(params *Params, args ...string) error {
 				return locale.WrapInputError(err, "exec_no_project_at_path", "Could not find project file at {{.V0}}", params.Path)
 			}
 		}
-		if s.proj == nil {
+		if proj == nil {
 			return locale.NewInputError("exec_no_project_found", "Could not find a project.  You need to be in a project directory or specify a global default project via `state activate --default`")
 		}
 		projectDir = filepath.Dir(proj.Source().Path())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1165" title="DX-1165" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1165</a>  EXEC: `--path` flag is not working
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I'm not entirely sure I understand how `--` should be handled, but I'm relying on the existing integration tests that use it as well as one I wrote for this PR. Presumably anything after the first `--` should be excluded from `state exec`'s handling, and passed to the command being executed.