### PR TITLE
Handle panics in sighandler.

### DIFF
--- a/internal/sighandler/awaiting.go
+++ b/internal/sighandler/awaiting.go
@@ -45,8 +45,8 @@ func (as *Awaiting) WaitForFunc(f func() error) error {
 	as.Resume()
 
 	go func() {
-		defer close(errCh)
 		defer func() { panics.HandlePanics(recover(), debug.Stack()) }()
+		defer close(errCh)
 		errCh <- f()
 	}()
 

--- a/internal/sighandler/awaiting.go
+++ b/internal/sighandler/awaiting.go
@@ -3,6 +3,9 @@ package sighandler
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
+
+	"github.com/ActiveState/cli/internal/runbits/panics"
 )
 
 var _ signalStacker = &Awaiting{}
@@ -43,6 +46,7 @@ func (as *Awaiting) WaitForFunc(f func() error) error {
 
 	go func() {
 		defer close(errCh)
+		defer func() { panics.HandlePanics(recover(), debug.Stack()) }()
 		errCh <- f()
 	}()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1470" title="DX-1470" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1470</a>  We're not catching panics happening in captain runners
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
