### PR TITLE
Add executor size e2e test

### DIFF
--- a/test/integration/executor_int_test.go
+++ b/test/integration/executor_int_test.go
@@ -72,6 +72,10 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorExitCode() {
 	cp.ExpectExitCode(42)
 }
 
+func sizeByMegs(megabytes float64) int64 {
+	return int64(megabytes * float64(1000000))
+}
+
 func (suite *ExecutorIntegrationTestSuite) TestExecutorSizeOnDisk() {
 	suite.OnlyRunForTags(tagsuite.Executor)
 
@@ -82,6 +86,6 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorSizeOnDisk() {
 	fi, err := os.Stat(execFilePath)
 	suite.Require().NoError(err, "should be able to obtain executor file info")
 
-	maxSize := int64(4000000)
+	maxSize := sizeByMegs(4)
 	suite.Require().LessOrEqual(fi.Size(), maxSize, "executor (%d bytes) should be less than or equal to %d bytes", fi.Size(), maxSize)
 }

--- a/test/integration/executor_int_test.go
+++ b/test/integration/executor_int_test.go
@@ -1,8 +1,12 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/exeutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/stretchr/testify/suite"
@@ -66,4 +70,18 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorExitCode() {
 
 	cp.SendLine("exit")
 	cp.ExpectExitCode(42)
+}
+
+func (suite *ExecutorIntegrationTestSuite) TestExecutorSizeOnDisk() {
+	suite.OnlyRunForTags(tagsuite.Executor)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	execFilePath := filepath.Join(ts.Dirs.Bin, constants.StateExecutorCmd+exeutils.Extension)
+	fi, err := os.Stat(execFilePath)
+	suite.Require().NoError(err, "should be able to obtain executor file info")
+
+	maxSize := int64(4000000)
+	suite.Require().LessOrEqual(fi.Size(), maxSize, "executor (%d bytes) should be less than or equal to %d bytes", fi.Size(), maxSize)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1323" title="DX-1323" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1323</a>  Add e2e test to monitor the size of state-exec
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
