### PR TITLE
Use different messages for `state clean uninstall` depending on whether or not `--all` is present.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1375,6 +1375,12 @@ err_clean_cache_activated:
 err_clean_config_activated:
   other: Cannot remove the config directory while in an activated state. Please deactivate by entering [ACTIONABLE]exit[/RESET] or pressing [ACTIONABLE]Ctrl+D[/RESET] and then try again.
 uninstall_confirm:
+  other: |
+    You are about to remove the State Tool.
+    Your config and cache files will remain.
+    If you would also like to remove those files, add the [ACTIONABLE]--all[/RESET] flag.
+    Continue?
+uninstall_confirm_all:
   other: You are about to remove the State Tool, installed language runtimes, and all configuration information. Continue?
 clean_cache_confirm:
   other: You are about to reset the State Tool cache. Continue?

--- a/internal/runners/clean/uninstall.go
+++ b/internal/runners/clean/uninstall.go
@@ -63,7 +63,11 @@ func (u *Uninstall) Run(params *UninstallParams) error {
 
 	if !params.Force {
 		defaultChoice := params.NonInteractive
-		ok, err := u.confirm.Confirm(locale.T("confirm"), locale.T("uninstall_confirm"), &defaultChoice)
+		confirmMessage := locale.T("uninstall_confirm")
+		if params.All {
+			confirmMessage = locale.T("uninstall_confirm_all")
+		}
+		ok, err := u.confirm.Confirm(locale.T("confirm"), confirmMessage, &defaultChoice)
 		if err != nil {
 			return locale.WrapError(err, "err_uninstall_confirm", "Could not confirm uninstall choice")
 		}

--- a/test/integration/uninstall_int_test.go
+++ b/test/integration/uninstall_int_test.go
@@ -44,6 +44,9 @@ func (suite *UninstallIntegrationTestSuite) testUninstall(all bool) {
 		cp = ts.Spawn("clean", "uninstall")
 	}
 	cp.Expect("You are about to remove")
+	if !all {
+		cp.Expect("--all") // verify mention of "--all" to remove everything
+	}
 	cp.SendLine("y")
 	if runtime.GOOS == "windows" {
 		cp.ExpectLongString("Deletion of State Tool has been scheduled.")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1612" title="DX-1612" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1612</a>  `state clean uninstall` - the message in the confirmation prompt is wrong for the use case without `--all`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
