### PR TITLE
Fix invalid python path in test

### DIFF
--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -3,10 +3,12 @@ package integration
 import (
 	"bytes"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
@@ -36,7 +38,10 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckout() {
 
 	// Verify runtime was installed correctly and works.
 	targetDir := target.ProjectDirToTargetDir(python3Dir, ts.Dirs.Cache)
-	pythonExe := filepath.Join(setup.ExecDir(targetDir), "python3")
+	pythonExe := filepath.Join(setup.ExecDir(targetDir), "python3"+osutils.ExeExt)
+	if runtime.GOOS == "windows" {
+		pythonExe = pythonExe + ".bat"
+	}
 	cp = ts.SpawnCmdWithOpts(
 		pythonExe,
 		e2e.WithArgs("--version"),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1384" title="DX-1384" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1384</a>  Checkout_int_test failing after reverting executors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
