### PR TITLE
`state reset` in non-interactive mode (like JSON) should reset without prompt.

### DIFF
--- a/internal/runners/reset/reset.go
+++ b/internal/runners/reset/reset.go
@@ -81,7 +81,7 @@ func (r *Reset) Run(params *Params) error {
 
 	r.out.Notice(locale.Tl("reset_commit", "Your project will be reset to [ACTIONABLE]{{.V0}}[/RESET]\n", commitID.String()))
 
-	defaultChoice := params.Force
+	defaultChoice := params.Force || !r.out.Config().Interactive
 	confirm, err := r.prompt.Confirm("", locale.Tl("reset_confim", "Resetting is destructive, you will lose any changes that were not pushed. Are you sure you want to do this?"), &defaultChoice)
 	if err != nil {
 		return locale.WrapError(err, "err_reset_confirm", "Could not confirm reset choice")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1847" title="DX-1847" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1847</a>  RESET: `state reset -o json` get an error that aborted by user instead of proper execution.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Just like `state use reset -o json`:
https://github.com/ActiveState/cli/blob/98ed655212d4a51f851f9c1f7399d2fdde750ee5/internal/runners/use/reset.go#L42