### PR TITLE
Use the correct verb "List" instead of "Manage" for `state packages`.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1065,7 +1065,7 @@ language_name_unknown:
 language_unknown_options:
   other: Unknown options
 package_cmd_description:
-  other: Manage packages used in your project
+  other: List packages used in your project
 users_plural:
   other: users
 package_install_cmd_description:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1263" title="DX-1263" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1263</a>  State help for packages uses the verb "manage" instead of "list"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
We only list packages, we don't manage them with this command.