### PR TITLE
Clarify the relationship of `state use` by `state init` in error messsage.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1512,7 +1512,7 @@ err_corrupted_build_request_response:
 err_arg_required:
   other: "The following argument is required:\n  Name: [NOTICE]{{.V0}}[/RESET]\n  Description: [NOTICE]{{.V1}}[/RESET]"
 err_init_no_language:
-  other: "You need to supply the [NOTICE]language[/RESET] argument, run '[ACTIONABLE]state init --help[/RESET]' for more information."
+  other: "A project has not been set using 'state use'. You must include the [NOTICE]language[/RESET] argument. For more help, run '[ACTIONABLE]state init --help[/RESET]'."
 err_bad_platform_version:
   other: You have to supply a platform version.
 platform_added:

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -110,7 +110,7 @@ func (r *Initialize) Run(params *RunParams) error {
 	}
 
 	if languageName == "" {
-		return locale.NewInputError("err_init_no_language", "You need to supply the [NOTICE]language[/RESET] argument, run [ACTIONABLE]`state init --help`[/RESET] for more information.")
+		return locale.NewInputError("err_init_no_language")
 	}
 
 	lang, err := language.MakeByNameAndVersion(languageName, languageVersion)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1761" title="DX-1761" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1761</a>  INIT: The message re missing language is confusing with the fact `languages` is defined as `optional`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
