### PR TITLE
projectfile deprecation: Fix commented out lines being detected

### DIFF
--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -49,7 +49,7 @@ var (
 	// CommitURLRe Regex used to validate commit info /commit/someUUID
 	CommitURLRe = regexp.MustCompile(urlCommitRegexStr)
 	// deprecatedRegex covers the deprecated fields in the project file
-	deprecatedRegex = regexp.MustCompile(`\s*(?:constraints|platforms|languages):`)
+	deprecatedRegex = regexp.MustCompile(`(?m)^\s*(?:constraints|platforms|languages):`)
 )
 
 type ErrorParseProject struct{ *locale.LocalizedError }

--- a/pkg/projectfile/projectfile_test.go
+++ b/pkg/projectfile/projectfile_test.go
@@ -449,6 +449,11 @@ func Test_detectDeprecations(t *testing.T) {
 			},
 		},
 		{
+			"Constraints Commented Out",
+			`#constraints: 0`,
+			[]string{},
+		},
+		{
 			"Platforms",
 			`platforms: 0"`,
 			[]string{
@@ -464,10 +469,10 @@ func Test_detectDeprecations(t *testing.T) {
 		},
 		{
 			"Mixed",
-			"foo: 0\nconstraints: 0\nbar: 0\nlanguages: 0, platforms: 0",
+			"foo: 0\nconstraints: 0\nbar: 0\nlanguages: 0\nplatforms: 0",
 			[]string{
-				locale.Tr("pjfile_deprecation_entry", "constraints", "6"),
-				locale.Tr("pjfile_deprecation_entry", "languages", "28"),
+				locale.Tr("pjfile_deprecation_entry", "constraints", "7"),
+				locale.Tr("pjfile_deprecation_entry", "languages", "29"),
 				locale.Tr("pjfile_deprecation_entry", "platforms", "42"),
 			},
 		},
@@ -481,9 +486,9 @@ languages:
     constraints:
         platform: Windows10Label,Linux64Label`,
 			[]string{
-				locale.Tr("pjfile_deprecation_entry", "platforms", "108"),
-				locale.Tr("pjfile_deprecation_entry", "languages", "142"),
-				locale.Tr("pjfile_deprecation_entry", "constraints", "166"),
+				locale.Tr("pjfile_deprecation_entry", "platforms", "109"),
+				locale.Tr("pjfile_deprecation_entry", "languages", "143"),
+				locale.Tr("pjfile_deprecation_entry", "constraints", "167"),
 			},
 		},
 		{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1456" title="DX-1456" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1456</a>  We detect outdated as.yamls and error out
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
