### PR TITLE
Add authentication check to invite

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -1,4 +1,4 @@
-project: https://platform.activestate.com/ActiveState/cli?branch=main&commitID=7a2fb89c-4bf0-4bb8-b45e-88b0d8af10e4
+project: https://platform.activestate.com/ActiveState/cli?branch=main&commitID=9eee7512-b2ab-4600-b78b-ab0cf2e817d8
 constants:
   - name: CLI_BUILDFLAGS
     value: -ldflags="-s -w"

--- a/internal/runners/invite/invite.go
+++ b/internal/runners/invite/invite.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/prompt"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
 )
@@ -28,12 +29,14 @@ type invite struct {
 	project *project.Project
 	out     output.Outputer
 	prompt  prompt.Prompter
+	auth    *authentication.Auth
 }
 
 type primeable interface {
 	primer.Projecter
 	primer.Outputer
 	primer.Prompter
+	primer.Auther
 }
 
 func New(prime primeable) *invite {
@@ -41,12 +44,16 @@ func New(prime primeable) *invite {
 		prime.Project(),
 		prime.Output(),
 		prime.Prompt(),
+		prime.Auth(),
 	}
 }
 
 func (i *invite) Run(params *Params, args []string) error {
 	if i.project == nil {
 		return locale.NewInputError("err_no_projectfile", "Must be in a project directory.")
+	}
+	if !i.auth.Authenticated() {
+		return locale.NewInputError("err_invite_not_logged_in", "You need to authenticate with [ACTIONABLE]`state auth`[/RESET] before you can invite new members.")
 	}
 
 	if len(args) > 1 {

--- a/internal/testhelpers/tagsuite/tagsuite.go
+++ b/internal/testhelpers/tagsuite/tagsuite.go
@@ -38,6 +38,7 @@ const (
 	Init            = "init"
 	InstallScripts  = "install-scripts"
 	Installer       = "installer"
+	Invite          = "invite"
 	RemoteInstaller = "remote-installer"
 	Interrupt       = "interrupt"
 	JSON            = "json"

--- a/test/integration/invite_int_test.go
+++ b/test/integration/invite_int_test.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/stretchr/testify/suite"
+)
+
+type InviteIntegrationTestSuite struct {
+	tagsuite.Suite
+}
+
+func (suite *InviteIntegrationTestSuite) TestInvite_NotAuthenticated() {
+	suite.OnlyRunForTags(tagsuite.Invite)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	url := "https://platform.activestate.com/ActiveState-CLI/Invite-Test?branch=main&commitID=eb8dd176-d557-4adc-8b79-7b17e3a03bd7"
+	suite.Require().NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "activestate.yaml"), []byte("project: "+url)))
+
+	cp := ts.Spawn("invite", "test-user@test.com")
+	cp.Expect("You need to authenticate")
+	cp.ExpectNotExitCode(0)
+}
+
+func TestInviteIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(InviteIntegrationTestSuite))
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1186" title="DX-1186" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1186</a>  INVITE: Error message is confusing once `invite` command executed without user previously authenticated.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
