### PR TITLE
Synchronize default Perl and Python versions with Platform defaults for `state init`

### DIFF
--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -72,11 +72,11 @@ var lookup = [...]languageData{
 		Executable{"powershell.exe", true},
 	},
 	{
-		"perl", "Perl", ".pl", true, "perl", "5.32.1",
+		"perl", "Perl", ".pl", true, "perl", "5.36.0",
 		Executable{constants.ActivePerlExecutable, false},
 	},
 	{
-		"python3", "Python 3", ".py", true, "python", "3.9.6",
+		"python3", "Python 3", ".py", true, "python", "3.10.8",
 		Executable{constants.ActivePython3Executable, false},
 	},
 	{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1467" title="DX-1467" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1467</a>  INIT: projects created with wrong defaults for python and perl
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
