### PR TITLE
Remove `state update --set-version`.

### DIFF
--- a/cmd/state/internal/cmdtree/update.go
+++ b/cmd/state/internal/cmdtree/update.go
@@ -23,11 +23,6 @@ func newUpdateCommand(prime *primer.Values) *captain.Command {
 				Description: locale.Tl("update_channel", "Switches to the given update channel, eg. 'release'."),
 				Value:       &params.Channel,
 			},
-			{
-				Name:        "set-version",
-				Description: locale.Tl("update_version", "Switches to the given State Tool version."),
-				Value:       &params.Version,
-			},
 		},
 		[]*captain.Argument{},
 		func(cmd *captain.Command, args []string) error {

--- a/internal/runners/update/update.go
+++ b/internal/runners/update/update.go
@@ -19,7 +19,6 @@ import (
 
 type Params struct {
 	Channel string
-	Version string
 }
 
 type Update struct {
@@ -48,25 +47,17 @@ func New(prime primeable) *Update {
 func (u *Update) Run(params *Params) error {
 	// Check for available update
 	checker := updater.NewDefaultChecker(u.cfg)
-	up, err := checker.CheckFor(params.Channel, params.Version)
+	up, err := checker.CheckFor(params.Channel, "")
 	if err != nil {
 		return locale.WrapError(err, "err_update_check", "Could not check for updates.")
 	}
 	if up == nil {
 		logging.Debug("No update found")
-		if params.Version == "" {
-			u.out.Notice(locale.T("update_none_found"))
-		} else {
-			u.out.Notice(locale.Tl("update_to_version_not_found", "No update to version {{.V0}} available", params.Version))
-		}
+		u.out.Notice(locale.T("update_none_found"))
 		return nil
 	}
 
-	if params.Version == "" {
-		u.out.Notice(locale.Tr("updating_version", up.Version))
-	} else {
-		u.out.Notice(locale.Tr("updating_version", params.Version))
-	}
+	u.out.Notice(locale.Tr("updating_version", up.Version))
 
 	// Handle switching channels
 	var installPath string

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -34,7 +34,6 @@ type matcherFunc func(expected interface{}, actual interface{}, msgAndArgs ...in
 // Update to release branch when possible
 var targetBranch = "beta"
 var oldUpdateVersion = "beta@0.32.2-SHA3e1d435"
-var specificVersion = "0.32.2-SHA3e1d435"
 
 func init() {
 	if constants.BranchName == targetBranch {
@@ -184,10 +183,9 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateChannel() {
 	tests := []struct {
 		Name    string
 		Channel string
-		Version string
 	}{
-		{"release-channel", "release", ""},
-		{"specific-update", targetBranch, specificVersion},
+		{"release-channel", "release"},
+		{"specific-update", targetBranch},
 	}
 
 	for _, tt := range tests {
@@ -198,9 +196,6 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateChannel() {
 			defer ts.Close()
 
 			updateArgs := []string{"update", "--set-channel", tt.Channel}
-			if tt.Version != "" {
-				updateArgs = append(updateArgs, "--set-version", tt.Version)
-			}
 			env := []string{fmt.Sprintf("%s=%s", constants.OverwriteDefaultInstallationPathEnvVarName, ts.Dirs.Bin)}
 			env = append(env, suite.env(false, false)...)
 			cp := ts.SpawnWithOpts(
@@ -211,10 +206,6 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateChannel() {
 			cp.ExpectExitCode(0, 1*time.Minute)
 
 			suite.branchCompare(ts, tt.Channel, suite.Equal)
-
-			if tt.Version != "" {
-				suite.versionCompare(ts, tt.Version, suite.Equal)
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1452" title="DX-1452" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1452</a>  Remove `update --set-version`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


As far as the ACs go:

* We already have a page on how to install older state tool versions: https://docs.activestate.com/platform/state/advanced-topics/locking/#how-do-i-install-older-versions-of-the-state-tool
* There are no UI messages that reference `--set-version`, so no need to point to that page from the state tool.