### PR TITLE
Do not report to rollbar the inability to fetch a process name.

### DIFF
--- a/internal/installmgr/stop.go
+++ b/internal/installmgr/stop.go
@@ -76,7 +76,7 @@ func stopSvc(installPath string) error {
 	for _, p := range procs {
 		n, err := p.Name()
 		if err != nil {
-			multilog.Error("Could not get process name: %v", err)
+			logging.Debug("Could not get process name: %v", err) // maybe we don't have permission
 			continue
 		}
 


### PR DESCRIPTION
Probably a permission issue that is not our responsibility.