### PR TITLE
Do not require installation directory to be empty if `--force` was given

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -237,7 +237,7 @@ func execute(out output.Outputer, cfg *config.Instance, an analytics.Dispatcher,
 	}
 
 	// If this is a fresh installation we ensure that the target directory is empty
-	if !stateToolInstalled && fileutils.DirExists(params.path) {
+	if !stateToolInstalled && fileutils.DirExists(params.path) && !params.force {
 		empty, err := fileutils.IsEmptyDir(params.path)
 		if err != nil {
 			return errs.Wrap(err, "Could not check if install path is empty")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1751" title="DX-1751" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1751</a>  Install.sh does not respect `--force` flag when install path non-empty
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
