### PR TITLE
Add newline between errors and "Need More Help?" header.

### DIFF
--- a/pkg/cmdlets/errors/errors.go
+++ b/pkg/cmdlets/errors/errors.go
@@ -67,6 +67,7 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 
 	// Print tips
 	if enableTips := os.Getenv(constants.DisableErrorTipsEnvVarName) != "true"; enableTips {
+		outLines = append(outLines, "") // separate error from "Need More Help?" header
 		outLines = append(outLines, output.Title(locale.Tl("err_more_help", "Need More Help?")).String())
 		for _, tip := range errorTips {
 			outLines = append(outLines, fmt.Sprintf(" [DISABLED]•[/RESET] %s", trimError(tip)))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1613" title="DX-1613" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1613</a>  Missing space between the message and `help` block
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
