### PR TITLE
Defer `state pull --set-project` from changing namespace until merge succeeds.

### DIFF
--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
-	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/prompt"
@@ -104,7 +103,6 @@ func (p *Pull) Run(params *PullParams) error {
 		localCommit = &v
 	}
 
-	previousNamespace := p.project.Namespace()
 	if params.SetProject != "" {
 		defaultChoice := params.Force
 		confirmed, err := p.prompt.Confirm(
@@ -118,11 +116,6 @@ func (p *Pull) Run(params *PullParams) error {
 		if !confirmed {
 			return locale.NewInputError("err_pull_aborted", "Pull aborted by user")
 		}
-
-		err = p.project.Source().SetNamespace(remoteProject.Owner, remoteProject.Project)
-		if err != nil {
-			return locale.WrapError(err, "err_pull_update_namespace", "Cannot update the namespace in your project file.")
-		}
 	}
 
 	remoteCommit := remoteProject.CommitID
@@ -135,17 +128,22 @@ func (p *Pull) Run(params *PullParams) error {
 				// No merge necessary
 				resultingCommit = localCommit
 			} else if !errors.Is(err, model.ErrMergeCommitInHistory) {
-				restoreNamespace(p.project, previousNamespace)
 				return locale.WrapError(err, "err_mergecommit", "Could not detect if merge is necessary.")
 			}
 		}
 		if err == nil && strategies != nil {
-			c, err := p.performMerge(strategies, *remoteCommit)
+			c, err := p.performMerge(strategies, *remoteCommit, *localCommit, remoteProject, p.project.BranchName())
 			if err != nil {
-				restoreNamespace(p.project, previousNamespace)
 				return errs.Wrap(err, "performing merge commit failed")
 			}
 			resultingCommit = &c
+		}
+	}
+
+	if params.SetProject != "" {
+		err = p.project.Source().SetNamespace(remoteProject.Owner, remoteProject.Project)
+		if err != nil {
+			return locale.WrapError(err, "err_pull_update_namespace", "Cannot update the namespace in your project file.")
 		}
 	}
 
@@ -175,22 +173,11 @@ func (p *Pull) Run(params *PullParams) error {
 	return nil
 }
 
-func restoreNamespace(proj *project.Project, namespace *project.Namespaced) {
-	if err := proj.Source().SetNamespace(namespace.Owner, namespace.Project); err == nil && namespace.CommitID != nil {
-		err2 := proj.Source().SetCommit(namespace.CommitID.String(), false)
-		if err2 != nil {
-			multilog.Error("Unable to restore project namespace commit: %v", err)
-		}
-	} else if err != nil {
-		multilog.Error("Unable to restore project namespace: %v", err)
-	}
-}
-
-func (p *Pull) performMerge(strategies *mono_models.MergeStrategies, remoteCommit strfmt.UUID) (strfmt.UUID, error) {
+func (p *Pull) performMerge(strategies *mono_models.MergeStrategies, remoteCommit strfmt.UUID, localCommit strfmt.UUID, namespace *project.Namespaced, branchName string) (strfmt.UUID, error) {
 	p.out.Notice(output.Title(locale.Tl("pull_diverged", "Merging history")))
 	p.out.Notice(locale.Tr(
 		"pull_diverged_message",
-		p.project.Namespace().String(), p.project.BranchName(), p.project.CommitID(), remoteCommit.String()))
+		namespace.String(), branchName, localCommit.String(), remoteCommit.String()))
 
 	commitMessage := locale.Tr("pull_merge_commit", remoteCommit.String(), p.project.CommitID())
 	resultCommit, err := model.CommitChangeset(remoteCommit, commitMessage, strategies.OverwriteChanges)

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -105,6 +105,24 @@ func (suite *PullIntegrationTestSuite) TestPull_Merge() {
 	cp.ExpectExitCode(0)
 }
 
+func (suite *PullIntegrationTestSuite) TestPull_RestoreNamespace() {
+	suite.OnlyRunForTags(tagsuite.Pull)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	ts.PrepareActiveStateYAML(`project: https://platform.activestate.com/ActiveState-CLI/small-python?commitID=9733d11a-dfb3-41de-a37a-843b7c421db4`)
+
+	// Attempt to update to unrelated project.
+	cp := ts.Spawn("pull", "--non-interactive", "--set-project", "ActiveState-CLI/Python3")
+	cp.ExpectLongString("Could not detect common parent")
+	cp.ExpectNotExitCode(0)
+
+	// Verify namespace is unchanged.
+	cp = ts.Spawn("show")
+	cp.Expect("ActiveState-CLI/small-python")
+	cp.ExpectExitCode(0)
+}
+
 func TestPullIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(PullIntegrationTestSuite))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1624" title="DX-1624" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1624</a>  PULL: The link in the YAML file was modified despite the command’s fails
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
