### PR TITLE
`state search --exact-term` should be case-sensitive.

### DIFF
--- a/internal/runners/packages/search.go
+++ b/internal/runners/packages/search.go
@@ -47,7 +47,7 @@ func (s *Search) Run(params SearchRunParams, nstype model.NamespaceType) error {
 
 	var packages []*model.IngredientAndVersion
 	if params.ExactTerm {
-		packages, err = model.SearchIngredientsStrict(ns, params.Name, false, true)
+		packages, err = model.SearchIngredientsStrict(ns, params.Name, true, true)
 	} else {
 		packages, err = model.SearchIngredients(ns, params.Name, true)
 	}

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -180,7 +180,11 @@ func (suite *PackageIntegrationTestSuite) TestPackage_searchWithExactTermWrongTe
 	defer ts.Close()
 	suite.PrepareActiveStateYAML(ts)
 
-	cp := ts.Spawn("search", "xxxrequestsxxx", "--exact-term")
+	cp := ts.Spawn("search", "Requests", "--exact-term")
+	cp.ExpectLongString("No packages in our catalog match")
+	cp.ExpectExitCode(1)
+
+	cp = ts.Spawn("search", "xxxrequestsxxx", "--exact-term")
 	cp.ExpectLongString("No packages in our catalog match")
 	cp.ExpectExitCode(1)
 }
@@ -253,6 +257,17 @@ func (suite *PackageIntegrationTestSuite) TestPackage_info() {
 	cp.Expect("What's next?")
 	cp.Expect("run `state install")
 	cp.ExpectExitCode(0)
+}
+
+func (suite *PackageIntegrationTestSuite) TestPackage_infoWrongCase() {
+	suite.OnlyRunForTags(tagsuite.Package)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+	suite.PrepareActiveStateYAML(ts)
+
+	cp := ts.Spawn("info", "Pexpect")
+	cp.Expect("No packages in our catalog are an exact match")
+	cp.ExpectExitCode(1)
 }
 
 const (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1641" title="DX-1641" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1641</a>  As a user I can expect state search and state info to behave consistently
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also added case-sensitivity tests for `state search` and `state info` to ensure they are consistent with each other.