### PR TITLE
Account for 1 or 2 heartbeat events during executor test.

### DIFF
--- a/test/integration/analytics_int_test.go
+++ b/test/integration/analytics_int_test.go
@@ -122,7 +122,11 @@ func (suite *AnalyticsIntegrationTestSuite) TestActivateEvents() {
 		})
 		suite.Require().Equal(1, countEvents(executorEvents, anaConst.CatRuntimeUsage, anaConst.ActRuntimeAttempt),
 			ts.DebugMessage("Should have a runtime attempt, events:\n"+debugEvents(suite.T(), executorEvents)))
-		suite.Require().Equal(1, countEvents(executorEvents, anaConst.CatRuntimeUsage, anaConst.ActRuntimeHeartbeat), "Should have a heartbeat")
+		// It's possible due to the timing of the heartbeats and the fact that they are async that we have gotten either
+		// one or two by this point. Technically more is possible, just very unlikely.
+		numHeartbeats := countEvents(executorEvents, anaConst.CatRuntimeUsage, anaConst.ActRuntimeHeartbeat)
+		suite.Require().Greater(numHeartbeats, 0, "Should have a heartbeat")
+		suite.Require().LessOrEqual(numHeartbeats, 2, "Should not have excessive heartbeats")
 		var heartbeatEvent *reporters.TestLogEntry
 		for _, e := range executorEvents {
 			if e.Action == anaConst.ActRuntimeHeartbeat {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1601" title="DX-1601" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1601</a>  TestAnalyticsIntegrationTestSuite/TestActivateEvents - heartbeat test failure (intermittent)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
