### PR TITLE
Fixed uninstall warning message when unrecognized files were not removed.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1923,8 +1923,7 @@ err_update_privilege_mismatch:
 uninstall_warn_not_empty:
   other: |
     [ERROR]Unable to remove all files in the directory the installation directory.[/RESET]
-    The directory may contain unrecognized files.
-    Encountered error: {{.V0}}
+    There were unrecognized files in that directory.
 err_state_exec:
   other: Could not get state exec
 err_service_exec:

--- a/internal/runners/clean/run_lin_mac.go
+++ b/internal/runners/clean/run_lin_mac.go
@@ -39,7 +39,7 @@ func (u *Uninstall) runUninstall() error {
 
 	err = removeInstall(u.cfg)
 	if errors.Is(err, errDirNotEmpty) {
-		u.out.Notice(locale.Tr("uninstall_warn_not_empty", errs.JoinMessage(err)))
+		u.out.Notice(locale.T("uninstall_warn_not_empty"))
 	} else if err != nil {
 		logging.Debug("Could not remove install: %s", errs.JoinMessage(err))
 		aggErr = locale.WrapError(aggErr, "uninstall_remove_executables_err", "Failed to remove all State Tool files in installation directory")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1500" title="DX-1500" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1500</a>  Uninstall failure malformed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The `errDirNotEmpty` error indicates there were unrecognized files that were not removed, so no need to print the error message (which was empty anyway).