### PR TITLE
Use inventory API's NormalizeNames endpoint before searching for a package to install.

### DIFF
--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -181,7 +181,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 			return locale.WrapInputError(err, "package_ingredient_alternatives", "", requirementName, strings.Join(suggestions, "\n"))
 		}
 
-		origRequirementName, requirementName = requirementName, normalized
+		requirementName = normalized
 
 		pg.Stop(locale.T("progress_found"))
 		pg = nil

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -157,10 +157,16 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 		requirementVersion = ""
 	}
 
+	origRequirementName := requirementName
 	if validatePkg {
 		pg = output.StartSpinner(out, locale.Tl("progress_search", "", requirementName), constants.TerminalAnimationInterval)
 
-		packages, err := model.SearchIngredientsStrict(ns, requirementName, false, false)
+		normalized, err := model.FetchNormalizedName(ns, requirementName)
+		if err != nil {
+			multilog.Error("Failed to normalize '%s': %v", requirementName, err)
+		}
+
+		packages, err := model.SearchIngredientsStrict(ns, normalized, false, false) // ideally case-sensitive would be true (PB-4371)
 		if err != nil {
 			return locale.WrapError(err, "package_err_cannot_obtain_search_results")
 		}
@@ -174,10 +180,8 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 			}
 			return locale.WrapInputError(err, "package_ingredient_alternatives", "", requirementName, strings.Join(suggestions, "\n"))
 		}
-		if name := packages[0].Ingredient.Name; name != nil && requirementName != *name {
-			logging.Debug("Requirement to install's letter case differs from Platform's ('%s' != '%s')", requirementName, *name)
-			requirementName = *name // match case
-		}
+
+		origRequirementName, requirementName = requirementName, normalized
 
 		pg.Stop(locale.T("progress_found"))
 		pg = nil
@@ -215,7 +219,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 	commitID, err = model.CommitRequirement(parentCommitID, operation, requirementName, requirementVersion, requirementBitWidth, ns)
 	if err != nil {
 		if operation == model.OperationRemoved && strings.Contains(err.Error(), "does not exist") {
-			return locale.WrapInputError(err, "err_package_remove_does_not_exist", "Requirement is not installed: {{.V0}}", requirementName)
+			return locale.WrapInputError(err, "err_package_remove_does_not_exist", "Requirement is not installed: {{.V0}}", origRequirementName)
 		}
 		return locale.WrapError(err, fmt.Sprintf("err_%s_%s", ns.Type(), operation))
 	}
@@ -279,6 +283,12 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 			ns.Type().String(),
 			string(operation),
 		}))
+
+	if origRequirementName != requirementName {
+		out.Notice(locale.Tl("package_version_differs",
+			"Note: the actual package name ({{.V0}}) is different from the requested package name ({{.V1}})",
+			requirementName, origRequirementName))
+	}
 
 	out.Notice(locale.T("operation_success_local"))
 

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -391,3 +391,19 @@ func FetchIngredientVersions(ingredientID *strfmt.UUID) ([]*inventory_models.Ing
 
 	return res.Payload.IngredientVersions, nil
 }
+
+func FetchNormalizedName(namespace Namespace, name string) (string, error) {
+	client := inventory.Get()
+	params := inventory_operations.NewNormalizeNamesParams()
+	params.SetNamespace(namespace.String())
+	params.SetNames(&inventory_models.UnnormalizedNames{Names: []string{name}})
+	params.SetHTTPClient(api.NewHTTPClient())
+	res, err := client.NormalizeNames(params, authentication.ClientAuth())
+	if err != nil {
+		return "", errs.Wrap(err, "NormalizeName failed")
+	}
+	if len(res.Payload.NormalizedNames) == 0 {
+		return "", errs.New("Normalized name for %s not found", name)
+	}
+	return *res.Payload.NormalizedNames[0].Normalized, nil
+}

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/stretchr/testify/suite"
 )
 
 type PackageIntegrationTestSuite struct {
@@ -493,6 +493,41 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 	cp.Expect(`{"name":"Text-CSV"`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
+}
+
+func (suite *PackageIntegrationTestSuite) TestNormalize() {
+	suite.OnlyRunForTags(tagsuite.Package)
+	if runtime.GOOS == "darwin" {
+		suite.T().Skip("Skipping mac for now as the builds are still too unreliable")
+		return
+	}
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Checked out project")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("install", "Charset_normalizer"),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
+	cp.Expect("charset-normalizer")
+	cp.Expect("is different")
+	cp.Expect("Charset_normalizer")
+	cp.ExpectExitCode(0)
+
+	anotherDir := filepath.Join(ts.Dirs.Work, "not-normalized")
+	suite.Require().NoError(fileutils.Mkdir(anotherDir))
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("install", "charset-normalizer"),
+		e2e.WithWorkDirectory(anotherDir),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
+	cp.Expect("charset-normalizer")
+	cp.ExpectExitCode(0)
+	suite.NotContains(cp.TrimmedSnapshot(), "is different")
 }
 
 func TestPackageIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1932" title="DX-1932" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1932</a>  We normalize package names provided to `state install`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
While there wasn't an issue for mismatched name case, it was an issue for mixed '-' and '_' for Python.