### PR TITLE
Attempt to work around GitHub CI slowness with DotProgress.

### DIFF
--- a/internal/output/progress_test.go
+++ b/internal/output/progress_test.go
@@ -20,5 +20,9 @@ func Test_Dotprogress(t *testing.T) {
 	time.Sleep(sleepTime)
 	dp.Stop("Done")
 	dots := strings.Repeat(".", (noIntervals / 20)) // To avoid race conditions we're only counting half the supposed dots
-	require.Regexp(t, regexp.MustCompile("Progress..."+dots+"\\.* Done"), out.ErrorOutput())
+
+	// GitHub CI's shell sometimes glitches and mixes up stdout, mostly on Windows, but
+	// occasionally on other platforms. Allow for the final space before "Done" to occur anywhere
+	// before it.
+	require.Regexp(t, regexp.MustCompile("Progress..."+dots+"(\\.* |\\.* \\.+)Done"), out.ErrorOutput())
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1560" title="DX-1560" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1560</a>  Test_Dotprogress failing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

