### PR TITLE
Updated default Ruby version for state init.

### DIFF
--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -84,7 +84,7 @@ var lookup = [...]languageData{
 		Executable{constants.ActivePython2Executable, false},
 	},
 	{
-		"ruby", "Ruby", ".rb", true, "ruby", "3.0.1",
+		"ruby", "Ruby", ".rb", true, "ruby", "3.1.2",
 		Executable{constants.RubyExecutable, false},
 	},
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1447" title="DX-1447" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1447</a>  state init ruby without a version argument selects an unsupported version of ActiveRuby
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
