### PR TITLE
Ensure the detected shell's rc file is available.

### DIFF
--- a/internal/subshell/subshell.go
+++ b/internal/subshell/subshell.go
@@ -146,12 +146,10 @@ func resolveBinaryPath(name string) string {
 }
 
 func ConfigureAvailableShells(shell SubShell, cfg sscommon.Configurable, env map[string]string, identifier sscommon.RcIdentification, userScope bool) error {
-	// Ensure active shell has RC file
-	if shell.IsActive() {
-		err := shell.EnsureRcFileExists()
-		if err != nil {
-			return errs.Wrap(err, "Could not ensure RC file for active shell")
-		}
+	// Ensure the given, detected, and current shell has an RC file or else it will not be considered "available"
+	err := shell.EnsureRcFileExists()
+	if err != nil {
+		return errs.Wrap(err, "Could not ensure RC file for current shell")
 	}
 
 	for _, s := range supportedShells {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1752" title="DX-1752" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1752</a>  subshell.Detect() returns 'zsh', but subshell/zsh.IsAvailable() returns false if ~/.zshrc does not exist
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
