### PR TITLE
Explicitly mark commands that do not support structured output.

### DIFF
--- a/cmd/state/internal/cmdtree/activate.go
+++ b/cmd/state/internal/cmdtree/activate.go
@@ -87,5 +87,6 @@ func newActivateCommand(prime *primer.Values) *captain.Command {
 		},
 	)
 	cmd.SetGroup(EnvironmentUsageGroup)
+	cmd.SetDoesNotSupportStructuredOutput()
 	return cmd
 }

--- a/cmd/state/internal/cmdtree/clean.go
+++ b/cmd/state/internal/cmdtree/clean.go
@@ -62,7 +62,7 @@ func newCleanUninstallCommand(prime *primer.Values, globals *globalOptions) *cap
 			params.NonInteractive = globals.NonInteractive // distinct from --force
 			return runner.Run(&params)
 		},
-	)
+	).SetDoesNotSupportStructuredOutput()
 }
 
 func newCleanCacheCommand(prime *primer.Values, globals *globalOptions) *captain.Command {
@@ -86,7 +86,7 @@ func newCleanCacheCommand(prime *primer.Values, globals *globalOptions) *captain
 			params.Force = globals.NonInteractive
 			return runner.Run(&params)
 		},
-	)
+	).SetDoesNotSupportStructuredOutput()
 }
 
 func newCleanConfigCommand(prime *primer.Values) *captain.Command {
@@ -109,5 +109,5 @@ func newCleanConfigCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, _ []string) error {
 			return runner.Run(&params)
 		},
-	)
+	).SetDoesNotSupportStructuredOutput()
 }

--- a/cmd/state/internal/cmdtree/exec.go
+++ b/cmd/state/internal/cmdtree/exec.go
@@ -45,6 +45,7 @@ func newExecCommand(prime *primer.Values, args ...string) *captain.Command {
 
 	cmd.SetGroup(EnvironmentUsageGroup)
 	cmd.SetHasVariableArguments()
+	cmd.SetDoesNotSupportStructuredOutput()
 
 	return cmd
 }

--- a/cmd/state/internal/cmdtree/export.go
+++ b/cmd/state/internal/cmdtree/export.go
@@ -158,7 +158,7 @@ func newExportGithubActionCommand(prime *primer.Values) *captain.Command {
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, _ []string) error {
 			return runner.Run(&params)
-		}).SetUnstable(true)
+		}).SetUnstable(true).SetDoesNotSupportStructuredOutput()
 }
 
 func newExportDocsCommand(prime *primer.Values) *captain.Command {

--- a/cmd/state/internal/cmdtree/run.go
+++ b/cmd/state/internal/cmdtree/run.go
@@ -49,6 +49,7 @@ func newRunCommand(prime *primer.Values) *captain.Command {
 	cmd.SetGroup(ProjectUsageGroup)
 	cmd.SetDisableFlagParsing(true)
 	cmd.SetHasVariableArguments()
+	cmd.SetDoesNotSupportStructuredOutput()
 
 	return cmd
 }

--- a/cmd/state/internal/cmdtree/scripts.go
+++ b/cmd/state/internal/cmdtree/scripts.go
@@ -50,6 +50,6 @@ func newScriptsEditCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, args []string) error {
 			return editRunner.Run(&params)
 		},
-	).SetUnstable(true)
+	).SetUnstable(true).SetDoesNotSupportStructuredOutput()
 
 }

--- a/cmd/state/internal/cmdtree/shell.go
+++ b/cmd/state/internal/cmdtree/shell.go
@@ -42,6 +42,7 @@ func newShellCommand(prime *primer.Values) *captain.Command {
 		},
 	)
 	cmd.SetGroup(EnvironmentUsageGroup)
+	cmd.SetDoesNotSupportStructuredOutput()
 	cmd.SetAliases("prompt")
 	return cmd
 }

--- a/internal/output/mediator.go
+++ b/internal/output/mediator.go
@@ -58,7 +58,7 @@ func mediatorValue(v interface{}, format Format) interface{} {
 			return vt.MarshalStructured(format)
 		}
 		multilog.Error("%s output not supported for message: %v", string(format), v)
-		return StructuredError{locale.Tl("err_no_structured_output", "", string(format))}
+		return StructuredError{locale.Tr("err_no_structured_output", string(format))}
 	}
 	if vt, ok := v.(Marshaller); ok {
 		return vt.MarshalOutput(format)

--- a/internal/output/mediator_test.go
+++ b/internal/output/mediator_test.go
@@ -67,7 +67,7 @@ func Test_mediatorValue(t *testing.T) {
 				"unstructured",
 				JSONFormatName,
 			},
-			StructuredError{locale.Tl("err_no_structured_output", "", string(JSONFormatName))},
+			StructuredError{locale.Tr("err_no_structured_output", string(JSONFormatName))},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/runners/export/apikey.go
+++ b/internal/runners/export/apikey.go
@@ -59,6 +59,11 @@ func (k *APIKey) Run(params APIKeyRunParams) error {
 	}
 
 	k.out.Notice(locale.T("export_apikey_user_notice"))
-	k.out.Print(key)
+	k.out.Print(output.Prepare(
+		key,
+		&struct {
+			Value string `json:"value"`
+		}{key},
+	))
 	return nil
 }

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -239,6 +239,17 @@ func (suite *ShellIntegrationTestSuite) TestUseShellUpdates() {
 	}
 }
 
+func (suite *ShellIntegrationTestSuite) TestJSON() {
+	suite.OnlyRunForTags(tagsuite.Shell, tagsuite.JSON)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("shell", "--output", "json")
+	cp.ExpectLongString(`"error":"This command does not support the json output format`)
+	cp.ExpectExitCode(0)
+	AssertValidJSON(suite.T(), cp)
+}
+
 func TestShellIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(ShellIntegrationTestSuite))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1721" title="DX-1721" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1721</a>  As a user I can expect json output to be usable at all times
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Also add structured output support for exporting new API keys.

The following commands have been explicitly marked as not supporting JSON/structured output and will show a JSON error message indicating so:

activate
exec
shell

run

scripts edit

clean cache
clean config
clean uninstall

export github-actions