### PR TITLE
Don't show message as part of JSON output

### DIFF
--- a/internal/runners/use/show.go
+++ b/internal/runners/use/show.go
@@ -21,14 +21,14 @@ func NewShow(prime primeable) *Show {
 }
 
 type outputFormat struct {
-	Message   string `locale:message,Message`
+	message   string `locale:message,Message`
 	Namespace string `locale:"namespace,Namespace"`
 	Path      string `locale:"path,Path"`
 }
 
 func (f *outputFormat) MarshalOutput(format output.Format) interface{} {
 	if format == output.PlainFormatName {
-		return f.Message
+		return f.message
 	}
 	return f
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1221" title="DX-1221" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1221</a>  `state use show --output json` should not include "Message"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
