### PR TITLE
Help text should show the state of optin.unstable config and how to toggle it.

### DIFF
--- a/internal/assets/contents/usage.tpl
+++ b/internal/assets/contents/usage.tpl
@@ -15,7 +15,7 @@ Aliases:
 {{- if .Cmd.Examples  }}
 
 Examples:
-{{- range  .Cmd.Examples }} 
+{{- range  .Cmd.Examples }}
     {{ . -}}
 {{- end }}
 {{- end }}
@@ -51,7 +51,15 @@ Additional help topics:
 
 Use "{{.Cobra.CommandPath}} [command] --help" for more information about a command.
 
+{{- if .OptinUnstable }}
+
+WARNING: You have an access to list of full commands, including unstable features still in beta, in order to hide these features run:
+
+"state config set optin.unstable false"
+{{- else }}
+
 To access the list of full commands, including unstable features still in beta, run:
 
 "state config set optin.unstable true"
+{{- end}}
 {{- end}}

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -864,8 +864,9 @@ func (cmd *Command) Usage() error {
 
 	var out bytes.Buffer
 	if err := tpl.Execute(&out, map[string]interface{}{
-		"Cmd":   cmd,
-		"Cobra": cmd.cobra,
+		"Cmd":           cmd,
+		"Cobra":         cmd.cobra,
+		"OptinUnstable": condition.OptInUnstable(cmd.cfg),
 	}); err != nil {
 		return errs.Wrap(err, "Could not execute template")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1395" title="DX-1395" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1395</a>  If `optin.unstable` set to TRUE executing `state --help` will show how to set it off.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
