### PR TITLE
Add more context to error message

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1976,6 +1976,13 @@ svcctl_wait_timeout:
     Please try running your command again.
 
     If this problem persists please report it on our forums: [ACTIONABLE]{{.V2}}[/RESET]
+svcctl_file_not_found:
+  other: |
+    Could not find the State Tool service executable.
+
+    Please try running your command again.
+
+    If this problem persists please reinstall the State Tool.
 err_autostart_app:
   other: Could not create new autostart app
 install_remote_title:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1982,7 +1982,7 @@ svcctl_file_not_found:
 
     Please try running your command again.
 
-    If this problem persists please reinstall the State Tool.
+    If this problem persists please report it on our forums: [ACTIONABLE]{{.V0}}[/RESET]
 err_autostart_app:
   other: Could not create new autostart app
 install_remote_title:

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -141,7 +141,7 @@ func startAndWait(ctx context.Context, ipComm IPCommunicator, exec, argText stri
 	defer profile.Measure("svcmanager:Start", time.Now())
 
 	if !fileutils.FileExists(exec) {
-		return locale.NewError("svcctl_file_not_found")
+		return locale.NewError("svcctl_file_not_found", constants.ForumsURL)
 	}
 
 	args := []string{"foreground", argText}

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -141,7 +141,7 @@ func startAndWait(ctx context.Context, ipComm IPCommunicator, exec, argText stri
 	defer profile.Measure("svcmanager:Start", time.Now())
 
 	if !fileutils.FileExists(exec) {
-		return locale.NewError("svcctl_file_not_found", "Service executable not found")
+		return locale.NewError("svcctl_file_not_found")
 	}
 
 	args := []string{"foreground", argText}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1204" title="DX-1204" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1204</a>  Rollbar: Could not start service
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The other rollbar errors related to `Unable to start service` are mostly due to a restrive environment preventing the service to start.