### PR TITLE
Continue on unscheduled unit test failures.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,8 +338,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - # === Fail on Unscheduled Unit Test Failures ===
-        name: Fail on Unscheduled Unit Test Failures
+      - # === Fail If Unscheduled Unit Tests Failed (Expand 'Unit Tests' above for more information) ===
+        name: Fail If Unscheduled Unit Tests Failed
         if: github.event_name != 'schedule' && steps.unit_tests.outcome == 'failure'
         shell: bash
         run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,9 +338,9 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - # === Fail on Unscheduled Unit or Integration Test Failures ===
-        name: Fail on Unscheduled Unit or Integration Test Failures
-        if: github.event_name != 'schedule' && (steps.unit_tests.outcome == 'failure' || steps.integration_tests.outcome == 'failure')
+      - # === Fail on Unscheduled Unit Test Failures ===
+        name: Fail on Unscheduled Unit Test Failures
+        if: github.event_name != 'schedule' && steps.unit_tests.outcome == 'failure'
         shell: bash
         run: exit 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,8 +163,10 @@ jobs:
 
       - # === Unit Tests ===
         name: Unit Tests
+        id: unit_tests
         shell: bash
         run: parallelize results Unit-Tests | gotestfmt
+        continue-on-error: ${{ github.event_name != 'schedule' }}
 
       - # === "Build: CLI" ===
         name: "Build: CLI"
@@ -335,6 +337,12 @@ jobs:
           PLATFORM_API_TOKEN: ${{ secrets.PLATFORM_API_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - # === Fail on Unscheduled Unit or Integration Test Failures ===
+        name: Fail on Unscheduled Unit or Integration Test Failures
+        if: github.event_name != 'schedule' && (steps.unit_tests.outcome == 'failure' || steps.integration_tests.outcome == 'failure')
+        shell: bash
+        run: exit 1
 
       - # === Notify Slack of Nightly Integration Test Failures ===
         name: Notify Slack of Nightly Integration Test Failures

--- a/internal/download/get_test.go
+++ b/internal/download/get_test.go
@@ -9,5 +9,6 @@ import (
 
 func TestGet(t *testing.T) {
 	_, err := Get(filepath.Join("download", "file1"))
-	assert.NoError(t, err, "Should download file")
+  assert.Error(t, err)
+	//assert.NoError(t, err, "Should download file")
 }

--- a/internal/download/get_test.go
+++ b/internal/download/get_test.go
@@ -9,6 +9,5 @@ import (
 
 func TestGet(t *testing.T) {
 	_, err := Get(filepath.Join("download", "file1"))
-  assert.Error(t, err)
-	//assert.NoError(t, err, "Should download file")
+	assert.NoError(t, err, "Should download file")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1332" title="DX-1332" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1332</a>  Always run both unit and integration tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This allow integration tests to still be run.