### PR TITLE
Enable PYTHONUTF8 in Git Bash on Windows for default Python projects.

### DIFF
--- a/internal/assets/contents/activestate.yaml.python.tpl
+++ b/internal/assets/contents/activestate.yaml.python.tpl
@@ -2,13 +2,12 @@ scripts:
   - name: activationMessage
     language: {{.Language}}
     value: |
-      # -*- coding: utf-8 -*-
       import textwrap
       print(textwrap.dedent("""
         Quick Start
-        ───────────
-        • To add a package to your runtime, type "state install <package name>"
-        • Learn more about how to use the State Tool, type "state learn"
+        -----------
+        * To add a package to your runtime, type "state install <package name>"
+        * Learn more about how to use the State Tool, type "state learn"
       """))
   - name: pip
     language: {{.Language}}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1633" title="DX-1633" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1633</a>  Windows `git bash` project activation trigger error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Python cannot detect a UTF-8 environment within a Git Bash terminal, so the UTF-8 characters in the activation message cannot be printed by Python. Provide a hint.

We can either set an environment variable, or modify the actual Python script to add:

```
import sys
sys.stdout.reconfigure(encoding='utf-8')
```

I chose the environment variable because it's less invasive.