### PR TITLE
Document --non-interactive flag.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -273,10 +273,11 @@ func newStateCommand(globals *globalOptions, prime *primer.Values) *captain.Comm
 				Value:       &opts.ConfirmExit,
 			},
 			{
-				Name:      "non-interactive", // Name and Shorthand should be kept in sync with cmd/state/output.go
-				Shorthand: "n",
-				Persist:   true,
-				Value:     &globals.NonInteractive,
+				Name:        "non-interactive", // Name and Shorthand should be kept in sync with cmd/state/output.go
+				Description: locale.T("flag_state_non_interactive_description"),
+				Shorthand:   "n",
+				Persist:     true,
+				Value:       &globals.NonInteractive,
 			},
 			{
 				Name:        "version",

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -31,6 +31,8 @@ flag_state_monochrome_output_description:
   other: Force monochrome text output
 flag_state_output_description:
   other: "Set the output method, possible values: plain, simple, json, editor"
+flag_state_non_interactive_description:
+  other: Run the State Tool without any prompts and accepting all default options
 flag_state_version_description:
   other: Show the version of our state executable
 flag_state_activate_path_description:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1277" title="DX-1277" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1277</a>  `-n, --non-interactive` is missing description in all commands
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
