### PR TITLE
Mark `state scripts edit` as unstable.

### DIFF
--- a/cmd/state/internal/cmdtree/scripts.go
+++ b/cmd/state/internal/cmdtree/scripts.go
@@ -50,6 +50,6 @@ func newScriptsEditCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, args []string) error {
 			return editRunner.Run(&params)
 		},
-	)
+	).SetUnstable(true)
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1674" title="DX-1674" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1674</a>  SCRIPTS: The subcommand `edit` should be unstable and shown only if `optin.unstable` is true.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Propagate-PR failed due to a version.txt conflict. Please force merge this PR @Naatan.
```
Found 2 branches that need to adopt this PR: version/0-38-0-RC1, master
   
Merging version/0-37-0-RC2 into version/0-38-0-RC1..
  |- Error: failed to merge version/0-37-0-RC2 into version/0-38-0-RC1. please manually merge the following branches: 
     Merge version/0-37-0-RC2 into version/0-38-0-RC1
     Merge version/0-38-0-RC1 into master
     stdout:
     Auto-merging version.txt
     CONFLICT (content): Merge conflict in version.txt
     Automatic merge failed; fix conflicts and then commit the result.
     
     stderr:
     : Exec failed: exit status 1
```