### PR TITLE
Only log to rollbar when commands attempt to output unstructured output normally.

### DIFF
--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -30,8 +30,8 @@ func (f *JSON) Type() Format {
 
 // Print will marshal and print the given value to the output writer
 func (f *JSON) Print(v interface{}) {
-	if _, isStructuredError := v.(StructuredError); isStructuredError {
-		multilog.Error("Attempted to write unstructured output as json.")
+	if err, isStructuredError := v.(StructuredError); isStructuredError {
+		multilog.Error("Attempted to write unstructured output as json: %v", err)
 		return
 	}
 

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -30,6 +30,11 @@ func (f *JSON) Type() Format {
 
 // Print will marshal and print the given value to the output writer
 func (f *JSON) Print(v interface{}) {
+	if _, isStructuredError := v.(StructuredError); isStructuredError {
+		multilog.Error("Attempted to write unstructured output as json.")
+		return
+	}
+
 	f.Fprint(f.cfg.OutWriter, v)
 }
 

--- a/internal/output/mediator.go
+++ b/internal/output/mediator.go
@@ -4,7 +4,6 @@ import (
 	"io"
 
 	"github.com/ActiveState/cli/internal/locale"
-	"github.com/ActiveState/cli/internal/multilog"
 )
 
 type Mediator struct {
@@ -57,7 +56,6 @@ func mediatorValue(v interface{}, format Format) interface{} {
 		if vt, ok := v.(StructuredMarshaller); ok {
 			return vt.MarshalStructured(format)
 		}
-		multilog.Error("%s output not supported for message: %v", string(format), v)
 		return StructuredError{locale.Tr("err_no_structured_output", string(format))}
 	}
 	if vt, ok := v.(Marshaller); ok {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1815" title="DX-1815" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1815</a>  JSON output notices are logged as errors (and thus to rollbar)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This is different than notices and errors.

I did a dummy `out.Print("hi")` in the `state refresh` runner, and running it with `-o json` gave this stacktrace:

```
(PID 4212) [ERR 17:26:30.742 multilog.go:19] Attempted to write unstructured output as json.

Stacktrace: ./internal\logging\logging.go:283:logging.Error
./internal\multilog\multilog.go:19:multilog.Error
./internal\output\json.go:34:output.(*JSON).Print
./internal\output\mediator.go:35:output.(*Mediator).Print
./internal\runners\refresh\refresh.go:75:refresh.(*Refresh).Run
./cmd\state\internal\cmdtree\refresh.go:32:cmdtree.newRefreshCommand.func1
./cmd\state\internal\cmdtree\intercepts\messenger\messenger.go:29:messenger.(*Messenger).Interceptor.func1
./cmd\state\internal\cmdtree\intercepts\cmdcall\cmdcall.go:33:cmdcall.(*CmdCall).InterceptExec.func1
./internal\captain\command.go:698:captain.(*Command).runner.func2
./internal\sighandler\awaiting.go:50:sighandler.(*sigHandler).WaitForFunc.func1
./..\..\..\Program Files\Go\src\runtime\asm_amd64.s:1598:runtime.goexit
```

That means we can pinpoint where these bad writes originate and fix them.

Other commands like `state shell -o json` (unsupported JSON) and `state use reset -o json` (only outputs notices, which are ignored) do not emit any errors to the log.