### PR TITLE
Specify job timeouts for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
       - # === Preprocess ===
         name: Preprocess
         shell: bash
+        timeout-minutes: 1
         run: state run preprocess
 
       - # === Parallel Tasks ===

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
   # === OS Specific Job (runs on each OS) ===
   os_specific:
     name: ${{ matrix.platform }}
+    timeout-minutes: 90
     strategy:
       matrix:
         go-version:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1119" title="DX-1119" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1119</a>  "Preprocess" github action should have a timeout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Timeout preprocess step after 1 minute since it should only take seconds unless something has gone horribly wrong.

Timeout the entire build job after 90m considering that: (1) the parallel tasks step is allotted 15 minutes and Windows can go the distance occasionally; (2) integration tests often push their 60m envelope, especially on Windows; (3) some extra wiggle room for Windows because it needs it.