### PR TITLE
Revert "Do not report inability to get state-svc executable path to r…

### DIFF
--- a/internal/installmgr/stop.go
+++ b/internal/installmgr/stop.go
@@ -83,14 +83,14 @@ func stopSvc(installPath string) error {
 		svcName := constants.ServiceCommandName + exeutils.Extension
 		if n == svcName {
 			exe, err := p.Exe()
-			if err == nil {
-				if !strings.Contains(strings.ToLower(exe), "activestate") {
-					multilog.Error("Found state-svc process in unexpected directory: %s", exe)
-					continue
-				}
-			} else {
-				logging.Debug("Could not get executable path for state-svc process, error: %v", err) // permissions issue
-				exe = "<unknown>"
+			if err != nil {
+				multilog.Error("Could not get executable path for state-svc process, error: %v", err)
+				continue
+			}
+
+			if !strings.Contains(strings.ToLower(exe), "activestate") {
+				multilog.Error("Found state-svc process in unexpected directory: %s", exe)
+				continue
 			}
 
 			logging.Debug("Found running state-svc process with PID %d, at %s", p.Pid, exe)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1284" title="DX-1284" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1284</a>  state-installer [-t -f --source-installer]: Could not get executable path for state-svc process, error: bad call to lsof
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…ollbar."

This reverts commit 13e3225eeea536feccb21ad21e58565d61b765dd.