### PR TITLE
If cleaning cache is not confirmed, notify the user via an input error.

### DIFF
--- a/internal/runners/clean/cache.go
+++ b/internal/runners/clean/cache.go
@@ -71,7 +71,7 @@ func (c *Cache) removeCache(path string, force bool) error {
 			return err
 		}
 		if !ok {
-			return nil
+			return locale.NewInputError("err_clean_cache_not_confirmed", "Cleaning of cache aborted by user")
 		}
 	}
 
@@ -86,7 +86,7 @@ func (c *Cache) removeProjectCache(projectDir, namespace string, force bool) err
 			return err
 		}
 		if !ok {
-			return nil
+			return locale.NewInputError("err_clean_cache_artifact_not_confirmed", "Cleaning of cached runtime aborted by user")
 		}
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1357" title="DX-1357" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1357</a>  `state clean cache` missing message when the user chooses not to confirm the execution
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
