### PR TITLE
Don't run subshell after install if env var is set

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -366,7 +366,7 @@ func postInstallEvents(out output.Outputer, cfg *config.Instance, an analytics.D
 			an.EventWithLabel(AnalyticsFunnelCat, "forward-activate-default-err", err.Error())
 			return errs.Silence(errs.Wrap(err, "Could not activate %s, error returned: %s", params.activateDefault.String(), errs.JoinMessage(err)))
 		}
-	case !params.isUpdate:
+	case !params.isUpdate && os.Getenv(constants.InstallerNoSubshell) != "true":
 		ss := subshell.New(cfg)
 		ss.SetEnv(envMap(binPath))
 		if err := ss.Activate(nil, cfg, out); err != nil {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -417,6 +417,9 @@ const ExecRecursionAllowEnvVarName = "ACTIVESTATE_CLI_EXECUTOR_RECURSION_ALLOW"
 // ExecRecursionMaxLevelEnvVarName is an environment variable storing the number of times the executor may be called recursively
 const ExecRecursionMaxLevelEnvVarName = "ACTIVESTATE_CLI_EXECUTOR_MAX_RECURSION_LEVEL"
 
+// InstallerNoSubshell is an environment variable that if set to true will tell the installer not to start a subshell
+const InstallerNoSubshell = "ACTIVESTATE_CLI_INSTALLER_NO_SUBSHELL"
+
 // InstallSourceFile is the file we use to record what installed the state tool
 const InstallSourceFile = "installsource.txt"
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1185" title="DX-1185" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1185</a>  We can run the installer without ending up in a subshell
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
