### PR TITLE
Wrap on words, not characters when possible.

### DIFF
--- a/internal/colorize/cropped_test.go
+++ b/internal/colorize/cropped_test.go
@@ -58,6 +58,11 @@ func Test_GetCroppedText(t *testing.T) {
 			[]CroppedLine{{"[HEADING]✔ Some", 6}, {" Text[/RESET]", 5}},
 		},
 		{
+			"Split multi-byte character with tags by words",
+			args{"[HEADING]✔ Some Text[/RESET]", 10},
+			[]CroppedLine{{"[HEADING]✔ Some", 6}, {"Text[/RESET]", 4}},
+		},
+		{
 			"Split line break",
 			args{"[HEADING]Hel\nlo[/RESET]", 5},
 			[]CroppedLine{{"[HEADING]Hel", 3}, {"lo[/RESET]", 2}},

--- a/test/integration/help_int_test.go
+++ b/test/integration/help_int_test.go
@@ -31,5 +31,6 @@ func (suite *HelpIntegrationTestSuite) TestCommandListing() {
 	cp.Expect("Version Control:")
 	cp.Expect("Automation:")
 	cp.Expect("Utilities:")
+	cp.Expect("    remove") // wrapped on word, not character
 	cp.Expect("Flags:")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1625" title="DX-1625" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1625</a>  Help output should wrap on words, not characters
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Note: the existing unit tests cover wrapping edge cases (no pun intended).