### PR TITLE
state-svc app should use actual install path rather than default

### DIFF
--- a/cmd/state-svc/app/app.go
+++ b/cmd/state-svc/app/app.go
@@ -29,7 +29,7 @@ func New() (*app.App, error) {
 		return nil, errs.Wrap(err, "Could not determine service executable")
 	}
 
-	installRoot, err := installation.DefaultInstallPath()
+	installRoot, err := installation.InstallPathFromExecPath()
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not determine install root")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1764" title="DX-1764" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1764</a>  As a user I'm not confused by an "State Service" application in my apps dir that seemingly does nothing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
