### PR TITLE
Rebase PYTHONPATH on runtime directory, not temp runtime directory, for Camel builds.

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -220,6 +220,13 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_PythonPath() {
 	// ensure that shell is functional
 	cp.WaitForInput()
 
+	if runtime.GOOS == "windows" {
+		cp.Send("echo %PYTHONPATH%")
+	} else {
+		cp.Send("echo $PYTHONPATH")
+	}
+	suite.Assert().NotContains(cp.TrimmedSnapshot(), constants.LocalRuntimeTempDirectory)
+
 	// test that PYTHONPATH is preserved in environment (https://www.pivotaltracker.com/story/show/178458102)
 	if runtime.GOOS == "windows" {
 		cp.Send("set PYTHONPATH=/custom_pythonpath")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1179" title="DX-1179" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1179</a>  PYTHONPATH is set up with _runtime_temp directory
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

