### PR TITLE
Cleaning up global default should not care about project dir

### DIFF
--- a/internal/globaldefault/default.go
+++ b/internal/globaldefault/default.go
@@ -77,8 +77,8 @@ func SetupDefaultActivation(subshell subshell.SubShell, cfg DefaultConfigurer, r
 	}
 
 	target := target.NewProjectTarget(proj, storage.GlobalBinDir(), nil, target.TriggerActivate)
-	fw := executor.NewWithBinPath(target, BinDir())
-	if err := fw.Update(env, exes); err != nil {
+	fw := executor.NewWithBinPath(BinDir())
+	if err := fw.Update(target, env, exes); err != nil {
 		return locale.WrapError(err, "err_globaldefault_fw", "Could not set up forwarders")
 	}
 
@@ -99,20 +99,13 @@ func ResetDefaultActivation(subshell subshell.SubShell, cfg DefaultConfigurer) (
 		return false, nil // nothing to reset
 	}
 
-	proj, err := project.FromPath(projectDir)
-	if err != nil {
-		return false, locale.WrapError(err, "err_globaldefault_get_proj", "Could not get default project.")
-	}
-
-	target := target.NewProjectTarget(proj, storage.GlobalBinDir(), nil, target.TriggerActivate)
-	fw := executor.NewWithBinPath(target, BinDir())
-	err = fw.Cleanup()
-	if err != nil {
+	fw := executor.NewWithBinPath(BinDir())
+	if err := fw.Cleanup(); err != nil {
 		return false, locale.WrapError(err, "err_globaldefault_fw_cleanup", "Could not clean up forwarders")
 	}
 
 	envUpdates := map[string]string{}
-	err = subshell.WriteUserEnv(cfg, envUpdates, sscommon.DefaultID, true)
+	err := subshell.WriteUserEnv(cfg, envUpdates, sscommon.DefaultID, true)
 	if err != nil {
 		return false, locale.WrapError(err, "err_globaldefault_update_env")
 	}

--- a/pkg/platform/runtime/executor/executor.go
+++ b/pkg/platform/runtime/executor/executor.go
@@ -44,27 +44,26 @@ type Targeter interface {
 }
 
 type Executor struct {
-	targeter     Targeter
 	executorPath string // The location to store the executors
 }
 
-func New(targeter Targeter) (*Executor, error) {
+func New() (*Executor, error) {
 	binPath, err := ioutil.TempDir("", "executor")
 	if err != nil {
 		return nil, errs.New("Could not create tempDir: %v", err)
 	}
-	return NewWithBinPath(targeter, binPath), nil
+	return NewWithBinPath(binPath), nil
 }
 
-func NewWithBinPath(targeter Targeter, executorPath string) *Executor {
-	return &Executor{targeter, executorPath}
+func NewWithBinPath(executorPath string) *Executor {
+	return &Executor{executorPath}
 }
 
 func (f *Executor) BinPath() string {
 	return f.executorPath
 }
 
-func (f *Executor) Update(env map[string]string, exes envdef.ExecutablePaths) error {
+func (f *Executor) Update(targeter Targeter, env map[string]string, exes envdef.ExecutablePaths) error {
 	logging.Debug("Creating executors at %s, exes: %v", f.executorPath, exes)
 
 	// We need to cover the use case of someone running perl.exe/python.exe
@@ -84,7 +83,7 @@ func (f *Executor) Update(env map[string]string, exes envdef.ExecutablePaths) er
 
 	sockPath := svcctl.NewIPCSockPathFromGlobals().String()
 	for _, exe := range exes {
-		if err := f.createExecutor(sockPath, env, exe); err != nil {
+		if err := f.createExecutor(targeter, sockPath, env, exe); err != nil {
 			return locale.WrapError(err, "err_createexecutor", "Could not create executor for {{.V0}}.", exe)
 		}
 	}
@@ -124,7 +123,7 @@ func (f *Executor) Cleanup() error {
 	return nil
 }
 
-func (f *Executor) createExecutor(sockPath string, env map[string]string, exe string) error {
+func (f *Executor) createExecutor(targeter Targeter, sockPath string, env map[string]string, exe string) error {
 	name := NameForExe(filepath.Base(exe))
 	target := filepath.Clean(filepath.Join(f.executorPath, name))
 
@@ -166,9 +165,9 @@ func (f *Executor) createExecutor(sockPath string, env map[string]string, exe st
 		"targetFile": exe,
 		"denote":     []string{executorDenoter, denoteTarget},
 		"Env":        env,
-		"commitID":   f.targeter.CommitUUID().String(),
-		"nameSpace":  project.NewNamespace(f.targeter.Owner(), f.targeter.Name(), f.targeter.CommitUUID().String()).String(),
-		"headless":   fmt.Sprintf("%t", f.targeter.Headless()),
+		"commitID":   targeter.CommitUUID().String(),
+		"nameSpace":  project.NewNamespace(targeter.Owner(), targeter.Name(), targeter.CommitUUID().String()).String(),
+		"headless":   fmt.Sprintf("%t", targeter.Headless()),
 	}
 	boxFile := "executor.sh"
 	if rt.GOOS == "windows" {

--- a/pkg/platform/runtime/executor/executor_test.go
+++ b/pkg/platform/runtime/executor/executor_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestExecutor(t *testing.T) {
 	target := target.NewCustomTarget("owner", "project", "1234abcd-1234-abcd-1234-abcd1234abcd", "dummy/path", target.NewExecTrigger("test"), false)
-	fw, err := New(target)
+	fw, err := New()
 	require.NoError(t, err, errs.Join(err, ": "))
 
 	exePath := "/i/am/an/exe/"
@@ -23,7 +23,7 @@ func TestExecutor(t *testing.T) {
 	env := map[string]string{"PATH": "exePath"}
 
 	t.Run("Create executors", func(t *testing.T) {
-		err = fw.Update(env, exes)
+		err = fw.Update(target, env, exes)
 		require.NoError(t, err, errs.Join(err, ": "))
 	})
 

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -266,8 +266,8 @@ func (s *Setup) updateExecutors(artifacts []artifact.ArtifactID) error {
 		return locale.WrapError(err, "err_setup_get_runtime_env", "Could not retrieve runtime environment")
 	}
 
-	exec := executor.NewWithBinPath(s.target, execPath)
-	if err := exec.Update(env, exePaths); err != nil {
+	exec := executor.NewWithBinPath(execPath)
+	if err := exec.Update(s.target, env, exePaths); err != nil {
 		return locale.WrapError(err, "err_deploy_executors", "Could not create executors")
 	}
 

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -46,7 +46,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckout() {
 		e2e.WithArgs("--version"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Python 3.6.6")
+	cp.Expect("Python 3")
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -37,7 +37,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.WithArgs("use", "ActiveState-CLI/Python3"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project Python3")
+	cp.Expect("Switched to project")
 	cp.ExpectExitCode(0)
 
 	// Verify runtime works.
@@ -50,7 +50,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.WithArgs("--version"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Python 3.6.6")
+	cp.Expect("Python 3")
 	cp.ExpectExitCode(0)
 
 	// Checkout another project.
@@ -66,7 +66,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.WithArgs("use", "ActiveState-CLI/Python-3.9"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project Python-3.9")
+	cp.Expect("Switched to project")
 	cp.ExpectExitCode(0)
 
 	// Verify the new runtime works.
@@ -75,7 +75,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.WithArgs("--version"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Python 3.9.10")
+	cp.Expect("Python 3")
 	cp.ExpectExitCode(0)
 
 	// Switch back using just the project name.
@@ -83,7 +83,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.WithArgs("use", "Python3"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project Python3")
+	cp.Expect("Switched to project")
 	cp.ExpectExitCode(0)
 
 	// Verify the first runtime is set up correctly and usable.
@@ -92,7 +92,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.WithArgs("--version"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Python 3.6.6")
+	cp.Expect("Python 3")
 	cp.ExpectExitCode(0)
 
 	// Test failure switching to project name that was not checked out.
@@ -121,7 +121,7 @@ func (suite *UseIntegrationTestSuite) TestReset() {
 		e2e.WithArgs("use", "ActiveState-CLI/Python3"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project Python3")
+	cp.Expect("Switched to project")
 	cp.ExpectExitCode(0)
 
 	python3Exe := filepath.Join(ts.Dirs.DefaultBin, "python3"+osutils.ExeExt)
@@ -181,7 +181,7 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 		e2e.WithArgs("use", "ActiveState-CLI/Python3"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project Python3")
+	cp.Expect("Switched to project")
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "show"))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1236" title="DX-1236" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1236</a>  USE: `state use reset` failed to reset if the project it pointed to was deleted.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
