### PR TITLE
macOS LaunchAgent should launch state-svc directly

### DIFF
--- a/cmd/state-svc/autostart/autostart.go
+++ b/cmd/state-svc/autostart/autostart.go
@@ -18,7 +18,7 @@ var Options = autostart.Options{}
 
 func RegisterConfigListener(cfg *config.Instance) {
 	if svcExec, err := installation.ServiceExec(); err == nil {
-		if as, err := autostart.New(App, svcExec, nil, Options, cfg); err == nil {
+		if as, err := autostart.New(App, svcExec, []string{"start"}, Options, cfg); err == nil {
 			configMediator.AddListener(constants.AutostartSvcConfigKey, func() {
 				if cfg.GetBool(constants.AutostartSvcConfigKey) {
 					logging.Debug("Enabling autostart")

--- a/cmd/state-svc/autostart/autostart_mac.go
+++ b/cmd/state-svc/autostart/autostart_mac.go
@@ -1,0 +1,8 @@
+package autostart
+
+import "github.com/ActiveState/cli/internal/constants"
+
+func init() {
+	Options.MacLabel = "com.activestate." + constants.StateSvcCmd
+	Options.MacInteractive = false
+}

--- a/cmd/state-tray/autostart/autostart_mac.go
+++ b/cmd/state-tray/autostart/autostart_mac.go
@@ -1,0 +1,8 @@
+package autostart
+
+import "github.com/ActiveState/cli/internal/constants"
+
+func init() {
+	Options.MacLabel = "com.activestate." + constants.StateTrayCmd
+	Options.MacInteractive = true
+}

--- a/internal/assets/contents/com.activestate.platform.state.plist.tpl
+++ b/internal/assets/contents/com.activestate.platform.state.plist.tpl
@@ -11,10 +11,6 @@
           <string>{{.Args}}</string>
           {{- end}}
         </array>
-        {{- if .Interactive }}
-        <key>ProcessType</key>
-        <string>Interactive</string>
-        {{- end}}
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>

--- a/internal/assets/contents/com.activestate.platform.state.plist.tpl
+++ b/internal/assets/contents/com.activestate.platform.state.plist.tpl
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>com.activestate.StateToolService</string>
+        <string>{{.Label}}</string>
         <key>ProgramArguments</key>
         <array>
           <string>{{.Exec}}</string>

--- a/internal/assets/contents/com.activestate.platform.state.plist.tpl
+++ b/internal/assets/contents/com.activestate.platform.state.plist.tpl
@@ -11,6 +11,10 @@
           <string>{{.Args}}</string>
           {{- end}}
         </array>
+        {{- if .Interactive }}
+        <key>ProcessType</key>
+        <string>Interactive</string>
+        {{- end}}
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>

--- a/internal/assets/contents/com.activestate.platform.state.plist.tpl
+++ b/internal/assets/contents/com.activestate.platform.state.plist.tpl
@@ -3,20 +3,14 @@
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>my.everydaytasks</string>
+        <string>com.activestate.StateToolService</string>
         <key>ProgramArguments</key>
         <array>
-            <!-- Wrap in `sh -c` so that $HOME is expanded -->
-            <string>sh</string>
-            <string>-c</string>
-            {{- if .Args }}
-            <string>{{.Exec}} {{.Args}}</string>
-            {{- else}}
-            <string>{{.Exec}}</string>
-            {{- end}}
+          <string>{{.Exec}}</string>
+          {{- if .Args }}
+          <string>{{.Args}}</string>
+          {{- end}}
         </array>
-        <key>ProcessType</key>
-        <string>Interactive</string>
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>

--- a/internal/osutils/autostart/autostart.go
+++ b/internal/osutils/autostart/autostart.go
@@ -30,6 +30,8 @@ type Options struct {
 	GenericName    string
 	Comment        string
 	Keywords       string
+	MacLabel       string // macOS plist Label
+	MacInteractive bool   // macOS plist Interactive ProcessType
 }
 
 type Configurable interface {

--- a/internal/osutils/autostart/autostart_mac.go
+++ b/internal/osutils/autostart/autostart_mac.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/ActiveState/cli/internal/assets"
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/osutils/user"
@@ -45,9 +44,10 @@ func (a *app) enable() error {
 	content, err := strutils.ParseTemplate(
 		string(asset),
 		map[string]interface{}{
+			"Label":       a.options.MacLabel,
 			"Exec":        a.Exec,
 			"Args":        strings.Join(a.Args, " "),
-			"Interactive": a.Name == constants.TrayAppName,
+			"Interactive": a.options.MacInteractive,
 		})
 	if err != nil {
 		return errs.Wrap(err, "Could not parse %s", fmt.Sprintf(launchFileFormatName, filepath.Base(a.Exec)))

--- a/internal/osutils/autostart/autostart_mac.go
+++ b/internal/osutils/autostart/autostart_mac.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ActiveState/cli/internal/assets"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/osutils/user"
@@ -43,7 +44,11 @@ func (a *app) enable() error {
 
 	content, err := strutils.ParseTemplate(
 		string(asset),
-		map[string]interface{}{"Exec": a.Exec, "Args": strings.Join(a.Args, " ")})
+		map[string]interface{}{
+			"Exec":        a.Exec,
+			"Args":        strings.Join(a.Args, " "),
+			"Interactive": a.Name == constants.TrayAppName,
+		})
 	if err != nil {
 		return errs.Wrap(err, "Could not parse %s", fmt.Sprintf(launchFileFormatName, filepath.Base(a.Exec)))
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1394" title="DX-1394" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1394</a>  macOS ventura doesn't like our state-svc start script
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Also use a proper identifier.

$HOME appears to be available anyway, and launching it through sh shows "sh" as the identifier, which is not descriptive. Using the executable directly shows something more informative and also takes the user to its location after the "get info" button is clicked.

Note: this PR does not meet the ACs as written, but I put a comment in the ticket why we cannot meet them with LaunchAgents like this.

<img width="531" alt="Screenshot 2022-11-30 at 3 54 44 PM" src="https://user-images.githubusercontent.com/12902397/204908668-ddd1548b-d61b-4069-b2bc-bdc9f1872bf8.png">
<img width="699" alt="Screenshot 2022-11-30 at 3 53 28 PM" src="https://user-images.githubusercontent.com/12902397/204908682-5cb4f719-e747-49fa-9816-11fea4132c9e.png">
