### PR TITLE
Drop redundant updateRequirement method with conflicting behaviour

### DIFF
--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -257,7 +257,10 @@ func (bp *BuildPlanner) StageCommit(params StageCommitParams) (strfmt.UUID, erro
 		}
 
 		if params.RequirementVersion != "" {
-			requirement.VersionRequirement = []bpModel.VersionRequirement{{bpModel.VersionRequirementComparatorKey: bpModel.ComparatorEQ, bpModel.VersionRequirementVersionKey: params.RequirementVersion}}
+			requirement.VersionRequirement = []bpModel.VersionRequirement{{
+				bpModel.VersionRequirementComparatorKey: bpModel.ComparatorEQ,
+				bpModel.VersionRequirementVersionKey:    params.RequirementVersion,
+			}}
 		}
 
 		err = expression.UpdateRequirement(params.Operation, requirement)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2020" title="DX-2020" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2020</a>  Package install attempt with NON existent version not generated any errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

