### PR TITLE
Fix logging rotation using wrong base dir

### DIFF
--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -117,7 +117,7 @@ func init() {
 
 	rotate := rotateLogs(files, time.Now().Add(-time.Hour), 10)
 	for _, file := range rotate {
-		if err := os.Remove(filepath.Join(datadir, file.Name())); err != nil {
+		if err := os.Remove(filepath.Join(logDir, file.Name())); err != nil {
 			Error("Could not clean up old log: %s, error: %v", file.Name(), err)
 		}
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1578" title="DX-1578" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1578</a>  Logging race condition
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
