### PR TITLE
Do not report to rollbar a failure to remove old installer files

### DIFF
--- a/cmd/state-installer/installer_windows.go
+++ b/cmd/state-installer/installer_windows.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 )
@@ -132,7 +131,7 @@ func removeOldExecutables(dir string) error {
 			logging.Debug("Deleting old file: %s", file.Name())
 			oldFile := filepath.Join(dir, file.Name())
 			if err := os.Remove(oldFile); err != nil {
-				multilog.Error("Failed to remove old executable: %s. Error: %s", oldFile, errs.JoinMessage(err))
+				logging.Debug("Failed to remove old executable: %s. Error: %s", oldFile, errs.JoinMessage(err))
 			}
 		}
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1270" title="DX-1270" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1270</a>  state-installer: Failed to remove old executable (reported many times per user)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Could be permission issues that are not our responsibility.