### PR TITLE
Log autoupdate failures instead of halting execution.

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -232,8 +232,10 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 
 	if childCmd != nil && !childCmd.SkipChecks() {
 		// Auto update to latest state tool version
-		if updated, err := autoUpdate(args, cfg, out); err != nil || updated {
-			return err
+		if updated, err := autoUpdate(args, cfg, out); err == nil && updated {
+			return nil // command will be run by updated exe
+		} else if err != nil {
+			multilog.Error("Failed to autoupdate: %v", err)
 		}
 
 		// Check for deprecation


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1640" title="DX-1640" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1640</a>  Auto update should not interrupt state tool
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
