### PR TITLE
Fix installer panic

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -202,8 +202,8 @@ func main() {
 			multilog.Critical("Installer error: " + errs.JoinMessage(err))
 		}
 
+		an.EventWithLabel(AnalyticsFunnelCat, "fail", errs.JoinMessage(err))
 		exitCode, err = errors.Unwrap(err)
-		an.EventWithLabel(AnalyticsFunnelCat, "fail", err.Error())
 		if err != nil {
 			out.Error(err)
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1388" title="DX-1388" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1388</a>  Installer panics if user ran command that exited non-zero
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
