### PR TITLE
Preserve trailing whitespace when wrapping words.

### DIFF
--- a/internal/colorize/cropped.go
+++ b/internal/colorize/cropped.go
@@ -39,13 +39,14 @@ func GetCroppedText(text string, maxLen int, includeLineEnds bool) CroppedLines 
 			wrapped := ""
 			wrappedLength := 0
 			nextCharIsSpace := pos+1 < len(text) && isSpace(text[pos+1])
-			if !isLineEnd && entry.Length == maxLen && !nextCharIsSpace {
+			if !isLineEnd && entry.Length == maxLen && !nextCharIsSpace && pos < len(text)-1 {
 				// Put the current word on the next line, if possible.
 				// Find the start of the current word and its printed length, taking color ranges and
 				// multi-byte characters into account.
 				i := len(entry.Line) - 1
 				for ; i > 0; i-- {
 					if isSpace(entry.Line[i]) {
+						i++ // preserve trailing space
 						break
 					}
 					if !inRange(pos-(len(entry.Line)-i), colorCodes) && !isUTF8TrailingByte(entry.Line[i]) {
@@ -54,9 +55,10 @@ func GetCroppedText(text string, maxLen int, includeLineEnds bool) CroppedLines 
 				}
 				// Extract the word from the current line if it doesn't start the line.
 				if i > 0 && i < len(entry.Line)-1 {
-					wrapped = entry.Line[i+1:]
+					wrapped = entry.Line[i:]
 					entry.Line = entry.Line[:i]
-					entry.Length -= wrappedLength + 1 // also strip space
+					entry.Length -= wrappedLength
+					isLineEnd = true // emulate for wrapping purposes
 				} else {
 					wrappedLength = 0 // reset
 				}

--- a/internal/colorize/cropped_test.go
+++ b/internal/colorize/cropped_test.go
@@ -60,7 +60,7 @@ func Test_GetCroppedText(t *testing.T) {
 		{
 			"Split multi-byte character with tags by words",
 			args{"[HEADING]✔ Some Text[/RESET]", 10},
-			[]CroppedLine{{"[HEADING]✔ Some", 6}, {"Text[/RESET]", 4}},
+			[]CroppedLine{{"[HEADING]✔ Some ", 7}, {"Text[/RESET]", 4}},
 		},
 		{
 			"Split line break",

--- a/test/integration/cve_int_test.go
+++ b/test/integration/cve_int_test.go
@@ -93,7 +93,7 @@ func (suite *CveIntegrationTestSuite) TestCveInvalidProject() {
 	ts.LoginAsPersistentUser()
 
 	cp := ts.Spawn("cve", "report", "invalid/invalid")
-	cp.Expect("Found no project with specified organization and name")
+	cp.ExpectLongString("Found no project with specified organization and name")
 
 	cp.ExpectNotExitCode(0)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1686" title="DX-1686" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1686</a>  Failing tests due to word wrapping
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Unit tests need it.