### PR TITLE
Made `state publish` meta file an optional flag instead of an optional argument

### DIFF
--- a/cmd/state/internal/cmdtree/publish.go
+++ b/cmd/state/internal/cmdtree/publish.go
@@ -74,14 +74,13 @@ func newPublish(prime *primer.Values) *captain.Command {
 				),
 				Value: &params.Depends,
 			},
-		},
-		[]*captain.Argument{
 			{
-				Name:        locale.Tl("meta_file", "meta file"),
+				Name:        "meta",
 				Description: locale.Tl("author_upload_metafile_description", "A yaml file expressing the ingredient meta information. Use --editor to review the file format."),
 				Value:       &params.MetaFilepath,
-				Required:    false,
 			},
+		},
+		[]*captain.Argument{
 			{
 				Name:        locale.Tl("filepath", "filepath"),
 				Description: locale.Tl("author_upload_filepath_description", "The binary ingredient file to upload."),

--- a/test/integration/publish_int_test.go
+++ b/test/integration/publish_int_test.go
@@ -64,7 +64,7 @@ func (suite *PublishIntegrationTestSuite) TestPublish() {
 		{
 			"New ingredient with file arg and flags",
 			input{
-				[]string{"", tempFile,
+				[]string{tempFile,
 					"--name", "im-a-name",
 					"--namespace", "{{.Username}}/shared",
 					"--version", "2.3.4",
@@ -90,7 +90,7 @@ func (suite *PublishIntegrationTestSuite) TestPublish() {
 		{
 			"New ingredient with meta file",
 			input{
-				[]string{"{{.MetaFile}}", tempFile},
+				[]string{"--meta", "{{.MetaFile}}", tempFile},
 				p.StrP(`
 name: im-a-name
 namespace: {{.Username}}/shared
@@ -118,7 +118,7 @@ authors:
 		{
 			"New ingredient with meta file and flags",
 			input{
-				[]string{"{{.MetaFile}}", tempFile, "--name", "im-a-name-from-flag", "--author", "author-name-from-flag <author-email-from-flag@domain.tld>"},
+				[]string{"--meta", "{{.MetaFile}}", tempFile, "--name", "im-a-name-from-flag", "--author", "author-name-from-flag <author-email-from-flag@domain.tld>"},
 				p.StrP(`
 name: im-a-name
 namespace: {{.Username}}/shared
@@ -146,7 +146,7 @@ authors:
 		{
 			"New ingredient with editor flag",
 			input{
-				[]string{"", tempFile, "--editor"},
+				[]string{tempFile, "--editor"},
 				nil,
 				p.StrP(`
 name: im-a-name
@@ -174,7 +174,7 @@ authors:
 		{
 			"Cancel upload",
 			input{
-				[]string{"", tempFile, "--name", "bogus", "--namespace", "{{.Username}}/shared"},
+				[]string{tempFile, "--name", "bogus", "--namespace", "{{.Username}}/shared"},
 				nil,
 				nil,
 				false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1937" title="DX-1937" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1937</a>  Better UX for uploading ingredient with meta flags
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
