### PR TITLE
Update init arg/flag usage in import e2e test

### DIFF
--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -297,7 +297,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_import() {
 	username := ts.CreateNewUser()
 	namespace := fmt.Sprintf("%s/%s", username, "Python3")
 
-	cp := ts.Spawn("init", namespace, "python3", "--path="+ts.Dirs.Work)
+	cp := ts.Spawn("init", "--language", "python3", namespace, ts.Dirs.Work)
 	cp.ExpectLongString("successfully initialized")
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1891" title="DX-1891" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1891</a>  TestPackage_import failing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
