### PR TITLE
Mark `state refresh` as unstable.

### DIFF
--- a/cmd/state/internal/cmdtree/refresh.go
+++ b/cmd/state/internal/cmdtree/refresh.go
@@ -33,5 +33,6 @@ func newRefreshCommand(prime *primer.Values) *captain.Command {
 		},
 	)
 	cmd.SetGroup(EnvironmentUsageGroup)
+	cmd.SetUnstable(true)
 	return cmd
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1705" title="DX-1705" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1705</a>  New commands and flags of 0.38 release should be set as `UNSTABLE`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Note that flags cannot be marked as unstable, so `state revert --to` would not be marked unstable.