### PR TITLE
Fix executor PATH append malfunctioning due to case sensitivity on windows

### DIFF
--- a/cmd/state-exec/meta.go
+++ b/cmd/state-exec/meta.go
@@ -59,7 +59,7 @@ func matchingBinByPath(bins map[string]string, path string) (string, error) {
 // the update value prepended to the existing PATH.
 func transformedEnv(current []string, updates []string) []string {
 	for _, update := range updates {
-		if strings.HasPrefix(update, pathEnvVarPrefix) {
+		if strings.HasPrefix(strings.ToLower(update), strings.ToLower(pathEnvVarPrefix)) {
 			pathCurrentV, pathCurrentK, ok := getEnvVar(current, pathEnvVarPrefix)
 			if ok {
 				current[pathCurrentK] = update + pathListSeparator + pathCurrentV
@@ -76,7 +76,7 @@ func transformedEnv(current []string, updates []string) []string {
 // variable separator.
 func getEnvVar(env []string, prefix string) (string, int, bool) {
 	for k, v := range env {
-		if strings.HasPrefix(v, prefix) {
+		if strings.HasPrefix(strings.ToLower(v), strings.ToLower(prefix)) {
 			return v[len(prefix):], k, true
 		}
 	}

--- a/cmd/state-exec/meta_test.go
+++ b/cmd/state-exec/meta_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func Test_transformedEnv(t *testing.T) {
+	I := string(os.PathListSeparator)
+	type args struct {
+		sourceEnv    []string
+		updatesToEnv []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			"Simple append",
+			args{
+				sourceEnv:    []string{"A=1", "B=2"},
+				updatesToEnv: []string{"C=3"},
+			},
+			[]string{"A=1", "B=2", "C=3"},
+		},
+		{
+			"Path append",
+			args{
+				sourceEnv:    []string{"PATH=A" + I + "B"},
+				updatesToEnv: []string{"PATH=C"},
+			},
+			[]string{"PATH=C" + I + "A" + I + "B"},
+		},
+		{
+			"Path append with missmatched casing",
+			args{
+				sourceEnv:    []string{"Path=A" + I + "B"},
+				updatesToEnv: []string{"PATH=C"},
+			},
+			[]string{"PATH=C" + I + "A" + I + "B"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := transformedEnv(tt.args.sourceEnv, tt.args.updatesToEnv); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("transformedEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1900" title="DX-1900" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1900</a>  activate events don't source full environment
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
