### PR TITLE
Fix state tool not detecting install path on Windows dev machine

### DIFF
--- a/internal/installation/paths.go
+++ b/internal/installation/paths.go
@@ -48,7 +48,7 @@ func InstallPathFromExecPath() (string, error) {
 	}
 
 	// Facilitate use-case of running executables from the build dir while developing
-	if !condition.BuiltViaCI() && strings.Contains(exePath, "/build/") {
+	if !condition.BuiltViaCI() && strings.Contains(exePath, string(os.PathSeparator)+"build"+string(os.PathSeparator)) {
 		return filepath.Dir(exePath), nil
 	}
 	if path, ok := os.LookupEnv(constants.OverwriteDefaultInstallationPathEnvVarName); ok {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1811" title="DX-1811" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1811</a>  As a DevX developer I can no longer use my own build/state executable because state-svc cannot find its install location
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
