### PR TITLE
For an unstable parent command, automatically mark its children as unstable too.

### DIFF
--- a/cmd/state/internal/cmdtree/use.go
+++ b/cmd/state/internal/cmdtree/use.go
@@ -29,8 +29,7 @@ func newUseCommand(prime *primer.Values) *captain.Command {
 		func(_ *captain.Command, _ []string) error {
 			return use.NewUse(prime).Run(params)
 		},
-	).SetGroup(EnvironmentUsageGroup)
-	cmd.SetUnstable(true)
+	).SetGroup(EnvironmentUsageGroup).SetUnstable(true)
 	return cmd
 }
 
@@ -63,6 +62,5 @@ func newUseShowCommand(prime *primer.Values) *captain.Command {
 			return use.NewShow(prime).Run()
 		},
 	)
-	cmd.SetUnstable(true)
 	return cmd
 }

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -451,6 +451,10 @@ func (c *Command) SortBefore(c2 *Command) bool {
 
 func (c *Command) AddChildren(children ...*Command) {
 	for _, child := range children {
+		if c.unstable {
+			child.SetUnstable(true)
+		}
+
 		c.commands = append(c.commands, child)
 		c.cobra.AddCommand(child.cobra)
 
@@ -900,5 +904,5 @@ func childCommands(cmd *Command) string {
 		}
 	}
 
-	return fmt.Sprintf("Available Commands:\n%s", table.Render())
+	return fmt.Sprintf("\n\nAvailable Commands:\n%s", table.Render())
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1397" title="DX-1397" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1397</a>  `state use` flags `show` and `reset` missing `Beta Feature: This feature is still in beta and may be unstable.` message.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
