### PR TITLE
Do not show "operating on project..." notice when listing packages for a specified project.

### DIFF
--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -42,7 +42,7 @@ func NewList(prime primeable) *List {
 func (l *List) Run(params ListRunParams, nstype model.NamespaceType) error {
 	logging.Debug("ExecuteList")
 
-	if l.project != nil {
+	if l.project != nil && params.Project == "" {
 		l.out.Notice(locale.Tl("operating_message", "", l.project.NamespaceString(), l.project.Dir()))
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1904" title="DX-1904" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1904</a>  Executing `state pkg --namespace <namespace_B>` have wrong info printed.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
