### PR TITLE
Allow partial version numbers for `state init`.

### DIFF
--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -120,16 +120,12 @@ func MakeByName(name string) Language {
 
 // MakeByNameAndVersion will retrieve a language by a given name and version.
 func MakeByNameAndVersion(name, version string) (Language, error) {
-	if version != "" && strings.ToLower(name) == Python3.Requirement() {
-		parts := strings.Split(version, ".")
-		if len(parts) == 0 || parts[0] == "" {
-			return Unknown, locale.NewError("err_invalid_language_version", "Invalid language version number: {{.V0}}", version)
-		}
-		name = name + parts[0]
-	}
-	if version == "" && strings.ToLower(name) == Python3.Requirement() {
-		// This addressed the language only specifying "python", in this case we default to python3
+	if strings.ToLower(name) == Python3.Requirement() {
 		name = Python3.String()
+		// Disambiguate python, preferring Python3.
+		if parts := strings.Split(version, "."); len(parts) > 0 && parts[0] == "2" {
+			name = Python2.String()
+		}
 	}
 	return MakeByName(name), nil
 }

--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/exeutils"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/thoas/go-funk"
 )
 
 // Language tracks the languages potentially used.
@@ -342,8 +343,8 @@ func RecognizedSupportedsNames() []string {
 	var supporteds []string
 	for i, data := range lookup {
 		l := Supported{Language(i)}
-		if l.Recognized() {
-			supporteds = append(supporteds, data.name)
+		if l.Recognized() && !funk.Contains(supporteds, data.require) {
+			supporteds = append(supporteds, data.require)
 		}
 	}
 	return supporteds

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -125,6 +125,11 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		return locale.NewInputError("err_init_no_language")
 	}
 
+	// Require 'python', 'python@3', or 'python@2' instead of 'python3' or 'python2'.
+	if languageName == language.Python3.String() || languageName == language.Python2.String() {
+		return language.UnrecognizedLanguageError(languageName, language.RecognizedSupportedsNames())
+	}
+
 	lang, err := language.MakeByNameAndVersion(languageName, languageVersion)
 	if err != nil {
 		if inferred {

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -134,18 +134,13 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		}
 	}
 
-	if err := lang.Validate(); err != nil {
+	err = verifyLangAndVersion(lang, languageVersion)
+	if err != nil {
 		if inferred {
 			return locale.WrapError(err, "err_init_lang", "", languageName, languageVersion)
 		} else {
 			return locale.WrapInputError(err, "err_init_lang", "", languageName, languageVersion)
 		}
-	}
-
-	version := deriveVersion(lang, languageVersion)
-
-	if err := verifyLangAndVersion(lang.Requirement(), version); err != nil {
-		return locale.WrapError(err, "err_init_verify_version", "Could not verify language")
 	}
 
 	createParams := &projectfile.CreateParams{
@@ -186,6 +181,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		return err
 	}
 
+	version := deriveVersion(lang, languageVersion)
 	commitID, err := model.CommitInitial(model.HostPlatform, lang.Requirement(), version)
 	if err != nil {
 		return locale.WrapError(err, "err_init_commit", "Could not create initial commit")
@@ -238,8 +234,17 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 	return nil
 }
 
-func verifyLangAndVersion(lang, version string) error {
-	pkgs, err := model.SearchIngredientsStrict(model.NewNamespaceLanguage(), lang, false, true)
+func verifyLangAndVersion(lang language.Language, version string) error {
+	err := lang.Validate()
+	if err != nil {
+		return errs.Wrap(err, "Failed to validate language")
+	}
+
+	if version == "" {
+		return nil // nothing to verify
+	}
+
+	pkgs, err := model.SearchIngredientsStrict(model.NewNamespaceLanguage(), lang.Requirement(), false, true)
 	if err != nil {
 		return locale.WrapError(err, "err_init_verify_language", "Inventory search failed unexpectedly")
 	}
@@ -249,7 +254,7 @@ func verifyLangAndVersion(lang, version string) error {
 	}
 
 	for _, pkg := range pkgs {
-		if pkg.Version == version {
+		if strings.HasPrefix(pkg.Version, version) {
 			return nil
 		}
 	}
@@ -262,10 +267,6 @@ func verifyLangAndVersion(lang, version string) error {
 		locale.Tl(
 			"version_not_found_check_format",
 			"Please ensure that the version format is valid.",
-		),
-		locale.Tl(
-			"version_not_found_suggest_micro",
-			"Additional detail may help. For example, '3.10.0' rather than '3.10'",
 		),
 	)
 }
@@ -282,7 +283,7 @@ func deriveVersion(lang language.Language, version string) string {
 	}
 
 	for _, l := range langs {
-		if lang.String() == l.Name || (lang == language.Python3 && l.Name == "python") {
+		if lang.String() == l.Name || (lang == language.Python3 && l.Name == language.Python3.Requirement()) {
 			return l.DefaultVersion
 		}
 	}

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -23,12 +23,12 @@ type InitIntegrationTestSuite struct {
 
 func (suite *InitIntegrationTestSuite) TestInit() {
 	suite.OnlyRunForTags(tagsuite.Init, tagsuite.Critical)
-	suite.runInitTest(false, "python3", "python3")
+	suite.runInitTest(false, "python", "python3")
 }
 
 func (suite *InitIntegrationTestSuite) TestInit_Path() {
 	suite.OnlyRunForTags(tagsuite.Init)
-	suite.runInitTest(true, "python3", "python3")
+	suite.runInitTest(true, "python", "python3")
 }
 
 func (suite *InitIntegrationTestSuite) TestInit_BadVersion() {
@@ -37,7 +37,7 @@ func (suite *InitIntegrationTestSuite) TestInit_BadVersion() {
 	defer ts.Close()
 	ts.LoginAsPersistentUser()
 
-	cp := ts.Spawn("init", "--language", "python3@1.0", "test-user/test-project")
+	cp := ts.Spawn("init", "--language", "python@1.0", "test-user/test-project")
 	cp.Expect("version")
 	cp.Expect("cannot be found")
 	cp.ExpectNotExitCode(0)
@@ -45,9 +45,15 @@ func (suite *InitIntegrationTestSuite) TestInit_BadVersion() {
 
 func (suite *InitIntegrationTestSuite) TestInit_DisambiguatePython() {
 	suite.OnlyRunForTags(tagsuite.Init)
-	suite.runInitTest(true, "python", "python3")
-	suite.runInitTest(true, "python@3.10.0", "python3")
-	suite.runInitTest(true, "python@2.7.18", "python2")
+	suite.runInitTest(false, "python", "python3")
+	suite.runInitTest(false, "python@3.10.0", "python3")
+	suite.runInitTest(false, "python@2.7.18", "python2")
+}
+
+func (suite *InitIntegrationTestSuite) TestInit_PartialVersions() {
+	suite.OnlyRunForTags(tagsuite.Init)
+	suite.runInitTest(false, "python@3.10", "python3")
+	suite.runInitTest(false, "python@2", "python2")
 }
 
 func (suite *InitIntegrationTestSuite) runInitTest(addPath bool, lang string, expectedConfigLanguage string, args ...string) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1927" title="DX-1927" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1927</a>  state init makes it painless to specify partial version numbers
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also remove `python3` and `python2` distinction.