### PR TITLE
Use goversioninfo to set icon for state-remote-installer

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -214,12 +214,13 @@ scripts:
       set -e
       $constants.SET_ENV
       TARGET=$BUILD_REMOTE_INSTALLER_TARGET
-      if [ "$GOOS" == "windows" ]; then
+      if [[ "$GOOS" == "windows" || "$OS" == "Windows_NT" ]]; then
         TARGET="${BUILD_REMOTE_INSTALLER_TARGET}.exe"
       fi
-      GOFLAGS="" go install github.com/akavel/rsrc@latest
-      rsrc -ico internal/assets/contents/icon.ico
-      go build -tags "$GO_BUILD_TAGS" -o $BUILD_TARGET_DIR/$TARGET ./cmd/state-remote-installer
+      GOFLAGS="" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
+      cd cmd/state-remote-installer
+      go generate
+      go build -tags "$GO_BUILD_TAGS" -o ../../$BUILD_TARGET_DIR/$TARGET .
   - name: build-updlg-all
     description: Invokes all build steps for the update dialog
     standalone: true

--- a/cmd/state-remote-installer/main_windows.go
+++ b/cmd/state-remote-installer/main_windows.go
@@ -1,0 +1,3 @@
+//go:generate goversioninfo
+
+package main

--- a/cmd/state-remote-installer/versioninfo.json
+++ b/cmd/state-remote-installer/versioninfo.json
@@ -1,0 +1,43 @@
+{
+  "FixedFileInfo": {
+    "FileVersion": {
+      "Major": 0,
+      "Minor": 1,
+      "Patch": 0,
+      "Build": 0
+    },
+    "ProductVersion": {
+      "Major": 0,
+      "Minor": 1,
+      "Patch": 0,
+      "Build": 0
+    },
+    "FileFlagsMask": "3f",
+    "FileFlags ": "00",
+    "FileOS": "040004",
+    "FileType": "01",
+    "FileSubType": "00"
+  },
+  "StringFileInfo": {
+    "Comments": "",
+    "CompanyName": "ActiveState Software Inc.",
+    "FileDescription": "",
+    "FileVersion": "0.1.0",
+    "InternalName": "",
+    "LegalCopyright": "© ActiveState Software, Inc. 2022",
+    "LegalTrademarks": "ActiveState®",
+    "OriginalFilename": "",
+    "PrivateBuild": "",
+    "ProductName": "State Tool Remote Installer",
+    "ProductVersion": "0.1.0",
+    "SpecialBuild": ""
+  },
+  "VarFileInfo": {
+    "Translation": {
+      "LangID": "0409",
+      "CharsetID": "04B0"
+    }
+  },
+  "IconPath": "../../internal/assets/contents/icon.ico",
+  "ManifestPath": ""
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1211" title="DX-1211" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1211</a>  state-remote-installer icon is not working
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
