### PR TITLE
Recognize ACTIVESTATE_HOME as fallback if HOME is not set

### DIFF
--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/cli/pkg/sysinfo"
@@ -158,7 +159,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 func (suite *InstallerIntegrationTestSuite) AssertConfig(ts *e2e.Session) {
 	if runtime.GOOS != "windows" {
 		// Test bashrc
-		homeDir, err := os.UserHomeDir()
+		homeDir, err := user.HomeDir()
 		suite.Require().NoError(err)
 
 		fname := ".bashrc"

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/machinebox/graphql v0.2.2
 	github.com/mash/go-tempfile-suffix v0.0.0-20150731093933-48f0f8a3a5ab
 	github.com/mattn/go-runewidth v0.0.13
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nicksnyder/go-i18n v1.10.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/phayes/permbits v0.0.0-20190108233746-1efae4548023
@@ -137,6 +136,7 @@ require (
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nwaples/rardecode v0.0.0-20171029023500-e06696f847ae // indirect

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -24,6 +24,9 @@ const ConfigFileName = "activestate.yaml"
 // InternalConfigNamespace holds the appdata folder name under which we store our config
 const InternalConfigNamespace = "activestate"
 
+// HomeEnvVarName is the fallback env var used to determine the user's home directory.
+const HomeEnvVarName = "ACTIVESTATE_HOME"
+
 // ConfigEnvVarName is the env var used to override the config dir that the State Tool uses
 const ConfigEnvVarName = "ACTIVESTATE_CLI_CONFIGDIR"
 

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -10,7 +10,6 @@ import (
 	"io/fs"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -823,16 +822,6 @@ func LogPath(path string) error {
 		}, "\n"))
 		return nil
 	})
-}
-
-// HomeDir returns the users homedir
-func HomeDir() (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-
-	return usr.HomeDir, nil
 }
 
 // IsDir returns true if the given path is a directory

--- a/internal/fileutils/fileutils_test.go
+++ b/internal/fileutils/fileutils_test.go
@@ -13,7 +13,8 @@ import (
 
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/stretchr/testify/assert"
+  "github.com/ActiveState/cli/internal/osutils/user"
+  "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thoas/go-funk"
 )
@@ -669,7 +670,7 @@ func TestIsWritableFile(t *testing.T) {
 }
 
 func TestIsWritableDir(t *testing.T) {
-	pathWithPermission, err := HomeDir()
+	pathWithPermission, err := user.HomeDir()
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/installation/paths_darwin.go
+++ b/internal/installation/paths_darwin.go
@@ -1,23 +1,22 @@
 package installation
 
 import (
-	"os/user"
 	"path/filepath"
 
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/mitchellh/go-homedir"
+	"github.com/ActiveState/cli/internal/osutils/user"
 )
 
 func InstallPathForBranch(branch string) (string, error) {
-	usr, err := user.Current()
+	home, err := user.HomeDir()
 	if err != nil {
-		return "", errs.Wrap(err, "Could not access info on current user")
+		return "", errs.Wrap(err, "Could not get home directory")
 	}
-	return filepath.Join(usr.HomeDir, ".local", "ActiveState", "StateTool", branch), nil
+	return filepath.Join(home, ".local", "ActiveState", "StateTool", branch), nil
 }
 
 func defaultSystemInstallPath() (string, error) {
-	home, err := homedir.Dir()
+	home, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}

--- a/internal/installation/paths_linux.go
+++ b/internal/installation/paths_linux.go
@@ -1,23 +1,22 @@
 package installation
 
 import (
-	"os/user"
 	"path/filepath"
 
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/mitchellh/go-homedir"
+	"github.com/ActiveState/cli/internal/osutils/user"
 )
 
 func InstallPathForBranch(branch string) (string, error) {
-	usr, err := user.Current()
+	home, err := user.HomeDir()
 	if err != nil {
-		return "", errs.Wrap(err, "Could not access info on current user")
+		return "", errs.Wrap(err, "Could not get home directory")
 	}
-	return filepath.Join(usr.HomeDir, ".local", "ActiveState", "StateTool", branch), nil
+	return filepath.Join(home, ".local", "ActiveState", "StateTool", branch), nil
 }
 
 func defaultSystemInstallPath() (string, error) {
-	home, err := homedir.Dir()
+	home, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -2009,3 +2009,8 @@ checkout_project_statement:
   other: Checked out project [ACTIONABLE]{{.V0}}[/RESET], located at [ACTIONABLE]{{.V1}}[/RESET].
 export_project_statement:
   other: Exporting env for project [ACTIONABLE]{{.V0}}[/RESET] located at [ACTIONABLE]{{.V1}}[/RESET].
+err_home_not_found:
+  other: |
+    Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.
+
+    This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.

--- a/internal/osutils/autostart/autostart_linux.go
+++ b/internal/osutils/autostart/autostart_linux.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/osutils/shortcut"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
-	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -168,7 +168,7 @@ func (a *app) IsEnabled() (bool, error) {
 }
 
 func prependHomeDir(path string) (string, error) {
-	homeDir, err := homedir.Dir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}

--- a/internal/osutils/autostart/autostart_mac.go
+++ b/internal/osutils/autostart/autostart_mac.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ActiveState/cli/internal/assets"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/strutils"
-	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -79,7 +79,7 @@ func (a *app) IsEnabled() (bool, error) {
 }
 
 func (a *app) InstallPath() (string, error) {
-	dir, err := homedir.Dir()
+	dir, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}

--- a/internal/osutils/user/user.go
+++ b/internal/osutils/user/user.go
@@ -1,0 +1,15 @@
+package user
+
+import (
+	"os"
+)
+
+// HomeDir returns the user's homedir
+func HomeDir() (string, error) {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return dir, nil
+}

--- a/internal/osutils/user/user.go
+++ b/internal/osutils/user/user.go
@@ -10,6 +10,7 @@ import (
 // from locale/errors.go because importing locale for NewInputError creates an import cycle.
 // Instead, return this error that looks like a LocalizedError.
 type HomeDirNotFoundError struct {
+	wrapped error
 }
 
 const homeDirNotFoundErrorMessage = "Could not proceed because your HOME environment variable is unset. " +
@@ -30,6 +31,10 @@ func (e *HomeDirNotFoundError) InputError() bool {
 	return true
 }
 
+func (e *HomeDirNotFoundError) Unwrap() error {
+	return e.wrapped
+}
+
 // HomeDir returns the user's homedir
 func HomeDir() (string, error) {
 	dir, err := os.UserHomeDir()
@@ -37,7 +42,7 @@ func HomeDir() (string, error) {
 		var exists bool
 		dir, exists = os.LookupEnv(constants.HomeEnvVarName)
 		if !exists {
-			return "", &HomeDirNotFoundError{}
+			return "", &HomeDirNotFoundError{err}
 		}
 	}
 	return dir, nil

--- a/internal/osutils/user/user.go
+++ b/internal/osutils/user/user.go
@@ -37,13 +37,12 @@ func (e *HomeDirNotFoundError) Unwrap() error {
 
 // HomeDir returns the user's homedir
 func HomeDir() (string, error) {
+	if dir := os.Getenv(constants.HomeEnvVarName); dir != "" {
+		return dir, nil
+	}
 	dir, err := os.UserHomeDir()
 	if err != nil {
-		var exists bool
-		dir, exists = os.LookupEnv(constants.HomeEnvVarName)
-		if !exists {
-			return "", &HomeDirNotFoundError{err}
-		}
+		return "", &HomeDirNotFoundError{err}
 	}
 	return dir, nil
 }

--- a/internal/osutils/user/user.go
+++ b/internal/osutils/user/user.go
@@ -2,14 +2,43 @@ package user
 
 import (
 	"os"
+
+	"github.com/ActiveState/cli/internal/constants"
 )
+
+// HomeDirNotFoundError is an error that implements the ErrorLocalier and ErrorInput interfaces
+// from locale/errors.go because importing locale for NewInputError creates an import cycle.
+// Instead, return this error that looks like a LocalizedError.
+type HomeDirNotFoundError struct {
+}
+
+const homeDirNotFoundErrorMessage = "Could not proceed because your HOME environment variable is unset. " +
+	"Please ensure that your HOME environment variable is set. " +
+	"Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable." +
+	"\n\n" +
+	"This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory."
+
+func (e *HomeDirNotFoundError) Error() string {
+	return homeDirNotFoundErrorMessage
+}
+
+func (e *HomeDirNotFoundError) UserError() string {
+	return homeDirNotFoundErrorMessage
+}
+
+func (e *HomeDirNotFoundError) InputError() bool {
+	return true
+}
 
 // HomeDir returns the user's homedir
 func HomeDir() (string, error) {
 	dir, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		var exists bool
+		dir, exists = os.LookupEnv(constants.HomeEnvVarName)
+		if !exists {
+			return "", &HomeDirNotFoundError{}
+		}
 	}
-
 	return dir, nil
 }

--- a/internal/osutils/user/user_test.go
+++ b/internal/osutils/user/user_test.go
@@ -1,0 +1,41 @@
+package user
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserHome(t *testing.T) {
+  // Fetch current home directory.
+	osHomeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+  // Verify user.HomeDir() returns the current home directory.
+	userHomeDir, err := HomeDir()
+	require.NoError(t, err)
+	assert.Equal(t, userHomeDir, osHomeDir)
+
+  // Verify ACTIVESTATE_HOME overrides current home directory.
+	os.Setenv(constants.HomeEnvVarName, "override")
+	userHomeDir, err = HomeDir()
+	require.NoError(t, err)
+	assert.Equal(t, userHomeDir, "override")
+	os.Unsetenv(constants.HomeEnvVarName)
+
+  // Verify lack of HOME and ACTIVESTATE_HOME shows nice error message.
+	if runtime.GOOS != "windows" {
+		os.Unsetenv("HOME")
+		defer func() { os.Setenv("HOME", osHomeDir) }()
+	} else {
+		os.Unsetenv("USERPROFILE")
+		defer func() { os.Setenv("USERPROFILE", osHomeDir) }()
+	}
+	userHomeDir, err = HomeDir()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HOME environment variable is unset")
+}

--- a/internal/osutils/user/user_test.go
+++ b/internal/osutils/user/user_test.go
@@ -11,23 +11,26 @@ import (
 )
 
 func TestUserHome(t *testing.T) {
-	// Fetch current home directory.
 	osHomeDir, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-	// Verify user.HomeDir() returns the current home directory.
 	userHomeDir, err := HomeDir()
 	require.NoError(t, err)
 	assert.Equal(t, userHomeDir, osHomeDir)
+}
 
-	// Verify ACTIVESTATE_HOME overrides current home directory.
+func TestActiveStateHome(t *testing.T) {
 	os.Setenv(constants.HomeEnvVarName, "override")
-	userHomeDir, err = HomeDir()
+	defer func() { os.Unsetenv(constants.HomeEnvVarName) }()
+	userHomeDir, err := HomeDir()
 	require.NoError(t, err)
 	assert.Equal(t, userHomeDir, "override")
-	os.Unsetenv(constants.HomeEnvVarName)
+}
 
-	// Verify lack of HOME and ACTIVESTATE_HOME shows nice error message.
+func TestNoHome(t *testing.T) {
+	osHomeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
 	if runtime.GOOS != "windows" {
 		os.Unsetenv("HOME")
 		defer func() { os.Setenv("HOME", osHomeDir) }()
@@ -35,7 +38,7 @@ func TestUserHome(t *testing.T) {
 		os.Unsetenv("USERPROFILE")
 		defer func() { os.Setenv("USERPROFILE", osHomeDir) }()
 	}
-	userHomeDir, err = HomeDir()
+	_, err = HomeDir()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "HOME environment variable is unset")
 }

--- a/internal/osutils/user/user_test.go
+++ b/internal/osutils/user/user_test.go
@@ -11,23 +11,23 @@ import (
 )
 
 func TestUserHome(t *testing.T) {
-  // Fetch current home directory.
+	// Fetch current home directory.
 	osHomeDir, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-  // Verify user.HomeDir() returns the current home directory.
+	// Verify user.HomeDir() returns the current home directory.
 	userHomeDir, err := HomeDir()
 	require.NoError(t, err)
 	assert.Equal(t, userHomeDir, osHomeDir)
 
-  // Verify ACTIVESTATE_HOME overrides current home directory.
+	// Verify ACTIVESTATE_HOME overrides current home directory.
 	os.Setenv(constants.HomeEnvVarName, "override")
 	userHomeDir, err = HomeDir()
 	require.NoError(t, err)
 	assert.Equal(t, userHomeDir, "override")
 	os.Unsetenv(constants.HomeEnvVarName)
 
-  // Verify lack of HOME and ACTIVESTATE_HOME shows nice error message.
+	// Verify lack of HOME and ACTIVESTATE_HOME shows nice error message.
 	if runtime.GOOS != "windows" {
 		os.Unsetenv("HOME")
 		defer func() { os.Setenv("HOME", osHomeDir) }()

--- a/internal/runners/prepare/prepare_linux.go
+++ b/internal/runners/prepare/prepare_linux.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/osutils/autostart"
-	"github.com/mitchellh/go-homedir"
+	"github.com/ActiveState/cli/internal/osutils/user"
 )
 
 func (r *Prepare) prepareOS() error {
@@ -62,7 +62,7 @@ func (r *Prepare) prepareOS() error {
 }
 
 func prependHomeDir(path string) (string, error) {
-	homeDir, err := homedir.Dir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}

--- a/internal/runners/tutorial/tutorial.go
+++ b/internal/runners/tutorial/tutorial.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ActiveState/cli/internal/language"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/runbits"
@@ -85,7 +86,7 @@ func (t *Tutorial) RunNewProject(params NewProjectParams) error {
 	}
 
 	// Prompt for project dir
-	homeDir, _ := fileutils.HomeDir()
+	homeDir, _ := user.HomeDir()
 	dir, err := t.prompt.Input("", locale.Tl(
 		"tutorial_prompt_projectdir",
 		"Where would you like your project directory to be mapped? This is usually the root of your repository, or the place where you have your project dotfiles."), &homeDir)

--- a/internal/scriptrun/test/integration/scriptrun_test.go
+++ b/internal/scriptrun/test/integration/scriptrun_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/language"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/testhelpers/osutil"
 	"github.com/ActiveState/cli/internal/testhelpers/outputhelper"
@@ -296,7 +297,7 @@ func (suite *ScriptRunSuite) TestPathProvidesLang() {
 
 	exec := language.Python3.Executable().Filename()
 
-	home, err := os.UserHomeDir()
+	home, err := user.HomeDir()
 	require.NoError(t, err)
 
 	paths := []string{temp, home}

--- a/internal/subshell/bash/bash.go
+++ b/internal/subshell/bash/bash.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/pkg/project"
@@ -106,7 +107,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 }
 
 func (v *SubShell) RcFile() (string, error) {
-	homeDir, err := fileutils.HomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "IO failure")
 	}

--- a/internal/subshell/fish/fish.go
+++ b/internal/subshell/fish/fish.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/pkg/project"
@@ -81,7 +82,7 @@ func (v *SubShell) RemoveLegacyInstallPath(cfg sscommon.Configurable) error {
 }
 
 func (v *SubShell) WriteCompletionScript(completionScript string) error {
-	homeDir, err := fileutils.HomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return errs.Wrap(err, "IO failure")
 	}
@@ -96,7 +97,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 }
 
 func (v *SubShell) RcFile() (string, error) {
-	homeDir, err := fileutils.HomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "IO failure")
 	}

--- a/internal/subshell/tcsh/tcsh.go
+++ b/internal/subshell/tcsh/tcsh.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/pkg/project"
@@ -84,7 +84,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 }
 
 func (v *SubShell) RcFile() (string, error) {
-	homeDir, err := fileutils.HomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "IO failure")
 	}

--- a/internal/subshell/zsh/zsh.go
+++ b/internal/subshell/zsh/zsh.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/pkg/project"
@@ -102,7 +102,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 		return errs.Wrap(err, "Could not write completions script")
 	}
 
-	homeDir, err := fileutils.HomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return errs.Wrap(err, "IO failure")
 	}
@@ -117,7 +117,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 }
 
 func (v *SubShell) RcFile() (string, error) {
-	homeDir, err := fileutils.HomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "IO failure")
 	}
@@ -169,11 +169,11 @@ func (v *SubShell) Activate(proj *project.Project, cfg sscommon.Configurable, ou
 		// commands.
 		userzdotdir := os.Getenv("ZDOTDIR")
 		if userzdotdir == "" {
-			u, err := user.Current()
+			homeDir, err := user.HomeDir()
 			if err != nil {
 				log.Println(locale.T("Warning: Could not load home directory for current user"))
 			} else {
-				userzdotdir = u.HomeDir
+				userzdotdir = homeDir
 			}
 		}
 

--- a/internal/uniqid/legacy.go
+++ b/internal/uniqid/legacy.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/ActiveState/cli/internal/osutils/user"
 )
 
 const legacyPersistDir = "activestate/persist"
@@ -42,7 +44,7 @@ func moveUniqidFile(destination string) error {
 }
 
 func legacyStorageDir() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := user.HomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot get home dir for uniqid file: %w", err)
 	}

--- a/internal/uniqid/uniqid.go
+++ b/internal/uniqid/uniqid.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/google/uuid"
 )
 
@@ -95,7 +96,7 @@ func storageDirectory(base BaseDirLocation) (string, error) {
 		dir = filepath.Join(os.TempDir(), persistDir)
 
 	default:
-		home, err := os.UserHomeDir()
+		home, err := user.HomeDir()
 		if err != nil {
 			return "", fmt.Errorf("cannot get home dir for uniqid file: %w", err)
 		}

--- a/pkg/cmdlets/checkout/path.go
+++ b/pkg/cmdlets/checkout/path.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/pkg/project"
 )
 
@@ -80,7 +81,7 @@ func getSafeWorkDir() (string, error) {
 		return dir, nil
 	}
 
-	dir, err = os.UserHomeDir()
+	dir, err = user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}

--- a/pkg/cmdlets/checkout/path.go
+++ b/pkg/cmdlets/checkout/path.go
@@ -3,15 +3,12 @@ package checkout
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/osutils"
-	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/pkg/project"
 )
 
@@ -69,22 +66,4 @@ func validatePath(ns *project.Namespaced, path string) error {
 	}
 
 	return nil
-}
-
-func getSafeWorkDir() (string, error) {
-	dir, err := osutils.Getwd()
-	if err != nil {
-		return "", errs.Wrap(err, "Could not get working directory")
-	}
-
-	if !strings.HasPrefix(strings.ToLower(dir), `c:\windows`) {
-		return dir, nil
-	}
-
-	dir, err = user.HomeDir()
-	if err != nil {
-		return "", errs.Wrap(err, "Could not get home directory")
-	}
-
-	return dir, nil
 }

--- a/test/integration/offinstall_int_test.go
+++ b/test/integration/offinstall_int_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ActiveState/cli/internal/exeutils"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/offinstall"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/subshell/cmd"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -249,7 +250,7 @@ func (suite *OffInstallIntegrationTestSuite) preparePayload(ts *e2e.Session) {
 func (suite *OffInstallIntegrationTestSuite) assertShellUpdated(dir string, exists bool, ts *e2e.Session) {
 	if runtime.GOOS != "windows" {
 		// Test bashrc
-		homeDir, err := os.UserHomeDir()
+		homeDir, err := user.HomeDir()
 		suite.Require().NoError(err)
 
 		fname := ".bashrc"

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/osutils/autostart"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/rtutils/singlethread"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -20,7 +21,6 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/runtime/executor"
 	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
 	rt "github.com/ActiveState/cli/pkg/platform/runtime/target"
-	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -62,7 +62,7 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 
 	// When installed in a non-desktop environment (i.e. on a server), verify the user's ~/.profile was amended.
 	if runtime.GOOS == "linux" {
-		homeDir, err := homedir.Dir()
+		homeDir, err := user.HomeDir()
 		suite.Require().NoError(err)
 		profile := filepath.Join(homeDir, ".profile")
 		profileContents := string(fileutils.ReadFileUnsafe(profile))
@@ -78,7 +78,7 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 
 	// When installed in a non-desktop environment (i.e. on a server), verify the user's ~/.profile was reverted.
 	if runtime.GOOS == "linux" {
-		homeDir, err := homedir.Dir()
+		homeDir, err := user.HomeDir()
 		suite.Require().NoError(err)
 		profile := filepath.Join(homeDir, ".profile")
 		profileContents := fileutils.ReadFileUnsafe(profile)

--- a/test/integration/uninstall_int_test.go
+++ b/test/integration/uninstall_int_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/osutils/user"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
-	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -70,7 +70,7 @@ func (suite *UninstallIntegrationTestSuite) TestUninstall() {
 
 	if runtime.GOOS == "linux" {
 		// When installed in a non-desktop environment (i.e. on a server), verify the user's ~/.profile was reverted.
-		homeDir, err := homedir.Dir()
+		homeDir, err := user.HomeDir()
 		suite.Require().NoError(err)
 		profile := filepath.Join(homeDir, ".profile")
 		suite.NotContains(string(fileutils.ReadFileUnsafe(profile)), ts.SvcExe, "autostart should not be configured for Linux server environment anymore")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1276" title="DX-1276" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1276</a>  When HOME is not set we error out and instruct the user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
If that still doesn't work, show an informative error to the user.

Also route all fetching of user's home directory through one function. It was previously obtained in 3 different ways.