### PR TITLE
Fixed inadvertent Linux installation path change.

### DIFF
--- a/internal/installation/paths_linux.go
+++ b/internal/installation/paths_linux.go
@@ -12,7 +12,7 @@ func installPathForBranch(branch string) (string, error) {
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}
-	return filepath.Join(home, ".ActiveState", "StateTool", branch), nil
+	return filepath.Join(home, ".local", "ActiveState", "StateTool", branch), nil
 }
 
 func defaultSystemInstallPath() (string, error) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2001" title="DX-2001" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2001</a>  Installation path is wrong 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
