### PR TITLE
Remove legacy way of checking for update in the installer.

### DIFF
--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -227,9 +227,9 @@ func isStateExecutable(name string) bool {
 	return false
 }
 
-func installedOnPath(installRoot, branch string) (bool, string, string, error) {
+func installedOnPath(installRoot, branch string) (bool, string, error) {
 	if !fileutils.DirExists(installRoot) {
-		return false, "", "", nil
+		return false, "", nil
 	}
 
 	// This is not using appinfo on purpose because we want to deal with legacy installation formats, which appinfo does not
@@ -245,9 +245,9 @@ func installedOnPath(installRoot, branch string) (bool, string, string, error) {
 	}
 	for _, candidate := range candidates {
 		if fileutils.TargetExists(candidate) {
-			return true, installRoot, candidate, nil
+			return true, installRoot, nil
 		}
 	}
 
-	return false, installRoot, stateCmd, nil
+	return false, installRoot, nil
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-985" title="DX-985" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-985</a>  Remove legacy handling of update flag in installer
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
