### PR TITLE
Print used command name

### DIFF
--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ActiveState/cli/internal/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/thoas/go-funk"
 )
 
 func init() {
@@ -175,7 +174,7 @@ func NewCommand(name, title, description string, prime primer, flags []*Flag, ar
 	cmd.cobra.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
 		if cmd.shouldWarnUnstable() {
 			if !condition.OptInUnstable(cmd.cfg) {
-				cmd.out.Notice(locale.Tr("unstable_command_warning", cmd.UsedName()))
+				cmd.out.Notice(locale.Tr("unstable_command_warning"))
 				return nil
 			}
 			cmd.outputTitleIfAny()
@@ -314,19 +313,6 @@ func (c *Command) SetDisableFlagParsing(b bool) {
 }
 
 func (c *Command) Name() string {
-	return c.name
-}
-
-func (c *Command) UsedName() string {
-	names := []string{c.name}
-	names = append(names, c.cobra.Aliases...)
-
-	for _, arg := range os.Args {
-		if funk.Contains(names, arg) {
-			return arg
-		}
-	}
-
 	return c.name
 }
 
@@ -604,7 +590,7 @@ func (c *Command) runner(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	if c.shouldWarnUnstable() && !condition.OptInUnstable(c.cfg) {
-		c.out.Notice(locale.Tr("unstable_command_warning", c.UsedName()))
+		c.out.Notice(locale.Tr("unstable_command_warning"))
 		return nil
 	}
 

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ActiveState/cli/internal/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/thoas/go-funk"
 )
 
 func init() {
@@ -174,7 +175,7 @@ func NewCommand(name, title, description string, prime primer, flags []*Flag, ar
 	cmd.cobra.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
 		if cmd.shouldWarnUnstable() {
 			if !condition.OptInUnstable(cmd.cfg) {
-				cmd.out.Notice(locale.Tr("unstable_command_warning", cmd.Name()))
+				cmd.out.Notice(locale.Tr("unstable_command_warning", cmd.UsedName()))
 				return nil
 			}
 			cmd.outputTitleIfAny()
@@ -313,6 +314,19 @@ func (c *Command) SetDisableFlagParsing(b bool) {
 }
 
 func (c *Command) Name() string {
+	return c.name
+}
+
+func (c *Command) UsedName() string {
+	names := []string{c.name}
+	names = append(names, c.cobra.Aliases...)
+
+	for _, arg := range os.Args {
+		if funk.Contains(names, arg) {
+			return arg
+		}
+	}
+
 	return c.name
 }
 
@@ -590,7 +604,7 @@ func (c *Command) runner(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	if c.shouldWarnUnstable() && !condition.OptInUnstable(c.cfg) {
-		c.out.Notice(locale.Tr("unstable_command_warning", c.Name()))
+		c.out.Notice(locale.Tr("unstable_command_warning", c.UsedName()))
 		return nil
 	}
 

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1875,7 +1875,7 @@ unstable_feature_banner:
   other: "[NOTICE]Beta Feature: This feature is still in beta and may be unstable.[/RESET]\n"
 unstable_command_warning:
   other: |
-    The command '[ACTIONABLE]state {{.V0}}[/RESET]' is still in beta. If you want to opt-in to unstable features, run the following command:
+    This command is still in beta. If you want to opt-in to unstable features, run the following command:
 
     [ACTIONABLE]state config set optin.unstable true[/RESET]
 secrets_unstable_warning:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1346" title="DX-1346" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1346</a>  PROMPT: `state prompt` shows help and errors for `state shell` it will confuse the user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This differs slightly from the `Expected Behaviour` in the ticket