### PR TITLE
Do not use terminal escape sequences in non-interactive terminals or the Windows command prompt.

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	// Set up our output formatter/writer
 	outFlags := parseOutputFlags(os.Args)
-	out, err := initOutput(outFlags, "")
+	out, err := initOutput(outFlags, "", subshell.New(cfg).Shell())
 	if err != nil {
 		multilog.Critical("Could not initialize outputer: %s", errs.JoinMessage(err))
 		os.Stderr.WriteString(locale.Tr("err_main_outputer", err.Error()))

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -82,7 +82,8 @@ func main() {
 
 	// Set up our output formatter/writer
 	outFlags := parseOutputFlags(os.Args)
-	out, err := initOutput(outFlags, "", subshell.New(cfg).Shell())
+	shellName, _ := subshell.DetectShell(cfg)
+	out, err := initOutput(outFlags, "", shellName)
 	if err != nil {
 		multilog.Critical("Could not initialize outputer: %s", errs.JoinMessage(err))
 		os.Stderr.WriteString(locale.Tr("err_main_outputer", err.Error()))

--- a/cmd/state/main_test.go
+++ b/cmd/state/main_test.go
@@ -15,37 +15,37 @@ type MainTestSuite struct {
 
 func (suite *MainTestSuite) TestOutputer() {
 	{
-		outputer, err := initOutput(outputFlags{"", false, false, false}, "")
+		outputer, err := initOutput(outputFlags{"", false, false, false}, "", "")
 		suite.Require().NoError(err, errs.Join(err, "\n").Error())
 		suite.Equal(output.PlainFormatName, outputer.Type(), "Returns Plain outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{string(output.PlainFormatName), false, false, false}, "")
+		outputer, err := initOutput(outputFlags{string(output.PlainFormatName), false, false, false}, "", "")
 		suite.Require().NoError(err)
 		suite.Equal(output.PlainFormatName, outputer.Type(), "Returns Plain outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{string(output.JSONFormatName), false, false, false}, "")
+		outputer, err := initOutput(outputFlags{string(output.JSONFormatName), false, false, false}, "", "")
 		suite.Require().NoError(err)
 		suite.Equal(output.JSONFormatName, outputer.Type(), "Returns JSON outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{"", false, false, false}, string(output.JSONFormatName))
+		outputer, err := initOutput(outputFlags{"", false, false, false}, string(output.JSONFormatName), "")
 		suite.Require().NoError(err)
 		suite.Equal(output.JSONFormatName, outputer.Type(), "Returns JSON outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{"", false, false, false}, string(output.EditorFormatName))
+		outputer, err := initOutput(outputFlags{"", false, false, false}, string(output.EditorFormatName), "")
 		suite.Require().NoError(err)
 		suite.Equal(output.EditorFormatName, outputer.Type(), "Returns JSON outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{"", false, false, false}, string(output.EditorV0FormatName))
+		outputer, err := initOutput(outputFlags{"", false, false, false}, string(output.EditorV0FormatName), "")
 		suite.Require().NoError(err)
 		suite.Equal(output.EditorV0FormatName, outputer.Type(), "Returns JSON outputer")
 	}

--- a/cmd/state/output.go
+++ b/cmd/state/output.go
@@ -46,7 +46,7 @@ func parseOutputFlags(args []string) outputFlags {
 	return flagSet
 }
 
-func initOutput(flags outputFlags, formatName string) (output.Outputer, error) {
+func initOutput(flags outputFlags, formatName string, shellName string) (output.Outputer, error) {
 	if formatName == "" {
 		formatName = flags.Output
 	}
@@ -56,12 +56,13 @@ func initOutput(flags outputFlags, formatName string) (output.Outputer, error) {
 		ErrWriter:   os.Stderr,
 		Colored:     !flags.DisableColor(),
 		Interactive: term.IsTerminal(int(os.Stdin.Fd())),
+		ShellName:   shellName,
 	})
 	if err != nil {
 		if errors.Is(err, output.ErrNotRecognized) {
 			// The formatter might still be registered, so default to plain for now
 			logging.Warning("Output format not recognized: %s, defaulting to plain output instead", formatName)
-			return initOutput(flags, string(output.PlainFormatName))
+			return initOutput(flags, string(output.PlainFormatName), shellName)
 		}
 		multilog.Log(logging.ErrorNoStacktrace, rollbar.Error)("Could not create outputer, name: %s, error: %s", formatName, err.Error())
 		return nil, errs.Wrap(err, "output.New %s failed", formatName)

--- a/cmd/state/output.go
+++ b/cmd/state/output.go
@@ -4,15 +4,14 @@ import (
 	"errors"
 	"os"
 
-	"github.com/jessevdk/go-flags"
-
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/rollbar"
 	"github.com/ActiveState/cli/internal/terminal"
-
+	"github.com/jessevdk/go-flags"
+	"golang.org/x/term"
 	survey "gopkg.in/AlecAivazis/survey.v1/core"
 )
 
@@ -56,7 +55,7 @@ func initOutput(flags outputFlags, formatName string) (output.Outputer, error) {
 		OutWriter:   os.Stdout,
 		ErrWriter:   os.Stderr,
 		Colored:     !flags.DisableColor(),
-		Interactive: true,
+		Interactive: term.IsTerminal(int(os.Stdin.Fd())),
 	})
 	if err != nil {
 		if errors.Is(err, output.ErrNotRecognized) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -90,4 +90,5 @@ type Config struct {
 	ErrWriter   io.Writer
 	Colored     bool
 	Interactive bool
+	ShellName   string
 }

--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -9,11 +9,12 @@ import (
 const moveCaretBackEscapeSequence = "\x1b[%dD" // %d is the number of characters to move back
 
 type Spinner struct {
-	frame    int
-	frames   []string
-	out      Outputer
-	stop     chan struct{}
-	interval time.Duration
+	frame         int
+	frames        []string
+	out           Outputer
+	stop          chan struct{}
+	interval      time.Duration
+	reportedError bool
 }
 
 var _ Marshaller = &Spinner{}
@@ -27,7 +28,7 @@ func StartSpinner(out Outputer, msg string, interval time.Duration) *Spinner {
 	if out.Config().Interactive {
 		frames = []string{`|`, `/`, `-`, `\`}
 	}
-	d := &Spinner{0, frames, out, make(chan struct{}, 1), interval}
+	d := &Spinner{0, frames, out, make(chan struct{}, 1), interval, false}
 
 	if msg != "" {
 		d.out.Fprint(d.out.Config().ErrWriter, strings.TrimSuffix(msg, " ")+" ")

--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -1,9 +1,12 @@
 package output
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
+
+const moveCaretBackEscapeSequence = "\x1b[%dD" // %d is the number of characters to move back
 
 type Spinner struct {
 	frame    int
@@ -47,7 +50,11 @@ func (d *Spinner) moveCaretBack() int {
 		prevPos = len(d.frames) - 1
 	}
 	prevFrame := d.frames[prevPos]
-	d.moveCaretBackInTerminal(len(prevFrame))
+	if d.out.Config().ShellName != "cmd" { // cannot use subshell/cmd.Name due to import cycle
+		d.moveCaretBackInTerminal(len(prevFrame))
+	} else {
+		d.moveCaretBackInCommandPrompt(len(prevFrame))
+	}
 
 	return len(prevFrame)
 }
@@ -92,4 +99,8 @@ func (d *Spinner) Stop(msg string) {
 	}
 
 	d.out.Fprint(d.out.Config().ErrWriter, "\n")
+}
+
+func (d *Spinner) moveCaretBackInTerminal(n int) {
+	d.out.Fprint(d.out.Config().ErrWriter, fmt.Sprintf(moveCaretBackEscapeSequence, n))
 }

--- a/internal/output/progress_unix.go
+++ b/internal/output/progress_unix.go
@@ -4,5 +4,6 @@
 package output
 
 func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
-	// No-op
+	// No-op (logging to Rollbar every tick would be a disaster)
+	// Rely on manual and unit testing to catch any errors in display.
 }

--- a/internal/output/progress_unix.go
+++ b/internal/output/progress_unix.go
@@ -1,0 +1,14 @@
+//go:build linux || darwin
+// +build linux darwin
+
+package output
+
+import (
+	"fmt"
+)
+
+const moveCaretBack = "\x1b[%dD" // %d is the number of characters to move back
+
+func (d *Spinner) moveCaretBackInTerminal(n int) {
+	d.out.Fprint(d.out.Config().ErrWriter, fmt.Sprintf(moveCaretBack, n))
+}

--- a/internal/output/progress_unix.go
+++ b/internal/output/progress_unix.go
@@ -3,7 +3,13 @@
 
 package output
 
+import (
+	"github.com/ActiveState/cli/internal/rollbar"
+)
+
 func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
-	// No-op (logging to Rollbar every tick would be a disaster)
-	// Rely on manual and unit testing to catch any errors in display.
+	if !d.reportedError {
+		rollbar.Error("Incorrectly detected Windows command prompt in Unix environment")
+		d.reportedError = true
+	}
 }

--- a/internal/output/progress_unix.go
+++ b/internal/output/progress_unix.go
@@ -3,12 +3,6 @@
 
 package output
 
-import (
-	"fmt"
-)
-
-const moveCaretBack = "\x1b[%dD" // %d is the number of characters to move back
-
-func (d *Spinner) moveCaretBackInTerminal(n int) {
-	d.out.Fprint(d.out.Config().ErrWriter, fmt.Sprintf(moveCaretBack, n))
+func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
+	// No-op
 }

--- a/internal/output/progress_win.go
+++ b/internal/output/progress_win.go
@@ -36,7 +36,7 @@ type consoleScreenBufferInfo struct {
 	maximumWindowSize coord
 }
 
-func (d *Spinner) moveCaretBackInTerminal(n int) {
+func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
 	handle := syscall.Handle(os.Stdout.Fd())
 
 	var csbi consoleScreenBufferInfo

--- a/internal/output/progress_win.go
+++ b/internal/output/progress_win.go
@@ -1,0 +1,50 @@
+//go:build windows
+// +build windows
+
+package output
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+var procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+var procSetConsoleCursorPosition = kernel32.NewProc("SetConsoleCursorPosition")
+
+type coord struct {
+	x short
+	y short
+}
+
+type short int16
+type word uint16
+
+type smallRect struct {
+	bottom short
+	left   short
+	right  short
+	top    short
+}
+
+type consoleScreenBufferInfo struct {
+	size              coord
+	cursorPosition    coord
+	attributes        word
+	window            smallRect
+	maximumWindowSize coord
+}
+
+func (d *Spinner) moveCaretBackInTerminal(n int) {
+	handle := syscall.Handle(os.Stdout.Fd())
+
+	var csbi consoleScreenBufferInfo
+	_, _, _ = procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+
+	var cursor coord
+	cursor.x = csbi.cursorPosition.x + short(-n)
+	cursor.y = csbi.cursorPosition.y
+
+	_, _, _ = procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
+}

--- a/internal/output/progress_win.go
+++ b/internal/output/progress_win.go
@@ -47,7 +47,7 @@ func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
 		cursor.x = csbi.cursorPosition.x + short(-n)
 		cursor.y = csbi.cursorPosition.y
 
-		_, _, err2 = procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
+		_, _, err2 := procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
 		if err2 != nil && !d.reportedError {
 			rollbar.Error("Error calling SetConsoleCursorPosition: %v", err2)
 			d.reportedError = true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1527" title="DX-1527" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1527</a>  Occasional panic errors and continues gibberish during runtime progress on Windows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
