### PR TITLE
Don't mention `state activate` from `state use`

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1899,7 +1899,7 @@ err_project_namespace_missmatch:
 err_project_fromenv:
   other: Could not detect an appropriate project to use, please provide a valid path or namespace.
 err_local_project_not_checked_out:
-  other: "Cannot find the [ACTIONABLE]{{.V0}}[/RESET] project. Please either check it out using [ACTIONABLE]`state checkout`[/RESET] or reactivate it using [ACTIONABLE]`state activate`[/RESET]"
+  other: "Cannot find the [ACTIONABLE]{{.V0}}[/RESET] project. Please either check it out using [ACTIONABLE]`state checkout`[/RESET] or run this command again from the project directory."
 arg_state_shell_namespace_description:
   other: The namespace of the project you wish to start a shell/prompt for, or just the project name if previously used
 err_language_by_commit:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1215" title="DX-1215" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1215</a>  `state use` should not advocate `state activate`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
