### PR TITLE
async.EventWithLabel should be run as a goroutine.

### DIFF
--- a/internal/analytics/client/async/client.go
+++ b/internal/analytics/client/async/client.go
@@ -75,10 +75,12 @@ func (a *Client) Event(category string, action string, dims ...*dimensions.Value
 
 // EventWithLabel logs an event with a label to google analytics
 func (a *Client) EventWithLabel(category string, action string, label string, dims ...*dimensions.Values) {
-	err := a.sendEvent(category, action, label, dims...)
-	if err != nil {
-		multilog.Error("Error during analytics.sendEvent: %v", errs.Join(err, ":"))
-	}
+	go func() {
+		err := a.sendEvent(category, action, label, dims...)
+		if err != nil {
+			multilog.Error("Error during analytics.sendEvent: %v", errs.Join(err, ":"))
+		}
+	}()
 }
 
 // Wait can be called to ensure that all events have been processed


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1170" title="DX-1170" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1170</a>  Noticing slowdown at "Setting config: projects"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
sendEvent blocks while sending analytics, but async.EventWithLabel does not care about the return value, so run sendEvent within a goroutine.