### PR TITLE
Clear interactive progress ticker after completion.

### DIFF
--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -92,6 +92,13 @@ func (d *Spinner) Stop(msg string) {
 	d.stop <- struct{}{}
 	close(d.stop)
 
+	if d.out.Config().Interactive {
+		nMoved := d.moveCaretBack()
+		if nMoved > len(msg) {
+			msg += strings.Repeat(" ", nMoved-len(msg)-1)
+		}
+	}
+
 	if msg != "" {
 		if !d.out.Config().Interactive {
 			d.out.Fprint(d.out.Config().ErrWriter, " ")

--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -92,6 +92,7 @@ func (d *Spinner) Stop(msg string) {
 	d.stop <- struct{}{}
 	close(d.stop)
 
+    // We're done, so remove the last spinner frame
 	if d.out.Config().Interactive {
 		nMoved := d.moveCaretBack()
 		if nMoved > len(msg) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1535" title="DX-1535" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1535</a>  Spinner isn't cleared during runtime progress
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
