### PR TITLE
Fix overly specific error assertion

### DIFF
--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -143,11 +143,7 @@ func (suite *SvcIntegrationTestSuite) TestStartDuplicateErrorOutput() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("foreground"))
-	cp.Expect("not start service: An existing")
-	cp.ExpectExitCode(1)
-
-	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("foreground", "test this"))
-	cp.Expect("not start service (invoked by \"test this\"): An existing")
+	cp.Expect("An existing server instance appears to be in use")
 	cp.ExpectExitCode(1)
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.WithArgs("stop"))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1819" title="DX-1819" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1819</a>  Nightly integration test failure: TestSvcIntegrationTestSuite/TestStartDuplicateErrorOutput
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
