### PR TITLE
svcModel is set on construction and only nil on CI.

### DIFF
--- a/internal/analytics/client/async/client.go
+++ b/internal/analytics/client/async/client.go
@@ -93,7 +93,7 @@ func (a *Client) Wait() {
 }
 
 func (a *Client) sendEvent(category, action, label string, dims ...*dimensions.Values) error {
-	if condition.InUnitTest() {
+	if a.svcModel == nil { // this is only true on CI
 		return nil
 	}
 

--- a/internal/analytics/client/async/client.go
+++ b/internal/analytics/client/async/client.go
@@ -93,6 +93,10 @@ func (a *Client) Wait() {
 }
 
 func (a *Client) sendEvent(category, action, label string, dims ...*dimensions.Values) error {
+	if condition.InUnitTest() {
+		return nil
+	}
+
 	if a.closed {
 		logging.Debug("Client is closed, not sending event")
 		return nil
@@ -101,13 +105,6 @@ func (a *Client) sendEvent(category, action, label string, dims ...*dimensions.V
 	userID := ""
 	if a.auth != nil && a.auth.UserID() != nil {
 		userID = string(*a.auth.UserID())
-	}
-
-	if a.svcModel == nil {
-		if condition.InUnitTest() {
-			return nil
-		}
-		return errs.New("Could not send analytics event, not connected to state-svc yet")
 	}
 
 	dim := dimensions.NewDefaultDimensions(a.projectNameSpace, a.sessionToken, a.updateTag)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1305" title="DX-1305" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1305</a>  Rollbar: exec: error during analytics.sendEvent: Could not send analytics event, not connected to state-svc yet
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
There was some refactoring in this area about a year ago and the svcModel is now being set on the construction of the analytics client, so that is the reasoning behind this change. The rollbar errors are from an earlier version of the state tool prior to this refactor where svcModel was being set sometime after construction when analytics events could be coming in before an svcModel was available.