### PR TITLE
Better organization of env management help

### DIFF
--- a/cmd/state/internal/cmdtree/activate.go
+++ b/cmd/state/internal/cmdtree/activate.go
@@ -86,6 +86,6 @@ func newActivateCommand(prime *primer.Values) *captain.Command {
 			return err
 		},
 	)
-	cmd.SetGroup(EnvironmentGroup)
+	cmd.SetGroup(EnvironmentUsageGroup)
 	return cmd
 }

--- a/cmd/state/internal/cmdtree/checkout.go
+++ b/cmd/state/internal/cmdtree/checkout.go
@@ -42,7 +42,7 @@ func newCheckoutCommand(prime *primer.Values) *captain.Command {
 			return checkout.NewCheckout(prime).Run(params)
 		},
 	)
-	cmd.SetGroup(EnvironmentGroup)
+	cmd.SetGroup(EnvironmentSetupGroup)
 	cmd.SetUnstable(true)
 	return cmd
 }

--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -210,12 +210,14 @@ type globalOptions struct {
 
 // Group instances are used to group command help output.
 var (
-	EnvironmentGroup = captain.NewCommandGroup(locale.Tl("group_environment", "Environment Management"), 10)
-	PackagesGroup    = captain.NewCommandGroup(locale.Tl("group_packages", "Package Management"), 9)
-	PlatformGroup    = captain.NewCommandGroup(locale.Tl("group_tools", "Platform"), 8)
-	VCSGroup         = captain.NewCommandGroup(locale.Tl("group_vcs", "Version Control"), 7)
-	AutomationGroup  = captain.NewCommandGroup(locale.Tl("group_automation", "Automation"), 6)
-	UtilsGroup       = captain.NewCommandGroup(locale.Tl("group_utils", "Utilities"), 5)
+	EnvironmentSetupGroup = captain.NewCommandGroup(locale.Tl("group_environment_setup", "Environment Setup"), 10)
+	EnvironmentUsageGroup = captain.NewCommandGroup(locale.Tl("group_environment_usage", "Environment Usage"), 9)
+	ProjectUsageGroup     = captain.NewCommandGroup(locale.Tl("group_project_usages", "Project Usage"), 8)
+	PackagesGroup         = captain.NewCommandGroup(locale.Tl("group_packages", "Package Management"), 7)
+	PlatformGroup         = captain.NewCommandGroup(locale.Tl("group_tools", "Platform"), 6)
+	VCSGroup              = captain.NewCommandGroup(locale.Tl("group_vcs", "Version Control"), 5)
+	AutomationGroup       = captain.NewCommandGroup(locale.Tl("group_automation", "Automation"), 4)
+	UtilsGroup            = captain.NewCommandGroup(locale.Tl("group_utils", "Utilities"), 3)
 )
 
 func newGlobalOptions() *globalOptions {

--- a/cmd/state/internal/cmdtree/deploy.go
+++ b/cmd/state/internal/cmdtree/deploy.go
@@ -52,7 +52,7 @@ func newDeployCommand(prime *primer.Values) *captain.Command {
 		func(cmd *captain.Command, args []string) error {
 			return runner.Run(params)
 		})
-	cmd.SetGroup(EnvironmentGroup)
+	cmd.SetGroup(EnvironmentSetupGroup)
 	cmd.SetHidden(true)
 	return cmd
 }

--- a/cmd/state/internal/cmdtree/exec.go
+++ b/cmd/state/internal/cmdtree/exec.go
@@ -43,7 +43,7 @@ func newExecCommand(prime *primer.Values, args ...string) *captain.Command {
 	cmd.SetSkipChecks(true)
 	cmd.SetDeferAnalytics(true)
 
-	cmd.SetGroup(EnvironmentGroup)
+	cmd.SetGroup(EnvironmentUsageGroup)
 	cmd.SetHasVariableArguments()
 
 	return cmd

--- a/cmd/state/internal/cmdtree/init.go
+++ b/cmd/state/internal/cmdtree/init.go
@@ -65,5 +65,5 @@ func newInitCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, _ []string) error {
 			return initRunner.Run(&params)
 		},
-	).SetGroup(EnvironmentGroup).SetUnstable(true)
+	).SetGroup(EnvironmentSetupGroup).SetUnstable(true)
 }

--- a/cmd/state/internal/cmdtree/projects.go
+++ b/cmd/state/internal/cmdtree/projects.go
@@ -21,7 +21,7 @@ func newProjectsCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, args []string) error {
 			return runner.Run(params)
 		},
-	).SetGroup(EnvironmentGroup)
+	).SetGroup(ProjectUsageGroup)
 }
 
 func newRemoteProjectsCommand(prime *primer.Values) *captain.Command {
@@ -38,5 +38,5 @@ func newRemoteProjectsCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, args []string) error {
 			return runner.RunRemote(params)
 		},
-	).SetGroup(EnvironmentGroup)
+	).SetGroup(ProjectUsageGroup)
 }

--- a/cmd/state/internal/cmdtree/run.go
+++ b/cmd/state/internal/cmdtree/run.go
@@ -46,7 +46,7 @@ func newRunCommand(prime *primer.Values) *captain.Command {
 		},
 	)
 
-	cmd.SetGroup(EnvironmentGroup)
+	cmd.SetGroup(ProjectUsageGroup)
 	cmd.SetDisableFlagParsing(true)
 	cmd.SetHasVariableArguments()
 

--- a/cmd/state/internal/cmdtree/shell.go
+++ b/cmd/state/internal/cmdtree/shell.go
@@ -41,7 +41,7 @@ func newShellCommand(prime *primer.Values) *captain.Command {
 			return runner.Run(params)
 		},
 	)
-	cmd.SetGroup(EnvironmentGroup)
+	cmd.SetGroup(EnvironmentUsageGroup)
 	cmd.SetAliases("prompt")
 	cmd.SetUnstable(true)
 	return cmd

--- a/cmd/state/internal/cmdtree/show.go
+++ b/cmd/state/internal/cmdtree/show.go
@@ -28,5 +28,5 @@ func newShowCommand(prime *primer.Values) *captain.Command {
 		func(_ *captain.Command, _ []string) error {
 			return runner.Run(params)
 		},
-	).SetGroup(EnvironmentGroup).SetUnstable(true)
+	).SetGroup(ProjectUsageGroup).SetUnstable(true)
 }

--- a/cmd/state/internal/cmdtree/switch.go
+++ b/cmd/state/internal/cmdtree/switch.go
@@ -30,7 +30,7 @@ func newSwitchCommand(prime *primer.Values) *captain.Command {
 			return runner.Run(params)
 		})
 
-	cmd.SetGroup(EnvironmentGroup)
+	cmd.SetGroup(EnvironmentSetupGroup)
 	cmd.SetUnstable(true)
 	return cmd
 }

--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -29,7 +29,7 @@ func newUseCommand(prime *primer.Values) *captain.Command {
 		func(_ *captain.Command, _ []string) error {
 			return use.NewUse(prime).Run(params)
 		},
-	).SetGroup(EnvironmentGroup)
+	).SetGroup(EnvironmentUsageGroup)
 	cmd.SetUnstable(true)
 	return cmd
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1226" title="DX-1226" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1226</a>  Better organization of env management help
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Updated output:
```
The ActiveState CLI allows you to easily switch between your ActiveState environments

Find more information at: https://docs.activestate.com/platform/state/

Usage:
    state [flags]
    state [command]Available Commands:

  Environment Setup:                                                                                
    checkout (Unstable)           Checkout the given project and setup its runtime                  
    init (Unstable)               Initialize a new project                                          
    switch (Unstable)             Switch to a branch, commit, or tag                                

  Environment Usage:                                                                                
    activate                      Activate a project                                                
    exec                          Intercept and run a script via a project runtime environment      
    shell (Unstable)              Starts a shell/prompt for the given project runtime               
    use (Unstable)                Use the given project runtime as the default for your system      

  Project Usage:                                                                                    
    projects                      List your projects                                                
    run                           Run your project scripts                                          
    show (Unstable)               Show information about a project                                  

  Package Management:                                                                               
    bundles (Unstable)            Manage bundles used in your project                               
    import                        Import packages from a list of dependencies                       
    info (Unstable)               Display information for the specified package                     
    install                       Add a new package to your project                                 
    packages                      List packages used in your project                                
    search (Unstable)             Search for available packages that can be added to your project   
    uninstall                     Remove a package from your project                                

  Platform:                                                                                         
    auth                          Authenticate against the ActiveState Platform                     
    branch (Unstable)             Manage your project's branches                                    
    invite (Unstable)             Invite new members to an organization                             
    languages (Unstable)          View the languages of a project                                   
    organizations (Unstable)      List member organizations on the ActiveState Platform             
    platforms (Unstable)          Manage platforms used in your project                             
    secrets (Unstable)            Manage your secrets                                               
    security (Unstable)           Show a summary of project vulnerabilities                         

  Version Control:                                                                                  
    fork                          Fork an existing ActiveState Platform project                     
    history                       View history of the active or given project                       
    pull                          Pull in the latest version of your project from the ActiveState   
                                  Platform                                                          
    push                          Push your latest changes to the platform                          
    reset                         Reset local checkout to a particular commit                       
    revert                        Revert a commit                                                   

  Automation:                                                                                       
    events (Unstable)             Manage project events                                             
    scripts (Unstable)            Show project scripts                                              

  Utilities:                                                                                        
    clean                         Clean caches, configuration files, or completely remove the stat  
                                  e tool                                                            
    export                        Print information based on the provided subcommand                
    learn                         Read the State Tool cheat sheet to learn about common commands    
    update                        Updates the State Tool to the latest available version            
    config                        Removes global State Tool configuration                           

Flags:
  -h, --help              help for state
  -l, --locale string     Set the localisation
      --mono              Force monochrome text output
  -n, --non-interactive   Run the State Tool without any prompts and accepting all default options
  -o, --output string     Set the output method, possible values: plain, simple, json, editor
  -v, --verbose           Verbose output
      --version           Show the version of our state executable

Use "state [command] --help" for more information about a command.

To access the list of full commands, including unstable features still in beta, run:

"state config set optin.unstable true"
```