### PR TITLE
Be smart about when to run the remote installer GitHub action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     name: Remote Installer
     timeout-minutes: 30
     runs-on: windows-2019
+    if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
     env:
       ACTIVESTATE_CLI_DISABLE_RUNTIME: true
       GOFLAGS: -mod=vendor
@@ -20,19 +21,6 @@ jobs:
 
     # === OS Specific Steps ===
     steps:
-      - # === Verify if needs to run ===
-        name: Verify if needs to run
-        shell: bash
-        run: |
-          if [[ "${{ github.event.ref_type }}" != "tag" ]]; then
-            echo "ref_type should be tag but is '${{ github.event.ref_type }}'"
-            exit 1
-          fi
-          if [[ "${{ github.event.ref }}" != release\/remote-installer* ]]; then
-            echo "ref should start with release/remote-installer but is '${{ github.event.ref }}'"
-            exit 1
-          fi
-
       - # Checkout Code
         name: Checkout code
         uses: actions/checkout@v2
@@ -70,14 +58,14 @@ jobs:
         run: |
           echo $MSI_CERT_BASE64 | base64 --decode > Cert.p12
           export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.11/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.16299.0/x86/:$PATH
-          
+
           GOOS=windows state run build-remote-installer
           signtool.exe sign -d "ActiveState State Tool Remote Installer" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-remote-installer.exe
           state run generate-remote-install-deployment windows amd64
-          
+
           GOOS=linux state run build-remote-installer
           state run generate-remote-install-deployment linux amd64
-          
+
           GOOS=darwin state run build-remote-installer
           state run generate-remote-install-deployment darwin amd64
         env:


### PR DESCRIPTION
Do not always run it and then error out when conditions are not satisfied.