### PR TITLE
Return high-level localized error if there was a low-level runtime setup error.

### DIFF
--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -266,7 +266,7 @@ func (s *Setup) updateArtifacts() ([]artifact.ArtifactID, error) {
 		return err
 	})
 	if err != nil {
-		return artifacts, errs.Wrap(err, "Error setting up runtime")
+		return artifacts, locale.WrapError(err, "err_runtime_setup", "Error setting up runtime")
 	}
 
 	return artifacts, nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1881" title="DX-1881" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1881</a>  Missing error l10n while setting up runtime
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


At least one error in the chain needs to be localized, so I picked the upper-most error that wraps lower-level errors like the "abnormal closure" error originally reported.

I tested by unplugging my network cable. It didn't give the same error, but I at least got my localized error:

```
█ Something Went Wrong

 x Could not install dependencies
 x Error setting up runtime
 x Could not resolve recipe for project mitchell-as/python#71a77bda-f2c3-4c4d-9dc7-f0b6d59d701e
 x Unknown error resolving order
```
