### PR TITLE
Fixed panic for remote project listings.

### DIFF
--- a/internal/runners/projects/projects.go
+++ b/internal/runners/projects/projects.go
@@ -58,6 +58,9 @@ func (o projectWithOrgs) MarshalOutput(f output.Format) interface{} {
 		checkouts := []string{}
 		executables := []string{}
 		for i, checkout := range v.LocalCheckouts {
+			if len(v.Executables) <= i {
+				continue // remote project listings do not have executables
+			}
 			execDir := v.Executables[i]
 			if execDir != "" {
 				checkouts = append(checkouts, locale.Tl("projects_local_checkout_exec", " ├─ Local Checkout → {{.V0}}", checkout))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1561" title="DX-1561" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1561</a>  IMPORT: Panic when try to run `state projects remote`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
