### PR TITLE
`state revert` reverts changes from a commit, rather than reverting to the commit itself.

### DIFF
--- a/cmd/state/internal/cmdtree/revert.go
+++ b/cmd/state/internal/cmdtree/revert.go
@@ -20,7 +20,7 @@ func newRevertCommand(prime *primer.Values, globals *globalOptions) *captain.Com
 		[]*captain.Argument{
 			{
 				Name:        "commit-id",
-				Description: locale.Tl("revert_arg_commit_id", "The commit ID to revert to"),
+				Description: locale.Tl("revert_arg_commit_id", "The commit ID to revert changes from"),
 				Required:    true,
 				Value:       &params.CommitID,
 			},

--- a/pkg/platform/model/vcs.go
+++ b/pkg/platform/model/vcs.go
@@ -888,23 +888,30 @@ func GetRevertCommit(from, to strfmt.UUID) (*mono_models.Commit, error) {
 	return res.Payload, nil
 }
 
-func RevertCommitWithinHistory(from, to strfmt.UUID) (*mono_models.Commit, error) {
-	ok, err := CommitWithinCommitHistory(from, to)
+func RevertCommitWithinHistory(from, to, latest strfmt.UUID) (*mono_models.Commit, error) {
+	ok, err := CommitWithinCommitHistory(latest, from)
 	if err != nil {
 		return nil, errs.Wrap(err, "API communication failed.")
 	}
 	if !ok {
-		return nil, locale.WrapError(err, "err_revert_commit_within_history_not_in", "The commit being reverted to is not within the current commit's history.")
+		return nil, locale.WrapError(err, "err_revert_commit_within_history_not_in", "The commit being reverted is not within the current commit's history.")
 	}
 
-	return RevertCommit(from, to)
+	return RevertCommit(from, to, latest)
 }
 
-func RevertCommit(from strfmt.UUID, to strfmt.UUID) (*mono_models.Commit, error) {
+func RevertCommit(from, to, latest strfmt.UUID) (*mono_models.Commit, error) {
 	revertCommit, err := GetRevertCommit(from, to)
 	if err != nil {
 		return nil, err
 	}
+	// The platform assumes revert commits are reverting to a particular commit, rather than reverting
+	// the changes in a commit. As a result, commit messages are of the form "Revert to commit X" and
+	// parent commit IDs are X. Change the message to reflect the fact we're reverting changes from
+	// X and change the parent to be the latest commit so that the revert commit applies to the latest
+	// project commit.
+	revertCommit.Message = locale.Tl("revert_commit", "Revert commit {{.V0}}", from.String())
+	revertCommit.ParentCommitID = latest
 
 	addCommit, err := AddRevertCommit(revertCommit)
 	if err != nil {

--- a/test/automation/revert_automation_test.go
+++ b/test/automation/revert_automation_test.go
@@ -22,7 +22,7 @@ func (suite *RevertAutomationTestSuite) TestRevert_MissingArg() {
 	cp := ts.Spawn("revert")
 	cp.ExpectLongString("The following argument is required")
 	cp.ExpectLongString("Name: commit-id")
-	cp.ExpectLongString("Description: The commit ID to revert changes from")
+	cp.ExpectLongString("Description: The commit ID to revert to")
 	cp.ExpectExitCode(1)
 }
 
@@ -127,7 +127,7 @@ func (suite *RevertAutomationTestSuite) TestRevert_PublicProject() {
 	// Testing if user choose YES for reset and reset have been successful
 	cp = ts.Spawn("revert", "66e5a9ba-6762-4027-a001-6e9c54437dde")
 	cp.SendLine("y")
-	cp.ExpectLongString("Successfully reverted commit: 66e5a9ba-6762-4027-a001-6e9c54437dde")
+	cp.ExpectLongString("Successfully reverted to commit: 66e5a9ba-6762-4027-a001-6e9c54437dde")
 	cp.ExpectExitCode(0)
 }
 
@@ -153,7 +153,7 @@ func (suite *RevertAutomationTestSuite) TestRevert_PrivateProject() {
 	// Testing if user choose YES for reset and reset have been successful
 	cp = ts.Spawn("revert", "d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
 	cp.SendLine("y")
-	cp.ExpectLongString("Successfully reverted commit: d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
+	cp.ExpectLongString("Successfully reverted to commit: d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
 	cp.ExpectExitCode(0)
 }
 

--- a/test/automation/revert_automation_test.go
+++ b/test/automation/revert_automation_test.go
@@ -22,7 +22,7 @@ func (suite *RevertAutomationTestSuite) TestRevert_MissingArg() {
 	cp := ts.Spawn("revert")
 	cp.ExpectLongString("The following argument is required")
 	cp.ExpectLongString("Name: commit-id")
-	cp.ExpectLongString("Description: The commit ID to revert to")
+	cp.ExpectLongString("Description: The commit ID to revert changes from")
 	cp.ExpectExitCode(1)
 }
 
@@ -127,7 +127,7 @@ func (suite *RevertAutomationTestSuite) TestRevert_PublicProject() {
 	// Testing if user choose YES for reset and reset have been successful
 	cp = ts.Spawn("revert", "66e5a9ba-6762-4027-a001-6e9c54437dde")
 	cp.SendLine("y")
-	cp.ExpectLongString("Successfully reverted to commit: 66e5a9ba-6762-4027-a001-6e9c54437dde")
+	cp.ExpectLongString("Successfully reverted commit: 66e5a9ba-6762-4027-a001-6e9c54437dde")
 	cp.ExpectExitCode(0)
 }
 
@@ -153,7 +153,7 @@ func (suite *RevertAutomationTestSuite) TestRevert_PrivateProject() {
 	// Testing if user choose YES for reset and reset have been successful
 	cp = ts.Spawn("revert", "d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
 	cp.SendLine("y")
-	cp.ExpectLongString("Successfully reverted to commit: d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
+	cp.ExpectLongString("Successfully reverted commit: d5b7cf36-bcc2-4ba9-a910-6b8ad1098eb2")
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"testing"
 	"time"

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -356,7 +356,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_headless_operation() {
 }
 
 func (suite *PackageIntegrationTestSuite) TestPackage_operation() {
-	suite.OnlyRunForTags(tagsuite.Package, tagsuite.Revert)
+	suite.OnlyRunForTags(tagsuite.Package, tagsuite.Package)
 	if runtime.GOOS == "darwin" {
 		suite.T().Skip("Skipping mac for now as the builds are still too unreliable")
 		return
@@ -367,7 +367,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_operation() {
 	username := ts.CreateNewUser()
 	namespace := fmt.Sprintf("%s/%s", username, "python3-pkgtest")
 
-	cp := ts.Spawn("fork", "ActiveState-CLI/Revert", "--org", username, "--name", "python3-pkgtest")
+	cp := ts.Spawn("fork", "ActiveState-CLI/Packages", "--org", username, "--name", "python3-pkgtest")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("activate", namespace, "--path="+ts.Dirs.Work, "--output=json")
@@ -375,15 +375,6 @@ func (suite *PackageIntegrationTestSuite) TestPackage_operation() {
 
 	cp = ts.Spawn("history", "--output=json")
 	cp.ExpectExitCode(0)
-
-	// Get the first commitID we find, which should be the first commit for the project
-	snapshot := cp.TrimmedSnapshot()
-	commitRe := regexp.MustCompile(`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`)
-	firstCommit := commitRe.FindString(snapshot)
-
-	if firstCommit == "" {
-		suite.FailNow("Could not match commitID against output:\n" + snapshot)
-	}
 
 	suite.Run("install", func() {
 		cp := ts.Spawn("install", "urllib3@1.25.6")
@@ -405,18 +396,6 @@ func (suite *PackageIntegrationTestSuite) TestPackage_operation() {
 		cp.ExpectRe("(?:Package uninstalled|being built)", 30*time.Second)
 		cp.Wait()
 	})
-
-	cp = ts.Spawn("revert", firstCommit)
-	cp.Send("y")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("pull")
-	cp.ExpectExitCode(0)
-
-	// expecting json output, as table wraps message in column
-	cp = ts.Spawn("history", "--output=json")
-	cp.ExpectLongString(fmt.Sprintf("Reverting to commit %s", firstCommit))
-	cp.ExpectExitCode(0)
 }
 
 func (suite *PackageIntegrationTestSuite) PrepareActiveStateYAML(ts *e2e.Session) {

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -53,7 +53,8 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	// Verify that argparse still exists (it was not reverted along with urllib3).
 	cp = ts.SpawnWithOpts(e2e.WithArgs("shell", "Revert"))
 	if runtime.GOOS == "linux" {
-		cp.SendLine("hash -r")
+		cp.SendLine("echo $PATH")
+		cp.SendLine("which python3")
 	}
 	cp.SendLine("python3")
 	cp.SendLine("import urllib3")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -51,13 +51,12 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	cp.Expect("+ python")   // initial commit
 
 	// Verify that argparse still exists (it was not reverted along with urllib3).
-	cp = ts.SpawnWithOpts(e2e.WithArgs("activate", namespace))
+	cp = ts.SpawnWithOpts(e2e.WithArgs("shell", "Revert"))
 	if runtime.GOOS == "linux" {
 		cp.SendLine("echo $PATH")
 		cp.SendLine("which python3")
 	}
 	cp.SendLine("python3")
-	cp.Expect("3.9.15")
 	cp.SendLine("import urllib3")
 	cp.Expect("No module named 'urllib3'")
 	cp.SendLine("import argparse")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -41,7 +41,6 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	cp = ts.SpawnWithOpts(
 		e2e.WithArgs("history"),
 		e2e.WithWorkDirectory(wd),
-		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Revert commit " + commitID)
 	cp.Expect("- urllib3")
@@ -50,7 +49,10 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	cp.Expect("+ python")   // initial commit
 
 	// Verify that argparse still exists (it was not reverted along with urllib3).
-	cp = ts.SpawnWithOpts(e2e.WithArgs("shell", "Revert"))
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("shell", "Revert"),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
 	cp.SendLine("python3")
 	cp.SendLine("import urllib3")
 	cp.Expect("No module named 'urllib3'")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -51,6 +52,9 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 
 	// Verify that argparse still exists (it was not reverted along with urllib3).
 	cp = ts.SpawnWithOpts(e2e.WithArgs("shell", "Revert"))
+	if runtime.GOOS == "linux" {
+		cp.SendLine("hash -r")
+	}
 	cp.SendLine("python3")
 	cp.SendLine("import urllib3")
 	cp.Expect("No module named 'urllib3'")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -50,11 +50,12 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	cp.Expect("+ python")   // initial commit
 
 	// Verify that argparse still exists (it was not reverted along with urllib3).
-	cp = ts.SpawnWithOpts(e2e.WithArgs("shell"), e2e.WithWorkDirectory(wd))
+	cp = ts.SpawnWithOpts(e2e.WithArgs("shell", "Revert"))
 	cp.SendLine("python3")
-	cp.Expect("3.9.15")
-	cp.SendLine("__import__('argparse').__version__")
-	cp.Expect("1.1")
+	cp.SendLine("import urllib3")
+	cp.Expect("No module named 'urllib3'")
+	cp.SendLine("import argparse")
+	suite.Assert().NotContains(cp.TrimmedSnapshot(), "No module named 'argparse'")
 	cp.SendLine("exit()") // exit python3
 	cp.SendLine("exit")   // exit state shell
 	cp.ExpectExitCode(0)

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -3,13 +3,61 @@ package integration
 import (
 	"fmt"
 	"path/filepath"
+	"testing"
 
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/stretchr/testify/suite"
 )
 
 type RevertIntegrationTestSuite struct {
 	tagsuite.Suite
+}
+
+func (suite *RevertIntegrationTestSuite) TestRevert() {
+	suite.OnlyRunForTags(tagsuite.Revert)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+	ts.LoginAsPersistentUser()
+
+	namespace := "activestate-cli/Revert"
+	cp := ts.SpawnWithOpts(e2e.WithArgs("checkout", namespace))
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Checked out project")
+	cp.ExpectExitCode(0)
+	wd := filepath.Join(ts.Dirs.Work, "Revert")
+
+	// Revert the commit that added urllib3.
+	commitID := "1f4f4f7d-7883-400e-b2ad-a5803c018ecd"
+	cp = ts.SpawnWithOpts(e2e.WithArgs("revert", commitID), e2e.WithWorkDirectory(wd))
+	cp.ExpectLongString(fmt.Sprintf("Operating on project %s", namespace))
+	cp.SendLine("Y")
+	cp.Expect("You are about to revert the following commit:")
+	cp.Expect(commitID)
+	cp.Expect("Successfully reverted commit:")
+	cp.ExpectExitCode(0)
+
+	// Verify the commit history has both the new revert commit and all prior history.
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("history"),
+		e2e.WithWorkDirectory(wd),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
+	cp.Expect("Revert commit " + commitID)
+	cp.Expect("- urllib3")
+	cp.Expect("+ argparse") // parent commit
+	cp.Expect("+ urllib3")  // commit whose changes were just reverted
+	cp.Expect("+ python")   // initial commit
+
+	// Verify that argparse still exists (it was not reverted along with urllib3).
+	cp = ts.SpawnWithOpts(e2e.WithArgs("shell"), e2e.WithWorkDirectory(wd))
+	cp.SendLine("python3")
+	cp.Expect("3.9.15")
+	cp.SendLine("__import__('argparse').__version__")
+	cp.Expect("1.1")
+	cp.SendLine("exit()") // exit python3
+	cp.SendLine("exit")   // exit state shell
+	cp.ExpectExitCode(0)
 }
 
 func (suite *RevertIntegrationTestSuite) TestRevert_failsOnCommitNotInHistory() {
@@ -17,23 +65,23 @@ func (suite *RevertIntegrationTestSuite) TestRevert_failsOnCommitNotInHistory() 
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.LoginAsPersistentUser()
-	username := e2e.PersistentUsername
-	project := "small-python"
-	namespace := fmt.Sprintf("%s/%s", username, project)
-
+	namespace := "activestate-cli/small-python"
 	cp := ts.SpawnWithOpts(e2e.WithArgs("checkout", namespace))
-	cp.ExpectLongString(fmt.Sprintf("Operating on project %s", namespace))
+	cp.Expect("Skipping runtime setup")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
+	wd := filepath.Join(ts.Dirs.Work, "small-python")
 
-	wd := filepath.Join(ts.Dirs.Work, namespace)
 	// valid commit id not from project
 	commitID := "cb9b1aab-8e40-4a1d-8ad6-5ea112da40f1" // from Perl-5.32
-
 	cp = ts.SpawnWithOpts(e2e.WithArgs("revert", commitID), e2e.WithWorkDirectory(wd))
+	cp.ExpectLongString(fmt.Sprintf("Operating on project %s", namespace))
 	cp.SendLine("Y")
 	cp.Expect(commitID)
-	cp.Expect("The target commit is not")
+	cp.ExpectLongString("The commit being reverted is not within the current commit's history")
 	cp.ExpectNotExitCode(0)
+}
+
+func TestRevertIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(RevertIntegrationTestSuite))
 }

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -54,6 +54,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.SendLine("python3")
+	cp.Expect("3.9.15")
 	cp.SendLine("import urllib3")
 	cp.Expect("No module named 'urllib3'")
 	cp.SendLine("import argparse")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -53,6 +53,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 		e2e.WithArgs("shell", "Revert"),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
+	cp.WaitForInput()
 	cp.SendLine("python3")
 	cp.Expect("3.9.15")
 	cp.SendLine("import urllib3")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -51,12 +51,13 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	cp.Expect("+ python")   // initial commit
 
 	// Verify that argparse still exists (it was not reverted along with urllib3).
-	cp = ts.SpawnWithOpts(e2e.WithArgs("shell", "Revert"))
+	cp = ts.SpawnWithOpts(e2e.WithArgs("activate", namespace))
 	if runtime.GOOS == "linux" {
 		cp.SendLine("echo $PATH")
 		cp.SendLine("which python3")
 	}
 	cp.SendLine("python3")
+	cp.Expect("3.9.15")
 	cp.SendLine("import urllib3")
 	cp.Expect("No module named 'urllib3'")
 	cp.SendLine("import argparse")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -53,8 +53,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	// Verify that argparse still exists (it was not reverted along with urllib3).
 	cp = ts.SpawnWithOpts(e2e.WithArgs("shell", "Revert"))
 	if runtime.GOOS == "linux" {
-		cp.SendLine("echo $PATH")
-		cp.SendLine("which python3")
+		cp.SendLine("hash -r")
 	}
 	cp.SendLine("python3")
 	cp.SendLine("import urllib3")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -52,9 +51,6 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 
 	// Verify that argparse still exists (it was not reverted along with urllib3).
 	cp = ts.SpawnWithOpts(e2e.WithArgs("shell", "Revert"))
-	if runtime.GOOS == "linux" {
-		cp.SendLine("hash -r")
-	}
 	cp.SendLine("python3")
 	cp.SendLine("import urllib3")
 	cp.Expect("No module named 'urllib3'")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1424" title="DX-1424" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1424</a>  state revert should revert "a" commit rather than "to" a commit.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
