### PR TITLE
Do not forward io.Writer errors to Rollbar.

### DIFF
--- a/internal/output/plain.go
+++ b/internal/output/plain.go
@@ -101,7 +101,7 @@ func (f *Plain) write(writer io.Writer, value interface{}) {
 func (f *Plain) writeNow(writer io.Writer, value string) {
 	_, err := colorize.Colorize(wordWrap(value), writer, !f.cfg.Colored)
 	if err != nil {
-		multilog.Log(logging.ErrorNoStacktrace, rollbar.Error)("Writing colored output failed: %v", err)
+		logging.ErrorNoStacktrace("Writing colored output failed: %v", err)
 	}
 }
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -11,7 +11,7 @@ import (
 // fdSupportsColors implements a heuristic checking whether a file descriptor supports colors
 func fdSupportsColors(fd int, lookupEnv func(string) (string, bool)) bool {
 	if runtime.GOOS == "windows" {
-		return true
+		return terminal.IsTerminal(fd)
 	}
 	termValue, ok := lookupEnv("TERM")
 	if !ok {
@@ -24,7 +24,6 @@ func fdSupportsColors(fd int, lookupEnv func(string) (string, bool)) bool {
 }
 
 // StdoutSupportsColors returns whether stdout supports color output
-// - It always returns true on Windows
 // - If the TERM variable is not set, or set to the "dumb" terminal, no color support
 //   is assumed.
 // - If stdout is not a terminal, color support is disabled


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1273" title="DX-1273" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1273</a>  state-installer []: Writing colored output failed: write /dev/stdout: The pipe is being closed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
