### PR TITLE
Fixed failing integration test.

### DIFF
--- a/internal/runbits/runtime/progress/progress.go
+++ b/internal/runbits/runtime/progress/progress.go
@@ -143,6 +143,7 @@ func (p *ProgressDigester) Handle(ev events.Eventer) error {
 		p.success = true
 
 	case events.SolveStart:
+		p.out.Notice(locale.Tl("setup_runtime", "Setting Up Runtime"))
 		p.solveSpinner = output.StartSpinner(p.out, locale.T("progress_solve"), refreshRate)
 
 	case events.SolveError:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1532" title="DX-1532" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1532</a>  TestSetupNotice failure
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The runtime progress refactor left out this notice.

Note we have two options for this PR: add the notice back, or delete the expectation from the failing unit test. I chose the former because the unit test is intentionally looking for the notice, so I think there's an expected UX element here.