### PR TITLE
Added new "autostart.svc" config parameter to toggle state-svc autostart

### DIFF
--- a/cmd/state-svc/autostart/autostart.go
+++ b/cmd/state-svc/autostart/autostart.go
@@ -1,7 +1,12 @@
 package autostart
 
 import (
+	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/installation"
+	"github.com/ActiveState/cli/internal/logging"
+	configMediator "github.com/ActiveState/cli/internal/mediators/config"
+	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/osutils/autostart"
 )
 
@@ -10,3 +15,23 @@ const (
 )
 
 var Options = autostart.Options{}
+
+func RegisterConfigListener(cfg *config.Instance) {
+	if svcExec, err := installation.ServiceExec(); err == nil {
+		if as, err := autostart.New(App, svcExec, nil, Options, cfg); err == nil {
+			configMediator.AddListener(constants.AutostartSvcConfigKey, func() {
+				if cfg.GetBool(constants.AutostartSvcConfigKey) {
+					logging.Debug("Enabling autostart")
+					as.Enable()
+				} else {
+					logging.Debug("Disabling autostart")
+					as.Disable()
+				}
+			})
+		} else {
+			multilog.Error("Could not add config listener: state-svc could not find its autostart")
+		}
+	} else {
+		multilog.Error("Could not add config listener state-svc could not find its executable")
+	}
+}

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -117,7 +117,7 @@ func run(cfg *config.Instance) error {
 			multilog.Error("state-svc could not find its autostart")
 		}
 	} else {
-		multilog.Error("state-svc could not find it's executable")
+		multilog.Error("state-svc could not find its executable")
 	}
 
 	if mousetrap.StartedByExplorer() {

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -11,16 +11,20 @@ import (
 	"syscall"
 	"time"
 
+	svcAutostart "github.com/ActiveState/cli/cmd/state-svc/autostart"
 	anaSync "github.com/ActiveState/cli/internal/analytics/client/sync"
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/events"
+	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/ipc"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
+	configMediator "github.com/ActiveState/cli/internal/mediators/config"
 	"github.com/ActiveState/cli/internal/multilog"
+	"github.com/ActiveState/cli/internal/osutils/autostart"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/rollbar"
@@ -98,6 +102,22 @@ func run(cfg *config.Instance) error {
 	})
 	if err != nil {
 		return errs.Wrap(err, "Could not initialize outputer")
+	}
+
+	if svcExec, err := installation.ServiceExec(); err == nil {
+		if as, err := autostart.New(svcAutostart.App, svcExec, nil, svcAutostart.Options, cfg); err == nil {
+			configMediator.AddListener(constants.AutostartSvcConfigKey, func() {
+				if cfg.GetBool(constants.AutostartSvcConfigKey) {
+					as.Enable()
+				} else {
+					as.Disable()
+				}
+			})
+		} else {
+			multilog.Error("state-svc could not find its autostart")
+		}
+	} else {
+		multilog.Error("state-svc could not find it's executable")
 	}
 
 	if mousetrap.StartedByExplorer() {

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -228,7 +228,7 @@ func (suite *SvcIntegrationTestSuite) TestAutostartConfigEnableDisable() {
 	suite.Require().NoError(err)
 	suite.Assert().Equal(!enabled, toggled, "autostart has not been changed")
 
-	// Re-enable it via state tool config.
+	// Toggle it again via state tool config.
 	cp = ts.SpawnWithOpts(e2e.WithArgs("config", "set", constants.AutostartSvcConfigKey, strconv.FormatBool(enabled)))
 	cp.ExpectExitCode(0)
 	time.Sleep(500 * time.Millisecond) // allow time to copy startup files into place

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -406,6 +406,9 @@ const StateAppName = "State Tool"
 // StateSvcCmd is the name of the state-svc binary
 const StateSvcCmd = "state-svc"
 
+// AutostartSvcConfigKey is the config key used to determine if the service should be run on startup.
+const AutostartSvcConfigKey = "autostart.svc"
+
 // StateCmd is the name of the state tool binary
 const StateCmd = "state"
 

--- a/internal/osutils/autostart/autostart.go
+++ b/internal/osutils/autostart/autostart.go
@@ -1,6 +1,15 @@
 package autostart
 
+import (
+	"github.com/ActiveState/cli/internal/constants"
+	configMediator "github.com/ActiveState/cli/internal/mediators/config"
+)
+
 type AppName string
+
+func init() {
+	configMediator.RegisterOption(constants.AutostartSvcConfigKey, configMediator.Bool, configMediator.EmptyEvent, configMediator.EmptyEvent)
+}
 
 func (a AppName) String() string {
 	return string(a)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1403" title="DX-1403" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1403</a>  Users can opt-out of having state-svc run on startup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
