### PR TITLE
Try waiting 50% longer between GitHub API requests.

### DIFF
--- a/scripts/internal/workflow-helpers/ghtransport.go
+++ b/scripts/internal/workflow-helpers/ghtransport.go
@@ -69,7 +69,7 @@ func (rlt *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, err
 	// If you're making a large number of POST, PATCH, PUT, or DELETE requests
 	// for a single user or client ID, wait at least one second between each request.
 	if rlt.delayNextRequest {
-		delay := multiplier * writeDelay
+		delay := time.Duration(multiplier * float64(writeDelay))
 		logging.Debug("Sleeping %s between write operations", delay)
 		time.Sleep(delay)
 	}

--- a/scripts/internal/workflow-helpers/ghtransport.go
+++ b/scripts/internal/workflow-helpers/ghtransport.go
@@ -42,6 +42,10 @@ SOFTWARE.
 const (
 	ctxId      = "id"
 	writeDelay = 720 * time.Millisecond // https://github.com/google/go-github/issues/431#issuecomment-248767702
+	// The above writeDelay is the minimum interval to avoid rate limiting as long as is only one
+	// job using the GitHub API at a time. Since this is likely not the case for us, we need a tunable
+	// parameter that can easily be adjusted based on experience.
+	multiplier = 1.5 // 150% of the minimum delay
 )
 
 // rateLimitTransport implements GitHub's best practices
@@ -65,8 +69,9 @@ func (rlt *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, err
 	// If you're making a large number of POST, PATCH, PUT, or DELETE requests
 	// for a single user or client ID, wait at least one second between each request.
 	if rlt.delayNextRequest {
-		logging.Debug("Sleeping %s between write operations", writeDelay)
-		time.Sleep(writeDelay)
+		delay := multiplier * writeDelay
+		logging.Debug("Sleeping %s between write operations", delay)
+		time.Sleep(delay)
 	}
 
 	rlt.delayNextRequest = isWriteMethod(req.Method)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1174" title="DX-1174" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1174</a>  GitHub API still rate limiting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This parameter can be tuned, but start here.

The default wait interval is based on an assumption of only one job hitting the GitHub API at a time. As soon as there are concurrent jobs, rate limiting is more probable.