### PR TITLE
Attempt to prevent panic caused by reusing an already completed progressbar

### DIFF
--- a/pkg/platform/runtime/setup/events/consumer.go
+++ b/pkg/platform/runtime/setup/events/consumer.go
@@ -150,6 +150,10 @@ func (eh *RuntimeEventConsumer) handleArtifactEvent(ev ArtifactSetupEventer) err
 		return eh.handleBuildArtifactEvent(ev)
 	}
 	artifactName := eh.ResolveArtifactName(ev.ArtifactID())
+	if eh.installationCompleted {
+		multilog.Error("Received an artifact event after installation was completed: %s (step=%s, artifact=%s)", ev.String(), ev.Step().String(), artifactName)
+		return nil
+	}
 	switch t := ev.(type) {
 	case ArtifactStartEvent:
 		// first download event starts the installation process
@@ -173,6 +177,7 @@ func (eh *RuntimeEventConsumer) handleArtifactEvent(ev ArtifactSetupEventer) err
 				return err
 			}
 			if eh.numInstallCompleted == eh.installTotal {
+				eh.installationCompleted = true
 				err := eh.progress.InstallationCompleted(eh.numInstallFailures > 0)
 				if err != nil {
 					return err


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1187" title="DX-1187" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1187</a>  CHECKOUT: panic error just after successful checkout - `panic: *mpb.Progress instance can't be reused after it's done!`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The screenshot and traceback seems to indicate an ArtifactStartEvent was received after an ArtifactCompleteEvent that completed installation.

This is not actually a user-facing error, since the runtime setup completes successfully. It's just that the reporting of it is possibly erroneous. Log it as an error instead of returning one. The primary objective is to prevent a Go panic.