### PR TITLE
`state use show` shows a better error message if the default project has been deleted

### DIFF
--- a/internal/runners/use/show.go
+++ b/internal/runners/use/show.go
@@ -3,9 +3,11 @@ package use
 import (
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
-	"github.com/ActiveState/cli/internal/runbits/findproject"
+	"github.com/ActiveState/cli/pkg/project"
+	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
 type Show struct {
@@ -39,9 +41,9 @@ func (s *Show) Run() error {
 		return locale.NewInputError("err_use_show_no_default_project", "No default project is set.")
 	}
 
-	proj, err := findproject.FromPath(projectDir, nil)
+	proj, err := project.FromPath(projectDir)
 	if err != nil {
-		if findproject.IsLocalProjectDoesNotExistError(err) {
+		if errs.Matches(err, &projectfile.ErrorNoProject{}) {
 			return locale.WrapError(err,
 				"err_use_show_default_project_does_not_exist",
 				"The default project no longer exists. Please either check it out again or run [ACTIONABLE]state use reset[/RESET].")

--- a/internal/runners/use/show.go
+++ b/internal/runners/use/show.go
@@ -46,7 +46,7 @@ func (s *Show) Run() error {
 		if errs.Matches(err, &projectfile.ErrorNoProject{}) {
 			return locale.WrapError(err,
 				"err_use_show_default_project_does_not_exist",
-				"The default project no longer exists. Please either check it out again or run [ACTIONABLE]state use reset[/RESET].")
+				"The default project no longer exists. Please either check it out again with [ACTIONABLE]state checkout[/RESET] or run [ACTIONABLE]state use reset[/RESET] to unset your default project.")
 		}
 		return locale.WrapError(err, "err_use_show_get_project", "Could not get default project.")
 	}

--- a/internal/runners/use/show.go
+++ b/internal/runners/use/show.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
-	"github.com/ActiveState/cli/pkg/project"
+	"github.com/ActiveState/cli/internal/runbits/findproject"
 )
 
 type Show struct {
@@ -39,8 +39,13 @@ func (s *Show) Run() error {
 		return locale.NewInputError("err_use_show_no_default_project", "No default project is set.")
 	}
 
-	proj, err := project.FromPath(projectDir)
+	proj, err := findproject.FromPath(projectDir, nil)
 	if err != nil {
+		if findproject.IsLocalProjectDoesNotExistError(err) {
+			return locale.WrapError(err,
+				"err_use_show_default_project_does_not_exist",
+				"The default project no longer exists. Please either check it out again or run [ACTIONABLE]state use reset[/RESET].")
+		}
 		return locale.WrapError(err, "err_use_show_get_project", "Could not get default project.")
 	}
 

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -196,6 +197,13 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 		cp.ExpectLongString(longPath)
 	}
 	cp.ExpectExitCode(0)
+
+	err := os.RemoveAll(projectDir)
+	suite.Require().NoError(err)
+
+	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "show"))
+	cp.ExpectLongString("The default project no longer exists")
+	cp.ExpectExitCode(1)
 
 	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "reset", "--non-interactive"))
 	cp.Expect("Reset")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1237" title="DX-1237" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1237</a>  USE: `state use show` failed to show info if the project it pointed to was deleted.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
