### PR TITLE
Handle `state clean uninstall -n` correctly and report abortion of uninstall process

### DIFF
--- a/cmd/state/internal/cmdtree/clean.go
+++ b/cmd/state/internal/cmdtree/clean.go
@@ -22,7 +22,7 @@ func newCleanCommand(prime *primer.Values) *captain.Command {
 	).SetGroup(UtilsGroup)
 }
 
-func newCleanUninstallCommand(prime *primer.Values) *captain.Command {
+func newCleanUninstallCommand(prime *primer.Values, globals *globalOptions) *captain.Command {
 	params := clean.UninstallParams{}
 	return captain.NewCommand(
 		"uninstall",
@@ -44,6 +44,7 @@ func newCleanUninstallCommand(prime *primer.Values) *captain.Command {
 				return err
 			}
 
+			params.NonInteractive = globals.NonInteractive // distinct from --force
 			return runner.Run(&params)
 		},
 	)

--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -66,7 +66,7 @@ func New(prime *primer.Values, args ...string) *CmdTree {
 
 	cleanCmd := newCleanCommand(prime)
 	cleanCmd.AddChildren(
-		newCleanUninstallCommand(prime),
+		newCleanUninstallCommand(prime, globals),
 		newCleanCacheCommand(prime, globals),
 		newCleanConfigCommand(prime),
 	)

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -187,7 +187,7 @@ tos_disclaimer:
       {{.V0}}
 tos_disclaimer_prompt:
   other: |
-    
+
     By continuing you accept the Terms of Service. Continue?
 tos_acceptance:
   other: Do you accept the ActiveState Platform Terms of Service?
@@ -1359,7 +1359,7 @@ cache_description:
 config_description:
   other: Removes global State Tool configuration. Project configuration will not be affected.
 flag_state_clean_uninstall_force_description:
-  other: Run uninstall operation without prompts
+  other: Run uninstall operation without prompts and ignoring any errors stopping running services
 flag_state_clean_ignore_errors_description:
   other: Does not stop when an error occurs, removing as much as possible
 flag_state_clean_cache_force_description:

--- a/internal/runners/clean/uninstall.go
+++ b/internal/runners/clean/uninstall.go
@@ -28,7 +28,8 @@ type Uninstall struct {
 }
 
 type UninstallParams struct {
-	Force bool
+	Force          bool
+	NonInteractive bool
 }
 
 type primeable interface {
@@ -59,12 +60,13 @@ func (u *Uninstall) Run(params *UninstallParams) error {
 	}
 
 	if !params.Force {
-		ok, err := u.confirm.Confirm(locale.T("confirm"), locale.T("uninstall_confirm"), new(bool))
+		defaultChoice := params.NonInteractive
+		ok, err := u.confirm.Confirm(locale.T("confirm"), locale.T("uninstall_confirm"), &defaultChoice)
 		if err != nil {
-			return err
+			return locale.WrapError(err, "err_uninstall_confirm", "Could not confirm uninstall choice")
 		}
 		if !ok {
-			return nil
+			return locale.NewInputError("err_uninstall_aborted", "Uninstall aborted by user")
 		}
 	}
 

--- a/internal/runners/clean/uninstall_test.go
+++ b/internal/runners/clean/uninstall_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ActiveState/cli/internal/analytics/client/blackhole"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/testhelpers/outputhelper"
 )
@@ -57,7 +58,8 @@ func (suite *CleanTestSuite) TestUninstall_PromptNo() {
 	runner, err := newUninstall(&outputhelper.TestOutputer{}, &confirmMock{}, newConfigMock(suite.T(), suite.cachePath, suite.configPath), nil, blackhole.New())
 	suite.Require().NoError(err)
 	err = runner.Run(&UninstallParams{})
-	suite.Require().NoError(err)
+	suite.Require().Error(err)
+	suite.Require().True(locale.IsInputError(err), "non-confirmed uninstall should return an error, not silently halt")
 
 	suite.Require().DirExists(suite.configPath)
 	suite.Require().DirExists(suite.cachePath)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1196" title="DX-1196" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1196</a>  UNINSTALL: `state clean uninstall -n` not uninstalling ST and have one row message print that confuse users.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
