### PR TITLE
Removed some `--force` flags in favor of `--non-interactive`.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -123,8 +123,8 @@ func New(prime *primer.Values, args ...string) *CmdTree {
 
 	updateCmd := newUpdateCommand(prime)
 	updateCmd.AddChildren(
-		newUpdateLockCommand(prime),
-		newUpdateUnlockCommand(prime))
+		newUpdateLockCommand(prime, globals),
+		newUpdateUnlockCommand(prime, globals))
 
 	branchCmd := newBranchCommand(prime)
 	branchCmd.AddChildren(

--- a/cmd/state/internal/cmdtree/update.go
+++ b/cmd/state/internal/cmdtree/update.go
@@ -34,7 +34,7 @@ func newUpdateCommand(prime *primer.Values) *captain.Command {
 	return cmd
 }
 
-func newUpdateLockCommand(prime *primer.Values) *captain.Command {
+func newUpdateLockCommand(prime *primer.Values, globals *globalOptions) *captain.Command {
 	runner := update.NewLock(prime)
 	params := update.LockParams{}
 
@@ -49,16 +49,10 @@ func newUpdateLockCommand(prime *primer.Values) *captain.Command {
 				Description: locale.Tl("update_channel", "Switches to the given update channel, eg. 'release'."),
 				Value:       &params.Channel,
 			},
-			{
-				Name: "force",
-				Description: locale.Tl(
-					"flag_update_force",
-					"Automatically confirm that you would like to update the State Tool version that your project is locked to."),
-				Value: &params.Force,
-			},
 		},
 		[]*captain.Argument{},
 		func(cmd *captain.Command, args []string) error {
+			params.NonInteractive = globals.NonInteractive
 			return runner.Run(&params)
 		},
 	)
@@ -66,7 +60,7 @@ func newUpdateLockCommand(prime *primer.Values) *captain.Command {
 	return cmd
 }
 
-func newUpdateUnlockCommand(prime *primer.Values) *captain.Command {
+func newUpdateUnlockCommand(prime *primer.Values, globals *globalOptions) *captain.Command {
 	runner := update.NewUnlock(prime)
 	params := update.UnlockParams{}
 
@@ -75,17 +69,10 @@ func newUpdateUnlockCommand(prime *primer.Values) *captain.Command {
 		locale.Tl("unlock_title", "Unlock the State Tool version"),
 		locale.Tl("unlock_description", "Unlock the State Tool version for the current project."),
 		prime,
-		[]*captain.Flag{
-			{
-				Name: "force",
-				Description: locale.Tl(
-					"flag_update_unlock_force",
-					"Automatically confirm that you would like to remove the lock."),
-				Value: &params.Force,
-			},
-		},
+		[]*captain.Flag{},
 		[]*captain.Argument{},
 		func(cmd *captain.Command, args []string) error {
+			params.NonInteractive = globals.NonInteractive
 			return runner.Run(&params)
 		},
 	)

--- a/internal/runners/update/lock.go
+++ b/internal/runners/update/lock.go
@@ -33,7 +33,7 @@ func (stv *StateToolChannelVersion) Type() string {
 
 type LockParams struct {
 	Channel StateToolChannelVersion
-	Force   bool
+	NonInteractive bool
 }
 
 type Lock struct {
@@ -55,7 +55,7 @@ func NewLock(prime primeable) *Lock {
 func (l *Lock) Run(params *LockParams) error {
 	l.out.Notice(locale.Tl("locking_version", "Locking State Tool version for current project."))
 
-	if l.project.IsLocked() && !params.Force {
+	if l.project.IsLocked() && !params.NonInteractive {
 		if err := confirmLock(l.prompt); err != nil {
 			return locale.WrapError(err, "err_update_lock_confirm", "Could not confirm whether to lock update.")
 		}

--- a/internal/runners/update/unlock.go
+++ b/internal/runners/update/unlock.go
@@ -11,7 +11,7 @@ import (
 )
 
 type UnlockParams struct {
-	Force bool
+	NonInteractive bool
 }
 
 type Unlock struct {
@@ -38,7 +38,7 @@ func (u *Unlock) Run(params *UnlockParams) error {
 
 	u.out.Notice(locale.Tl("unlocking_version", "Unlocking State Tool version for current project."))
 
-	if !params.Force {
+	if !params.NonInteractive {
 		err := confirmUnlock(u.prompt)
 		if err != nil {
 			return locale.WrapError(err, "err_update_unlock_confirm", "Unlock cancelled by user.")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1611" title="DX-1611" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1611</a>  Various commands have `--force` and `-n` flags with the same functionality
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The examples in the ticket, `state clean uninstall` and `state clean config` need to keep their `--force` options in order to override OS errors (e.g. file in use). `--non-interactive` should not do that. Instead, I've identified other commands we can replace `--force` with.