### PR TITLE
Save existing refresh token during dcag instead of creating new one

### DIFF
--- a/pkg/cmdlets/auth/login.go
+++ b/pkg/cmdlets/auth/login.go
@@ -247,10 +247,10 @@ func AuthenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 		out.Notice(locale.Tr("err_browser_open", *response.VerificationURIComplete))
 	}
 
-	var refreshToken string
+	var apiKey string
 	if !response.Nopoll {
 		// Wait for user to complete authentication
-		refreshToken, err = auth.AuthenticateWithDevicePolling(strfmt.UUID(*response.DeviceCode), time.Duration(response.Interval)*time.Second)
+		apiKey, err = auth.AuthenticateWithDevicePolling(strfmt.UUID(*response.DeviceCode), time.Duration(response.Interval)*time.Second)
 		if err != nil {
 			return locale.WrapError(err, "err_auth_device")
 		}
@@ -265,13 +265,13 @@ func AuthenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 				return errs.Wrap(err, "Prompt failed")
 			}
 		}
-		refreshToken, err = auth.AuthenticateWithDevice(strfmt.UUID(*response.DeviceCode))
+		apiKey, err = auth.AuthenticateWithDevice(strfmt.UUID(*response.DeviceCode))
 		if err != nil {
 			return locale.WrapError(err, "err_auth_device")
 		}
 	}
 
-	if err := auth.SaveToken(refreshToken); err != nil {
+	if err := auth.SaveToken(apiKey); err != nil {
 		return locale.WrapError(err, "err_auth_token", "Failed to create token after authenticating with browser.")
 	}
 

--- a/pkg/cmdlets/auth/login.go
+++ b/pkg/cmdlets/auth/login.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	secretsapi "github.com/ActiveState/cli/pkg/platform/api/secrets"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
-	"github.com/ActiveState/cli/pkg/platform/model/auth"
+	model "github.com/ActiveState/cli/pkg/platform/model/auth"
 	"github.com/go-openapi/strfmt"
 )
 
@@ -30,7 +30,14 @@ func Authenticate(cfg keypairs.Configurable, out output.Outputer, prompt prompt.
 }
 
 // AuthenticateWithInput will prompt the user for authentication if the input doesn't already provide it
-func AuthenticateWithInput(username, password, totp string, nonInteractive bool, cfg keypairs.Configurable, out output.Outputer, prompt prompt.Prompter, auth *authentication.Auth) error {
+func AuthenticateWithInput(
+	username, password, totp string,
+	nonInteractive bool,
+	cfg keypairs.Configurable,
+	out output.Outputer,
+	prompt prompt.Prompter,
+	auth *authentication.Auth,
+) error {
 	logging.Debug("Authenticating with input")
 
 	credentials := &mono_models.Credentials{Username: username, Password: password, Totp: totp}
@@ -240,9 +247,11 @@ func AuthenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 		out.Notice(locale.Tr("err_browser_open", *response.VerificationURIComplete))
 	}
 
+	var refreshToken string
 	if !response.Nopoll {
 		// Wait for user to complete authentication
-		if err := auth.AuthenticateWithDevicePolling(strfmt.UUID(*response.DeviceCode), time.Duration(response.Interval)*time.Second); err != nil {
+		refreshToken, err = auth.AuthenticateWithDevicePolling(strfmt.UUID(*response.DeviceCode), time.Duration(response.Interval)*time.Second)
+		if err != nil {
 			return locale.WrapError(err, "err_auth_device")
 		}
 	} else {
@@ -256,12 +265,13 @@ func AuthenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 				return errs.Wrap(err, "Prompt failed")
 			}
 		}
-		if err := auth.AuthenticateWithDevice(strfmt.UUID(*response.DeviceCode)); err != nil {
+		refreshToken, err = auth.AuthenticateWithDevice(strfmt.UUID(*response.DeviceCode))
+		if err != nil {
 			return locale.WrapError(err, "err_auth_device")
 		}
 	}
 
-	if err := auth.CreateToken(); err != nil {
+	if err := auth.SaveToken(refreshToken); err != nil {
 		return locale.WrapError(err, "err_auth_token", "Failed to create token after authenticating with browser.")
 	}
 

--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -233,10 +233,10 @@ func (s *Auth) AuthenticateWithModel(credentials *mono_models.Credentials) error
 	return nil
 }
 
-func (s *Auth) AuthenticateWithDevice(deviceCode strfmt.UUID) (refreshToken string, err error) {
+func (s *Auth) AuthenticateWithDevice(deviceCode strfmt.UUID) (apiKey string, err error) {
 	logging.Debug("AuthenticateWithDevice")
 
-	jwtToken, refToken, err := model.CheckDeviceAuthorization(deviceCode)
+	jwtToken, apiKeyToken, err := model.CheckDeviceAuthorization(deviceCode)
 	if err != nil {
 		return "", errs.Wrap(err, "Authorization failed")
 	}
@@ -249,7 +249,7 @@ func (s *Auth) AuthenticateWithDevice(deviceCode strfmt.UUID) (refreshToken stri
 		return "", errs.Wrap(err, "Storing JWT failed")
 	}
 
-	return refToken.Token, nil
+	return apiKeyToken.Token, nil
 }
 
 func (s *Auth) AuthenticateWithDevicePolling(deviceCode strfmt.UUID, interval time.Duration) (string, error) {

--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -233,39 +233,38 @@ func (s *Auth) AuthenticateWithModel(credentials *mono_models.Credentials) error
 	return nil
 }
 
-func (s *Auth) AuthenticateWithDevice(deviceCode strfmt.UUID) error {
+func (s *Auth) AuthenticateWithDevice(deviceCode strfmt.UUID) (refreshToken string, err error) {
 	logging.Debug("AuthenticateWithDevice")
 
-	token, err := model.CheckDeviceAuthorization(deviceCode)
+	jwtToken, refToken, err := model.CheckDeviceAuthorization(deviceCode)
 	if err != nil {
-		return errs.Wrap(err, "Authorization failed")
+		return "", errs.Wrap(err, "Authorization failed")
 	}
 
-	if token == nil {
-		return errNotYetGranted
+	if jwtToken == nil {
+		return "", errNotYetGranted
 	}
 
-	if err := s.updateSession(token); err != nil {
-		return errs.Wrap(err, "Storing JWT failed")
+	if err := s.updateSession(jwtToken); err != nil {
+		return "", errs.Wrap(err, "Storing JWT failed")
 	}
 
-	return nil
-
+	return refToken.Token, nil
 }
 
-func (s *Auth) AuthenticateWithDevicePolling(deviceCode strfmt.UUID, interval time.Duration) error {
+func (s *Auth) AuthenticateWithDevicePolling(deviceCode strfmt.UUID, interval time.Duration) (string, error) {
 	logging.Debug("AuthenticateWithDevicePolling, polling: %v", interval.String())
 	for start := time.Now(); time.Since(start) < 5*time.Minute; {
-		err := s.AuthenticateWithDevice(deviceCode)
+		token, err := s.AuthenticateWithDevice(deviceCode)
 		if err == nil {
-			return nil
+			return token, nil
 		} else if !errors.Is(err, errNotYetGranted) {
-			return errs.Wrap(err, "Device authentication failed")
+			return "", errs.Wrap(err, "Device authentication failed")
 		}
 		time.Sleep(interval) // then try again
 	}
 
-	return locale.NewInputError("err_auth_device_timeout")
+	return "", locale.NewInputError("err_auth_device_timeout")
 }
 
 // AuthenticateWithToken will try to authenticate using the given token

--- a/pkg/platform/model/auth/auth.go
+++ b/pkg/platform/model/auth/auth.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/api"
 	"github.com/ActiveState/cli/pkg/platform/api/mono"
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_client/oauth"
-	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
+	mms "github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	"github.com/go-openapi/strfmt"
 )
 
@@ -15,7 +15,7 @@ import (
 // returns the device code needed for authorization.
 // The user is subsequently required to visit the device code's URI and click the "Authorize"
 // button.
-func RequestDeviceAuthorization() (*mono_models.DeviceCode, error) {
+func RequestDeviceAuthorization() (*mms.DeviceCode, error) {
 	postParams := oauth.NewAuthDevicePostParams()
 	response, err := mono.Get().Oauth.AuthDevicePost(postParams)
 	if err != nil {
@@ -25,7 +25,7 @@ func RequestDeviceAuthorization() (*mono_models.DeviceCode, error) {
 	return response.Payload, nil
 }
 
-func CheckDeviceAuthorization(deviceCode strfmt.UUID) (*mono_models.JWT, error) {
+func CheckDeviceAuthorization(deviceCode strfmt.UUID) (jwt *mms.JWT, refreshToken *mms.NewToken, err error) {
 	getParams := oauth.NewAuthDeviceGetParams()
 	getParams.SetDeviceCode(deviceCode)
 
@@ -37,14 +37,14 @@ func CheckDeviceAuthorization(deviceCode strfmt.UUID) (*mono_models.JWT, error) 
 			switch *errorToken {
 			case oauth.AuthDeviceGetBadRequestBodyErrorAuthorizationPending, oauth.AuthDeviceGetBadRequestBodyErrorSlowDown:
 				logging.Debug("Authorization still pending")
-				return nil, nil
+				return nil, nil, nil
 			case oauth.AuthDeviceGetBadRequestBodyErrorExpiredToken:
-				return nil, locale.WrapInputError(err, "auth_device_timeout")
+				return nil, nil, locale.WrapInputError(err, "auth_device_timeout")
 			}
 		}
 
-		return nil, errs.Wrap(err, api.ErrorMessageFromPayload(err))
+		return nil, nil, errs.Wrap(err, api.ErrorMessageFromPayload(err))
 	}
 
-	return response.Payload.AccessToken, nil
+	return response.Payload.AccessToken, response.Payload.RefreshToken, nil
 }

--- a/pkg/platform/model/auth/auth.go
+++ b/pkg/platform/model/auth/auth.go
@@ -25,7 +25,7 @@ func RequestDeviceAuthorization() (*mms.DeviceCode, error) {
 	return response.Payload, nil
 }
 
-func CheckDeviceAuthorization(deviceCode strfmt.UUID) (jwt *mms.JWT, refreshToken *mms.NewToken, err error) {
+func CheckDeviceAuthorization(deviceCode strfmt.UUID) (jwt *mms.JWT, apiKey *mms.NewToken, err error) {
 	getParams := oauth.NewAuthDeviceGetParams()
 	getParams.SetDeviceCode(deviceCode)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1873" title="DX-1873" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1873</a>  state auth creates two apikeys
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

