### PR TITLE
Fix state-svc logs not appearing in integration tests

### DIFF
--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -82,14 +82,8 @@ func FilePathForCmd(cmd string, pid int) string {
 
 func init() {
 	defer handlePanics(recover())
-	timestamp = time.Now().UnixNano()
-	handler := newFileHandler()
-	SetHandler(handler)
 
-	log.SetOutput(&writer{})
-	Debug("Args: %v", os.Args)
-
-	// Clean up old log files
+	// Set up datadir
 	var err error
 	datadir, err = storage.AppDataPath()
 	if err != nil {
@@ -97,7 +91,16 @@ func init() {
 		return
 	}
 
-	files, err := ioutil.ReadDir(datadir)
+	// Set up handler
+	timestamp = time.Now().UnixNano()
+	handler := newFileHandler()
+	SetHandler(handler)
+	log.SetOutput(&writer{})
+
+	Debug("Args: %v", os.Args)
+
+	// Clean up old log files
+	files, err := ioutil.ReadDir(filepath.Dir(FilePath()))
 	if err != nil && !os.IsNotExist(err) {
 		Error("Could not scan config dir to clean up stale logs: %v", err)
 		return

--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -87,6 +87,7 @@ func init() {
 	SetHandler(handler)
 
 	log.SetOutput(&writer{})
+	Debug("Args: %v", os.Args)
 
 	// Clean up old log files
 	var err error
@@ -115,5 +116,4 @@ func init() {
 		}
 	}
 
-	Debug("Args: %v", os.Args)
 }

--- a/internal/logging/formatter.go
+++ b/internal/logging/formatter.go
@@ -14,9 +14,9 @@ type SimpleFormatter struct {
 }
 
 func (f *SimpleFormatter) Format(ctx *MessageContext, message string, args ...interface{}) string {
-	return fmt.Sprintf(f.FormatString, ctx.Level, ctx.TimeStamp.UnixNano(), ctx.File, ctx.Line, fmt.Sprintf(message, args...))
+	return fmt.Sprintf(f.FormatString, ctx.Level, ctx.TimeStamp.Format("15:04:05.000"), ctx.File, ctx.Line, fmt.Sprintf(message, args...))
 }
 
 var DefaultFormatter Formatter = &SimpleFormatter{
-	FormatString: "[%[1]s %[2]d %[3]s:%[4]d] %[5]s",
+	FormatString: "[%[1]s %[2]s %[3]s:%[4]d] %[5]s",
 }

--- a/internal/logging/rotate.go
+++ b/internal/logging/rotate.go
@@ -9,16 +9,17 @@ import (
 	"time"
 )
 
+var LogPrefixRx = regexp.MustCompile(`^[a-zA-Z\-]+`)
+
 func rotateLogs(files []fs.FileInfo, timeCutoff time.Time, amountCutoff int) []fs.FileInfo {
 	rotate := []fs.FileInfo{}
 
 	sort.Slice(files, func(i, j int) bool { return files[i].ModTime().After(files[j].ModTime()) })
 
 	// Collect the possible file prefixes that we're going to want to run through
-	prefixRx := regexp.MustCompile(`^[a-zA-Z\-]+`)
 	prefixes := map[string]struct{}{}
 	for _, file := range files {
-		prefix := prefixRx.FindString(filepath.Base(file.Name()))
+		prefix := LogPrefixRx.FindString(filepath.Base(file.Name()))
 		if _, exists := prefixes[prefix]; !exists {
 			prefixes[prefix] = struct{}{}
 		}

--- a/internal/runbits/rtusage/rtusage.go
+++ b/internal/runbits/rtusage/rtusage.go
@@ -2,6 +2,10 @@ package rtusage
 
 import (
 	"context"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -11,9 +15,6 @@ import (
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/notify"
 	"github.com/ActiveState/cli/internal/output"
-	"os"
-	"strconv"
-	"time"
 )
 
 const CfgKeyLastNotify = "notify.rtusage.last"
@@ -74,6 +75,7 @@ func NotifyRuntimeUsage(cfg *config.Instance, data dataHandler, orgName string) 
 	}
 
 	if usage > res.Limit {
+		logging.Debug("Soft limit: Sending notification for %s", orgName)
 		err := notify.Send(locale.T("runtime_limit_reached_title"),
 			locale.Tr("runtime_limit_reached_msg", orgName),
 			locale.T("runtime_limit_reached_action"),

--- a/internal/runbits/rtusage/rtusage.go
+++ b/internal/runbits/rtusage/rtusage.go
@@ -75,7 +75,6 @@ func NotifyRuntimeUsage(cfg *config.Instance, data dataHandler, orgName string) 
 	}
 
 	if usage > res.Limit {
-		logging.Debug("Soft limit: Sending notification for %s", orgName)
 		err := notify.Send(locale.T("runtime_limit_reached_title"),
 			locale.Tr("runtime_limit_reached_msg", orgName),
 			locale.T("runtime_limit_reached_action"),

--- a/internal/svcctl/comm.go
+++ b/internal/svcctl/comm.go
@@ -3,6 +3,7 @@ package svcctl
 import (
 	"context"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/rtutils/p"
+	"github.com/ActiveState/cli/internal/runbits/panics"
 	"github.com/ActiveState/cli/internal/runbits/rtusage"
 	"github.com/ActiveState/cli/internal/svcctl/svcmsg"
 	"github.com/ActiveState/cli/pkg/platform/runtime/executors/execmeta"
@@ -89,6 +91,8 @@ func HeartbeatHandler(cfg *config.Instance, resolver Resolver, analyticsReporter
 		hb := svcmsg.NewHeartbeatFromSvcMsg(data)
 
 		go func() {
+			defer panics.HandlePanics(recover(), debug.Stack())
+			
 			pidNum, err := strconv.Atoi(hb.ProcessID)
 			if err != nil {
 				multilog.Error("Heartbeat: Could not convert pid string (%s) to int in heartbeat handler: %s", hb.ProcessID, err)

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -415,19 +414,12 @@ func (s *Session) DebugMessage(prefix string) string {
 {{.Stacktrace}}{{.Z}}
 {{.A}}Terminal snapshot:
 {{.FullSnapshot}}{{.Z}}
-{{.A}}State Tool Log:
-{{.StateLog}}{{.Z}}
-{{.A}}State Svc Log:
-{{.SvcLog}}{{.Z}}
-{{.A}}State Installer Log:
-{{.InstallerLog}}{{.Z}}
+{{.Logs}}
 `, map[string]interface{}{
 		"Prefix":       prefix,
 		"Stacktrace":   stacktrace.Get().String(),
 		"FullSnapshot": snapshot,
-		"StateLog":     s.MostRecentStateLog(),
-		"SvcLog":       s.SvcLog(),
-		"InstallerLog": s.InstallerLog(),
+		"Logs":         s.DebugLogs(),
 		"A":            sectionStart,
 		"Z":            sectionEnd,
 	})
@@ -451,47 +443,9 @@ func observeExpectFn(s *Session) expect.ExpectObserver {
 			sep = ", "
 		}
 
-		var sectionStart, sectionEnd string
-		sectionStart = "\n=== "
-		if os.Getenv("GITHUB_ACTIONS") == "true" {
-			sectionStart = "##[group]"
-			sectionEnd = "##[endgroup]"
-		}
-
-		v, err := strutils.ParseTemplate(`
-Could not meet expectation: '{{.Expectation}}'
-Error: {{.Error}}
-{{.A}}Stack:
-{{.Stacktrace}}{{.Z}}
-{{.A}}Partial Terminal snapshot:
-{{.PartialSnapshot}}{{.Z}}
-{{.A}}Full Terminal snapshot:
-{{.FullSnapshot}}{{.Z}}
-{{.A}}Parsed output:
-{{.ParsedOutput}}{{.Z}}
-{{.A}}State Tool Log:
-{{.StateLog}}{{.Z}}
-{{.A}}State Svc Log:
-{{.SvcLog}}{{.Z}}
-{{.A}}State Installer Log:
-{{.InstallerLog}}{{.Z}}
-`, map[string]interface{}{
-			"Expectation":     value,
-			"Error":           err,
-			"Stacktrace":      stacktrace.Get().String(),
-			"PartialSnapshot": ms.TermState.String(),
-			"FullSnapshot":    s.cp.Snapshot(),
-			"ParsedOutput":    fmt.Sprintf("%+q", ms.Buf.String()),
-			"StateLog":        s.MostRecentStateLog(),
-			"SvcLog":          s.SvcLog(),
-			"InstallerLog":    s.InstallerLog(),
-			"A":               sectionStart,
-			"Z":               sectionEnd,
-		})
-		if err != nil {
-			s.t.Fatalf("Parsing template failed: %s", err)
-		}
-		s.t.Fatal(v)
+		s.t.Fatal(s.DebugMessage(fmt.Sprintf(`
+Could not meet expectation: '%s'
+Error: %s`, value, err)))
 	}
 }
 
@@ -614,45 +568,36 @@ func (s *Session) SvcLog() string {
 	return fmt.Sprintf("Could not find state-svc log, checked under %s, found: \n%v\n, files: \n%v\n", logDir, lines, files)
 }
 
-func (s *Session) MostRecentStateLog() string {
-	rx := regexp.MustCompile(`state-\d`)
+func (s *Session) DebugLogs() string {
 	logDir := filepath.Join(s.Dirs.Config, "logs")
 	if !fileutils.DirExists(logDir) {
-		return ""
+		return "No logs found in " + logDir
 	}
-	var result string
-	var newest time.Time
+
+	var sectionStart, sectionEnd string
+	sectionStart = "\n=== "
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		sectionStart = "##[group]"
+		sectionEnd = "##[endgroup]"
+	}
+
+	result := "Logs:\n"
 	err := filepath.WalkDir(logDir, func(path string, f fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !rx.MatchString(f.Name()) {
+		if f.IsDir() {
 			return nil
 		}
 
-		info, err := f.Info()
-		if err != nil {
-			panic("Could not get file info")
-		}
-
-		ts := info.ModTime()
-		if ts.After(newest) {
-			result = path
-			newest = ts
-		}
-
+		result += fmt.Sprintf("%s%s:\n%s%s\n", sectionStart, filepath.Base(path), fileutils.ReadFileUnsafe(path), sectionEnd)
 		return nil
 	})
 	if err != nil {
-		panic(fmt.Sprintf("Could not walk log dir: %v", err))
+		return errs.JoinMessage(err)
 	}
 
-	if result == "" {
-		return fmt.Sprintf("Could not find state log, checked under %s", logDir)
-	}
-
-	b := fileutils.ReadFileUnsafe(result)
-	return string(b) + "\n\nCurrent time: " + time.Now().String()
+	return result
 }
 
 func RunningOnCI() bool {

--- a/test/integration/analytics_int_test.go
+++ b/test/integration/analytics_int_test.go
@@ -77,13 +77,13 @@ func (suite *AnalyticsIntegrationTestSuite) TestActivateEvents() {
 
 	// Runtime:start events
 	suite.assertNEvents(events, 1, anaConst.CatRuntime, anaConst.ActRuntimeStart,
-		fmt.Sprintf("output:\n%s\nState Log:\n%s\nSvc Log:\n%s",
-			cp.Snapshot(), ts.MostRecentStateLog(), ts.SvcLog()))
+		fmt.Sprintf("output:\n%s\n%s",
+			cp.Snapshot(), ts.DebugLogs()))
 
 	// Runtime:success events
 	suite.assertNEvents(events, 1, anaConst.CatRuntime, anaConst.ActRuntimeSuccess,
-		fmt.Sprintf("output:\n%s\nState Log:\n%s\nSvc Log:\n%s",
-			cp.Snapshot(), ts.MostRecentStateLog(), ts.SvcLog()))
+		fmt.Sprintf("output:\n%s\n%s",
+			cp.Snapshot(), ts.DebugLogs()))
 
 	heartbeatInitialCount := countEvents(events, anaConst.CatRuntimeUsage, anaConst.ActRuntimeHeartbeat)
 	if heartbeatInitialCount < 2 {
@@ -99,8 +99,8 @@ func (suite *AnalyticsIntegrationTestSuite) TestActivateEvents() {
 
 	// Runtime-use:heartbeat events - should now be at least +1 because we waited <heartbeatInterval>
 	suite.assertGtEvents(events, heartbeatInitialCount, anaConst.CatRuntimeUsage, anaConst.ActRuntimeHeartbeat,
-		fmt.Sprintf("output:\n%s\nState Log:\n%s\nSvc Log:\n%s",
-			cp.Snapshot(), ts.MostRecentStateLog(), ts.SvcLog()))
+		fmt.Sprintf("output:\n%s\n%s",
+			cp.Snapshot(), ts.DebugLogs()))
 
 	cp.SendLine("exit")
 
@@ -119,7 +119,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestActivateEvents() {
 	suite.Equal(eventsAfterExit, eventsAfterWait,
 		fmt.Sprintf("Heartbeats should stop ticking after exiting subshell.\n"+
 			"output:\n%s\nState Log:\n%s\nSvc Log:\n%s",
-			cp.Snapshot(), ts.MostRecentStateLog(), ts.SvcLog()))
+			cp.Snapshot(), ts.DebugLogs(), ts.SvcLog()))
 
 	// Ensure any analytics events from the state tool have the instance ID set
 	for _, e := range events {
@@ -367,8 +367,8 @@ func (suite *AnalyticsIntegrationTestSuite) TestInputError() {
 	suite.assertSequentialEvents(events)
 
 	suite.assertNEvents(events, 1, anaConst.CatDebug, anaConst.ActInputError,
-		fmt.Sprintf("output:\n%s\nState Log:\n%s\nSvc Log:\n%s",
-			cp.Snapshot(), ts.MostRecentStateLog(), ts.SvcLog()))
+		fmt.Sprintf("output:\n%s\n%s",
+			cp.Snapshot(), ts.DebugLogs()))
 
 	for _, event := range events {
 		if event.Category == anaConst.CatDebug && event.Action == anaConst.ActInputError {

--- a/test/integration/performance_int_test.go
+++ b/test/integration/performance_int_test.go
@@ -43,7 +43,7 @@ func TestPerformanceIntegrationTestSuite(t *testing.T) {
 
 func performanceTest(commands []string, expect string, samples int, maxTime time.Duration, suite tagsuite.Suite, ts *e2e.Session) time.Duration {
 	rx := regexp.MustCompile(`Profiling: main took .*\((\d+)\)`)
-	var firstEntry, firstStateLog, firstSvcLog string
+	var firstEntry, firstLogs string
 	times := []time.Duration{}
 	var total time.Duration
 	for x := 0; x < samples+1; x++ {
@@ -64,8 +64,7 @@ func performanceTest(commands []string, expect string, samples int, maxTime time
 
 		if firstEntry == "" {
 			firstEntry = cp.Snapshot()
-			firstStateLog = ts.MostRecentStateLog()
-			firstSvcLog = ts.SvcLog()
+			firstLogs = ts.DebugLogs()
 		}
 		if x == 0 {
 			// Skip the first one as this one will always be slower due to having to wait for state-svc or sourcing a runtime
@@ -89,10 +88,6 @@ func performanceTest(commands []string, expect string, samples int, maxTime time
 	Output of first run:
 	%s
 
-	State Tool log:
-	%s
-
-	Svc log:
 	%s`,
 				strings.Join(commands, " "),
 				avg.String(),
@@ -100,8 +95,7 @@ func performanceTest(commands []string, expect string, samples int, maxTime time
 				time.Duration(total).String(),
 				times,
 				firstEntry,
-				firstStateLog,
-				firstSvcLog))
+				firstLogs))
 	}
 
 	return avg


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1542" title="DX-1542" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1542</a>  state-svc logs always empty on CI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Upon fixing the issue I realized how silly the old implementation was. Integration tests already create their own config dir, so there would only ever be logs relevant to the test in question. So instead of any sort of "latest log" logic I rewrote it to just dump all the logs in the log directory.

Additionally I added some small improvements to make the logs more digestible and generally useful.
