### PR TITLE
`state import --non-interactive` should import by default without confirmation

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -88,7 +88,7 @@ func New(prime *primer.Values, args ...string) *CmdTree {
 
 	installCmd := newInstallCommand(prime)
 	uninstallCmd := newUninstallCommand(prime)
-	importCmd := newImportCommand(prime)
+	importCmd := newImportCommand(prime, globals)
 	searchCmd := newSearchCommand(prime)
 	infoCmd := newInfoCommand(prime)
 

--- a/cmd/state/internal/cmdtree/packages.go
+++ b/cmd/state/internal/cmdtree/packages.go
@@ -97,7 +97,7 @@ func newUninstallCommand(prime *primer.Values) *captain.Command {
 	).SetGroup(PackagesGroup)
 }
 
-func newImportCommand(prime *primer.Values) *captain.Command {
+func newImportCommand(prime *primer.Values, globals *globalOptions) *captain.Command {
 	runner := packages.NewImport(prime)
 
 	params := packages.NewImportRunParams()
@@ -123,7 +123,8 @@ func newImportCommand(prime *primer.Values) *captain.Command {
 			},
 		},
 		func(_ *captain.Command, _ []string) error {
-			return runner.Run(*params)
+			params.NonInteractive = globals.NonInteractive
+			return runner.Run(params)
 		},
 	).SetGroup(PackagesGroup)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1377" title="DX-1377" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1377</a>  `state import <file> -n` not executing the import but cancel it.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
