### PR TITLE
Default to reporting a runtime usage limit of 1.

### DIFF
--- a/cmd/state-svc/internal/resolver/resolver.go
+++ b/cmd/state-svc/internal/resolver/resolver.go
@@ -219,7 +219,7 @@ func (r *Resolver) CheckRuntimeUsage(_ context.Context, organizationName string)
 
 	if usage == nil {
 		return &graph.CheckRuntimeUsageResponse{
-			Limit: 0,
+			Limit: 1,
 			Usage: 0,
 		}, nil
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1622" title="DX-1622" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1622</a>  Soft limit message have wrong numbers of available runitimes and overall runtimes in the org
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
At this time, usage cannot be obtained when not authenticated, so make sure it is non-zero.