### PR TITLE
Only install artifacts after all of them have been fetched, unpacked, and prepared for install.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -490,3 +490,7 @@ const AnalyticsPixelOverrideEnv = "ACTIVESTATE_CLI_ANALYTICS_PIXEL"
 
 // TerminalAnimationInterval is the interval we use for terminal animations
 const TerminalAnimationInterval = 150 * time.Millisecond
+
+// RuntimeSetupWaitEnvVarName is only used for an integration test to pause installation and wait
+// for Ctrl+C.
+const RuntimeSetupWaitEnvVarName = "ACTIVESTATE_CLI_RUNTIME_SETUP_WAIT"

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -874,6 +874,8 @@ err_no_valid_artifact:
   other: Your project is not producing any usable artifacts, is your State Tool up to date?
 err_runtime_download_no_response:
   other: Could not find bits associated with your runtime environment, please contact support
+err_runtime_setup:
+  other: Error setting up runtime
 err_signs3_invalid_url:
   other: API Responded with an invalid S3 URL, please contact support
 err_artifact_invalid_url:

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ActiveState/cli/internal/analytics"
 	anaConsts "github.com/ActiveState/cli/internal/analytics/constants"
 	"github.com/ActiveState/cli/internal/analytics/dimensions"
+	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
@@ -298,6 +299,11 @@ func (s *Setup) updateArtifacts() ([]artifact.ArtifactID, error) {
 	})
 	if err != nil {
 		return artifacts, locale.WrapError(err, "err_runtime_setup")
+	}
+
+	if os.Getenv(constants.RuntimeSetupWaitEnvVarName) != "" && condition.OnCI() {
+		ch := make([]byte, 1)
+		os.Stdin.Read(ch) // block until Ctrl-C is sent
 	}
 
 	// Move files to final installation path after successful download and unpack.

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -1,5 +1,18 @@
 package integration
 
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ActiveState/cli/internal/exeutils"
+	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
+	"github.com/ActiveState/cli/pkg/platform/runtime/target"
+	"github.com/stretchr/testify/suite"
+)
+
 // Disabled due to DX-1514
 /*func TestOfflineInstaller(t *testing.T) {
 	// Each artifact of the form UUID.tar.gz has the following structure:
@@ -61,8 +74,42 @@ package integration
 		filename := filepath.Join(dir, "tmp", filename) // each file is in a "tmp" dir in the archive
 		suite.Assert().True(fileutils.FileExists(filename), "file '%s' was not extracted from its artifact", filename)
 	}
+}*/
+
+type RuntimeIntegrationTestSuite struct {
+	tagsuite.Suite
+}
+
+func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
+	suite.OnlyRunForTags(tagsuite.Interrupt)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.SpawnWithOpts(
+		e2e.WithArgs("checkout", "ActiveState-CLI/small-python#863c45e2-3626-49b6-893c-c15e85a17241", "."),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+	)
+	cp.Expect("Checked out project")
+
+	targetDir := target.ProjectDirToTargetDir(ts.Dirs.Work, ts.Dirs.Cache)
+	pythonExe := filepath.Join(setup.ExecDir(targetDir), "python3"+exeutils.Extension)
+	cp = ts.SpawnCmd(pythonExe, "-c", `print(__import__('sys').version)`)
+	cp.Expect("3.8.8")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("pull"),
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
+			"ACTIVESTATE_CLI_RUNTIME_SETUP_WAIT=true"),
+	)
+	time.Sleep(10 * time.Second)
+	cp.SendCtrlC() // cancel pull/update
+
+	cp = ts.SpawnCmd(pythonExe, "-c", `print(__import__('sys').version)`)
+	cp.Expect("3.8.8") // current runtime still works
+	cp.ExpectExitCode(0)
 }
 
 func TestRuntimeIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(RuntimeIntegrationTestSuite))
-}*/
+}

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -86,7 +86,7 @@ func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
 	defer ts.Close()
 
 	cp := ts.SpawnWithOpts(
-		e2e.WithArgs("checkout", "ActiveState-CLI/small-python#863c45e2-3626-49b6-893c-c15e85a17241", "."),
+		e2e.WithArgs("checkout", "ActiveState-CLI/test-interrupt-small-python#863c45e2-3626-49b6-893c-c15e85a17241", "."),
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Checked out project")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1933" title="DX-1933" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1933</a>  State tool should install to a temp dir and then only move it to actual runtime dir when the entire installation completes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Otherwise, if an error occurs during installation of one artifact, the entire runtime may be corrupted.