### PR TITLE
Only sign release-build executables.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
       - # === Sign Binaries (Windows only) ===
         name: Sign Binaries (Windows only)
         shell: bash
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && contains(fromJSON('["ref/heads/release", "ref/heads/beta", "ref/heads/version/"]'), github.ref)
         run: |
           echo $MSI_CERT_BASE64 | base64 --decode > Cert.p12
           export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.11/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.16299.0/x86/:$PATH


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1300" title="DX-1300" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1300</a>  We should not sign executables in non-release builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
