### PR TITLE
Mark `state scripts edit` as unstable.

### DIFF
--- a/cmd/state/internal/cmdtree/scripts.go
+++ b/cmd/state/internal/cmdtree/scripts.go
@@ -50,6 +50,6 @@ func newScriptsEditCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, args []string) error {
 			return editRunner.Run(&params)
 		},
-	)
+	).SetUnstable(true)
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1674" title="DX-1674" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1674</a>  SCRIPTS: The subcommand `edit` should be unstable and shown only if `optin.unstable` is true.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
