### PR TITLE
Initial implementation of `state projects delete`.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -120,6 +120,7 @@ func New(prime *primer.Values, args ...string) *CmdTree {
 
 	projectsCmd := newProjectsCommand(prime)
 	projectsCmd.AddChildren(newRemoteProjectsCommand(prime))
+	projectsCmd.AddChildren(newDeleteProjectsCommand(prime))
 
 	updateCmd := newUpdateCommand(prime)
 	updateCmd.AddChildren(

--- a/cmd/state/internal/cmdtree/projects.go
+++ b/cmd/state/internal/cmdtree/projects.go
@@ -40,3 +40,27 @@ func newRemoteProjectsCommand(prime *primer.Values) *captain.Command {
 		},
 	).SetGroup(ProjectUsageGroup)
 }
+
+func newDeleteProjectsCommand(prime *primer.Values) *captain.Command {
+	runner := projects.NewDelete(prime)
+	params := projects.NewDeleteParams()
+
+	return captain.NewCommand(
+		"delete",
+		locale.Tl("projects_delete_title", "Delete a project"),
+		locale.Tl("projects_delete_description", "Delete the specified project from the Platform"),
+		prime,
+		[]*captain.Flag{},
+		[]*captain.Argument{
+			{
+				Name:        "namespace",
+				Description: locale.Tl("projects_delete_namespace_description", "org/project"),
+				Value:       params.Project,
+				Required:    true,
+			},
+		},
+		func(_ *captain.Command, _ []string) error {
+			return runner.Run(params)
+		},
+	).SetGroup(ProjectUsageGroup)
+}

--- a/internal/runners/projects/delete.go
+++ b/internal/runners/projects/delete.go
@@ -1,0 +1,60 @@
+package projects
+
+import (
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/internal/prompt"
+	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_client/projects"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/project"
+)
+
+type DeleteParams struct {
+	Project *project.Namespaced
+}
+
+type Delete struct {
+	auth   *authentication.Auth
+	out    output.Outputer
+	prompt prompt.Prompter
+}
+
+func NewDeleteParams() *DeleteParams {
+	return &DeleteParams{&project.Namespaced{}}
+}
+
+func NewDelete(prime primeable) *Delete {
+	return &Delete{
+		prime.Auth(),
+		prime.Output(),
+		prime.Prompt(),
+	}
+}
+
+func (d *Delete) Run(params *DeleteParams) error {
+	if !d.auth.Authenticated() {
+		return locale.NewInputError("err_projects_delete_authenticated", "You need to be authenticated to delete a project.")
+	}
+
+	defaultChoice := !d.out.Config().Interactive
+	confirm, err := d.prompt.Confirm("", locale.Tl("project_delete_confim", "Are you sure you want to delete the project {{.V0}}?", params.Project.String()), &defaultChoice)
+	if err != nil {
+		return locale.WrapError(err, "err_project_delete_confirm", "Could not confirm delete choice")
+	}
+	if !confirm {
+		return locale.NewInputError("err_project_delete_aborted", "Delete aborted by user")
+	}
+
+	monoParams := projects.NewDeleteProjectParams()
+	monoParams.SetOrganizationName(params.Project.Owner)
+	monoParams.SetProjectName(params.Project.Project)
+
+	_, err = d.auth.Client().Projects.DeleteProject(monoParams, d.auth.ClientAuth())
+	if err != nil {
+		return locale.WrapError(err, "err_projects_delete", "Unable to delete project")
+	}
+
+	d.out.Notice(locale.Tl("notice_projects_delete", "Your project was deleted. Please delete any additional copies that are checked out, as they will be inoperable."))
+
+	return nil
+}

--- a/internal/runners/projects/delete.go
+++ b/internal/runners/projects/delete.go
@@ -4,8 +4,8 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/prompt"
-	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_client/projects"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
 )
 
@@ -45,11 +45,7 @@ func (d *Delete) Run(params *DeleteParams) error {
 		return locale.NewInputError("err_project_delete_aborted", "Delete aborted by user")
 	}
 
-	monoParams := projects.NewDeleteProjectParams()
-	monoParams.SetOrganizationName(params.Project.Owner)
-	monoParams.SetProjectName(params.Project.Project)
-
-	_, err = d.auth.Client().Projects.DeleteProject(monoParams, d.auth.ClientAuth())
+	err = model.DeleteProject(params.Project.Owner, params.Project.Project, d.auth)
 	if err != nil {
 		return locale.WrapError(err, "err_projects_delete", "Unable to delete project")
 	}

--- a/internal/runners/projects/projects.go
+++ b/internal/runners/projects/projects.go
@@ -104,6 +104,7 @@ type primeable interface {
 	primer.Auther
 	primer.Outputer
 	primer.Configurer
+	primer.Prompter
 }
 
 func NewParams() *Params {

--- a/internal/testhelpers/e2e/clean.go
+++ b/internal/testhelpers/e2e/clean.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_client/users"
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/model"
 )
 
 func cleanUser(t *testing.T, username string, auth *authentication.Auth) error {
@@ -15,7 +16,7 @@ func cleanUser(t *testing.T, username string, auth *authentication.Auth) error {
 		return err
 	}
 	for _, proj := range projects {
-		err = deleteProject(username, proj.Name, auth)
+		err = model.DeleteProject(username, proj.Name, auth)
 		if err != nil {
 			return err
 		}
@@ -33,19 +34,6 @@ func getProjects(org string, auth *authentication.Auth) ([]*mono_models.Project,
 	}
 
 	return listProjectsOK.Payload, nil
-}
-
-func deleteProject(org, name string, auth *authentication.Auth) error {
-	params := projects.NewDeleteProjectParams()
-	params.SetOrganizationName(org)
-	params.SetProjectName(name)
-
-	_, err := auth.Client().Projects.DeleteProject(params, auth.ClientAuth())
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func deleteUser(name string, auth *authentication.Auth) error {

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/ActiveState/termtest"
 	"github.com/ActiveState/termtest/expect"
@@ -512,7 +513,7 @@ func (s *Session) Close() error {
 	}
 
 	for _, proj := range s.createdProjects {
-		err := deleteProject(proj.Owner, proj.Project, auth)
+		err := model.DeleteProject(proj.Owner, proj.Project, auth)
 		if err != nil {
 			s.t.Errorf("Could not delete project %s: %v", proj.Project, errs.JoinMessage(err))
 		}

--- a/pkg/platform/model/projects.go
+++ b/pkg/platform/model/projects.go
@@ -269,3 +269,17 @@ func AddBranch(projectID strfmt.UUID, label string) (strfmt.UUID, error) {
 
 	return res.Payload.BranchID, nil
 }
+
+func DeleteProject(owner, project string, auth *authentication.Auth) error {
+	params := projects.NewDeleteProjectParams()
+	params.SetOrganizationName(owner)
+	params.SetProjectName(project)
+
+	_, err := auth.Client().Projects.DeleteProject(params, auth.ClientAuth())
+	if err != nil {
+		msg := api.ErrorMessageFromPayload(err)
+		return locale.WrapError(err, msg)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1775" title="DX-1775" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1775</a>  ST support delete project action
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Since deleting projects via the MonoAPI is so simple, I didn't see a need to update the integration tests to use `state projects delete` when deleting projects created in tests. Also, there's the matter of ensuring project deletion even if errors occur; there's no guarantee if we switch to running `state projects delete` for cleanup.