### PR TITLE
Make inability to stop state-svc when installing an input error (due …

### DIFF
--- a/internal/installmgr/stop.go
+++ b/internal/installmgr/stop.go
@@ -143,7 +143,7 @@ func killProcess(proc *process.Process, name string) error {
 		for _, c := range children {
 			err = c.Kill()
 			if err != nil {
-				return errs.WrapInputError(err, "err_stop_svc_permissions")
+				return locale.WrapInputError(err, "err_stop_svc_permissions")
 			}
 		}
 	} else {
@@ -152,7 +152,7 @@ func killProcess(proc *process.Process, name string) error {
 
 	err = proc.Kill()
 	if err != nil {
-		return errs.WrapInputError(err, "err_stop_svc_permissions")
+		return locale.WrapInputError(err, "err_stop_svc_permissions")
 	}
 
 	logging.Debug("Stopped %s process with SIGKILL", name)

--- a/internal/installmgr/stop.go
+++ b/internal/installmgr/stop.go
@@ -143,7 +143,7 @@ func killProcess(proc *process.Process, name string) error {
 		for _, c := range children {
 			err = c.Kill()
 			if err != nil {
-				return errs.Wrap(err, "Could not kill child process of %s", name)
+				return errs.WrapInputError(err, "err_stop_svc_permissions")
 			}
 		}
 	} else {
@@ -152,7 +152,7 @@ func killProcess(proc *process.Process, name string) error {
 
 	err = proc.Kill()
 	if err != nil {
-		return errs.Wrap(err, "Could not kill %s process", name)
+		return errs.WrapInputError(err, "err_stop_svc_permissions")
 	}
 
 	logging.Debug("Stopped %s process with SIGKILL", name)

--- a/internal/installmgr/stop.go
+++ b/internal/installmgr/stop.go
@@ -33,7 +33,8 @@ func StopRunning(installPath string) (rerr error) {
 
 	err = stopSvc(installPath)
 	if err != nil {
-		return locale.WrapInputError(err, "err_stop_svc")
+		multilog.Critical("Could not stop running service, error: %v", errs.JoinMessage(err))
+		return locale.WrapError(err, "err_stop_svc", "Unable to stop state-svc process. Please manually kill any running processes with name [NOTICE]state-svc[/RESET] and try again")
 	}
 
 	return nil

--- a/internal/installmgr/stop.go
+++ b/internal/installmgr/stop.go
@@ -33,8 +33,7 @@ func StopRunning(installPath string) (rerr error) {
 
 	err = stopSvc(installPath)
 	if err != nil {
-		multilog.Critical("Could not stop running service, error: %v", errs.JoinMessage(err))
-		return locale.WrapError(err, "err_stop_svc", "Unable to stop state-svc process. Please manually kill any running processes with name [NOTICE]state-svc[/RESET] and try again")
+		return locale.WrapInputError(err, "err_stop_svc")
 	}
 
 	return nil

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1935,6 +1935,11 @@ uninstall_warn_not_empty:
     [WARNING]Unable to remove all files in the directory the installation directory.[/RESET]
     The directory may contain unrecognized files.
     Encountered error: {{.V0}}
+err_stop_svc:
+  other: |
+    Could not stop running State Tool process due to insufficient permissions.
+
+    State Tool works best if you run it as a user, rather than an admin. You might be encountering this issue because you have originally installed or ran the State Tool as admin. If this is the case it is suggested that you uninstall the State Tool as admin, and install it again as a user.
 err_state_exec:
   other: Could not get state exec
 err_service_exec:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1935,11 +1935,6 @@ uninstall_warn_not_empty:
     [WARNING]Unable to remove all files in the directory the installation directory.[/RESET]
     The directory may contain unrecognized files.
     Encountered error: {{.V0}}
-err_stop_svc:
-  other: |
-    Could not stop running State Tool process due to insufficient permissions.
-
-    State Tool works best if you run it as a user, rather than an admin. You might be encountering this issue because you have originally installed or ran the State Tool as admin. If this is the case it is suggested that you uninstall the State Tool as admin, and install it again as a user.
 err_state_exec:
   other: Could not get state exec
 err_service_exec:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1935,7 +1935,7 @@ uninstall_warn_not_empty:
     [WARNING]Unable to remove all files in the directory the installation directory.[/RESET]
     The directory may contain unrecognized files.
     Encountered error: {{.V0}}
-err_stop_svc:
+err_stop_svc_permissions:
   other: |
     Could not stop running State Tool process due to insufficient permissions.
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1279" title="DX-1279" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1279</a>  state-installer []: Installer error: Failed to stop running services: ... Could not kill child pro
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…to lack of permissions).

Do not report this to rollbar.