### PR TITLE
Increase logging for WinAPI failures.

### DIFF
--- a/internal/output/progress_win.go
+++ b/internal/output/progress_win.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/ActiveState/cli/internal/rollbar"
+	"github.com/ActiveState/cli/internal/multilog"
 )
 
 var kernel32 = syscall.NewLazyDLL("kernel32.dll")
@@ -49,11 +49,11 @@ func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
 
 		_, _, err2 := procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
 		if err2 != nil && !d.reportedError {
-			rollbar.Error("Error calling SetConsoleCursorPosition: %v", err2)
+			multilog.Error("Error calling SetConsoleCursorPosition: %v", err2)
 			d.reportedError = true
 		}
 	} else if !d.reportedError {
-		rollbar.Error("Error calling GetConsoleScreenBufferInfo: %v", err)
+		multilog.Error("Error calling GetConsoleScreenBufferInfo: %v", err)
 		d.reportedError = true
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1571" title="DX-1571" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1571</a>  CLONE - Spinner isn't cleared during runtime progress
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I suspect that a Win32 API call to move the cursor back is failing. I'm enabling debug logging to verify it. When one of us runs into the issue, we should check the debug log.