### PR TITLE
Fixed error message if `state import file` fails.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1166,8 +1166,6 @@ package_err_cannot_obtain_search_results:
   other: Cannot obtain search results
 err_cannot_commit_changeset:
   other: Cannot commit changeset
-err_obtaining_change_request:
-  other: Cannot obtain change request
 package_no_data:
   other: No data found - Please verify the provided commit id
 package_list_no_packages:

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -122,7 +122,7 @@ func (i *Import) Run(params *ImportRunParams) error {
 
 	changeset, err := fetchImportChangeset(reqsimport.Init(), params.FileName, lang.Name)
 	if err != nil {
-		return locale.WrapError(err, "err_obtaining_change_request", "Could not process change set: {{.V0}}.", api.ErrorMessageFromPayload(err))
+		return err
 	}
 
 	packageReqs := model.FilterCheckpointNamespace(reqs, model.NamespacePackage, model.NamespaceBundle)
@@ -165,12 +165,12 @@ func removeRequirements(conf Confirmer, project *project.Project, params *Import
 func fetchImportChangeset(cp ChangesetProvider, file string, lang string) (model.Changeset, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
-		return nil, err
+		return nil, locale.WrapInputError(err, "err_reading_changeset_file", "Cannot read import file: {{.V0}}", err.Error())
 	}
 
 	changeset, err := cp.Changeset(data, lang)
 	if err != nil {
-		return nil, err
+		return nil, locale.WrapError(err, "err_obtaining_change_request", "Could not process change set: {{.V0}}.", api.ErrorMessageFromPayload(err))
 	}
 
 	return changeset, err

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -122,7 +122,7 @@ func (i *Import) Run(params *ImportRunParams) error {
 
 	changeset, err := fetchImportChangeset(reqsimport.Init(), params.FileName, lang.Name)
 	if err != nil {
-		return err
+		return errs.Wrap(err, "Could not import changeset")
 	}
 
 	packageReqs := model.FilterCheckpointNamespace(reqs, model.NamespacePackage, model.NamespaceBundle)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1503" title="DX-1503" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1503</a>  Error message is not actionable for state import 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Differentiate between I/O errors and Platform errors. That makes the message more actionable for users.