### PR TITLE
Ensure runtime can be used on control error (e.g. needsupdate)

### DIFF
--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -128,7 +128,9 @@ func (r *Runtime) validateCache() error {
 		if err != nil {
 			return errs.Wrap(err, "Unable to get remote build expression")
 		}
-		r.store.StoreBuildExpression(bpExpr, commitID)
+		if err := r.store.StoreBuildExpression(bpExpr, commitID); err != nil {
+			return errs.Wrap(err, "Unable to store build expression")
+		}
 		expr = bpExpr.String()
 	}
 

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -68,7 +68,7 @@ func newRuntime(target setup.Targeter, an analytics.Dispatcher, svcModel *model.
 
 	err := rt.validateCache()
 	if err != nil {
-		return nil, err // do not wrap; could be NeedsUpdateError, NeedsStageError, etc.
+		return rt, err
 	}
 
 	return rt, nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1940" title="DX-1940" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1940</a>  Local order feature branch: runtime.Runtime panic
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
