### PR TITLE
Shorten stacktrace format.

### DIFF
--- a/internal/logging/formatter.go
+++ b/internal/logging/formatter.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"fmt"
-	"time"
 )
 
 // A formatting interface- it is responsible of taking the arguments and composing a message
@@ -15,9 +14,9 @@ type SimpleFormatter struct {
 }
 
 func (f *SimpleFormatter) Format(ctx *MessageContext, message string, args ...interface{}) string {
-	return fmt.Sprintf(f.FormatString, ctx.Level, ctx.TimeStamp.Format(time.StampNano), ctx.File, ctx.Line, fmt.Sprintf(message, args...))
+	return fmt.Sprintf(f.FormatString, ctx.Level, ctx.TimeStamp.UnixMicro(), ctx.File, ctx.Line, fmt.Sprintf(message, args...))
 }
 
 var DefaultFormatter Formatter = &SimpleFormatter{
-	FormatString: "[%[1]s %[2]s, %[3]s:%[4]d] %[5]s",
+	FormatString: "[%[1]s %[2]d %[3]s:%[4]d] %[5]s",
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -7,16 +7,10 @@
 // 		logging.Info("This object is %s and that is %s", obj, that)
 //
 // example output:
-//	2013/05/07 01:20:26 INFO @ db.go:528: Registering plugin REPLICATION
-//	2013/05/07 01:20:26 INFO @ db.go:562: Registered 6 plugins and 22 commands
-//	2013/05/07 01:20:26 INFO @ slave.go:277: Running replication watchdog loop!
-//	2013/05/07 01:20:26 INFO @ redis.go:49: Redis adapter listening on 0.0.0.0:2000
-//	2013/05/07 01:20:26 WARN @ main.go:69: Starting adapter...
-//	2013/05/07 01:20:26 INFO @ db.go:966: Finished dump load. Loaded 2 objects from dump
-//	2013/05/07 01:22:26 INFO @ db.go:329: Checking persistence... 0 changes since 2m0.000297531s
-//	2013/05/07 01:22:26 INFO @ db.go:337: No need to save the db. no changes...
-//	2013/05/07 01:22:26 DEBUG @ db.go:341: Sleeping for 2m0s
 //
+// [DBG 1670353253256778 instance.go:123] Setting config: projects
+// [DBG 1670353253259897 subshell.go:95] Detected SHELL: zsh
+// [DBG 1670353253259915 subshell.go:132] Using binary: /bin/zsh
 package logging
 
 // This package may NOT depend on failures (directly or indirectly)
@@ -53,7 +47,7 @@ const (
 
 var levels_ascending = []int{DEBUG, INFO, WARNING, ERROR, NOTICE, CRITICAL}
 
-var LevlelsByName = map[string]int{
+var LevelsByName = map[string]int{
 	"DEBUG":    DEBUG,
 	"INFO":     INFO,
 	"WARNING":  WARN,
@@ -105,7 +99,7 @@ func SetMinimalLevel(l int) {
 // Possible level names are DEBUG, INFO, WARNING, ERROR, NOTICE, CRITICAL
 func SetMinimalLevelByName(l string) error {
 	l = strings.ToUpper(strings.Trim(l, " "))
-	level, found := LevlelsByName[l]
+	level, found := LevelsByName[l]
 	if !found {
 		Error("Could not set level - not found level %s", l)
 		return fmt.Errorf("Invalid level %s", l)
@@ -155,7 +149,7 @@ func (l *strandardHandler) Emit(ctx *MessageContext, message string, args ...int
 // logging handlers to 3rd party libraries
 func (l *strandardHandler) Printf(msg string, args ...interface{}) {
 	logMsg := fmt.Sprintf("Third party log message: %s", msg)
-	l.Emit(getContext("DEBUG", 1), logMsg, args...)
+	l.Emit(getContext("DBG", 1), logMsg, args...)
 }
 
 func (l *strandardHandler) Close() {}
@@ -197,7 +191,7 @@ func getContext(level string, skipDepth int) *MessageContext {
 // Output debug logging messages
 func Debug(msg string, args ...interface{}) {
 	if level&DEBUG != 0 {
-		writeMessage("DEBUG", msg, args...)
+		writeMessage("DBG", msg, args...)
 	}
 }
 
@@ -205,7 +199,7 @@ type writer struct{}
 
 func (w *writer) Write(p []byte) (n int, err error) {
 	if level&DEBUG != 0 {
-		writeMessage("DEBUG", string(p))
+		writeMessage("DBG", string(p))
 	}
 	return len(p), nil
 }
@@ -279,7 +273,7 @@ func Info(msg string, args ...interface{}) {
 
 	if level&INFO != 0 {
 
-		writeMessage("INFO", msg, args...)
+		writeMessage("INF", msg, args...)
 
 	}
 }
@@ -287,7 +281,7 @@ func Info(msg string, args ...interface{}) {
 // Output WARNING level messages
 func Warning(msg string, args ...interface{}) {
 	if level&WARN != 0 {
-		writeMessage("WARNING", msg, args...)
+		writeMessage("WRN", msg, args...)
 	}
 }
 
@@ -295,21 +289,21 @@ func Warning(msg string, args ...interface{}) {
 // This should be used sparingly, as multilog.Error() is preferred.
 func Error(msg string, args ...interface{}) {
 	if level&ERROR != 0 {
-		writeMessage("ERROR", msg+"\n\nStacktrace: "+stacktrace.Get().String()+"\n", args...)
+		writeMessage("ERR", msg+"\n\nStacktrace: "+stacktrace.Get().String()+"\n", args...)
 	}
 }
 
 // Same as Error() but without a stacktrace.
 func ErrorNoStacktrace(msg string, args ...interface{}) {
 	if level&ERROR != 0 {
-		writeMessage("ERROR", msg, args...)
+		writeMessage("ERR", msg, args...)
 	}
 }
 
 // Output NOTICE level messages
 func Notice(msg string, args ...interface{}) {
 	if level&NOTICE != 0 {
-		writeMessage("NOTICE", msg, args...)
+		writeMessage("NOT", msg, args...)
 	}
 }
 
@@ -317,7 +311,7 @@ func Notice(msg string, args ...interface{}) {
 // This should be called sparingly, as multilog.Critical() is preferred.
 func Critical(msg string, args ...interface{}) {
 	if level&CRITICAL != 0 {
-		writeMessage("CRITICAL", msg, args...)
+		writeMessage("CRT", msg, args...)
 		log.Println(string(debug.Stack()))
 	}
 }
@@ -353,7 +347,7 @@ func (lb bridge) Write(p []byte) (n int, err error) {
 // through this logger, at a given level.
 func BridgeStdLog(level int) {
 
-	for k, l := range LevlelsByName {
+	for k, l := range LevelsByName {
 		if l == level {
 			b := bridge{
 				level:     l,

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -187,19 +187,19 @@ func Test_Formatting(t *testing.T) {
 	msg := formatter.Format(ctx, "FOO %s", "bar")
 
 	//fmt.Println("Message: ", msg)
-	if msg != "[TEST Jan  1 00:00:00.000000000, testung:100] FOO bar" {
+	if msg != "[TEST -62135596800000000 testung:100] FOO bar" {
 		t.Fatal("Got wrong formatting:", msg)
 	}
 
 	//"[%[1]s %[2]s, %[3]s:%[4]d] %[5]s",
-	format := "%[5]s @ %[4]d:%[3]s: %[2]s %[1]s"
+	format := "%[5]s @ %[4]d:%[3]s: %[2]d %[1]s"
 	formatter = &SimpleFormatter{format}
 
 	mesg := "FOO %s"
 
 	s := formatter.Format(ctx, mesg, "BAR")
 	fmt.Println(s)
-	if s != "FOO BAR @ 100:testung: Jan  1 00:00:00.000000000 TEST" {
+	if s != "FOO BAR @ 100:testung: -62135596800000000 TEST" {
 		t.Fatal(s)
 	}
 
@@ -219,14 +219,14 @@ func TestLogTail(t *testing.T) {
 
 	contents := ReadTail()
 	fmt.Println(contents)
-	if !strings.Contains(contents, "[INFO ") {
-		t.Fatal("Tail does not contain '[INFO '")
+	if !strings.Contains(contents, "[INF ") {
+		t.Fatal("Tail does not contain '[INF '")
 	}
 	if !strings.Contains(contents, "] Foo Bar 1") {
 		t.Fatal("Tail does not contain '] Foo Bar 1'")
 	}
-	if !strings.Contains(contents, "[WARNING ") {
-		t.Fatal("Tail does not contain '[WARNING '")
+	if !strings.Contains(contents, "[WRN ") {
+		t.Fatal("Tail does not contain '[WRN '")
 	}
 	if !strings.Contains(contents, "] Bar Baz 2") {
 		t.Fatal("Tail does not contain '] Bar Baz 2'")

--- a/internal/osutils/stacktrace/stacktrace.go
+++ b/internal/osutils/stacktrace/stacktrace.go
@@ -33,6 +33,13 @@ type Frame struct {
 // for purpose of performance optimisation.
 var FrameCap = 20
 
+var environmentRootPath string
+
+func init() {
+	// Note: ignore any error. It cannot be logged due to logging's dependence on this package.
+	environmentRootPath, _ = environment.GetRootPath()
+}
+
 // String returns a string representation of a stacktrace
 // For example:
 //   ./package/file.go:123:file.func
@@ -46,9 +53,9 @@ func (t *Stacktrace) String() string {
 		if strings.HasPrefix(path, build.Default.GOROOT) {
 			// Convert "/path/to/go/distribution/file" to "<go>/file".
 			path = strings.Replace(path, build.Default.GOROOT, "<go>", 1)
-		} else if root, err := environment.GetRootPath(); err == nil {
+		} else if environmentRootPath != "" {
 			// Convert "/path/to/cli/file" to "./file".
-			if relPath, err2 := filepath.Rel(root, path); err2 == nil {
+			if relPath, err := filepath.Rel(environmentRootPath, path); err == nil {
 				path = "./" + relPath
 			}
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1374" title="DX-1374" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1374</a>  Our logging format is concise
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reduce data sent to Rollbar, but keep it meaningful.