### PR TITLE
Use the correct "List" verb instead of "Manage" for `state projects`

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -354,7 +354,7 @@ unknown_value:
 total:
   other: Total
 projects_description:
-  other: Manage your projects
+  other: List your projects
 projects_list_description:
   other: List your platform projects
 err_api_not_authenticated:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1262" title="DX-1262" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1262</a>  State help for projects uses the verb "manage" instead of "list"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
We only list projects, we don't manage them.