### PR TITLE
Fix incorrect parameter in WinAPI call.

### DIFF
--- a/internal/output/progress_win.go
+++ b/internal/output/progress_win.go
@@ -47,7 +47,7 @@ func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
 		cursor.x = csbi.cursorPosition.x + short(-n)
 		cursor.y = csbi.cursorPosition.y
 
-		r2, _, err2 := procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
+		r2, _, err2 := procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*((*uint32)(unsafe.Pointer(&cursor)))))
 		if r2 == 0 && !d.reportedError {
 			multilog.Error("Error calling SetConsoleCursorPosition: %v", err2)
 			d.reportedError = true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1870" title="DX-1870" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1870</a>  Windows bug calling SetConsoleCursorPosition for runtime progress.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
