### PR TITLE
Rebase PYTHONPATH on ${INSTALLDIR} for Camel builds.

### DIFF
--- a/pkg/platform/runtime/setup/implementations/camel/prepare_mac.go
+++ b/pkg/platform/runtime/setup/implementations/camel/prepare_mac.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package camel
@@ -7,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -55,7 +57,7 @@ func (m *MetaData) Prepare(installRoot string) error {
 	if pythonpath, ok := os.LookupEnv("PYTHONPATH"); ok {
 		m.PathListEnv["PYTHONPATH"] = pythonpath
 	} else if fileutils.DirExists(sitePackages) {
-		m.PathListEnv["PYTHONPATH"] = sitePackages
+		m.PathListEnv["PYTHONPATH"] = strings.Replace(sitePackages, installRoot, "${INSTALLDIR}", 1)
 	}
 
 	if m.TargetedRelocations == nil {

--- a/pkg/platform/runtime/setup/implementations/camel/prepare_mac.go
+++ b/pkg/platform/runtime/setup/implementations/camel/prepare_mac.go
@@ -57,7 +57,10 @@ func (m *MetaData) Prepare(installRoot string) error {
 	if pythonpath, ok := os.LookupEnv("PYTHONPATH"); ok {
 		m.PathListEnv["PYTHONPATH"] = pythonpath
 	} else if fileutils.DirExists(sitePackages) {
-		m.PathListEnv["PYTHONPATH"] = strings.Replace(sitePackages, installRoot, "${INSTALLDIR}", 1)
+		if strings.HasPrefix(sitePackages, installRoot) {
+			sitePackages = strings.Replace(sitePackages, installRoot, "${INSTALLDIR}", 1)
+		}
+		m.PathListEnv["PYTHONPATH"] = sitePackages
 	}
 
 	if m.TargetedRelocations == nil {

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -221,6 +221,26 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_PythonPath() {
 	// ensure that shell is functional
 	cp.WaitForInput()
 
+	// Verify that PYTHONPATH is set correctly to the installed site-packages, not a temp runtime
+	// setup directory.
+	if runtime.GOOS == "windows" {
+		cp.Send("echo %PYTHONPATH%")
+	} else {
+		cp.Send("echo $PYTHONPATH")
+	}
+	suite.Assert().NotContains(cp.TrimmedSnapshot(), constants.LocalRuntimeTempDirectory)
+	// Verify the temp runtime setup directory has been removed.
+	runtimeFound := false
+	entries, err := fileutils.ListDir(ts.Dirs.Cache, true)
+	suite.Require().NoError(err)
+	for _, entry := range entries {
+		if entry.IsDir() && fileutils.DirExists(filepath.Join(entry.Path(), constants.LocalRuntimeEnvironmentDirectory)) {
+			runtimeFound = true
+			suite.Assert().NoDirExists(filepath.Join(entry.Path(), constants.LocalRuntimeTempDirectory))
+		}
+	}
+	suite.Assert().True(runtimeFound, "runtime directory was not found in ts.Dirs.Cache")
+
 	// test that PYTHONPATH is preserved in environment (https://www.pivotaltracker.com/story/show/178458102)
 	if runtime.GOOS == "windows" {
 		cp.Send("set PYTHONPATH=/custom_pythonpath")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1179" title="DX-1179" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1179</a>  PYTHONPATH is set up with _runtime_temp directory
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It will be expanded later, like other env vars and file transformations.