### PR TITLE
Always show notice about unstable commands in command help.

### DIFF
--- a/internal/assets/contents/usage.tpl
+++ b/internal/assets/contents/usage.tpl
@@ -51,15 +51,17 @@ Additional help topics:
 
 Use "{{.Cobra.CommandPath}} [command] --help" for more information about a command.
 
-{{- if .OptinUnstable }}
-
-WARNING: You have an access to list of full commands, including unstable features still in beta, in order to hide these features run:
-
-"state config set optin.unstable false"
-{{- else }}
+{{- if not .OptinUnstable}}
 
 To access the list of full commands, including unstable features still in beta, run:
 
 "state config set optin.unstable true"
 {{- end}}
+{{- end}}
+
+{{- if .OptinUnstable }}
+
+WARNING: You have access to all State Tool commands, including unstable features still in beta, in order to hide these features run:
+
+"state config set optin.unstable false"
 {{- end}}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1648" title="DX-1648" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1648</a>  `optin.unstable` variable help printout per command
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
