### PR TITLE
Added `state use show` command with integration test.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -142,7 +142,10 @@ func New(prime *primer.Values, args ...string) *CmdTree {
 	checkoutCmd := newCheckoutCommand(prime)
 
 	useCmd := newUseCommand(prime)
-	useCmd.AddChildren(newUseResetCommand(prime, globals))
+	useCmd.AddChildren(
+		newUseResetCommand(prime, globals),
+		newUseShowCommand(prime),
+	)
 
 	shellCmd := newShellCommand(prime)
 

--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -50,3 +50,17 @@ func newUseResetCommand(prime *primer.Values, globals *globalOptions) *captain.C
 		},
 	)
 }
+
+func newUseShowCommand(prime *primer.Values) *captain.Command {
+	return captain.NewCommand(
+		"show",
+		"",
+		locale.Tl("use_show_description", "Show your default project runtime"),
+		prime,
+		[]*captain.Flag{},
+		[]*captain.Argument{},
+		func(_ *captain.Command, _ []string) error {
+			return use.NewShow(prime).Run()
+		},
+	)
+}

--- a/internal/runners/use/show.go
+++ b/internal/runners/use/show.go
@@ -1,0 +1,40 @@
+package use
+
+import (
+	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/pkg/project"
+)
+
+type Show struct {
+	out output.Outputer
+	cfg *config.Instance
+}
+
+func NewShow(prime primeable) *Show {
+	return &Show{
+		prime.Output(),
+		prime.Config(),
+	}
+}
+
+func (s *Show) Run() error {
+	projectDir := s.cfg.GetString(constants.GlobalDefaultPrefname)
+	if projectDir == "" {
+		return locale.NewInputError("err_use_show_no_default_project", "No default project is set.")
+	}
+
+	proj, err := project.FromPath(projectDir)
+	if err != nil {
+		return locale.WrapError(err, "err_use_show_get_project", "Could not get default project.")
+	}
+
+	s.out.Print(locale.Tl("use_show", "The default project to use is {{.V0}}, located at {{.V1}}",
+		proj.NamespaceString(),
+		projectDir,
+	))
+
+	return nil
+}

--- a/internal/runners/use/show.go
+++ b/internal/runners/use/show.go
@@ -20,6 +20,19 @@ func NewShow(prime primeable) *Show {
 	}
 }
 
+type outputFormat struct {
+	Message   string `locale:message,Message`
+	Namespace string `locale:"namespace,Namespace"`
+	Path      string `locale:"path,Path"`
+}
+
+func (f *outputFormat) MarshalOutput(format output.Format) interface{} {
+	if format == output.PlainFormatName {
+		return f.Message
+	}
+	return f
+}
+
 func (s *Show) Run() error {
 	projectDir := s.cfg.GetString(constants.GlobalDefaultPrefname)
 	if projectDir == "" {
@@ -31,10 +44,14 @@ func (s *Show) Run() error {
 		return locale.WrapError(err, "err_use_show_get_project", "Could not get default project.")
 	}
 
-	s.out.Print(locale.Tl("use_show", "The default project to use is {{.V0}}, located at {{.V1}}",
+	s.out.Print(&outputFormat{
+		locale.Tl("use_show", "The default project to use is {{.V0}}, located at {{.V1}}",
+			proj.NamespaceString(),
+			projectDir,
+		),
 		proj.NamespaceString(),
 		projectDir,
-	))
+	})
 
 	return nil
 }

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -160,6 +160,45 @@ func (suite *UseIntegrationTestSuite) TestReset() {
 	}
 }
 
+func (suite *UseIntegrationTestSuite) TestShow() {
+	suite.OnlyRunForTags(tagsuite.Use)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.SpawnWithOpts(e2e.WithArgs("use", "show"))
+	cp.Expect("No default project is set")
+	cp.ExpectExitCode(1)
+
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("checkout", "ActiveState-CLI/Python3"),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
+	cp.Expect("Checked out Python3")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("use", "ActiveState-CLI/Python3"),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
+	cp.Expect("Switched to Python3")
+	cp.ExpectExitCode(0)
+
+	projectDir := filepath.Join(ts.Dirs.Work, "Python3")
+	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "show"))
+	cp.ExpectLongString("The default project to use is ActiveState-CLI/Python3, located at")
+	cp.ExpectLongString(projectDir)
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "reset", "--non-interactive"))
+	cp.Expect("Reset")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "show"))
+	cp.Expect("No default project is set")
+	cp.ExpectExitCode(1)
+}
+
 func TestUseIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(UseIntegrationTestSuite))
 }

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -191,14 +191,10 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 	if runtime.GOOS != "windows" {
 		cp.ExpectLongString(projectDir)
 	} else {
-		output := strings.Replace(cp.TrimmedSnapshot(), "\n", "", -1)
-		// Windows sometimes uses shortened paths, sometimes not.
-		longPath, err := fileutils.GetLongPathName(projectDir)
-		suite.Require().NoError(err)
+		// Windows uses the short path here.
 		shortPath, err := fileutils.GetShortPathName(projectDir)
 		suite.Require().NoError(err)
-		suite.Assert().True(strings.Contains(output, longPath) || strings.Contains(output, shortPath),
-			"expected to find ActiveState-CLI/Python3 project path in output")
+		cp.ExpectLongString(shortPath)
 	}
 	cp.ExpectExitCode(0)
 

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/config"

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -186,15 +186,15 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 
 	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "show"))
 	cp.ExpectLongString("The default project to use is ActiveState-CLI/Python3, located at")
+	projectDir := filepath.Join(ts.Dirs.Work, "Python3")
 	if runtime.GOOS != "windows" {
-		projectDir := filepath.Join(ts.Dirs.Work, "Python3")
 		cp.ExpectLongString(projectDir)
 	} else {
+		output := cp.TrimmedSnapshot()
 		// Windows sometimes uses shortened paths, sometimes not.
-		// Just verify the last two components of the path are there and assume all is well,
-		// especially if the Linux and macOS tests are passing.
-		projectDir := filepath.Join(filepath.Base(ts.Dirs.Work), "Python3")
-		cp.ExpectLongString(projectDir)
+		suite.Assert().True(strings.Contains(output, fileutils.GetLongPath(projectDir)) ||
+			strings.Contains(output, fileutils.GetShortPath(projectDir)),
+			"expected to find ActiveState-CLI/Python3 project path in output")
 	}
 	cp.ExpectExitCode(0)
 

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/config"
@@ -192,8 +193,11 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 	} else {
 		output := cp.TrimmedSnapshot()
 		// Windows sometimes uses shortened paths, sometimes not.
-		suite.Assert().True(strings.Contains(output, fileutils.GetLongPath(projectDir)) ||
-			strings.Contains(output, fileutils.GetShortPath(projectDir)),
+		longPath, err := fileutils.GetLongPathName(projectDir)
+		suite.Require().NoError(err)
+		shortPath, err := fileutils.GetShortPathName(projectDir)
+		suite.Require().NoError(err)
+		suite.Assert().True(strings.Contains(output, longPath) || strings.Contains(output, shortPath),
 			"expected to find ActiveState-CLI/Python3 project path in output")
 	}
 	cp.ExpectExitCode(0)

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -184,10 +184,18 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 	cp.Expect("Switched to Python3")
 	cp.ExpectExitCode(0)
 
-	projectDir := filepath.Join(ts.Dirs.Work, "Python3")
 	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "show"))
 	cp.ExpectLongString("The default project to use is ActiveState-CLI/Python3, located at")
-	cp.ExpectLongString(projectDir)
+	if runtime.GOOS != "windows" {
+		projectDir := filepath.Join(ts.Dirs.Work, "Python3")
+		cp.ExpectLongString(projectDir)
+	} else {
+		// Windows sometimes uses shortened paths, sometimes not.
+		// Just verify the last two components of the path are there and assume all is well,
+		// especially if the Linux and macOS tests are passing.
+		projectDir := filepath.Join(filepath.Base(ts.Dirs.Work), "Python3")
+		cp.ExpectLongString(projectDir)
+	}
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "reset", "--non-interactive"))

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -191,7 +191,7 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 	if runtime.GOOS != "windows" {
 		cp.ExpectLongString(projectDir)
 	} else {
-		output := cp.TrimmedSnapshot()
+		output := strings.Replace(cp.TrimmedSnapshot(), "\n", "", -1)
 		// Windows sometimes uses shortened paths, sometimes not.
 		longPath, err := fileutils.GetLongPathName(projectDir)
 		suite.Require().NoError(err)

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -190,10 +190,10 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 	if runtime.GOOS != "windows" {
 		cp.ExpectLongString(projectDir)
 	} else {
-		// Windows uses the short path here.
-		shortPath, err := fileutils.GetShortPathName(projectDir)
+		// Windows uses the long path here.
+		longPath, err := fileutils.GetLongPathName(projectDir)
 		suite.Require().NoError(err)
-		cp.ExpectLongString(shortPath)
+		cp.ExpectLongString(longPath)
 	}
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1198" title="DX-1198" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1198</a>  USE: User can print current default that defined by `state use <namespace>`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
