### PR TITLE
Initial use of Python-like build scripts.

### DIFF
--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -1,6 +1,8 @@
 package buildscript
 
 import (
+	"encoding/json"
+
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -48,7 +50,11 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		// For now, if commitID is given, a mutation happened, so prefer the remote build expression.
 		// Otherwise, prefer local changes.
 		if commitID == nil {
-			expr, err = bpModel.NewBuildExpression([]byte(script.String()))
+			bytes, err := json.Marshal(script)
+			if err != nil {
+				return errs.Wrap(err, "Unable to marshal local build script to JSON")
+			}
+			expr, err = bpModel.NewBuildExpression(bytes)
 			if err != nil {
 				return errs.Wrap(err, "Unable to translate local build script to build expression")
 			}

--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -13,13 +13,13 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-func getBuildExpression(proj *project.Project, customCommit *strfmt.UUID, auth *authentication.Auth) (*bpModel.BuildScript, error) {
+func getBuildExpression(proj *project.Project, customCommit *strfmt.UUID, auth *authentication.Auth) (*bpModel.BuildExpression, error) {
 	bp := model.NewBuildPlanner(auth)
 	commitID := proj.CommitUUID()
 	if customCommit != nil {
 		commitID = *customCommit
 	}
-	return bp.GetBuildScript(proj.Owner(), proj.Name(), commitID.String())
+	return bp.GetBuildExpression(proj.Owner(), proj.Name(), commitID.String())
 }
 
 // Sync synchronizes the local build script with the remote one.
@@ -48,29 +48,27 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		// For now, if commitID is given, a mutation happened, so prefer the remote build expression.
 		// Otherwise, prefer local changes.
 		if commitID == nil {
-			// TODO: translate from script to expression in DX-1858.
-			//expr = script
+			expr, err = bpModel.NewBuildExpression([]byte(script.String()))
+			if err != nil {
+				return errs.Wrap(err, "Unable to translate local build script to build expression")
+			}
 		}
 
 		out.Notice(locale.Tl("buildscript_update", "Updating project to reflect build script changes..."))
 
 		bp := model.NewBuildPlanner(auth)
-		// Note: these commits will be staged commits in a later ticket.
-		commit, err := bp.PushCommit(model.PushCommitParams{
-			Owner:           proj.Owner(),
-			Project:         proj.Name(),
-			ParentCommit:    proj.CommitID(),
-			BranchRef:       proj.BranchName(),
-			Description:     locale.Tl("buildscript_commit_description", "Update project due to build script change."),
-			BuildExpression: expr,
+		stagedCommitID, err := bp.StageCommit(model.StateCommitParams{
+			Owner:        proj.Owner(),
+			Project:      proj.Name(),
+			ParentCommit: proj.CommitID(),
+			Script:       expr,
 		})
 		if err != nil {
 			return errs.Wrap(err, "Could not update project to reflect build script changes.")
 		}
-		newCommitID := strfmt.UUID(commit.CommitID)
-		commitID = &newCommitID
+		commitID = &stagedCommitID
 
-		expr, err = getBuildExpression(proj, commitID, auth)
+		expr, err = getBuildExpression(proj, commitID, auth) // timestamps might be different
 		if err != nil {
 			return errs.Wrap(err, "Could not get remote build expr")
 		}

--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -57,7 +57,7 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		out.Notice(locale.Tl("buildscript_update", "Updating project to reflect build script changes..."))
 
 		bp := model.NewBuildPlanner(auth)
-		stagedCommitID, err := bp.StageCommit(model.StateCommitParams{
+		stagedCommitID, err := bp.StageCommit(model.StageCommitParams{
 			Owner:        proj.Owner(),
 			Project:      proj.Name(),
 			ParentCommit: proj.CommitID(),

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/runtime/target"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/ActiveState/cli/pkg/projectfile"
-	"github.com/thoas/go-funk"
 )
 
 type PackageVersion struct {

--- a/pkg/platform/api/graphql/model/buildplanner/buildExpression.go
+++ b/pkg/platform/api/graphql/model/buildplanner/buildExpression.go
@@ -60,7 +60,7 @@ type BuildExpression struct {
 	expression       map[string]interface{}
 	solveNode        *map[string]interface{}
 	requirementsNode []interface{}
-	bytes            []byte
+	raw              json.RawMessage
 }
 
 func NewBuildExpression(data []byte) (*BuildExpression, error) {
@@ -89,7 +89,7 @@ func NewBuildExpression(data []byte) (*BuildExpression, error) {
 		expression:       expression,
 		solveNode:        &solveNode,
 		requirementsNode: requirementsNode,
-		bytes:            data,
+		raw:              data,
 	}, nil
 }
 
@@ -247,5 +247,5 @@ func getFuncNode(expression map[string]interface{}, funcName string) (map[string
 }
 
 func (bx *BuildExpression) String() string {
-	return string(bx.bytes)
+	return string(bx.raw)
 }

--- a/pkg/platform/api/graphql/model/buildplanner/buildExpression.go
+++ b/pkg/platform/api/graphql/model/buildplanner/buildExpression.go
@@ -60,6 +60,7 @@ type BuildExpression struct {
 	expression       map[string]interface{}
 	solveNode        *map[string]interface{}
 	requirementsNode []interface{}
+	bytes            []byte
 }
 
 func NewBuildExpression(data []byte) (*BuildExpression, error) {
@@ -88,6 +89,7 @@ func NewBuildExpression(data []byte) (*BuildExpression, error) {
 		expression:       expression,
 		solveNode:        &solveNode,
 		requirementsNode: requirementsNode,
+		bytes:            data,
 	}, nil
 }
 
@@ -242,4 +244,8 @@ func getFuncNode(expression map[string]interface{}, funcName string) (map[string
 	}
 
 	return nil, funcNodeNotFoundError
+}
+
+func (bx *BuildExpression) String() string {
+	return string(bx.bytes)
 }

--- a/pkg/platform/runtime/buildscript/buildexpression.go
+++ b/pkg/platform/runtime/buildscript/buildexpression.go
@@ -109,6 +109,7 @@ func newValue(valueInterface interface{}, preferIdent bool) (*Value, error) {
 
 	default:
 		// An empty value is interpreted as JSON null.
+		value.Null = &Null{}
 	}
 
 	return value, nil

--- a/pkg/platform/runtime/buildscript/buildexpression.go
+++ b/pkg/platform/runtime/buildscript/buildexpression.go
@@ -2,9 +2,11 @@ package buildscript
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/rtutils/p"
 	"github.com/ActiveState/cli/pkg/platform/api/graphql/model/buildplanner"
 )
@@ -201,4 +203,11 @@ func (s *Script) EqualsBuildExpression(otherJson []byte) bool {
 	return err == nil && string(myJson) == string(otherJson)
 }
 
-func (s *Script) Equals(other *model.BuildScript) bool { return false } // TODO
+func (s *Script) Equals(other *model.BuildExpression) bool {
+	expr, err := model.NewBuildExpression([]byte(s.String()))
+	if err != nil {
+		multilog.Error("Could not translate build script to build expression: %v", err)
+		return false
+	}
+	return reflect.DeepEqual(expr, other)
+}

--- a/pkg/platform/runtime/buildscript/buildexpression.go
+++ b/pkg/platform/runtime/buildscript/buildexpression.go
@@ -33,7 +33,7 @@ func NewScriptFromBuildExpression(expr []byte) (*Script, error) {
 	if !ok {
 		return nil, errs.New("Build expression's 'let' object has no 'in' key")
 	}
-	delete(letMap, "in")
+	delete(letMap, "in") // prevent duplication of "in" field when writing the build script
 
 	let, err := newLet(letMap)
 	if err != nil {

--- a/pkg/platform/runtime/buildscript/buildexpression.go
+++ b/pkg/platform/runtime/buildscript/buildexpression.go
@@ -2,12 +2,10 @@ package buildscript
 
 import (
 	"encoding/json"
-	"reflect"
 	"sort"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/rtutils/p"
 	"github.com/ActiveState/cli/pkg/platform/api/graphql/model/buildplanner"
 )
@@ -209,10 +207,5 @@ func (s *Script) EqualsBuildExpression(otherJson []byte) bool {
 }
 
 func (s *Script) Equals(other *model.BuildExpression) bool {
-	expr, err := model.NewBuildExpression([]byte(s.String()))
-	if err != nil {
-		multilog.Error("Could not translate build script to build expression: %v", err)
-		return false
-	}
-	return reflect.DeepEqual(expr, other)
+	return s.EqualsBuildExpression([]byte(other.String()))
 }

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -26,12 +26,17 @@ type Assignment struct {
 
 type Value struct {
 	FuncCall *FuncCall `parser:"@@"`
-	List     *[]*Value `parser:"| '[' @@ (',' @@)* ','? ']'"`
+	List     *[]*Value `parser:"| '[' (@@ (',' @@)* ','?)? ']'"`
 	Str      *string   `parser:"| @String"`
+	Null     *Null     `parser:"| @@"`
 
 	Assignment *Assignment    `parser:"| @@"`                        // only in FuncCall
 	Object     *[]*Assignment `parser:"| '{' @@ (',' @@)* ','? '}'"` // only in List
 	Ident      *string        `parser:"| @Ident"`                    // only in FuncCall
+}
+
+type Null struct {
+	Null string `parser:"'null'"`
 }
 
 type FuncCall struct {

--- a/pkg/platform/runtime/buildscript/file.go
+++ b/pkg/platform/runtime/buildscript/file.go
@@ -33,7 +33,7 @@ func newScriptFromFile(path string) (*Script, error) {
 	return NewScript(data)
 }
 
-func UpdateOrCreate(dir string, newScript *model.BuildScript) error {
+func UpdateOrCreate(dir string, newScript *model.BuildExpression) error {
 	// If a build script exists, check to see if an update is needed.
 	script, err := NewScriptFromProjectDir(dir)
 	if err != nil && !IsDoesNotExistError(err) {

--- a/pkg/platform/runtime/buildscript/file.go
+++ b/pkg/platform/runtime/buildscript/file.go
@@ -43,11 +43,15 @@ func UpdateOrCreate(dir string, newScript *model.BuildExpression) error {
 		return nil
 	}
 
+	script, err = NewScriptFromBuildExpression([]byte(newScript.String()))
+	if err != nil {
+		return errs.Wrap(err, "Could not parse build expression")
+	}
+
 	logging.Debug("Writing build script")
-	//TODO: enable in DX-1858
-	//err := fileutils.WriteFile(path, []byte(newScript.String()))
-	//if err != nil {
-	//return errs.Wrap(err, "Could not write build script to file")
-	//}
+	err = fileutils.WriteFile(filepath.Join(dir, constants.BuildScriptFileName), []byte(script.String()))
+	if err != nil {
+		return errs.Wrap(err, "Could not write build script to file")
+	}
 	return nil
 }

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -32,6 +32,8 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 		return json.Marshal(v.List)
 	case v.Str != nil:
 		return json.Marshal(strings.Trim(*v.Str, `"`))
+	case v.Null != nil:
+		return json.Marshal(nil)
 	case v.Assignment != nil:
 		return json.Marshal(v.Assignment)
 	case v.Object != nil:
@@ -43,7 +45,7 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 	case v.Ident != nil:
 		return json.Marshal(v.Ident)
 	}
-	return json.Marshal(nil)
+	return json.Marshal([]*Value{}) // participle does not create v.List if it's empty
 }
 
 func (f *FuncCall) MarshalJSON() ([]byte, error) {

--- a/pkg/platform/runtime/model/buildplanner.go
+++ b/pkg/platform/runtime/model/buildplanner.go
@@ -235,7 +235,8 @@ type StageCommitParams struct {
 	PackageVersion   string
 	PackageNamespace vcsModel.Namespace
 	Operation        model.Operation
-	// ... or a script (e.g. from pull).
+	// ... or commits can have a script (e.g. from pull). When pulling a script, we do not compute
+	// its changes into a series of above operations. Instead, we just pass the new script directly.
 	Script *model.BuildExpression
 }
 

--- a/pkg/platform/runtime/model/recipe.go
+++ b/pkg/platform/runtime/model/recipe.go
@@ -49,7 +49,7 @@ type BuildResult struct {
 	BuildStatusResponse *headchef_models.V1BuildStatusResponse
 	BuildStatus         headchef.BuildStatusEnum
 	BuildReady          bool
-	BuildExpression     *bpModel.BuildScript
+	BuildExpression     *bpModel.BuildExpression
 }
 
 func (b *BuildResult) OrderedArtifacts() []artifact.ArtifactID {

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -103,18 +103,12 @@ type Targeter interface {
 }
 
 type Setup struct {
-	model         ModelProvider
 	auth          *authentication.Auth
 	target        Targeter
 	eventHandler  events.Handler
 	store         *store.Store
 	analytics     analytics.Dispatcher
 	artifactCache *artifactcache.ArtifactCache
-}
-
-// ModelProvider is the interface for all functions that involve backend communication
-type ModelProvider interface {
-	GetBuildScript(owner, project, commitID string) (*bpModel.BuildScript, error)
 }
 
 type Setuper interface {
@@ -135,16 +129,11 @@ type artifactInstaller func(artifact.ArtifactID, string, ArtifactSetuper) error
 
 // New returns a new Setup instance that can install a Runtime locally on the machine.
 func New(target Targeter, eventHandler events.Handler, auth *authentication.Auth, an analytics.Dispatcher) *Setup {
-	return NewWithModel(target, eventHandler, model.NewBuildPlanner(auth), auth, an)
-}
-
-// NewWithModel returns a new Setup instance with a customized model eg., for testing purposes
-func NewWithModel(target Targeter, eventHandler events.Handler, model ModelProvider, auth *authentication.Auth, an analytics.Dispatcher) *Setup {
 	cache, err := artifactcache.New()
 	if err != nil {
 		multilog.Error("Could not create artifact cache: %v", err)
 	}
-	return &Setup{model, auth, target, eventHandler, store.New(target.Dir()), an, cache}
+	return &Setup{auth, target, eventHandler, store.New(target.Dir()), an, cache}
 }
 
 // Update installs the runtime locally (or updates it if it's already partially installed)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1858" title="DX-1858" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1858</a>  Local orders use the Python representation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Hooking things up was relatively straightforward. I did have to change StageCommit to allow for a build expression update rather than an individual requirement update. Other than that, I discovered some minor errors in the build script implementation: null values and empty lists were not being handled properly, build script assignment order was not stable, and the "in" key was being duplicated on write because it is inside "let" in build expressions.