### PR TITLE
Show executable runtime directories in `state projects`.

### DIFF
--- a/internal/runners/projects/projects.go
+++ b/internal/runners/projects/projects.go
@@ -4,11 +4,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ActiveState/cli/internal/installation/storage"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
+	"github.com/ActiveState/cli/pkg/platform/runtime/target"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/ActiveState/cli/pkg/projectfile"
 )
@@ -18,15 +21,32 @@ type projectWithOrg struct {
 	Name           string   `json:"name"`
 	Organization   string   `json:"organization"`
 	LocalCheckouts []string `json:"local_checkouts,omitempty"`
+	Executables    []string `json:"executables,omitempty"`
 }
 
 type projectWithOrgs []projectWithOrg
+
+func newProjectWithOrg(name, org string, checkouts []string) *projectWithOrg {
+	p := projectWithOrg{Name: name, Organization: org, LocalCheckouts: checkouts}
+	for _, checkout := range checkouts {
+		var execDir string
+		if proj, err := project.FromPath(checkout); err == nil {
+			projectTarget := target.NewProjectTarget(proj, storage.CachePath(), nil, "")
+			execDir = setup.ExecDir(projectTarget.Dir())
+		} else {
+			multilog.Error("Unable to get project %s from checkout: %v", checkout, err)
+		}
+		p.Executables = append(p.Executables, execDir)
+	}
+	return &p
+}
 
 func (o projectWithOrgs) MarshalOutput(f output.Format) interface{} {
 	type projectOutputPlain struct {
 		Name           string
 		Organization   string
 		LocalCheckouts string `locale:"local_checkouts,Local Checkouts" opts:"emptyNil,separateLine"`
+		Executables    string `locale:"executables,Executables" opts:"emptyNil,separateLine"`
 	}
 
 	if f != output.PlainFormatName {
@@ -36,10 +56,23 @@ func (o projectWithOrgs) MarshalOutput(f output.Format) interface{} {
 	r := []projectOutputPlain{}
 	for _, v := range o {
 		checkouts := []string{}
-		for _, checkout := range v.LocalCheckouts {
-			checkouts = append(checkouts, locale.Tl("projects_local_checkout", " └─ ✔ Local Checkout → {{.V0}}", checkout))
+		executables := []string{}
+		for i, checkout := range v.LocalCheckouts {
+			execDir := v.Executables[i]
+			if execDir != "" {
+				checkouts = append(checkouts, locale.Tl("projects_local_checkout_exec", " ├─ Local Checkout → {{.V0}}", checkout))
+				if f == output.PlainFormatName {
+					// Show executable path below checkout path for plain text output.
+					checkouts = append(checkouts, locale.Tl("projects_executables", " └─ Executables → {{.V0}}", execDir))
+				} else {
+					// Show executables in a separate table.
+					executables = append(executables, execDir)
+				}
+			} else {
+				checkouts = append(checkouts, locale.Tl("projects_local_checkout", " └─ Local Checkout → {{.V0}}", checkout))
+			}
 		}
-		r = append(r, projectOutputPlain{v.Name, v.Organization, strings.Join(checkouts, "\n")})
+		r = append(r, projectOutputPlain{v.Name, v.Organization, strings.Join(checkouts, "\n"), strings.Join(executables, "\n")})
 	}
 	return r
 }
@@ -92,11 +125,7 @@ func (r *Projects) Run(params *Params) error {
 			continue
 		}
 
-		projects = append(projects, projectWithOrg{
-			Name:           ns.Project,
-			Organization:   ns.Owner,
-			LocalCheckouts: checkouts,
-		})
+		projects = append(projects, *newProjectWithOrg(ns.Project, ns.Owner, checkouts))
 	}
 	sort.SliceStable(projects, func(i, j int) bool {
 		if projects[i].Organization == projects[j].Organization {

--- a/internal/runners/projects/projects.go
+++ b/internal/runners/projects/projects.go
@@ -26,7 +26,7 @@ type projectWithOrg struct {
 
 type projectWithOrgs []projectWithOrg
 
-func newProjectWithOrg(name, org string, checkouts []string) *projectWithOrg {
+func newProjectWithOrg(name, org string, checkouts []string) projectWithOrg {
 	p := projectWithOrg{Name: name, Organization: org, LocalCheckouts: checkouts}
 	for _, checkout := range checkouts {
 		var execDir string
@@ -38,7 +38,7 @@ func newProjectWithOrg(name, org string, checkouts []string) *projectWithOrg {
 		}
 		p.Executables = append(p.Executables, execDir)
 	}
-	return &p
+	return p
 }
 
 func (o projectWithOrgs) MarshalOutput(f output.Format) interface{} {
@@ -125,7 +125,7 @@ func (r *Projects) Run(params *Params) error {
 			continue
 		}
 
-		projects = append(projects, *newProjectWithOrg(ns.Project, ns.Owner, checkouts))
+		projects = append(projects, newProjectWithOrg(ns.Project, ns.Owner, checkouts))
 	}
 	sort.SliceStable(projects, func(i, j int) bool {
 		if projects[i].Organization == projects[j].Organization {

--- a/internal/testhelpers/tagsuite/tagsuite.go
+++ b/internal/testhelpers/tagsuite/tagsuite.go
@@ -49,6 +49,7 @@ const (
 	Perl            = "perl"
 	Platforms       = "platforms"
 	Prepare         = "prepare"
+	Projects        = "projects"
 	Pull            = "pull"
 	Push            = "push"
 	Python          = "python"

--- a/test/integration/projects_int_test.go
+++ b/test/integration/projects_int_test.go
@@ -55,9 +55,19 @@ func (suite *ProjectsIntegrationTestSuite) TestProjects() {
 	cp = ts.SpawnWithOpts(e2e.WithArgs("projects", "--output", "json"))
 	cp.Expect(`"name":"Python3"`)
 	cp.Expect(`"local_checkouts":["`)
-	cp.ExpectLongString(filepath.Join(ts.Dirs.Work, "Python3") + `"]`)
+	if runtime.GOOS != "windows" {
+		cp.ExpectLongString(filepath.Join(ts.Dirs.Work, "Python3") + `"]`)
+	} else {
+		// Windows uses the long path here.
+		longPath, _ := fileutils.GetLongPathName(filepath.Join(ts.Dirs.Work, "Python3"))
+		cp.ExpectLongString(strings.ReplaceAll(longPath, "\\", "\\\\") + `"]`)
+	}
 	cp.Expect(`"executables":["`)
-	cp.ExpectLongString(ts.Dirs.Cache)
+	if runtime.GOOS != "windows" {
+		cp.ExpectLongString(ts.Dirs.Cache)
+	} else {
+		cp.ExpectLongString(strings.ReplaceAll(ts.Dirs.Cache, "\\", "\\\\"))
+	}
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/projects_int_test.go
+++ b/test/integration/projects_int_test.go
@@ -1,0 +1,52 @@
+package integration
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProjectsIntegrationTestSuite struct {
+	tagsuite.Suite
+}
+
+func (suite *ProjectsIntegrationTestSuite) TestProjects() {
+	suite.OnlyRunForTags(tagsuite.Projects, tagsuite.VSCode)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.SpawnWithOpts(e2e.WithArgs("checkout", "ActiveState-CLI/small-python"))
+	cp.ExpectExitCode(0)
+	cp = ts.SpawnWithOpts(e2e.WithArgs("checkout", "ActiveState-CLI/Python3"))
+	cp.ExpectExitCode(0)
+
+	// Verify local checkouts and executables are grouped together under projects.
+	cp = ts.SpawnWithOpts(e2e.WithArgs("projects"))
+	cp.Expect("Python3")
+	cp.Expect("Local Checkout")
+	cp.ExpectLongString(ts.Dirs.Work)
+	cp.Expect("Executables")
+	cp.ExpectLongString(ts.Dirs.Cache)
+	cp.Expect("small-python")
+	cp.Expect("Local Checkout")
+	cp.ExpectLongString(ts.Dirs.Work)
+	cp.Expect("Executables")
+	cp.ExpectLongString(ts.Dirs.Cache)
+	cp.ExpectExitCode(0)
+
+	// Verify separate "local_checkouts" and "executables" fields for JSON output.
+	cp = ts.SpawnWithOpts(e2e.WithArgs("projects", "--output", "json"))
+	cp.Expect(`"name":"Python3"`)
+	cp.Expect(`"local_checkouts":["`)
+	cp.ExpectLongString(filepath.Join(ts.Dirs.Work, "Python3") + `"]`)
+	cp.Expect(`"executables":["`)
+	cp.ExpectLongString(ts.Dirs.Cache)
+	cp.ExpectExitCode(0)
+}
+
+func TestProjectsIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(ProjectsIntegrationTestSuite))
+}

--- a/test/integration/projects_int_test.go
+++ b/test/integration/projects_int_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/fileutils"

--- a/test/integration/projects_int_test.go
+++ b/test/integration/projects_int_test.go
@@ -2,8 +2,10 @@ package integration
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/stretchr/testify/suite"
@@ -27,12 +29,24 @@ func (suite *ProjectsIntegrationTestSuite) TestProjects() {
 	cp = ts.SpawnWithOpts(e2e.WithArgs("projects"))
 	cp.Expect("Python3")
 	cp.Expect("Local Checkout")
-	cp.ExpectLongString(ts.Dirs.Work)
+	if runtime.GOOS != "windows" {
+		cp.ExpectLongString(ts.Dirs.Work)
+	} else {
+		// Windows uses the long path here.
+		longPath, _ := fileutils.GetLongPathName(ts.Dirs.Work)
+		cp.ExpectLongString(longPath)
+	}
 	cp.Expect("Executables")
 	cp.ExpectLongString(ts.Dirs.Cache)
 	cp.Expect("small-python")
 	cp.Expect("Local Checkout")
-	cp.ExpectLongString(ts.Dirs.Work)
+	if runtime.GOOS != "windows" {
+		cp.ExpectLongString(ts.Dirs.Work)
+	} else {
+		// Windows uses the long path here.
+		longPath, _ := fileutils.GetLongPathName(ts.Dirs.Work)
+		cp.ExpectLongString(longPath)
+	}
 	cp.Expect("Executables")
 	cp.ExpectLongString(ts.Dirs.Cache)
 	cp.ExpectExitCode(0)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1493" title="DX-1493" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1493</a>  `state projects` includes runtime executable dir
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
There are separate output formats for plain text and JSON.