### PR TITLE
Use median for performance tests instead of mean.

### DIFF
--- a/test/integration/performance_expansion_int_test.go
+++ b/test/integration/performance_expansion_int_test.go
@@ -44,7 +44,7 @@ func (suite *PerformanceExpansionIntegrationTestSuite) TestExpansionPerformance(
 	suite.OnlyRunForTags(tagsuite.Performance)
 	baseline := DefaultMaxTime
 	suite.Run("CallScript", func() {
-		avg := suite.testScriptPerformance(scriptPerformanceOptions{
+		median := suite.testScriptPerformance(scriptPerformanceOptions{
 			script: projectfile.Script{
 				Name:     "call-script",
 				Value:    `echo "Hello World"`,
@@ -54,7 +54,7 @@ func (suite *PerformanceExpansionIntegrationTestSuite) TestExpansionPerformance(
 			samples: DefaultSamples,
 			max:     DefaultMaxTime,
 		})
-		variance := float64(avg) + (float64(avg) * DefaultVariance)
+		variance := float64(median) + (float64(median) * DefaultVariance)
 		baseline = time.Duration(variance)
 	})
 

--- a/test/integration/performance_expansion_int_test.go
+++ b/test/integration/performance_expansion_int_test.go
@@ -26,7 +26,7 @@ const (
 	DefaultMaxTime        = 1000 * time.Millisecond
 	DefaultSamples        = 10
 	DefaultVariance       = 0.75
-	DefaultSecretsMaxTime = 3500 * time.Millisecond
+	DefaultSecretsMaxTime = 4500 * time.Millisecond
 	// Add other configuration values on per-test basis if needed
 )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1567" title="DX-1567" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1567</a>  Our performance tests use the median value rather than the mean
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
