### PR TITLE
BE-1554 Fix some pip shim issues

### DIFF
--- a/internal/assets/contents/activestate.yaml.python.tpl
+++ b/internal/assets/contents/activestate.yaml.python.tpl
@@ -20,18 +20,27 @@ scripts:
         env = os.environ.copy()
         env["ACTIVESTATE_SHIM"] = "pip"
 
+        project_path = os.path.join(r"${project.path()}", "activestate.yaml")
+
+        def configure_message():
+            print("To configure this shim edit the following file:\n" + project_path + "\n")
+
         def mapcmds(mapping):
             for fromCmd, toCmd in mapping.items():
+                if len(sys.argv) == 1:
+                    print("pip requires an argument. Try:\n pip [install, uninstall, list, show, search, help]")
+                    sys.exit()
                 if sys.argv[1] != fromCmd:
                     continue
 
-                print(("Shimming command to 'state %s', to configure this shim edit the following file:\n" +
-                       "${project.path()}/activestate.yaml\n") % toCmd)
+                print(("Shimming command to: 'state %s'") % toCmd)
+                configure_message()
 
                 code = subprocess.call(["state", toCmd] + sys.argv[2:], env=env)
                 sys.exit(code)
 
         mapcmds({
+            "help": "help",
             "install": "install",
             "uninstall": "uninstall",
             "list": "packages",
@@ -39,10 +48,9 @@ scripts:
             "search": "search",
         })
 
-        print("Could not shim your command as it is not supported by the State Tool.\nPlease check 'state --help' to find " +
-              "the best analog for the command you're trying to run.\n" +
-              "To configure this shim edit the following file:\n${project.path()}/activestate.yaml\n")
-
+        print("Could not shim your command as it is not supported by the State Tool.\n" + 
+              "Please check 'state --help' to find the best analog for the command you're trying to run.\n")
+        configure_message()
 
 events:
   # This is the ACTIVATE event, it will run whenever a new virtual environment is created (eg. by running `state activate`)


### PR DESCRIPTION
Add a check to see if an argument has been passed to pip and
display a help message with possible arguments.
Add Help to the list of pip arguments.
Fix the path that is displayed in the configure message. Use raw
data to deal with unicode issue when translating displayed path
for windows.  Use os.path.join for universal path separators.