### PR TITLE
Fixed error detection of Win32 API calls.

### DIFF
--- a/internal/output/progress_win.go
+++ b/internal/output/progress_win.go
@@ -42,13 +42,13 @@ func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
 	handle := syscall.Handle(os.Stdout.Fd())
 
 	var csbi consoleScreenBufferInfo
-	if _, _, err := procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi))); err != nil {
+	if r, _, err := procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi))); r != 0 {
 		var cursor coord
 		cursor.x = csbi.cursorPosition.x + short(-n)
 		cursor.y = csbi.cursorPosition.y
 
-		_, _, err2 := procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
-		if err2 != nil && !d.reportedError {
+		r2, _, err2 := procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
+		if r2 == 0 && !d.reportedError {
 			multilog.Error("Error calling SetConsoleCursorPosition: %v", err2)
 			d.reportedError = true
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1571" title="DX-1571" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1571</a>  CLONE - Spinner isn't cleared during runtime progress
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
