### PR TITLE
Print absolute project path on `state init` if a relative path was given.

### DIFF
--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -99,8 +99,14 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		return locale.NewInputError("err_projectfile_exists")
 	}
 
-	if err := fileutils.MkdirUnlessExists(path); err != nil {
+	err := fileutils.MkdirUnlessExists(path)
+	if err != nil {
 		return locale.WrapError(err, "err_init_preparedir", "Could not create directory at [NOTICE]{{.V0}}[/RESET]. Error: {{.V1}}", params.Path, err.Error())
+	}
+
+	path, err = filepath.Abs(params.Path)
+	if err != nil {
+		return locale.WrapInputError(err, "err_init_abs_path", "Could not determine absolute path to [NOTICE]{{.V0}}[/RESET]. Error: {{.V1}}", path, err.Error())
 	}
 
 	var languageName, languageVersion string


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1878" title="DX-1878" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1878</a>  INIT: If `--path` flag used the summary for initialized project print not an absolute path like it do without the flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
