### PR TITLE
Windows uninstaller should allow the user to confirm exit before clos…

### DIFF
--- a/cmd/state/internal/cmdtree/clean.go
+++ b/cmd/state/internal/cmdtree/clean.go
@@ -42,6 +42,14 @@ func newCleanUninstallCommand(prime *primer.Values, globals *globalOptions) *cap
 				Description: locale.T("flag_state_clean_uninstall_force_description"),
 				Value:       &params.Force,
 			},
+			{
+				// This option is only used on Windows to prevent the popup cmd from closing before the
+				// user can take note of the printed log path.
+				Name:        "confirm-exit",
+				Description: "Prompts the user to press enter before exiting",
+				Hidden:      true, // this is not a user-facing flag
+				Value:       &params.ConfirmExit,
+			},
 		},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {

--- a/internal/runners/clean/run_win.go
+++ b/internal/runners/clean/run_win.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/internal/rtutils/p"
 	"github.com/ActiveState/cli/internal/scriptfile"
 )
 
@@ -80,6 +81,10 @@ func (u *Uninstall) runUninstall(params *UninstallParams) error {
 	}
 
 	u.out.Print(locale.Tr("clean_message_windows", logFile.Name()))
+	if params.ConfirmExit {
+		u.out.Print(locale.Tl("clean_uninstall_confirm_exit", "Press enter to exit."))
+		fmt.Scanln(p.StrP("")) // Wait for input from user
+	}
 	return nil
 }
 

--- a/internal/runners/clean/uninstall.go
+++ b/internal/runners/clean/uninstall.go
@@ -32,6 +32,7 @@ type UninstallParams struct {
 	Force          bool
 	NonInteractive bool
 	All            bool
+	ConfirmExit    bool
 }
 
 type primeable interface {

--- a/internal/runners/prepare/prepare_windows.go
+++ b/internal/runners/prepare/prepare_windows.go
@@ -45,7 +45,7 @@ func (r *Prepare) prepareStartShortcut() error {
 		return locale.WrapInputError(err, "err_preparestart_mkdir", "Could not create start menu entry: %s", shortcutDir)
 	}
 
-	sc := shortcut.New(shortcutDir, "Uninstall State Tool", r.subshell.Binary(), "/C \"state clean uninstall\"")
+	sc := shortcut.New(shortcutDir, "Uninstall State Tool", r.subshell.Binary(), "/C \"state clean uninstall --confirm-exit\"")
 	err := sc.Enable()
 	if err != nil {
 		return locale.WrapError(err, "err_preparestart_shortcut", "", sc.Path())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1689" title="DX-1689" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1689</a>  Uninstall pop-up window closed without providing any info to the user or the path to the uninstall log.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…ing popup cmd prompt.

Otherwise the user cannot see its contents.