### PR TITLE
Cleanup after a failed `state init`.

### DIFF
--- a/internal/osutils/osutils.go
+++ b/internal/osutils/osutils.go
@@ -71,7 +71,7 @@ func winPathToLinPath(name string) (string, error) {
 	return path, nil
 }
 
-// Getwd is an alias of osutils.Getwd which wraps the error in our localized error message and FailGetWd, which is user facing (doesn't get logged)
+// Getwd is an alias of os.Getwd which wraps the error in our localized error message and FailGetWd, which is user facing (doesn't get logged)
 func Getwd() (string, error) {
 	r, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1791" title="DX-1791" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1791</a>  INIT: Folder and as.yaml was created despite failure
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
