### PR TITLE
Add `--to` option for `state revert`.

### DIFF
--- a/cmd/state/internal/cmdtree/revert.go
+++ b/cmd/state/internal/cmdtree/revert.go
@@ -16,7 +16,13 @@ func newRevertCommand(prime *primer.Values, globals *globalOptions) *captain.Com
 		locale.Tl("revert_title", "Reverting Commit"),
 		locale.Tl("revert_description", "Revert a commit"),
 		prime,
-		[]*captain.Flag{},
+		[]*captain.Flag{
+			{
+				Name:        "to",
+				Description: locale.Tl("revert_arg_to", "Create a new commit that brings the runtime back to the same state as the commit given"),
+				Value:       &params.To,
+			},
+		},
 		[]*captain.Argument{
 			{
 				Name:        "commit-id",

--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -73,15 +73,15 @@ func (r *Revert) Run(params *Params) error {
 	if !strfmt.IsUUID(params.CommitID) {
 		return locale.NewInputError("err_invalid_commit_id", "Invalid commit ID")
 	}
-	if params.CommitID == r.project.CommitID() && params.To {
-		return locale.NewInputError("err_revert_to_current_commit", "Cannot revert to current commit")
+	latestCommit := r.project.CommitUUID()
+	if params.CommitID == latestCommit.String() && params.To {
+		return locale.NewInputError("err_revert_to_current_commit", "The commit to revert to cannot be the latest commit")
 	}
 	r.out.Notice(locale.Tl("operating_message", "", r.project.NamespaceString(), r.project.Dir()))
 	commitID := strfmt.UUID(params.CommitID)
 
-	var targetCommit *mono_models.Commit
+	var targetCommit *mono_models.Commit // the commit to revert the contents of, or the commit to revert to
 	var fromCommit, toCommit strfmt.UUID
-	latestCommit := r.project.CommitUUID()
 	if !params.To {
 		priorCommits, err := model.CommitHistoryPaged(commitID, 0, 2)
 		if err != nil {

--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -30,6 +30,7 @@ type Revert struct {
 
 type Params struct {
 	CommitID string
+	To       bool
 	Force    bool
 }
 
@@ -72,28 +73,50 @@ func (r *Revert) Run(params *Params) error {
 	if !strfmt.IsUUID(params.CommitID) {
 		return locale.NewInputError("err_invalid_commit_id", "Invalid commit ID")
 	}
+	if params.CommitID == r.project.CommitID() && params.To {
+		return locale.NewInputError("err_revert_to_current_commit", "Cannot revert to current commit")
+	}
 	r.out.Notice(locale.Tl("operating_message", "", r.project.NamespaceString(), r.project.Dir()))
 	commitID := strfmt.UUID(params.CommitID)
 
-	priorCommits, err := model.CommitHistoryPaged(commitID, 0, 2)
-	if err != nil {
-		return locale.WrapError(err, "err_revert_get_commit", "Could not fetch commit details for commit with ID: {{.V0}}", params.CommitID)
+	var targetCommit *mono_models.Commit
+	var fromCommit, toCommit strfmt.UUID
+	latestCommit := r.project.CommitUUID()
+	if !params.To {
+		priorCommits, err := model.CommitHistoryPaged(commitID, 0, 2)
+		if err != nil {
+			return locale.WrapError(err, "err_revert_get_commit", "Could not fetch commit details for commit with ID: {{.V0}}", params.CommitID)
+		}
+		if priorCommits.TotalCommits < 2 {
+			return locale.NewInputError("err_revert_no_history", "Cannot revert commit {{.V0}}: no prior history", params.CommitID)
+		}
+		targetCommit = priorCommits.Commits[0]
+		fromCommit = commitID
+		toCommit = priorCommits.Commits[1].CommitID // parent commit
+	} else {
+		var err error
+		targetCommit, err = model.GetCommitWithinCommitHistory(latestCommit, commitID)
+		if err != nil {
+			return locale.WrapError(err, "err_revert_to_get_commit", "Could not fetch commit details for commit with ID: {{.V0}}", params.CommitID)
+		}
+		fromCommit = latestCommit
+		toCommit = targetCommit.CommitID
 	}
-	if priorCommits.TotalCommits < 2 {
-		return locale.NewInputError("err_revert_no_history", "Cannot revert commit {{.V0}}: no prior history", params.CommitID)
-	}
-	commitToRevert := priorCommits.Commits[0]
-	parentCommit := priorCommits.Commits[1]
 
 	var orgs []gqlmodel.Organization
-	if commitToRevert.Author != nil {
-		orgs, err = model.FetchOrganizationsByIDs([]strfmt.UUID{*commitToRevert.Author})
+	if targetCommit.Author != nil {
+		var err error
+		orgs, err = model.FetchOrganizationsByIDs([]strfmt.UUID{*targetCommit.Author})
 		if err != nil {
 			return locale.WrapError(err, "err_revert_get_organizations", "Could not get organizations for current user")
 		}
 	}
-	r.out.Print(locale.Tl("revert_info", "You are about to revert the following commit:"))
-	commit.PrintCommit(r.out, commitToRevert, orgs)
+	preposition := ""
+	if params.To {
+		preposition = " to" // need leading whitespace
+	}
+	r.out.Print(locale.Tl("revert_info", "You are about to revert{{.V0}} the following commit:", preposition))
+	commit.PrintCommit(r.out, targetCommit, orgs)
 
 	defaultChoice := params.Force
 	revert, err := r.prompt.Confirm("", locale.Tl("revert_confirm", "Continue?"), &defaultChoice)
@@ -104,12 +127,13 @@ func (r *Revert) Run(params *Params) error {
 		return locale.NewInputError("err_revert_aborted", "Revert aborted by user")
 	}
 
-	revertCommit, err := model.RevertCommitWithinHistory(commitID, parentCommit.CommitID, r.project.CommitUUID())
+	revertCommit, err := model.RevertCommitWithinHistory(fromCommit, toCommit, latestCommit)
 	if err != nil {
 		return locale.WrapError(
 			err,
 			"err_revert_commit",
-			"Could not revert commit: {{.V0}} please ensure that the local project is synchronized with the platform and that the given commit ID belongs to the current project",
+			"Could not revert{{.V0}} commit: {{.V1}} please ensure that the local project is synchronized with the platform and that the given commit ID belongs to the current project",
+			preposition,
 			params.CommitID,
 		)
 	}
@@ -124,7 +148,7 @@ func (r *Revert) Run(params *Params) error {
 		return locale.WrapError(err, "err_revert_set_commit", "Could not set revert commit ID in projectfile")
 	}
 
-	r.out.Print(locale.Tl("revert_success", "Successfully reverted commit: {{.V0}}", params.CommitID))
+	r.out.Print(locale.Tl("revert_success", "Successfully reverted{{.V0}} commit: {{.V1}}", preposition, params.CommitID))
 	r.out.Print(locale.T("operation_success_local"))
 	return nil
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1506" title="DX-1506" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1506</a>  State revert has a `--to` flag to get back to the state of the target commit
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Allow reverting to a given commit, like in the Dashboard.