### PR TITLE
Error out if runtime progress was badly reported

### DIFF
--- a/internal/runbits/runtime/progress/progress.go
+++ b/internal/runbits/runtime/progress/progress.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/go-openapi/strfmt"
 	"github.com/vbauerster/mpb/v7"
@@ -357,13 +358,11 @@ Still expecting:
 				p.buildsExpected, p.downloadsExpected, p.installsExpected,
 			)
 
-			/* Disabled for v0.36 as we're still ironing out the kinks
 			if pending > 0 {
 				// We only error out if we determine the issue is down to one of our bars not completing.
 				// Otherwise this is an issue with the mpb package which is currently a known limitation, end goal is to get rid of mpb.
 				return locale.NewError("err_rtprogress_outofsync", "", constants.BugTrackerURL, logging.FilePath())
 			}
-			*/
 		}
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1576" title="DX-1576" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1576</a>  Enable progress events out of order error for v0.37
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
