### PR TITLE
Updated to latest termtest tag.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/99designs/gqlgen v0.13.0
 	github.com/ActiveState/archiver v3.1.1+incompatible
 	github.com/ActiveState/go-ogle-analytics v0.0.0-20170510030904-9b3f14901527
-	github.com/ActiveState/termtest v0.7.1
+	github.com/ActiveState/termtest v0.7.2
 	github.com/ActiveState/termtest/expect v0.7.0
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/ActiveState/archiver v3.1.1+incompatible h1:uSvaGvIm9/QszTShi5ojEfgxZ
 github.com/ActiveState/archiver v3.1.1+incompatible/go.mod h1:tiVVhFlOSJ4y8iEjflUccKQk0xV5f2CuQwaAom2h3rg=
 github.com/ActiveState/go-ogle-analytics v0.0.0-20170510030904-9b3f14901527 h1:lW+qgVXf/iAnSs8SgagWxh8d6nsbpmwyhmeg9/fp0Os=
 github.com/ActiveState/go-ogle-analytics v0.0.0-20170510030904-9b3f14901527/go.mod h1:/9SyzKLlJSuIa7WAsLUUhHqTK9+PtZD8cKF8G4SLpa0=
-github.com/ActiveState/termtest v0.7.1 h1:Nd6iVqnYoJNkJXHSG967bWJ+b1zbCmZp9+NQMeWobus=
-github.com/ActiveState/termtest v0.7.1/go.mod h1:krmYxOsjckZpOKlHI+wDqaGkpOBtM55Lr8YZckriE+0=
+github.com/ActiveState/termtest v0.7.2 h1:vNPMpI2AyZnLZzZn/CRpMZzIuVL0XhaTLA4qyghIGF8=
+github.com/ActiveState/termtest v0.7.2/go.mod h1:krmYxOsjckZpOKlHI+wDqaGkpOBtM55Lr8YZckriE+0=
 github.com/ActiveState/termtest/conpty v0.5.0 h1:JLUe6YDs4Jw4xNPCU+8VwTpniYOGeKzQg4SM2YHQNA8=
 github.com/ActiveState/termtest/conpty v0.5.0/go.mod h1:LO4208FLsxw6DcNZ1UtuGUMW+ga9PFtX4ntv8Ymg9og=
 github.com/ActiveState/termtest/expect v0.7.0 h1:VNrcfXTHXXoe7i+3WgF5QJhstQLGP4saj+XYM9ZzBvY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ github.com/ActiveState/archiver
 # github.com/ActiveState/go-ogle-analytics v0.0.0-20170510030904-9b3f14901527
 ## explicit
 github.com/ActiveState/go-ogle-analytics
-# github.com/ActiveState/termtest v0.7.1
+# github.com/ActiveState/termtest v0.7.2
 ## explicit; go 1.14
 github.com/ActiveState/termtest
 github.com/ActiveState/termtest/internal/osutils


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1331" title="DX-1331" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1331</a>  wait_ready is broken 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

So I thought the nightly test failures were due to changes made in #2162 , so I updated termtest to use the same method for detecting a user's home directory. However it turns out #2162 is still in review and hasn't landed yet. Therefore I don't know why we were getting failures. My suspicion is that GitHub Actions' CI for Linux somehow changed home directory/environment variable behind the scenes and we're seeing some fallout from that (the macOS and Windows tests are not having an issue with wait_ready.)

Nevertheless, the tests seem to be passing with the update to termtest, so I'm submitting this PR. I don't know if it will ultimately fix our nightly failures though.