### PR TITLE
State switch panic fix

### DIFF
--- a/internal/runners/swtch/switch.go
+++ b/internal/runners/swtch/switch.go
@@ -88,7 +88,7 @@ func (s *Switch) Run(params SwitchParams) error {
 		return locale.WrapError(err, "err_fetch_project", "", s.project.Namespace().String())
 	}
 
-	identifier, err := resolveIdentifierCommitID(project, params.Identifier)
+	identifier, err := resolveIdentifier(project, params.Identifier)
 	if err != nil {
 		return locale.WrapError(err, "err_resolve_identifier", "Could not resolve identifier {{.V0}}", params.Identifier)
 	}
@@ -115,14 +115,14 @@ func (s *Switch) Run(params SwitchParams) error {
 	return nil
 }
 
-func resolveIdentifierCommitID(project *mono_models.Project, idParam string) (identifier, error) {
+func resolveIdentifier(project *mono_models.Project, idParam string) (identifier, error) {
 	if strfmt.IsUUID(idParam) {
 		return commitIdentifier{strfmt.UUID(idParam)}, nil
 	}
 
 	branch, err := model.BranchForProjectByName(project, idParam)
 	if err != nil {
-		locale.WrapError(err, "err_identifier_branch", "Could not get branch {{.V0}} for current project", idParam)
+		return nil, locale.WrapError(err, "err_identifier_branch", "Could not get branch {{.V0}} for current project", idParam)
 
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1148" title="DX-1148" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1148</a>  There is a command to easily export the location of my python interpreter (eg. state export env)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
