### PR TITLE
Fix checkout failing if dir is non-empty even if there is no as.yaml

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed `state export private-key` giving an uninformative error message when 
   improperly authenticated.
 - Fixed `state show` not working with commits that haven't been pushed to the platform.
+- Fixed `state checkout` failing if target dir is non-empty but does not contain an activestate.yaml.
 
 ### Removed
 

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1820,10 +1820,6 @@ err_ping_version_mismatch:
     If this issue persists please reinstall the State Tool.
 err_get_wd:
   other: Unable to get appropriate parent directory for project, please ensure you have write permissions in your current directory.
-err_directory_in_use:
-  other: |
-    Project directory at {{.V0}} is not empty. When activating a new project the project directory must be empty.
-    To use a custom path when activating a project use the [ACTIONABLE]--path <path/to/project>[/RESET] flag
 err_jwt_not_authenticated:
   other: |
     You are not authenticated. In order to export a JWT please first authenticate with [ACTIONABLE]state auth[/RESET]

--- a/pkg/cmdlets/checkout/path.go
+++ b/pkg/cmdlets/checkout/path.go
@@ -51,8 +51,7 @@ func validatePath(ns *project.Namespaced, path string) error {
 
 	configFile := filepath.Join(path, constants.ConfigFileName)
 	if !fileutils.FileExists(configFile) {
-		// Directory is not empty and does not contain a config file
-		return locale.NewInputError("err_directory_in_use", "", path)
+		return nil
 	}
 
 	pj, err := project.Parse(configFile)

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
 	"github.com/ActiveState/cli/pkg/platform/runtime/target"
+	"github.com/ActiveState/cli/pkg/projectfile"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -40,6 +42,36 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckout() {
 	pythonExe := filepath.Join(setup.ExecDir(targetDir), "python3"+exeutils.Extension)
 	cp = ts.SpawnCmd(pythonExe, "--version")
 	cp.Expect("Python 3")
+	cp.ExpectExitCode(0)
+}
+
+func (suite *CheckoutIntegrationTestSuite) TestCheckoutNonEmptyDir() {
+	suite.OnlyRunForTags(tagsuite.Checkout)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	tmpdir := fileutils.TempDirUnsafe()
+	_, err := projectfile.Create(&projectfile.CreateParams{Owner: "foo", Project: "bar", Directory: tmpdir})
+	suite.Require().NoError(err, "could not write project file")
+	_, err2 := fileutils.WriteTempFile(tmpdir, "active", []byte("test"), 0600)
+	suite.Require().NoError(err2, "could not write test file")
+
+	// Checkout and verify.
+	cp := ts.SpawnWithOpts(
+		e2e.WithArgs("checkout", "ActiveState-CLI/Python3", tmpdir),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=true"),
+	)
+	cp.Expect("project at the target path does not match")
+	cp.ExpectExitCode(1)
+
+	// remove file
+	suite.Require().NoError(os.Remove(filepath.Join(tmpdir, constants.ConfigFileName)))
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("checkout", "ActiveState-CLI/Python3", tmpdir),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=true"),
+	)
+	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -54,7 +54,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutNonEmptyDir() {
 	tmpdir := fileutils.TempDirUnsafe()
 	_, err := projectfile.Create(&projectfile.CreateParams{Owner: "foo", Project: "bar", Directory: tmpdir})
 	suite.Require().NoError(err, "could not write project file")
-	_, err2 := fileutils.WriteTempFile(tmpdir, "active", []byte("test"), 0600)
+	_, err2 := fileutils.WriteTempFile("bogus.txt", []byte("test"))
 	suite.Require().NoError(err2, "could not write test file")
 
 	// Checkout and verify.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1546" title="DX-1546" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1546</a>  State checkout fails if dir is non-empty but has no activestate.yaml
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

