### PR TITLE
Mark `state use show` as unstable.

### DIFF
--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -52,7 +52,7 @@ func newUseResetCommand(prime *primer.Values, globals *globalOptions) *captain.C
 }
 
 func newUseShowCommand(prime *primer.Values) *captain.Command {
-	return captain.NewCommand(
+	cmd := captain.NewCommand(
 		"show",
 		"",
 		locale.Tl("use_show_description", "Show your default project runtime"),
@@ -63,4 +63,6 @@ func newUseShowCommand(prime *primer.Values) *captain.Command {
 			return use.NewShow(prime).Run()
 		},
 	)
+	cmd.SetUnstable(true)
+	return cmd
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1345" title="DX-1345" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1345</a>  USE: `state use show` successfully executed despite `state config set optin.unstable false`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
