### PR TITLE
Fixed other integration tests that use `state init` with "python3" as a language.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -321,6 +321,8 @@ err_activate_output_build_in_progress:
   other: Platform project build is in progress. Please wait for a few minutes and try "Reactivate Runtime" option in "State Tool" menu
 err_unsupported_platform:
   other: "Unsupported platform: [NOTICE]{{.V0}}[/RESET]"
+err_detect_language:
+  other: Could not detect which language to use
 err_language_not_found:
   other: "Could not find language: [NOTICE]{{.V0}}@{{.V1}}[/RESET]"
 error_state_activate_copy_save:

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -25,7 +25,7 @@ var (
 // Checkpoint represents a collection of requirements
 type Checkpoint []*mono_models.Checkpoint
 
-// Language represents a langauge requirement
+// Language represents a language requirement
 type Language struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
@@ -49,6 +49,21 @@ func GetRequirement(commitID strfmt.UUID, namespace Namespace, requirement strin
 	return nil, nil
 }
 
+// getVersionFromConstraints attempts to determine a language version from a set of requirement
+// constraints.
+// For example, `state init --language python` creates a commit with the constraints
+// "python >=3.x.y,<3.x.y+1". In these cases, return 3.x.y.
+// For other cases, return an error.
+func getVersionFromConstraints(constraints mono_models.Constraints) (string, error) {
+	if len(constraints) != 2 {
+		return "", errs.New("Unrecognized constraint")
+	}
+	if constraints[0].Comparator != "gte" || constraints[1].Comparator != "lt" {
+		return "", errs.New("Unrecognized constraint")
+	}
+	return constraints[0].Version, nil
+}
+
 // FetchLanguagesForCommit fetches a list of language names for the given commit
 func FetchLanguagesForCommit(commitID strfmt.UUID) ([]Language, error) {
 	checkpoint, _, err := FetchCheckpointForCommit(commitID)
@@ -59,10 +74,18 @@ func FetchLanguagesForCommit(commitID strfmt.UUID) ([]Language, error) {
 	languages := []Language{}
 	for _, requirement := range checkpoint {
 		if NamespaceMatch(requirement.Namespace, NamespaceLanguageMatch) {
-			languages = append(languages, Language{
+			lang := Language{
 				Name:    requirement.Requirement,
 				Version: requirement.VersionConstraint,
-			})
+			}
+			if lang.Version == "" {
+				version, err := getVersionFromConstraints(requirement.VersionConstraints)
+				if err != nil {
+					return nil, errs.Wrap(err, "Unable to determine commit's language version based on constraints")
+				}
+				lang.Version = version
+			}
+			languages = append(languages, lang)
 		}
 	}
 
@@ -189,7 +212,15 @@ func CheckpointToLanguage(requirements []*gqlModel.Requirement) (*Language, erro
 		if !NamespaceMatch(req.Namespace, NamespaceLanguageMatch) {
 			continue
 		}
-		lang, err := FetchLanguageByDetails(req.Requirement, req.VersionConstraint)
+		version := req.VersionConstraint
+		if version == "" {
+			var err error
+			version, err = getVersionFromConstraints(req.VersionConstraints)
+			if err != nil {
+				return nil, locale.WrapError(err, "err_detect_language")
+			}
+		}
+		lang, err := FetchLanguageByDetails(req.Requirement, version)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -311,10 +311,10 @@ func FetchPlatformByDetails(name, version string, word int) (*Platform, error) {
 func FetchLanguageForCommit(commitID strfmt.UUID) (*Language, error) {
 	langs, err := FetchLanguagesForCommit(commitID)
 	if err != nil {
-		return nil, err
+		return nil, locale.WrapError(err, "err_detect_language")
 	}
 	if len(langs) == 0 {
-		return nil, locale.WrapError(err, "err_langfromcommit_zero", "Could not detect which language to use.")
+		return nil, locale.NewError("err_detect_language")
 	}
 	return &langs[0], nil
 }

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -297,7 +297,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_import() {
 	username := ts.CreateNewUser()
 	namespace := fmt.Sprintf("%s/%s", username, "Python3")
 
-	cp := ts.Spawn("init", "--language", "python3", namespace, ts.Dirs.Work)
+	cp := ts.Spawn("init", "--language", "python", namespace, ts.Dirs.Work)
 	cp.ExpectLongString("successfully initialized")
 	cp.ExpectExitCode(0)
 

--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -39,8 +39,8 @@ func (suite *PushIntegrationTestSuite) SetupSuite() {
 	suite.extraPackage = "JSON"
 	suite.extraPackage2 = "DateTime"
 	if runtime.GOOS == "darwin" {
-		suite.language = "python3"
-		suite.languageFull = "python3"
+		suite.language = "python"
+		suite.languageFull = "python"
 		suite.baseProject = "ActiveState-CLI/small-python"
 		suite.extraPackage = "trender"
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1963" title="DX-1963" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1963</a>  Nightlies failure: TestPackageIntegrationTestSuite/TestPackage_import
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

It was changed to just "python".

Also do some simple language inferring. This fixes `state import` as well as showing the version number.