### PR TITLE
Treat BuildPlanner errors are input errors

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -2067,3 +2067,5 @@ err_edit_local_checkouts:
   other: Could not update local checkouts
 err_edit_project_mapping:
   other: Could not update project mapping
+err_buildplanner:
+  other: The Platform failed to plan the build for this project.

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -2067,5 +2067,3 @@ err_edit_local_checkouts:
   other: Could not update local checkouts
 err_edit_project_mapping:
   other: Could not update project mapping
-err_buildplanner:
-  other: The Platform failed to plan the build for this project.

--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -83,13 +83,15 @@ func (o Operation) String() string {
 }
 
 type BuildPlannerError struct {
-	Wrapped          error
 	ValidationErrors []string
 	IsTransient      bool
 }
 
-func (e *BuildPlannerError) Unwrap() error {
-	return e.Wrapped
+// InputError returns true as we want to treat all build planner errors as input errors
+// and not report them to Rollbar. We defer the responsibility of logging these errors
+// to the maintainers of the build planner.
+func (e *BuildPlannerError) InputError() bool {
+	return true
 }
 
 func (e *BuildPlannerError) Error() string {
@@ -185,7 +187,6 @@ func (b *BuildPlanByProject) Build() (*Build, error) {
 			}
 		}
 		return nil, &BuildPlannerError{
-			Wrapped:          locale.NewInputError("err_buildplanner"),
 			ValidationErrors: errs,
 			IsTransient:      isTransient,
 		}
@@ -263,7 +264,6 @@ func (b *BuildPlanByCommit) Build() (*Build, error) {
 			}
 		}
 		return nil, &BuildPlannerError{
-			Wrapped:          locale.NewInputError("err_buildplanner"),
 			ValidationErrors: errs,
 			IsTransient:      isTransient,
 		}

--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -83,8 +83,13 @@ func (o Operation) String() string {
 }
 
 type BuildPlannerError struct {
+	Wrapped          error
 	ValidationErrors []string
 	IsTransient      bool
+}
+
+func (e *BuildPlannerError) Unwrap() error {
+	return e.Wrapped
 }
 
 func (e *BuildPlannerError) Error() string {
@@ -180,6 +185,7 @@ func (b *BuildPlanByProject) Build() (*Build, error) {
 			}
 		}
 		return nil, &BuildPlannerError{
+			Wrapped:          locale.NewInputError("err_buildplanner"),
 			ValidationErrors: errs,
 			IsTransient:      isTransient,
 		}
@@ -257,6 +263,7 @@ func (b *BuildPlanByCommit) Build() (*Build, error) {
 			}
 		}
 		return nil, &BuildPlannerError{
+			Wrapped:          locale.NewInputError("err_buildplanner"),
 			ValidationErrors: errs,
 			IsTransient:      isTransient,
 		}

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -305,7 +305,6 @@ func (bp *BuildPlanner) StageCommit(params StageCommitParams) (strfmt.UUID, erro
 			}
 		}
 		return "", &bpModel.BuildPlannerError{
-			Wrapped:          locale.NewInputError("err_buildplanner"),
 			ValidationErrors: errs,
 			IsTransient:      isTransient,
 		}

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -305,6 +305,7 @@ func (bp *BuildPlanner) StageCommit(params StageCommitParams) (strfmt.UUID, erro
 			}
 		}
 		return "", &bpModel.BuildPlannerError{
+			Wrapped:          locale.NewInputError("err_buildplanner"),
 			ValidationErrors: errs,
 			IsTransient:      isTransient,
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2000" title="DX-2000" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2000</a>  We treat buildplan errors as input errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This PR adds back the `Wrapped` field to the `BuildPlanError` type. When we report errors we unwrap the error and check to see if any of the underlying errors are input errors, if they are we do not report.

This is only added when we encounter a planning error as other errors before this occur when a commit or project could not be found.