### PR TITLE
Log to Rollbar outdated Windows versions.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -441,7 +441,7 @@ func assertCompatibility() error {
 		if err != nil {
 			return locale.WrapError(err, "windows_compatibility_warning", "", err.Error())
 		} else if osv.Major < 10 || (osv.Major == 10 && osv.Micro < 17134) {
-			return locale.WrapError(err, "windows_compatibility_error")
+			return locale.WrapError(err, "windows_compatibility_error", "", osv.Name, osv.Version)
 		}
 	}
 

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1668,6 +1668,7 @@ windows_compatibility_error:
     Unfortunately State Tool is not compatible with your version of Windows.
 
     The minimum version supported is Windows 10 build 17134.1.
+    The detected version is {{.V0}} {{.V1}}.
 exec_description:
   other: Intercept and run a script via a project runtime environment
 flag_state_exec_path_description:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1631" title="DX-1631" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1631</a>  Report windows version to rollbar when we encounter incompatible Windows version
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
That way we have an idea of what users are trying to run the State Tool on.