### PR TITLE
Show a "default project no longer exists" error message for state shell too when applicable

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1896,6 +1896,8 @@ arg_state_use_namespace_description:
   other: The org/project namespace of the project that you wish to use, or just the project name if previously used
 err_use_commit_id_mismatch:
   other: "Cannot switch to the given commit ID. Please use [ACTIONABLE]`state checkout`[/RESET] to check out a specific commit ID and then try again."
+err_use_default_project_does_not_exist:
+  other: "The default project no longer exists. Please either check it out again with [ACTIONABLE]state checkout[/RESET] or run [ACTIONABLE]state use reset[/RESET] to unset your default project."
 err_shell_commit_id_mismatch:
   other: "Cannot start a shell/prompt for the given commit ID. Please use [ACTIONABLE]`state checkout`[/RESET] to check out a specific commit ID and then try again."
 err_shell_cannot_load_project:

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
@@ -18,6 +19,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
 	"github.com/ActiveState/cli/pkg/platform/runtime/target"
 	"github.com/ActiveState/cli/pkg/project"
+	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
 type Params struct {
@@ -62,6 +64,9 @@ func (u *Shell) Run(params *Params) error {
 
 	proj, err := findproject.FromInputByPriority("", params.Namespace, u.config, u.prompt)
 	if err != nil {
+		if errs.Matches(err, &projectfile.ErrorNoProject{}) {
+			return locale.WrapError(err, "err_use_default_project_does_not_exist")
+		}
 		return locale.WrapError(err, "err_shell_cannot_load_project")
 	}
 

--- a/internal/runners/use/show.go
+++ b/internal/runners/use/show.go
@@ -44,9 +44,7 @@ func (s *Show) Run() error {
 	proj, err := project.FromPath(projectDir)
 	if err != nil {
 		if errs.Matches(err, &projectfile.ErrorNoProject{}) {
-			return locale.WrapError(err,
-				"err_use_show_default_project_does_not_exist",
-				"The default project no longer exists. Please either check it out again with [ACTIONABLE]state checkout[/RESET] or run [ACTIONABLE]state use reset[/RESET] to unset your default project.")
+			return locale.WrapError(err, "err_use_default_project_does_not_exist")
 		}
 		return locale.WrapError(err, "err_use_show_get_project", "Could not get default project.")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1252" title="DX-1252" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1252</a>  SHELL: When project that set as default deleted `state shell` execution should have this as a possible reason for failing.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
