### PR TITLE
Fixed typo in `state config set` help documentation.

### DIFF
--- a/cmd/state/internal/cmdtree/config.go
+++ b/cmd/state/internal/cmdtree/config.go
@@ -63,7 +63,7 @@ func newConfigSetCommand(prime *primer.Values) *captain.Command {
 			},
 			{
 				Name:        "value",
-				Description: locale.Tl("arg_config_set_value", "Config key"),
+				Description: locale.Tl("arg_config_set_value", "Config value"),
 				Required:    true,
 				Value:       &params.Value,
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1265" title="DX-1265" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1265</a>  `state config set --help` shows incorrect description for "<value>" argument
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
