### PR TITLE
Installer should overwrite State Service.app.

### DIFF
--- a/internal/app/app_darwin.go
+++ b/internal/app/app_darwin.go
@@ -61,7 +61,7 @@ func (a *App) install() error {
 		}
 	}
 
-	if err := fileutils.MoveAllFiles(tmpDir, installDir); err != nil {
+	if err := fileutils.CopyAndRenameFiles(tmpDir, installDir); err != nil {
 		return errs.Wrap(err, "Could not move .app to Applications directory")
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1722" title="DX-1722" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1722</a>  Install 0.38.0-RC1 fails with "Installation of service app failed"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
