### PR TITLE
Do not report silent errors.

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -263,7 +263,7 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 	}
 
 	err = cmds.Execute(args[1:])
-	if err != nil {
+	if err != nil && !errs.IsSilent(err) {
 		cmdName := ""
 		if childCmd != nil {
 			cmdName = childCmd.UseFull() + " "


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1617" title="DX-1617" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1617</a>  `state exec {garbage_value}` results in poor experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
`state exec` scripts may return non-zero status, and those errors are silenced because the script prints its own error information.