### PR TITLE
Uninstall on Windows should remove the same files as on macOS/Linux

### DIFF
--- a/internal/runners/clean/run_win.go
+++ b/internal/runners/clean/run_win.go
@@ -111,7 +111,7 @@ func removeInstall(logFile string, params *UninstallParams, cfg *config.Instance
 	// This is because Windows often thinks the installation.InstallDirMarker and
 	// constants.StateInstallerCmd files are still in use.
 	branchDir := filepath.Dir(filepath.Dir(stateExec))
-	if condition.OnCI() && !params.All {
+	if condition.InTest() && !params.All {
 		// On CI, the installation root also contains cache and config directories, and they should
 		// not be removed. Instead, just remove the installation bin directory.
 		branchDir = filepath.Dir(stateExec)

--- a/internal/runners/clean/run_win.go
+++ b/internal/runners/clean/run_win.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/ActiveState/cli/internal/assets"
+	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/exeutils"
@@ -106,14 +107,18 @@ func removeInstall(logFile string, params *UninstallParams, cfg *config.Instance
 		return locale.WrapError(err, "err_state_exec")
 	}
 
-	paths := []string{}
+	// Schedule removal of the entire branch name directory.
+	// This is because Windows often thinks the installation.InstallDirMarker and
+	// constants.StateInstallerCmd files are still in use.
+	branchDir := filepath.Dir(filepath.Dir(stateExec))
+	if condition.OnCI() && !params.All {
+		// On CI, the installation root also contains cache and config directories, and they should
+		// not be removed. Instead, just remove the installation bin directory.
+		branchDir = filepath.Dir(stateExec)
+	}
+	paths := []string{branchDir}
 	if params.All {
-		// Schedule removal of the branch name directory and the config directory
-		paths = append(paths, filepath.Dir(filepath.Dir(stateExec)))
-		paths = append(paths, cfg.ConfigPath())
-	} else {
-		// Schedule the removal of just the bin directory.
-		paths = append(paths, filepath.Dir(stateExec))
+		paths = append(paths, cfg.ConfigPath()) // also remove the config directory
 	}
 	// If the transitional state tool path is known, we remove it. This is done in the background, because the transitional State Tool can be the initiator of the uninstall request
 	if transitionalStateTool := cfg.GetString(installation.CfgTransitionalStateToolPath); transitionalStateTool != "" {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1614" title="DX-1614" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1614</a>  Reinstall is fail if previous version was uninstalled and all config/cache folders remain
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The previous fix was erroneously tailored towards the integration tests. It was not deleting the installer exe and install root stub. 