### PR TITLE
`state use` should use the working project if no namespace is given.

### DIFF
--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -23,7 +23,6 @@ func newUseCommand(prime *primer.Values) *captain.Command {
 			{
 				Name:        locale.T("arg_state_use_namespace"),
 				Description: locale.T("arg_state_use_namespace_description"),
-				Required:    true,
 				Value:       params.Namespace,
 			},
 		},

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -105,6 +105,39 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 	cp.ExpectExitCode(1)
 }
 
+func (suite *UseIntegrationTestSuite) TestUseCwd() {
+	suite.OnlyRunForTags(tagsuite.Use)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	pythonDir := filepath.Join(ts.Dirs.Work, "MyPython3")
+
+	cp := ts.SpawnWithOpts(
+		e2e.WithArgs("checkout", "ActiveState-CLI/Python3", pythonDir),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
+	cp.Expect("Checked out project")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("use"),
+		e2e.WithWorkDirectory(pythonDir),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
+	cp.Expect("Switched to project")
+	cp.ExpectExitCode(0)
+
+	emptyDir := filepath.Join(ts.Dirs.Work, "EmptyDir")
+	suite.Require().NoError(fileutils.Mkdir(emptyDir))
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("use"),
+		e2e.WithWorkDirectory(emptyDir),
+	)
+	cp.Expect("Unable to use project")
+	cp.ExpectExitCode(1)
+}
+
 func (suite *UseIntegrationTestSuite) TestReset() {
 	suite.OnlyRunForTags(tagsuite.Use)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1244" title="DX-1244" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1244</a>  `state use` should be able to use CWD if no namespace given
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
