### PR TITLE
App uses correct service executable path

### DIFF
--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -103,16 +103,16 @@ func (i *Installer) Install() (rerr error) {
 		return errs.Wrap(err, "Failed to copy installation files to dir %s. Error received: %s", i.path, errs.JoinMessage(err))
 	}
 
-	// Install the state service as an app if necessary
-	if err := i.installSvcApp(); err != nil {
-		return errs.Wrap(err, "Installation of service app failed.")
-	}
-
 	// Set up the environment
 	binDir := filepath.Join(i.path, installation.BinDirName)
 	isAdmin, err := osutils.IsAdmin()
 	if err != nil {
 		return errs.Wrap(err, "Could not determine if running as Windows administrator")
+	}
+
+	// Install the state service as an app if necessary
+	if err := i.installSvcApp(binDir); err != nil {
+		return errs.Wrap(err, "Installation of service app failed.")
 	}
 
 	// Configure available shells
@@ -164,8 +164,8 @@ func (i *Installer) sanitizeInput() error {
 	return nil
 }
 
-func (i *Installer) installSvcApp() error {
-	app, err := svcApp.New()
+func (i *Installer) installSvcApp(binDir string) error {
+	app, err := svcApp.NewFromDir(binDir)
 	if err != nil {
 		return errs.Wrap(err, "Could not create app")
 	}

--- a/cmd/state-svc/app/app.go
+++ b/cmd/state-svc/app/app.go
@@ -9,6 +9,15 @@ import (
 
 var Options = app.Options{}
 
+func NewFromDir(dir string) (*app.App, error) {
+	svcExec, err := installation.ServiceExecFromDir(dir)
+	if err != nil {
+		return nil, errs.Wrap(err, "Could not determine service executable")
+	}
+
+	return app.New(constants.SvcAppName, svcExec, []string{"start"}, Options)
+}
+
 func New() (*app.App, error) {
 	svcExec, err := installation.ServiceExec()
 	if err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1435" title="DX-1435" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1435</a>  The state-svc autostarts as an .app on macOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
