### PR TITLE
Ensure error information isn't lost when uninstalling

### DIFF
--- a/internal/runners/clean/run_lin_mac.go
+++ b/internal/runners/clean/run_lin_mac.go
@@ -26,11 +26,13 @@ func (u *Uninstall) runUninstall() error {
 	var aggErr error
 	err := removeCache(storage.CachePath())
 	if err != nil {
+		logging.Debug("Could not remove cache at %s: %s", storage.CachePath(), errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_remove_cache_err", "Failed to remove cache directory {{.V0}}.", storage.CachePath())
 	}
 
 	err = undoPrepare(u.cfg)
 	if err != nil {
+		logging.Debug("Could not undo prepare: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_prepare_err", "Failed to undo some installation steps.")
 	}
 
@@ -38,21 +40,25 @@ func (u *Uninstall) runUninstall() error {
 	if errors.Is(err, errDirNotEmpty) {
 		u.out.Notice(locale.T("uninstall_warn_not_empty", errs.JoinMessage(err)))
 	} else if err != nil {
+		logging.Debug("Could not remove install: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_remove_executables_err", "Failed to remove all State Tool files in installation directory")
 	}
 
 	err = removeEnvPaths(u.cfg)
 	if err != nil {
+		logging.Debug("Could not remove env paths: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_remove_paths_err", "Failed to remove PATH entries from environment")
 	}
 
 	path := u.cfg.ConfigPath()
 	if err := u.cfg.Close(); err != nil {
+		logging.Debug("Could not close config: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_close_config", "Could not stop config database connection.")
 	}
 
 	err = removeConfig(path, u.out)
 	if err != nil {
+		logging.Debug("Could not remove config: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_remove_config_err", "Failed to remove configuration directory {{.V0}}", u.cfg.ConfigPath())
 
 	}

--- a/internal/runners/clean/run_win.go
+++ b/internal/runners/clean/run_win.go
@@ -29,31 +29,37 @@ func (u *Uninstall) runUninstall() error {
 	var aggErr error
 	logFile, err := ioutil.TempFile("", "state-clean-uninstall")
 	if err != nil {
+		logging.Error("Could not create temporary log file: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "err_clean_logfile", "Could not create temporary log file")
 	}
 
 	stateExec, err := installation.StateExec()
 	if err != nil {
+		logging.Debug("Could not get State Tool executable: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "err_state_exec")
 	}
 
 	err = removeInstall(logFile.Name(), u.cfg)
 	if err != nil {
+		logging.Debug("Could not remove installation: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_remove_executables_err", "Failed to remove all State Tool files in installation directory {{.V0}}", filepath.Dir(stateExec))
 	}
 
 	err = removeCache(storage.CachePath())
 	if err != nil {
+		logging.Debug("Could not remove cache at %s: %s", storage.CachePath(), errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_remove_cache_err", "Failed to remove cache directory {{.V0}}.", storage.CachePath())
 	}
 
 	err = undoPrepare(u.cfg)
 	if err != nil {
+		logging.Debug("Could not undo prepare: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_prepare_err", "Failed to undo some installation steps.")
 	}
 
 	err = removeEnvPaths(u.cfg)
 	if err != nil {
+		logging.Debug("Could not remove environment paths: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_remove_paths_err", "Failed to remove PATH entries from environment")
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1382" title="DX-1382" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1382</a>  `state clean uninstall` failed on WIN11 for 0.35.0-RC1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Not super happy with this implementation, but given this is a bug and not a story I had to minimize my solution. Filed a followup here: https://activestatef.atlassian.net/browse/DX-1383
