### PR TITLE
Fire initial runtime-use event from the state tool

### DIFF
--- a/cmd/state-svc/internal/rtwatcher/watcher.go
+++ b/cmd/state-svc/internal/rtwatcher/watcher.go
@@ -121,5 +121,4 @@ func (w *Watcher) Watch(pid int, exec string, dims *dimensions.Values) {
 	dims.Sequence = p.IntP(-1) // sequence is meaningless for heartbeat events
 	e := entry{pid, exec, dims}
 	w.watching = append(w.watching, e)
-	w.RecordUsage(e)
 }

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -202,6 +202,10 @@ func (r *Runtime) recordUsage() {
 		ProjectNameSpace: p.StrP(project.NewNamespace(r.target.Owner(), r.target.Name(), r.target.CommitUUID().String()).String()),
 		InstanceID:       p.StrP(instanceid.ID()),
 	}
+
+	// Fire initial runtime usage event right away, subsequent events will be fired via the service so long as the process is running
+	r.analytics.Event(anaConsts.CatRuntime, anaConsts.ActRuntimeHeartbeat, dims)
+
 	dimsJson, err := dims.Marshal()
 	if err != nil {
 		multilog.Critical("Could not marshal dimensions for runtime-usage: %s", errs.JoinMessage(err))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1290" title="DX-1290" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1290</a>  Our runtime fires the initial heartbeat from the runtime process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
