### PR TITLE
Remove release note about `state init` now being stable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,8 +15,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- We've graduated `state init` to now be *stable*. You no longer need to opt-in
-  to unstable commands to use it.
 - Running `state init` and `state refresh` successfully will now give the same
   environment information as commands like `state checkout` and `state use`.
 - The `state init` command now takes a `path` argument, replacing the previous


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1918" title="DX-1918" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1918</a>  Mark `state init` unstable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
