### PR TITLE
`state use reset` with no project in use is a user error.

### DIFF
--- a/internal/runners/use/reset.go
+++ b/internal/runners/use/reset.go
@@ -36,8 +36,7 @@ func (u *Reset) Run(params *ResetParams) error {
 	logging.Debug("Resetting default project runtime")
 
 	if !globaldefault.IsSet(u.config) {
-		u.out.Notice(locale.T("use_reset_notice_not_reset"))
-		return nil
+		return locale.NewInputError(locale.T("use_reset_notice_not_reset"))
 	}
 
 	defaultChoice := params.Force
@@ -54,8 +53,7 @@ func (u *Reset) Run(params *ResetParams) error {
 	if err != nil {
 		return locale.WrapError(err, "err_use_reset", "Could not stop using your project.")
 	} else if !reset {
-		u.out.Notice(locale.T("use_reset_notice_not_reset"))
-		return nil
+		return locale.NewInputError(locale.T("use_reset_notice_not_reset"))
 	}
 
 	u.out.Notice(locale.Tl("use_reset_notice_reset", "Stopped using your project runtime"))

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -159,7 +159,7 @@ func (suite *UseIntegrationTestSuite) TestReset() {
 
 	cp = ts.SpawnWithOpts(e2e.WithArgs("use", "reset"))
 	cp.Expect("No project to stop using")
-	cp.ExpectExitCode(0)
+	cp.ExpectExitCode(1)
 
 	if runtime.GOOS != "windows" && fileutils.FileExists(rcfile) {
 		suite.NotContains(string(fileutils.ReadFileUnsafe(rcfile)), ts.Dirs.DefaultBin, "PATH still has your project in it")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1565" title="DX-1565" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1565</a>  USE: `reset` flag - error message have no uniformity compare to the same command other flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
