### PR TITLE
Manually map "Next Feasible" to avoid pushing to feature freeze branches

### DIFF
--- a/scripts/internal/workflow-helpers/jira.go
+++ b/scripts/internal/workflow-helpers/jira.go
@@ -125,10 +125,19 @@ func ParseTargetFixVersion(issue *jira.Issue, availableVersions []semver.Version
 
 	switch fixVersion.Name {
 	case VersionNextFeasible:
+		target, err := ParseJiraVersion(strings.Split(fixVersion.Description, " ")[0])
+		if err != nil {
+			return semver.Version{}, nil, errs.Wrap(err, "Failed to parse Jira version from description: %s", fixVersion.Description)
+		}
 		if len(availableVersions) < 1 {
 			return semver.Version{}, nil, errs.New("No feasible versions available")
 		}
-		return availableVersions[0], fixVersion, nil
+		for _, version := range availableVersions {
+			if version.EQ(target) {
+				return version, fixVersion, nil
+			}
+		}
+		return semver.Version{}, nil, errs.New("Next feasible version does not exist: %s", target.String())
 	case VersionNextUnscheduled:
 		return VersionMaster, fixVersion, nil
 	}

--- a/scripts/internal/workflow-helpers/jira_test.go
+++ b/scripts/internal/workflow-helpers/jira_test.go
@@ -28,12 +28,13 @@ func TestFetchAvailableVersions(t *testing.T) {
 }
 
 func TestParseTargetFixVersion(t *testing.T) {
-	getIssue := func(fixVersion string) *jira.Issue {
+	getIssue := func(fixVersion, desc string) *jira.Issue {
 		return &jira.Issue{
 			Fields: &jira.IssueFields{
 				FixVersions: []*jira.FixVersion{
 					{
-						Name: fixVersion,
+						Name:        fixVersion,
+						Description: desc,
 					},
 				},
 			},
@@ -53,19 +54,19 @@ func TestParseTargetFixVersion(t *testing.T) {
 		{
 			name: "Next Feasible",
 			args: args{
-				getIssue("Next Feasible"),
+				getIssue("Next Feasible", "v1.2.5-RC1 -- bogus."),
 				[]semver.Version{
 					{Major: 1, Minor: 2, Patch: 3},
 					{Major: 2, Minor: 3, Patch: 4},
-					{Major: 1, Minor: 2, Patch: 5},
+					{Major: 1, Minor: 2, Patch: 5, Pre: []semver.PRVersion{{VersionStr: "RC1"}}},
 				},
 			},
-			want: semver.Version{Major: 1, Minor: 2, Patch: 3},
+			want: semver.Version{Major: 1, Minor: 2, Patch: 5, Pre: []semver.PRVersion{{VersionStr: "RC1"}}},
 		},
 		{
 			name: "Next Unscheduled",
 			args: args{
-				getIssue("Next Unscheduled"),
+				getIssue("Next Unscheduled", ""),
 				[]semver.Version{
 					{Major: 1, Minor: 2, Patch: 3},
 					{Major: 2, Minor: 3, Patch: 4},
@@ -77,7 +78,7 @@ func TestParseTargetFixVersion(t *testing.T) {
 		{
 			name: "Custom Version",
 			args: args{
-				getIssue("1.2.3"),
+				getIssue("1.2.3", ""),
 				[]semver.Version{},
 			},
 			want: semver.Version{Major: 1, Minor: 2, Patch: 3},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1363" title="DX-1363" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1363</a>  "Next Feasible" should not target versions in feature/code freeze
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
