### PR TITLE
Sort and group commands in docs more intuitively

### DIFF
--- a/internal/runners/export/docs/docs.go
+++ b/internal/runners/export/docs/docs.go
@@ -2,7 +2,6 @@ package docs
 
 import (
 	_ "embed"
-	"sort"
 
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/errs"
@@ -58,10 +57,6 @@ func grabChildren(cmd *captain.Command) []*captain.Command {
 		children = append(children, child)
 		children = append(children, grabChildren(child)...)
 	}
-
-	sort.Slice(children, func(i, j int) bool {
-		return children[i].SortBefore(children[j])
-	})
 
 	return children
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1658" title="DX-1658" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1658</a>  Command reference docs aren't sorted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
