### PR TITLE
Postpone uninstalling of outdated artifacts until the last minute.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1734,6 +1734,8 @@ artifact_download_failed:
   other: Failed to download artifact {{.V0}} ({{.V1}})
 artifact_setup_failed:
   other: Failed to install artifact {{.V0}} ({{.V1}})
+err_stored_artifacts:
+  other: Could not unmarshal stored artifacts, your install may be corrupted.
 err_fetch_branch:
   other: "Could not get branch [NOTICE]{{.V0}}[/RESET] for project"
 err_refresh_runtime:

--- a/pkg/platform/runtime/setup/implementations/camel/runtime.go
+++ b/pkg/platform/runtime/setup/implementations/camel/runtime.go
@@ -1,10 +1,13 @@
 package camel
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
-	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/pkg/platform/api/headchef/headchef_models"
 	"github.com/ActiveState/cli/pkg/platform/runtime/artifact"
 	"github.com/ActiveState/cli/pkg/platform/runtime/store"
@@ -23,8 +26,18 @@ func (s *Setup) DeleteOutdatedArtifacts(_ artifact.ArtifactChangeset, _, already
 	if len(alreadyInstalled) != 0 {
 		return nil
 	}
-	if err := os.RemoveAll(s.store.InstallPath()); err != nil {
-		multilog.Error("Error removing previous camel installation: %v", err)
+	files, err := ioutil.ReadDir(s.store.InstallPath())
+	if err != nil {
+		return errs.Wrap(err, "Error reading previous camel installation")
+	}
+	for _, file := range files {
+		if file.Name() == constants.LocalRuntimeTempDirectory || file.Name() == constants.LocalRuntimeEnvironmentDirectory {
+			continue // do not delete files that do not belong to previous installation
+		}
+		err = os.Remove(filepath.Join(s.store.InstallPath(), file.Name()))
+		if err != nil {
+			return errs.Wrap(err, "Error removing previous camel installation")
+		}
 	}
 	return nil
 }

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -985,6 +985,8 @@ func (s *Setup) deleteOutdatedArtifacts(setup Setuper, changedArtifacts artifact
 
 	err = setup.DeleteOutdatedArtifacts(changedArtifacts, storedArtifacts, alreadyInstalled)
 	if err != nil {
+		// This multilog is technically redundant and may be dropped after we can collect data on this error for a while as rollbar is not surfacing the returned error
+		// https://github.com/ActiveState/cli/pull/2620#discussion_r1256103647
 		multilog.Error("Could not delete outdated artifacts: %s", errs.JoinMessage(err))
 		return errs.Wrap(err, "Could not delete outdated artifacts")
 	}

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -985,11 +985,8 @@ func (s *Setup) deleteOutdatedArtifacts(setup Setuper, changedArtifacts artifact
 
 	err = setup.DeleteOutdatedArtifacts(changedArtifacts, storedArtifacts, alreadyInstalled)
 	if err != nil {
-		multilog.Error("Could not delete outdated artifacts: %v, falling back to removing everything", err)
-		err = os.RemoveAll(s.store.InstallPath())
-		if err != nil {
-			return errs.Wrap(err, "Failed to clean installation path")
-		}
+		multilog.Error("Could not delete outdated artifacts: %s", errs.JoinMessage(err))
+		return errs.Wrap(err, "Could not delete outdated artifacts")
 	}
 	return nil
 }

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -102,7 +102,7 @@ func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
 		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
 			"ACTIVESTATE_CLI_RUNTIME_SETUP_WAIT=true"),
 	)
-	time.Sleep(10 * time.Second)
+	time.Sleep(30 * time.Second)
 	cp.SendCtrlC() // cancel pull/update
 
 	cp = ts.SpawnCmd(pythonExe, "-c", `print(__import__('sys').version)`)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1933" title="DX-1933" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1933</a>  State tool should install to a temp dir and then only move it to actual runtime dir when the entire installation completes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
If outdated artifacts are deleted during the fetch and prepare stage, the runtime could become corrupted. Wait until just before installing updated artifacts.