### PR TITLE
State shell show default project path on error

### DIFF
--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -1,10 +1,9 @@
 package shell
 
 import (
-	"errors"
-
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
@@ -65,7 +64,7 @@ func (u *Shell) Run(params *Params) error {
 
 	proj, err := findproject.FromInputByPriority("", params.Namespace, u.config, u.prompt)
 	if err != nil {
-		if errors.As(err, &projectfile.ErrorNoDefaultProject{}) {
+		if errs.Matches(err, &projectfile.ErrorNoDefaultProject{}) {
 			return locale.WrapError(err, "err_use_default_project_does_not_exist")
 		}
 		return locale.WrapError(err, "err_shell_cannot_load_project")

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -1,9 +1,10 @@
 package shell
 
 import (
+	"errors"
+
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
-	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
@@ -64,7 +65,7 @@ func (u *Shell) Run(params *Params) error {
 
 	proj, err := findproject.FromInputByPriority("", params.Namespace, u.config, u.prompt)
 	if err != nil {
-		if errs.Matches(err, &projectfile.ErrorNoProject{}) {
+		if errors.As(err, &projectfile.ErrorNoDefaultProject{}) {
 			return locale.WrapError(err, "err_use_default_project_does_not_exist")
 		}
 		return locale.WrapError(err, "err_shell_cannot_load_project")

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -835,7 +835,7 @@ func getProjectFilePathFromDefault() (_ string, rerr error) {
 		if !errors.Is(err, fileutils.ErrorFileNotFound) {
 			return "", errs.Wrap(err, "fileutils.FindFileInPath %s failed", defaultProjectPath)
 		}
-		return "", &ErrorNoDefaultProject{locale.NewInputError("err_no_default_project", "Could not find default project at: {{.V0}}", defaultProjectPath)}
+		return "", &ErrorNoDefaultProject{locale.NewInputError("err_no_default_project", "Could not find default project at: [ACTIONABLE]{{.V0}}[/RESET]", defaultProjectPath)}
 	}
 	return path, nil
 }

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -55,6 +55,8 @@ type ErrorNoProject struct{ *locale.LocalizedError }
 
 type ErrorNoProjectFromEnv struct{ *locale.LocalizedError }
 
+type ErrorNoDefaultProject struct{ *locale.LocalizedError }
+
 // projectURL comprises all fields of a parsed project URL
 type projectURL struct {
 	Owner      string
@@ -829,8 +831,11 @@ func getProjectFilePathFromDefault() (_ string, rerr error) {
 	}
 
 	path, err := fileutils.FindFileInPath(defaultProjectPath, constants.ConfigFileName)
-	if err != nil && !errors.Is(err, fileutils.ErrorFileNotFound) {
-		return "", errs.Wrap(err, "fileutils.FindFileInPath %s failed", defaultProjectPath)
+	if err != nil {
+		if !errors.Is(err, fileutils.ErrorFileNotFound) {
+			return "", errs.Wrap(err, "fileutils.FindFileInPath %s failed", defaultProjectPath)
+		}
+		return "", ErrorNoDefaultProject{locale.NewInputError("err_no_default_project", "Could not find default project at: {{.V0}}", defaultProjectPath)}
 	}
 	return path, nil
 }

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -835,7 +835,7 @@ func getProjectFilePathFromDefault() (_ string, rerr error) {
 		if !errors.Is(err, fileutils.ErrorFileNotFound) {
 			return "", errs.Wrap(err, "fileutils.FindFileInPath %s failed", defaultProjectPath)
 		}
-		return "", ErrorNoDefaultProject{locale.NewInputError("err_no_default_project", "Could not find default project at: {{.V0}}", defaultProjectPath)}
+		return "", &ErrorNoDefaultProject{locale.NewInputError("err_no_default_project", "Could not find default project at: {{.V0}}", defaultProjectPath)}
 	}
 	return path, nil
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1254" title="DX-1254" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1254</a>  When applicable, display the org/project and path of a project not found
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
