### PR TITLE
Show version SHA for available updates.

### DIFF
--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -56,7 +56,7 @@ func autoUpdate(args []string, cfg *config.Instance, out output.Outputer) (bool,
 	if !isEnabled(cfg) {
 		logging.Debug("Not performing autoupdates because user turned off autoupdates.")
 		out.Notice(output.Heading(locale.Tl("update_available_header", "Auto Update")))
-		out.Notice(locale.Tr("update_available", constants.VersionNumber, up.Version))
+		out.Notice(locale.Tr("update_available", constants.Version, up.Version))
 		return false, nil
 	}
 

--- a/pkg/cmdlets/checker/checker.go
+++ b/pkg/cmdlets/checker/checker.go
@@ -74,5 +74,5 @@ func RunUpdateNotifier(svc *model.SvcModel, out output.Outputer) {
 		return
 	}
 	out.Notice(output.Heading(locale.Tr("update_available_header")))
-	out.Notice(locale.Tr("update_available", constants.VersionNumber, up.Version))
+	out.Notice(locale.Tr("update_available", constants.Version, up.Version))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1413" title="DX-1413" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1413</a>  Update available output has a different version number than if `state --version` executed.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is consistent with the version displayed by `state --version`.