### PR TITLE
Revert "Mark `state init` as no longer unstable."

### DIFF
--- a/cmd/state/internal/cmdtree/init.go
+++ b/cmd/state/internal/cmdtree/init.go
@@ -55,5 +55,5 @@ func newInitCommand(prime *primer.Values) *captain.Command {
 		func(ccmd *captain.Command, _ []string) error {
 			return initRunner.Run(&params)
 		},
-	).SetGroup(EnvironmentSetupGroup)
+	).SetGroup(EnvironmentSetupGroup).SetUnstable(true)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1918" title="DX-1918" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1918</a>  Mark `state init` unstable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This reverts commit af8c9aa126e0b090f39b7ad0ec57e33baed0d181.