### PR TITLE
Revert back to Go 1.16.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.18.x
+          - 1.17.x
         platform:
           - ubuntu-20.04
           - macos-11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.17.x
+          - 1.16.x
         platform:
           - ubuntu-20.04
           - macos-11

--- a/.github/workflows/propagate.yml
+++ b/.github/workflows/propagate.yml
@@ -35,7 +35,7 @@ jobs:
         name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: ${{ matrix.go-version }}
 
       - # === Setup ===
         name: Setup

--- a/.github/workflows/propagate.yml
+++ b/.github/workflows/propagate.yml
@@ -35,7 +35,7 @@ jobs:
         name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.17.x
 
       - # === Setup ===
         name: Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Remote Installer
     timeout-minutes: 30
     runs-on: windows-2019
-    if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
+    #if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
     env:
       ACTIVESTATE_CLI_DISABLE_RUNTIME: true
       GOFLAGS: -mod=vendor
@@ -29,7 +29,7 @@ jobs:
         name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.17.x
 
       - # === Setup ===
         name: Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Remote Installer
     timeout-minutes: 30
     runs-on: windows-2019
-    #if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
+    if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
     env:
       ACTIVESTATE_CLI_DISABLE_RUNTIME: true
       GOFLAGS: -mod=vendor
@@ -29,7 +29,7 @@ jobs:
         name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - # === Setup ===
         name: Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Remote Installer
     timeout-minutes: 30
     runs-on: windows-2019
-    #if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
+    if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
     env:
       ACTIVESTATE_CLI_DISABLE_RUNTIME: true
       GOFLAGS: -mod=vendor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Remote Installer
     timeout-minutes: 30
     runs-on: windows-2019
-    if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
+    #if: github.event.ref_type == 'tag' && contains(github.event.ref, 'release/remote-installer')
     env:
       ACTIVESTATE_CLI_DISABLE_RUNTIME: true
       GOFLAGS: -mod=vendor

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,7 +38,7 @@ jobs:
         name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.17.x
 
       - # === Setup ===
         name: Setup

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,7 +38,7 @@ jobs:
         name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: ${{ matrix.go-version }}
 
       - # === Setup ===
         name: Setup

--- a/internal/logging/formatter.go
+++ b/internal/logging/formatter.go
@@ -14,7 +14,7 @@ type SimpleFormatter struct {
 }
 
 func (f *SimpleFormatter) Format(ctx *MessageContext, message string, args ...interface{}) string {
-	return fmt.Sprintf(f.FormatString, ctx.Level, ctx.TimeStamp.UnixMicro(), ctx.File, ctx.Line, fmt.Sprintf(message, args...))
+	return fmt.Sprintf(f.FormatString, ctx.Level, ctx.TimeStamp.UnixNano(), ctx.File, ctx.Line, fmt.Sprintf(message, args...))
 }
 
 var DefaultFormatter Formatter = &SimpleFormatter{

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -187,7 +187,7 @@ func Test_Formatting(t *testing.T) {
 	msg := formatter.Format(ctx, "FOO %s", "bar")
 
 	//fmt.Println("Message: ", msg)
-	if msg != "[TEST -62135596800000000 testung:100] FOO bar" {
+	if msg != "[TEST -6795364578871345152 testung:100] FOO bar" {
 		t.Fatal("Got wrong formatting:", msg)
 	}
 
@@ -199,7 +199,7 @@ func Test_Formatting(t *testing.T) {
 
 	s := formatter.Format(ctx, mesg, "BAR")
 	fmt.Println(s)
-	if s != "FOO BAR @ 100:testung: -62135596800000000 TEST" {
+	if s != "FOO BAR @ 100:testung: -6795364578871345152 TEST" {
 		t.Fatal(s)
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ For usage information please refer to the [State Tool Documentation](http://docs
 ## Development
 
 ### Requirements
-* Go 1.17 or above
+* Go 1.16 or above
 
 ### Building & Testing
 

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ For usage information please refer to the [State Tool Documentation](http://docs
 ## Development
 
 ### Requirements
-* Go 1.18 or above
+* Go 1.17 or above
 
 ### Building & Testing
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1457" title="DX-1457" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1457</a>  Tests failing with `interrupt: No such file or directory`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


There is currently an issue in Go 1.17 and 1.18 that prevents the TestRunIntegrationTestSuite's `go build ./interrupt ./interrupt.go` run script in as.yaml from running. (It appears to crash). I am not able to reproduce this locally, either on macOS or in a Linux docker environment.

I've moved DX-1441 back into "TODO" status to properly debug and address this. I'd like to get CI back on its feet ASAP.