### PR TITLE
Use "List" instead of "Manage" in remote project description.

### DIFF
--- a/cmd/state/internal/cmdtree/projects.go
+++ b/cmd/state/internal/cmdtree/projects.go
@@ -31,7 +31,7 @@ func newRemoteProjectsCommand(prime *primer.Values) *captain.Command {
 	return captain.NewCommand(
 		"remote",
 		locale.Tl("projects_remote_title", "Listing Remote Projects"),
-		locale.Tl("projects_remote_description", "Manage all projects, including ones you have not checked out locally"),
+		locale.Tl("projects_remote_description", "List all projects, including ones you have not checked out locally"),
 		prime,
 		[]*captain.Flag{},
 		[]*captain.Argument{},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1262" title="DX-1262" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1262</a>  State help for projects uses the verb "manage" instead of "list"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
All we do is list, not manage.