### PR TITLE
Do not close legacy auth config.

### DIFF
--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -64,7 +64,6 @@ func LegacyGet() *Auth {
 			multilog.Error("Could not get configuration required by auth: %v", err)
 			os.Exit(1)
 		}
-		defer cfg.Close()
 
 		persist = New(cfg)
 		if err := persist.Sync(); err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1427" title="DX-1427" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1427</a>  Race condition in `state secrets get`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It will be closed by the auth object itself. Closing it now would result in "database is closed" errors anytime a config read attempt is made.