### PR TITLE
Disable runtime progress out of sync error handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 0.38.1
+
+### Fixed
+
+- We've reverted a change that would cause runtime installation to fail when we
+  received out of order progress events. This was causing some runtimes to
+  report failure when in actuality they were installed successfully.
+
 ### 0.38.0
 
 ### Added

--- a/internal/runbits/runtime/progress/progress.go
+++ b/internal/runbits/runtime/progress/progress.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/go-openapi/strfmt"
 	"github.com/vbauerster/mpb/v7"
@@ -358,11 +357,13 @@ Still expecting:
 				p.buildsExpected, p.downloadsExpected, p.installsExpected,
 			)
 
+			/* https://activestatef.atlassian.net/browse/DX-1831
 			if pending > 0 {
 				// We only error out if we determine the issue is down to one of our bars not completing.
 				// Otherwise this is an issue with the mpb package which is currently a known limitation, end goal is to get rid of mpb.
 				return locale.NewError("err_rtprogress_outofsync", "", constants.BugTrackerURL, logging.FilePath())
 			}
+			*/
 		}
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1831" title="DX-1831" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1831</a>  Disabled forced runtime process errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
