### PR TITLE
subshell/cmd.cleanPath() should be able to clean multiple path entries at once

### DIFF
--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -75,14 +75,14 @@ func (u *Uninstall) Run(params *Params) error {
 			locale.Tl("err_deploy_uninstall_not_deployed_tip", "Either change the current directory to a deployment or supply '--path <path>' arguments."))
 	}
 
-	err := os.RemoveAll(path)
-	if err != nil {
-		return locale.WrapError(err, "err_deploy_uninstall", "Unable to remove deployed runtime at '{{.V0}}'", path)
-	}
-
 	err = u.subshell.CleanUserEnv(u.cfg, sscommon.DeployID, params.UserScope)
 	if err != nil {
 		return locale.WrapError(err, "err_deploy_uninstall_env", "Failed to remove deploy directory from PATH")
+	}
+
+	err := os.RemoveAll(path)
+	if err != nil {
+		return locale.WrapError(err, "err_deploy_uninstall", "Unable to remove deployed runtime at '{{.V0}}'", path)
 	}
 
 	u.output.Notice(locale.T("deploy_uninstall_success"))

--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -75,12 +75,12 @@ func (u *Uninstall) Run(params *Params) error {
 			locale.Tl("err_deploy_uninstall_not_deployed_tip", "Either change the current directory to a deployment or supply '--path <path>' arguments."))
 	}
 
-	err = u.subshell.CleanUserEnv(u.cfg, sscommon.DeployID, params.UserScope)
+	err := u.subshell.CleanUserEnv(u.cfg, sscommon.DeployID, params.UserScope)
 	if err != nil {
 		return locale.WrapError(err, "err_deploy_uninstall_env", "Failed to remove deploy directory from PATH")
 	}
 
-	err := os.RemoveAll(path)
+	err = os.RemoveAll(path)
 	if err != nil {
 		return locale.WrapError(err, "err_deploy_uninstall", "Unable to remove deployed runtime at '{{.V0}}'", path)
 	}

--- a/internal/subshell/cmd/env.go
+++ b/internal/subshell/cmd/env.go
@@ -76,7 +76,7 @@ func cleanPath(keyValue, oldEntry string) string {
 
 	var newValue []string
 	for _, entry := range strings.Split(keyValue, string(os.PathListSeparator)) {
-		if _, ok := oldEntries[filepath.Clean(entry)]; ok {
+		if oldEntries[filepath.Clean(entry)] {
 			continue
 		}
 		newValue = append(newValue, entry)

--- a/internal/subshell/cmd/env.go
+++ b/internal/subshell/cmd/env.go
@@ -69,9 +69,14 @@ func (c *CmdEnv) unset(keyName, oldValue string) error {
 }
 
 func cleanPath(keyValue, oldEntry string) string {
+	oldEntries := make(map[string]bool)
+	for _, entry := range strings.Split(oldEntry, string(os.PathListSeparator)) {
+		oldEntries[filepath.Clean(entry)] = true
+	}
+
 	var newValue []string
 	for _, entry := range strings.Split(keyValue, string(os.PathListSeparator)) {
-		if filepath.Clean(entry) == filepath.Clean(oldEntry) {
+		if _, ok := oldEntries[filepath.Clean(entry)]; ok {
 			continue
 		}
 		newValue = append(newValue, entry)

--- a/internal/subshell/cmd/env_test.go
+++ b/internal/subshell/cmd/env_test.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/thoas/go-funk"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/thoas/go-funk"
 )
 
 type RegistryKeyMock struct {
@@ -281,4 +283,15 @@ func registryValidator(t *testing.T, got []string, want *[]string, name string) 
 			}
 		}
 	}
+}
+
+func TestCleanPath(t *testing.T) {
+	paths := []string{"foo", "bar", "baz/quux"}
+	path := strings.Join(paths, string(os.PathListSeparator))
+
+	cleaned := cleanPath(path, "bar")
+	assert.Equal(t, cleaned, strings.Join([]string{"foo", "baz/quux"}, string(os.PathListSeparator)))
+
+	cleaned = cleanPath(path, strings.Join([]string{"bar", "baz/quux"}, string(os.PathListSeparator)))
+	assert.Equal(t, cleaned, "foo")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-848" title="DX-848" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-848</a>  We can revert `state deploy` with `state deploy uninstall`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
