### PR TITLE
Timeout "Install Deps" GitHub Action step after 1 minute.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
       - # === Install Deps ===
         name: Install Deps
         shell: bash
+        timeout-minutes: 1
         run: state run install-deps
 
       - # === Preprocess ===


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1704" title="DX-1704" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1704</a>  Make "Install Deps" GitHub Action step timeout after 1 minute.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

In practice it takes less than 10s, but can sometimes hang.