### PR TITLE
Fixed locale key clash.

### DIFF
--- a/cmd/state/internal/cmdtree/clean.go
+++ b/cmd/state/internal/cmdtree/clean.go
@@ -86,7 +86,7 @@ func newCleanConfigCommand(prime *primer.Values) *captain.Command {
 	return captain.NewCommand(
 		"config",
 		locale.Tl("clean_config_title", "Cleaning Configuration"),
-		locale.T("config_description"),
+		locale.T("clean_config_description"),
 		prime,
 		[]*captain.Flag{
 			{

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1362,7 +1362,7 @@ uninstall_description:
   other: Remove the State Tool, installed languages, and any configuration files
 cache_description:
   other: Removes cached Runtime Environments
-config_description:
+clean_config_description:
   other: Removes global State Tool configuration. Project configuration will not be affected.
 flag_state_clean_uninstall_force_description:
   other: Run uninstall operation without prompts and ignoring any errors stopping running services


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1635" title="DX-1635" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1635</a>  Help description for config command is wrong
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The description for `state config` was already set to "Manage the State Tool configuration", but the key clash was overriding this value with the description for `state clean config`.