### PR TITLE
Send state-svc logs along with state tool logs to Rollbar.

### DIFF
--- a/cmd/state-svc/internal/resolver/resolver.go
+++ b/cmd/state-svc/internal/resolver/resolver.go
@@ -185,3 +185,7 @@ func (r *Resolver) ConfigChanged(ctx context.Context, key string) (*graph.Config
 	go configMediator.NotifyListeners(key)
 	return &graph.ConfigChangedResponse{Received: true}, nil
 }
+
+func (r *Resolver) FetchLogTail(ctx context.Context) (string, error) {
+	return logging.ReadTail(), nil
+}

--- a/cmd/state-svc/schema/schema.graphqls
+++ b/cmd/state-svc/schema/schema.graphqls
@@ -46,6 +46,7 @@ type Query {
   runtimeUsage(pid: Int!, exec: String!, dimensionsJson: String!): RuntimeUsageResponse
   checkDeprecation: DeprecationInfo
   configChanged(key: String!): ConfigChangedResponse
+  fetchLogTail: String!
 }
 
 type ConfigChangedResponse {

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -155,10 +155,11 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 	logging.SetSvcTailProvider(func() string {
 		ctx, cancel := context.WithTimeout(context.Background(), model.SvcTimeoutMinimal)
 		defer cancel()
-		if tail, err := svcmodel.FetchLogTail(ctx); err == nil {
-			return tail
+		tail, err := svcmodel.FetchLogTail(ctx)
+		if err != nil {
+			return fmt.Sprintf("Could not fetch state-svc log: %v", err)
 		}
-		return ""
+		return tail
 	})
 
 	// Retrieve project file

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -152,7 +152,7 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 
 	// Amend Rollbar data to also send the state-svc log tail. This cannot be done inside the rollbar
 	// package itself because importing pkg/platform/model creates an import cycle.
-	rollbar.SetLogDataAmender(func(logData string) string {
+	rollbar.AddLogDataAmender(func(logData string) string {
 		ctx, cancel := context.WithTimeout(context.Background(), model.SvcTimeoutMinimal)
 		defer cancel()
 		svcLogData, err := svcmodel.FetchLogTail(ctx)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -237,26 +237,6 @@ func ReadTail() string {
 	return logTail.Read()
 }
 
-var svcTailProvider func() string
-
-// SetSvcTailProvider registers the given function as providing the state-svc log tail.
-// Fetching that log via pkg/platform/model is not possible here due to an import cycle, so the
-// given function is expected to do that.
-func SetSvcTailProvider(f func() string) {
-	svcTailProvider = f
-}
-
-// ReadSvcTail returns the tail end of the state-svc log, just like ReadTail().
-// This exists in order to have Rollbar send both state logs and state-svc logs together.
-// If no provider function was given earlier, this function returns a constant, so calling it
-// from state-svc is safe. (i.e. state-svc is sending its own error log to Rollbar.)
-func ReadSvcTail() string {
-	if svcTailProvider != nil {
-		return svcTailProvider()
-	}
-	return "No svc tail log provider set"
-}
-
 func writeMessageDepth(depth int, level string, msg string, args ...interface{}) {
 	ctx := getContext(level, depth)
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -238,7 +238,6 @@ func ReadTail() string {
 }
 
 var svcTailProvider func() string
-var SvcTailProviderNotSet = "no svc tail log provider set"
 
 // SetSvcTailProvider registers the given function as providing the state-svc log tail.
 // Fetching that log via pkg/platform/model is not possible here due to an import cycle, so the
@@ -255,7 +254,7 @@ func ReadSvcTail() string {
 	if svcTailProvider != nil {
 		return svcTailProvider()
 	}
-	return SvcTailProviderNotSet
+	return "No svc tail log provider set"
 }
 
 func writeMessageDepth(depth int, level string, msg string, args ...interface{}) {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -238,6 +238,7 @@ func ReadTail() string {
 }
 
 var svcTailProvider func() string
+var SvcTailProviderNotSet = "no svc tail log provider set"
 
 // SetSvcTailProvider registers the given function as providing the state-svc log tail.
 // Fetching that log via pkg/platform/model is not possible here due to an import cycle, so the
@@ -248,13 +249,13 @@ func SetSvcTailProvider(f func() string) {
 
 // ReadSvcTail returns the tail end of the state-svc log, just like ReadTail().
 // This exists in order to have Rollbar send both state logs and state-svc logs together.
-// If no provider function was given earlier, this function returns the empty string, so calling it
+// If no provider function was given earlier, this function returns a constant, so calling it
 // from state-svc is safe. (i.e. state-svc is sending its own error log to Rollbar.)
 func ReadSvcTail() string {
 	if svcTailProvider != nil {
 		return svcTailProvider()
 	}
-	return ""
+	return SvcTailProviderNotSet
 }
 
 func writeMessageDepth(depth int, level string, msg string, args ...interface{}) {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -237,6 +237,26 @@ func ReadTail() string {
 	return logTail.Read()
 }
 
+var svcTailProvider func() string
+
+// SetSvcTailProvider registers the given function as providing the state-svc log tail.
+// Fetching that log via pkg/platform/model is not possible here due to an import cycle, so the
+// given function is expected to do that.
+func SetSvcTailProvider(f func() string) {
+	svcTailProvider = f
+}
+
+// ReadSvcTail returns the tail end of the state-svc log, just like ReadTail().
+// This exists in order to have Rollbar send both state logs and state-svc logs together.
+// If no provider function was given earlier, this function returns the empty string, so calling it
+// from state-svc is safe. (i.e. state-svc is sending its own error log to Rollbar.)
+func ReadSvcTail() string {
+	if svcTailProvider != nil {
+		return svcTailProvider()
+	}
+	return ""
+}
+
 func writeMessageDepth(depth int, level string, msg string, args ...interface{}) {
 	ctx := getContext(level, depth)
 

--- a/internal/rollbar/rollbar.go
+++ b/internal/rollbar/rollbar.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ActiveState/cli/internal/logging"
 	configMediator "github.com/ActiveState/cli/internal/mediators/config"
 	"github.com/ActiveState/cli/internal/singleton/uniqid"
-
 	"github.com/rollbar/rollbar-go"
 )
 
@@ -111,6 +110,13 @@ func logToRollbar(critical bool, message string, args ...interface{}) {
 	logData := logging.ReadTail()
 	if len(logData) == logging.TailSize {
 		logData = "<truncated>\n" + logData
+	}
+	if svcLogData := logging.ReadSvcTail(); svcLogData != "" { // will be "" if called from state-svc
+		logData += "\nstate-svc log:\n"
+		if len(svcLogData) == logging.TailSize {
+			logData += "<truncated>\n"
+		}
+		logData += svcLogData
 	}
 	data["log_file_data"] = logData
 

--- a/internal/rollbar/rollbar.go
+++ b/internal/rollbar/rollbar.go
@@ -111,7 +111,7 @@ func logToRollbar(critical bool, message string, args ...interface{}) {
 	if len(logData) == logging.TailSize {
 		logData = "<truncated>\n" + logData
 	}
-	svcLogData := logging.ReadSvcTail()
+	svcLogData := logging.ReadSvcTail() // will show up in state-svc Rollbar errors, but there's no harmful recursion, etc.
 	logData += "\nstate-svc log:\n"
 	if len(svcLogData) == logging.TailSize {
 		logData += "<truncated>\n"

--- a/internal/rollbar/rollbar.go
+++ b/internal/rollbar/rollbar.go
@@ -99,12 +99,12 @@ func UpdateRollbarPerson(userID, username, email string) {
 // Wait is a wrapper around rollbar.Wait().
 func Wait() { rollbar.Wait() }
 
-var logDataAmender func(string) string
+var logDataAmenders []func(string) string
 
-// SetLogDataAmender routes log data to be sent to Rollbar through the given function first.
+// AddLogDataAmender routes log data to be sent to Rollbar through the given function first.
 // For example, that function might add more log data to be sent.
-func SetLogDataAmender(f func(string) string) {
-	logDataAmender = f
+func AddLogDataAmender(f func(string) string) {
+	logDataAmenders = append(logDataAmenders, f)
 }
 
 func logToRollbar(critical bool, message string, args ...interface{}) {
@@ -119,8 +119,8 @@ func logToRollbar(critical bool, message string, args ...interface{}) {
 	if len(logData) == logging.TailSize {
 		logData = "<truncated>\n" + logData
 	}
-	if logDataAmender != nil {
-		logData = logDataAmender(logData)
+	for _, f := range logDataAmenders {
+		logData = f(logData)
 	}
 	data["log_file_data"] = logData
 

--- a/internal/rollbar/rollbar.go
+++ b/internal/rollbar/rollbar.go
@@ -111,7 +111,7 @@ func logToRollbar(critical bool, message string, args ...interface{}) {
 	if len(logData) == logging.TailSize {
 		logData = "<truncated>\n" + logData
 	}
-	if svcLogData := logging.ReadSvcTail(); svcLogData != "" { // will be "" if called from state-svc
+	if svcLogData := logging.ReadSvcTail(); svcLogData != logging.SvcTailProviderNotSet {
 		logData += "\nstate-svc log:\n"
 		if len(svcLogData) == logging.TailSize {
 			logData += "<truncated>\n"

--- a/internal/rollbar/rollbar.go
+++ b/internal/rollbar/rollbar.go
@@ -111,13 +111,12 @@ func logToRollbar(critical bool, message string, args ...interface{}) {
 	if len(logData) == logging.TailSize {
 		logData = "<truncated>\n" + logData
 	}
-	if svcLogData := logging.ReadSvcTail(); svcLogData != logging.SvcTailProviderNotSet {
-		logData += "\nstate-svc log:\n"
-		if len(svcLogData) == logging.TailSize {
-			logData += "<truncated>\n"
-		}
-		logData += svcLogData
+	svcLogData := logging.ReadSvcTail()
+	logData += "\nstate-svc log:\n"
+	if len(svcLogData) == logging.TailSize {
+		logData += "<truncated>\n"
 	}
+	logData += svcLogData
 	data["log_file_data"] = logData
 
 	exec := CurrentCmd

--- a/pkg/platform/api/svc/request/fetchlogtail.go
+++ b/pkg/platform/api/svc/request/fetchlogtail.go
@@ -1,0 +1,17 @@
+package request
+
+type FetchLogTail struct{}
+
+func NewFetchLogTail() *FetchLogTail {
+	return &FetchLogTail{}
+}
+
+func (r *FetchLogTail) Query() string {
+	return `query() {
+		fetchLogTail
+	}`
+}
+
+func (r *FetchLogTail) Vars() map[string]interface{} {
+	return nil
+}

--- a/pkg/platform/model/svc.go
+++ b/pkg/platform/model/svc.go
@@ -156,9 +156,9 @@ func (m *SvcModel) FetchLogTail(ctx context.Context) (string, error) {
 	logging.Debug("Fetching log svc log")
 	defer profile.Measure("svc:FetchLogTail", time.Now())
 
-	request := request.NewFetchLogTail()
+	req := request.NewFetchLogTail()
 	response := make(map[string]string)
-	if err := m.request(ctx, request, &response); err != nil {
+	if err := m.request(ctx, req, &response); err != nil {
 		return "", errs.Wrap(err, "Error sending FetchLogTail request to state-svc")
 	}
 	if log, ok := response["fetchLogTail"]; ok {

--- a/pkg/platform/model/svc.go
+++ b/pkg/platform/model/svc.go
@@ -141,7 +141,7 @@ func (m *SvcModel) CheckDeprecation(ctx context.Context) (*graph.DeprecationInfo
 }
 
 func (m *SvcModel) ConfigChanged(ctx context.Context, key string) error {
-	defer profile.Measure("svc:RecordRuntimeUsage", time.Now())
+	defer profile.Measure("svc:ConfigChanged", time.Now())
 
 	r := request.NewConfigChanged(key)
 	u := graph.ConfigChangedResponse{}
@@ -150,6 +150,21 @@ func (m *SvcModel) ConfigChanged(ctx context.Context, key string) error {
 	}
 
 	return nil
+}
+
+func (m *SvcModel) FetchLogTail(ctx context.Context) (string, error) {
+	logging.Debug("Fetching log svc log")
+	defer profile.Measure("svc:FetchLogTail", time.Now())
+
+	request := request.NewFetchLogTail()
+	response := make(map[string]string)
+	if err := m.request(ctx, request, &response); err != nil {
+		return "", errs.Wrap(err, "Error sending FetchLogTail request to state-svc")
+	}
+	if log, ok := response["fetchLogTail"]; ok {
+		return log, nil
+	}
+	return "", errs.New("svcModel.FetchLogTail() did not return an expected value")
 }
 
 func jsonFromMap(m map[string]interface{}) string {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1375" title="DX-1375" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1375</a>  Include state-svc log in rollbar reports
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Create a way for state-svc to send over its logs on request.