### PR TITLE
/bin/sh does not recognize '==' operator in expressions, so use '=' instead

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -136,7 +136,7 @@ $FETCH $TMPDIR/$ARCHIVE $STATEURL
 # If curl was used, make sure the file downloaded is of type 'data', according to the UNIX `file`
 # command. (The XML error will be reported as a 'text' type.)
 # If wget returned an error or curl fetched a "forbidden" response, raise an error and exit.
-if [ $? -ne 0 -o \( "`echo $FETCH | grep -o 'curl'`" == "curl" -a -z "`file -b $TMPDIR/$ARCHIVE | grep -o 'data'`" \) ]; then
+if [ $? -ne 0 -o \( "`echo $FETCH | grep -o 'curl'`" = "curl" -a -z "`file -b $TMPDIR/$ARCHIVE | grep -o 'data'`" \) ]; then
   rm -f $TMPDIR/$ARCHIVE
   progress_fail
   error "Could not download the State Tool installer at $STATEURL. Please try again."


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1154" title="DX-1154" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1154</a>  install.sh spits out an error about a closing paren expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
