### PR TITLE
Clean up use of cp.Expect() and cp.WaitForInput()

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -65,7 +65,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateUsingCommitID() {
 	)
 
 	cp.Expect("Activated", 40*time.Second)
-	cp.WaitForInput(10 * time.Second)
+	cp.WaitForInput()
 
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -81,7 +81,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateNotOnPath() {
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Activated", 40*time.Second)
-	cp.WaitForInput(10 * time.Second)
+	cp.WaitForInput()
 
 	if runtime.GOOS == "windows" {
 		cp.SendLine("doskey /macros | findstr state=")
@@ -112,8 +112,8 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 
 	if runtime.GOOS == "linux" {
 		cp.Expect("Creating a Virtual Environment")
-		cp.Expect("Activated")
-		cp.WaitForInput(40 * time.Second)
+		cp.Expect("Activated", 40*time.Second)
+		cp.WaitForInput()
 		cp.SendLine("exit")
 		cp.ExpectExitCode(0)
 	} else if runtime.GOOS == "windows" {
@@ -178,7 +178,8 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 
 	cp.SendLine("state activate --default")
 	cp.ExpectLongString("Creating a Virtual Environment")
-	cp.WaitForInput(40 * time.Second)
+	cp.Expect("Activated", 40*time.Second)
+	cp.WaitForInput()
 	pythonShim := pythonExe
 	if runtime.GOOS == "windows" {
 		pythonShim = pythonExe + ".bat"
@@ -327,9 +328,9 @@ version: %s
 		e2e.WithArgs("activate"),
 		e2e.WithWorkDirectory(filepath.Join(ts.Dirs.Work, "foo", "bar", "baz")),
 	)
-	c2.Expect("Activated")
+	c2.Expect("Activated", 40*time.Second)
 
-	c2.WaitForInput(40 * time.Second)
+	c2.WaitForInput()
 	c2.SendLine("exit")
 	c2.ExpectExitCode(0)
 }
@@ -361,9 +362,9 @@ project: "https://platform.activestate.com/ActiveState-CLI/Python3"
 		e2e.WithWorkDirectory(targetPath),
 	)
 	c2.ExpectLongString("ActiveState-CLI/Python2")
-	c2.Expect("Activated")
+	c2.Expect("Activated", 40*time.Second)
 
-	c2.WaitForInput(40 * time.Second)
+	c2.WaitForInput()
 	if runtime.GOOS == "windows" {
 		c2.SendLine("@echo %cd%")
 	} else {

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -178,8 +178,7 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 
 	cp.SendLine("state activate --default")
 	cp.ExpectLongString("Creating a Virtual Environment")
-	cp.Expect("Activated", 40*time.Second)
-	cp.WaitForInput()
+	cp.WaitForInput(40 * time.Second)
 	pythonShim := pythonExe
 	if runtime.GOOS == "windows" {
 		pythonShim = pythonExe + ".bat"

--- a/test/integration/analytics_int_test.go
+++ b/test/integration/analytics_int_test.go
@@ -64,8 +64,8 @@ func (suite *AnalyticsIntegrationTestSuite) TestActivateEvents() {
 	}
 
 	cp.Expect("Creating a Virtual Environment")
-	cp.Expect("Activated")
-	cp.WaitForInput(120 * time.Second)
+	cp.Expect("Activated", 120*time.Second)
+	cp.WaitForInput()
 
 	time.Sleep(time.Second) // Ensure state-svc has time to report events
 
@@ -255,8 +255,8 @@ scripts:
 	)
 
 	cp.Expect("Creating a Virtual Environment")
-	cp.Expect("Activated")
-	cp.WaitForInput(120 * time.Second)
+	cp.Expect("Activated", 120*time.Second)
+	cp.WaitForInput()
 
 	cp = ts.Spawn("run", "pip")
 	cp.Wait()

--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -171,7 +171,7 @@ func (suite *PushIntegrationTestSuite) TestPush_NoPermission_NewProject() {
 
 	cp := ts.SpawnWithOpts(e2e.WithArgs("activate", suite.baseProject, "--path", ts.Dirs.Work))
 	cp.Expect("Activated", 40*time.Second)
-	cp.WaitForInput(10 * time.Second)
+	cp.WaitForInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -111,7 +111,7 @@ func (suite *RunIntegrationTestSuite) TestInActivatedEnv() {
 
 	cp := ts.Spawn("activate")
 	cp.Expect("Activated")
-	cp.WaitForInput(10 * time.Second)
+	cp.WaitForInput()
 
 	cp.SendLine(fmt.Sprintf("%s run testMultipleLanguages", cp.Executable()))
 	cp.Expect("3")
@@ -146,7 +146,7 @@ func (suite *RunIntegrationTestSuite) TestScriptBashSubshell() {
 
 	cp := ts.SpawnWithOpts(e2e.WithArgs("activate"), e2e.AppendEnv("SHELL=bash"))
 	cp.Expect("Activated")
-	cp.WaitForInput(10 * time.Second)
+	cp.WaitForInput()
 
 	cp.SendLine("helloWorld")
 	cp.Expect("Hello World!")
@@ -236,7 +236,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Unauthenticated() {
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Activated", 40*time.Second)
-	cp.WaitForInput(120 * time.Second)
+	cp.WaitForInput()
 
 	cp.SendLine(fmt.Sprintf("%s run testMultipleLanguages", cp.Executable()))
 	cp.Expect("2")
@@ -302,7 +302,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
 		),
 	)
 	cp.Expect("Activated")
-	cp.WaitForInput(10 * time.Second)
+	cp.WaitForInput()
 
 	cp.SendLine("perl -MEnglish -e 'print $PERL_VERSION'")
 	cp.Expect("v5.32.0")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1089" title="DX-1089" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1089</a>  Random e2e fail: TestActivateIntegrationTestSuite/TestActivateUsingCommitID
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Most cp.Expect() return when input is ready, so no need to wait for input with a timeout.