### PR TITLE
Add executables path to `state use show` JSON output.

### DIFF
--- a/internal/runners/use/show.go
+++ b/internal/runners/use/show.go
@@ -39,19 +39,22 @@ func (s *Show) Run() error {
 	}
 
 	projectTarget := target.NewProjectTarget(proj, nil, "")
+	executables := setup.ExecDir(projectTarget.Dir())
 
 	s.out.Print(output.Prepare(
 		locale.Tl("use_show_project_statement", "",
 			proj.NamespaceString(),
 			projectDir,
-			setup.ExecDir(projectTarget.Dir()),
+			executables,
 		),
 		&struct {
-			Namespace string `json:"namespace"`
-			Path      string `json:"path"`
+			Namespace   string `json:"namespace"`
+			Path        string `json:"path"`
+			Executables string `json:"executables"`
 		}{
 			proj.NamespaceString(),
 			projectDir,
+			executables,
 		},
 	))
 

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -283,6 +283,7 @@ func (suite *UseIntegrationTestSuite) TestJSON() {
 	cp = ts.Spawn("use", "show", "--output", "json")
 	cp.Expect(`"namespace":`)
 	cp.Expect(`"path":`)
+	cp.Expect(`"executables":`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1841" title="DX-1841" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1841</a>  USE `-o json`: `state use show -o json` missing executables key:value.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
