### PR TITLE
Show executables path after init

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1242,6 +1242,7 @@ init_success:
   other: |
     Project '[NOTICE]{{.V0}}[/RESET]' has been successfully initialized at '[NOTICE]{{.V1}}[/RESET]' and pushed to the Platform.
     You can start using your project with [ACTIONABLE]`state shell`[/RESET] and [ACTIONABLE]`state use`[/RESET].
+    For editors and other tooling use the executables at: [ACTIONABLE]{{.V2}}[/RESET].
 arg_state_init_namespace:
   other: org/project
 arg_state_init_namespace_description:

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ActiveState/cli/internal/runbits"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
+	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
 	"github.com/ActiveState/cli/pkg/platform/runtime/target"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/ActiveState/cli/pkg/projectfile"
@@ -186,14 +187,19 @@ func (r *Initialize) Run(params *RunParams) error {
 
 	projectfile.StoreProjectMapping(r.config, params.Namespace.String(), filepath.Dir(proj.Source().Path()))
 
+	projectTarget := target.NewProjectTarget(proj, nil, "").Dir()
+	executables := setup.ExecDir(projectTarget)
+
 	r.out.Print(output.Prepare(
-		locale.Tr("init_success", params.Namespace.String(), path),
+		locale.Tr("init_success", params.Namespace.String(), path, executables),
 		&struct {
-			Namespace string `json:"namespace"`
-			Path      string `json:"path" `
+			Namespace   string `json:"namespace"`
+			Path        string `json:"path" `
+			Executables string `json:"executables"`
 		}{
 			params.Namespace.String(),
 			path,
+			executables,
 		},
 	))
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1879" title="DX-1879" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1879</a>  INIT: Summary of the successful initialization of the project not includes path to executables
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
