### PR TITLE
Check if paths were actually removed to show correct message.

### DIFF
--- a/internal/assets/contents/scripts/removePaths.bat
+++ b/internal/assets/contents/scripts/removePaths.bat
@@ -30,14 +30,20 @@ echo "Waiting for process %exe% with PID %pid% to end..." >> %logfile%
     )
 
 echo "Process %exe% has ended" >> %logfile%
+set success=true
 for /d %%i in (%paths%) do (
     echo "Attempting to remove path %%i" >> %logfile%
     rmdir /s /q %%i >> %logfile%
     if exist %%i (
         echo "Could not remove directory: %%i" >> %logfile%
+        set success=false
     ) else (
         echo "Successfully removed path %%i" >> %logfile%
     )
 )
 
-echo "Successfully removed State Tool installation and related files." >> %logfile%
+if "%success%"=="true" (
+    echo "Successfully removed State Tool installation and related files." >> %logfile%
+) else (
+    echo "Failed to remove one or more State Tool files." >>  %logfile%
+)

--- a/internal/assets/contents/scripts/removePaths.bat
+++ b/internal/assets/contents/scripts/removePaths.bat
@@ -32,12 +32,8 @@ echo "Waiting for process %exe% with PID %pid% to end..." >> %logfile%
 echo "Process %exe% has ended" >> %logfile%
 for /d %%i in (%paths%) do (
     echo "Attempting to remove path %%i" >> %logfile%
-    if exist %%i\* (
-        rmdir /s /q %%i >> %logfile%
-    ) else (
-        del /q %%i >> %logfile%
-    )
-    if %ERRORLEVEL% NEQ 0 (
+    rmdir /s /q %%i >> %logfile%
+    if exist %%i (
         echo "Could not remove directory: %%i" >> %logfile%
     ) else (
         echo "Successfully removed path %%i" >> %logfile%


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1548" title="DX-1548" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1548</a>  CLEAN: `state clean config/uninstall` generates a success message even if failed to delete the `config.db` file.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Windows' rmdir and del commands do not set %ERRORLEVEL%. Instead, check if the directories still exist.

Also, rmdir and del are equivalent.

For more information, see https://stackoverflow.com/questions/11137702/rd-exits-with-errorlevel-set-to-0-on-error-when-deletion-fails-etc (note that RD is an alias for RMDIR)