### PR TITLE
Fix failing installer test.

### DIFF
--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -155,12 +155,11 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall_NonEmptyTarget() {
 	script := scriptPath(suite.T(), ts.Dirs.Work)
 	argsPlain := []string{script, "-t", ts.Dirs.Work}
 	argsPlain = append(argsPlain, "-b", constants.BranchName)
-	argsWithActive := append(argsPlain, "-f")
 	var cp *termtest.ConsoleProcess
 	if runtime.GOOS != "windows" {
-		cp = ts.SpawnCmdWithOpts("bash", e2e.WithArgs(argsWithActive...))
+		cp = ts.SpawnCmdWithOpts("bash", e2e.WithArgs(argsPlain...))
 	} else {
-		cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(argsWithActive...), e2e.AppendEnv("SHELL="))
+		cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.WithArgs(argsPlain...), e2e.AppendEnv("SHELL="))
 	}
 	cp.ExpectLongString("Installation path must be an empty directory")
 	cp.ExpectExitCode(1)


### PR DESCRIPTION
`--force` ignores non-empty directories now.