### PR TITLE
Do not log "bad call to lsof" to Rollbar.

### DIFF
--- a/internal/installmgr/stop.go
+++ b/internal/installmgr/stop.go
@@ -85,6 +85,11 @@ func stopSvc(installPath string) error {
 		if n == svcName {
 			exe, err := p.Exe()
 			if err != nil {
+				if runtime.GOOS == "darwin" && strings.Contains(err.Error(), "bad call to lsof") {
+					// There's nothing we can do about this, so just debug log it.
+					logging.Debug("Could not get executable path for state-svc process, error: %v", err)
+					continue
+				}
 				multilog.Error("Could not get executable path for state-svc process, error: %v", err)
 				continue
 			}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1284" title="DX-1284" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1284</a>  state-installer [-t -f --source-installer]: Could not get executable path for state-svc process, error: bad call to lsof
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
