### PR TITLE
Check for authentication early in `state revert`.

### DIFF
--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -69,6 +69,10 @@ func (r *Revert) Run(params *Params) error {
 	if r.project == nil {
 		return locale.NewInputError("err_no_project")
 	}
+	if !r.auth.Authenticated() {
+		// Authentication is required in order to make a revert commit. Fail now rather than later.
+		return locale.NewInputError("err_api_not_authenticated")
+	}
 	r.out.Notice(locale.Tl("operating_message", "", r.project.NamespaceString(), r.project.Dir()))
 	commitID := strfmt.UUID(params.CommitID)
 


### PR DESCRIPTION
Erroring out due to lack of authentication after the user answers prompts is backwards.