### PR TITLE
`state init` and `state install` supports wildcard notation for language and package versions.

### DIFF
--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -225,7 +225,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 		return errs.Wrap(err, "Could not resolve requirement name and version")
 	}
 
-	requirements, err := versionStringToRequirements(version)
+	requirements, err := model.VersionStringToRequirements(version)
 	if err != nil {
 		return errs.Wrap(err, "Could not process version string into requirements")
 	}
@@ -410,20 +410,4 @@ func initializeProject() (*project.Project, error) {
 	}
 
 	return project.FromPath(target)
-}
-
-func versionStringToRequirements(version string) ([]bpModel.VersionRequirement, error) {
-	constraints, err := model.VersionStringToConstraints(version)
-	if err != nil {
-		return nil, errs.Wrap(err, "Unable to process version string into constraints")
-	}
-
-	requirements := make([]bpModel.VersionRequirement, len(constraints))
-	for i, constraint := range constraints {
-		requirements[i] = bpModel.VersionRequirement{
-			bpModel.VersionRequirementComparatorKey: constraint.Comparator,
-			bpModel.VersionRequirementVersionKey:    constraint.Version,
-		}
-	}
-	return requirements, nil
 }

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -225,12 +225,17 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 		return errs.Wrap(err, "Could not resolve requirement name and version")
 	}
 
+	requirements, err := versionStringToRequirements(version)
+	if err != nil {
+		return errs.Wrap(err, "Could not process version string into requirements")
+	}
+
 	params := model.StageCommitParams{
 		Owner:                pj.Owner(),
 		Project:              pj.Name(),
 		ParentCommit:         string(parentCommitID),
 		RequirementName:      name,
-		RequirementVersion:   version,
+		RequirementVersion:   requirements,
 		RequirementNamespace: ns,
 		Operation:            operation,
 		TimeStamp:            *latest,
@@ -405,4 +410,20 @@ func initializeProject() (*project.Project, error) {
 	}
 
 	return project.FromPath(target)
+}
+
+func versionStringToRequirements(version string) ([]bpModel.VersionRequirement, error) {
+	constraints, err := model.VersionStringToConstraints(version)
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to process version string into constraints")
+	}
+
+	requirements := make([]bpModel.VersionRequirement, len(constraints))
+	for i, constraint := range constraints {
+		requirements[i] = bpModel.VersionRequirement{
+			bpModel.VersionRequirementComparatorKey: constraint.Comparator,
+			bpModel.VersionRequirementVersionKey:    constraint.Version,
+		}
+	}
+	return requirements, nil
 }

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -139,7 +139,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		}
 	}
 
-	version, err := deriveVersion(lang, languageVersion)
+	version, err := deriveVersion(getKnownVersionsFromPlatform, lang, languageVersion)
 	if err != nil {
 		if inferred || !locale.IsInputError(err) {
 			return locale.WrapError(err, "err_init_lang", "", languageName, languageVersion)
@@ -238,6 +238,8 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 	return nil
 }
 
+type knownVersionsFunc func(language.Language) ([]string, error)
+
 func getKnownVersionsFromPlatform(lang language.Language) ([]string, error) {
 	pkgs, err := model.SearchIngredientsStrict(model.NewNamespaceLanguage(), lang.Requirement(), false, true)
 	if err != nil {
@@ -255,10 +257,7 @@ func getKnownVersionsFromPlatform(lang language.Language) ([]string, error) {
 	return knownVersions, nil
 }
 
-// Can be overridden in tests.
-var getKnownVersions func(language.Language) ([]string, error) = getKnownVersionsFromPlatform
-
-func deriveVersion(lang language.Language, version string) (string, error) {
+func deriveVersion(getKnownVersions knownVersionsFunc, lang language.Language, version string) (string, error) {
 	err := lang.Validate()
 	if err != nil {
 		return "", errs.Wrap(err, "Failed to validate language")

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -139,9 +139,9 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		}
 	}
 
-	err = verifyLangAndVersion(lang, languageVersion)
+	version, err := deriveVersion(lang, languageVersion)
 	if err != nil {
-		if inferred {
+		if inferred || !locale.IsInputError(err) {
 			return locale.WrapError(err, "err_init_lang", "", languageName, languageVersion)
 		} else {
 			return locale.WrapInputError(err, "err_init_lang", "", languageName, languageVersion)
@@ -186,7 +186,6 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		return err
 	}
 
-	version := deriveVersion(lang, languageVersion)
 	commitID, err := model.CommitInitial(model.HostPlatform, lang.Requirement(), version)
 	if err != nil {
 		return locale.WrapError(err, "err_init_commit", "Could not create initial commit")
@@ -239,60 +238,83 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 	return nil
 }
 
-func verifyLangAndVersion(lang language.Language, version string) error {
-	err := lang.Validate()
-	if err != nil {
-		return errs.Wrap(err, "Failed to validate language")
-	}
-
-	if version == "" {
-		return nil // nothing to verify
-	}
-
+func getKnownVersionsFromPlatform(lang language.Language) ([]string, error) {
 	pkgs, err := model.SearchIngredientsStrict(model.NewNamespaceLanguage(), lang.Requirement(), false, true)
 	if err != nil {
-		return locale.WrapError(err, "err_init_verify_language", "Inventory search failed unexpectedly")
+		return nil, locale.WrapError(err, "err_init_verify_language", "Inventory search failed unexpectedly")
 	}
 
 	if len(pkgs) == 0 {
-		return locale.NewInputError("err_init_language_not_found", "The selected language cannot be found")
+		return nil, locale.NewInputError("err_init_language_not_found", "The selected language cannot be found")
 	}
 
-	for _, pkg := range pkgs {
-		if strings.HasPrefix(pkg.Version, version) {
-			return nil
-		}
+	knownVersions := make([]string, len(pkgs))
+	for i, pkg := range pkgs {
+		knownVersions[i] = pkg.Version
 	}
-
-	return errs.AddTips(
-		locale.NewInputError(
-			"err_init_language_version_not_found",
-			"The selected version of the language cannot be found",
-		),
-		locale.Tl(
-			"version_not_found_check_format",
-			"Please ensure that the version format is valid.",
-		),
-	)
+	return knownVersions, nil
 }
 
-func deriveVersion(lang language.Language, version string) string {
-	if version != "" {
-		return version
-	}
+// Can be overridden in tests.
+var getKnownVersions func(language.Language) ([]string, error) = getKnownVersionsFromPlatform
 
-	langs, err := model.FetchSupportedLanguages(model.HostPlatform)
+func deriveVersion(lang language.Language, version string) (string, error) {
+	err := lang.Validate()
 	if err != nil {
-		multilog.Error("Failed to fetch supported languages (using hardcoded default version): %s", errs.JoinMessage(err))
-		return lang.RecommendedVersion()
+		return "", errs.Wrap(err, "Failed to validate language")
 	}
 
-	for _, l := range langs {
-		if lang.String() == l.Name || (lang == language.Python3 && l.Name == language.Python3.Requirement()) {
-			return l.DefaultVersion
+	if version == "" {
+		// Return default language.
+		langs, err := model.FetchSupportedLanguages(model.HostPlatform)
+		if err != nil {
+			multilog.Error("Failed to fetch supported languages (using hardcoded default version): %s", errs.JoinMessage(err))
+			return lang.RecommendedVersion(), nil
+		}
+
+		for _, l := range langs {
+			if lang.String() == l.Name || (lang == language.Python3 && l.Name == language.Python3.Requirement()) {
+				return l.DefaultVersion, nil
+			}
+		}
+
+		multilog.Error("Could not find requested language in fetched languages (using hardcoded default version): %s", lang)
+		return lang.RecommendedVersion(), nil
+	}
+
+	// Fetch known list of languages and verify the given version matches it, either exactly or partially.
+	knownVersions, err := getKnownVersions(lang)
+	if err != nil {
+		return "", errs.Wrap(err, "Unable to get known versions for language %s", lang.Requirement())
+	}
+
+	prefix := strings.Replace(strings.Replace(version, ".x", "", 1), ".X", "", 1) // strip any wildcard
+	validVersionPrefix := false
+	for _, knownVersion := range knownVersions {
+		if knownVersion == version {
+			return knownVersion, nil // e.g. python@3.10.10
+		} else if strings.HasPrefix(knownVersion, prefix) {
+			validVersionPrefix = true // e.g. python@3.10
+			break
 		}
 	}
 
-	multilog.Error("Could not find requested language in fetched languages (using hardcoded default version): %s", lang)
-	return lang.RecommendedVersion()
+	if !validVersionPrefix {
+		return "", errs.AddTips(
+			locale.NewInputError(
+				"err_init_language_version_not_found",
+				"The selected version of the language cannot be found",
+			),
+			locale.Tl(
+				"version_not_found_check_format",
+				"Please ensure that the version format is valid.",
+			),
+		)
+	}
+
+	if prefix == version {
+		return version + ".x", nil // not an exact match, e.g. python@3.10
+	}
+
+	return version, nil
 }

--- a/internal/runners/initialize/init_test.go
+++ b/internal/runners/initialize/init_test.go
@@ -1,0 +1,46 @@
+package initialize
+
+import (
+	"testing"
+
+	"github.com/ActiveState/cli/internal/language"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getKnownVersionsTest(lang language.Language) ([]string, error) {
+	return []string{"2.7.18.1", "3.10.12", "3.11.4"}, nil
+}
+
+func TestDeriveVersion(t *testing.T) {
+	getKnownVersions = getKnownVersionsTest
+
+	tests := []struct {
+		version string
+		want    string
+		wantErr bool
+	}{
+		// Exact version numbers.
+		{"2.7.18.1", "2.7.18.1", false},
+		{"3.10.12", "3.10.12", false},
+		// Partial version numbers.
+		{"2", "2.x", false},
+		{"3.10", "3.10.x", false},
+		// Wildcards.
+		{"3.10.x", "3.10.x", false},
+		{"2.X", "2.X", false},
+		// Unknown languages.
+		{"4", "", true},
+		{"3.9.x", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := deriveVersion(language.Python3, tt.version)
+		if !tt.wantErr {
+			require.NoError(t, err)
+		} else {
+			assert.Error(t, err)
+		}
+		assert.Equal(t, tt.want, got)
+	}
+}

--- a/internal/runners/initialize/init_test.go
+++ b/internal/runners/initialize/init_test.go
@@ -8,13 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getKnownVersionsTest(lang language.Language) ([]string, error) {
+func getKnownVersionsFromTest(lang language.Language) ([]string, error) {
 	return []string{"2.7.18.1", "3.10.12", "3.11.4"}, nil
 }
 
 func TestDeriveVersion(t *testing.T) {
-	getKnownVersions = getKnownVersionsTest
-
 	tests := []struct {
 		version string
 		want    string
@@ -35,7 +33,7 @@ func TestDeriveVersion(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got, err := deriveVersion(language.Python3, tt.version)
+		got, err := deriveVersion(getKnownVersionsFromTest, language.Python3, tt.version)
 		if !tt.wantErr {
 			require.NoError(t, err)
 		} else {

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -358,4 +359,45 @@ func processBuildPlannerError(bpErr error, fallbackMessage string) error {
 		}
 	}
 	return errs.Wrap(bpErr, fallbackMessage)
+}
+
+func isWildcardVersion(version string) bool {
+	return strings.Index(version, ".x") >= 0 || strings.Index(version, ".X") >= 0
+}
+
+func VersionStringToRequirements(version string) ([]bpModel.VersionRequirement, error) {
+	if !isWildcardVersion(version) {
+		return []bpModel.VersionRequirement{{
+			bpModel.VersionRequirementComparatorKey: "eq",
+			bpModel.VersionRequirementVersionKey:    version,
+		}}, nil // exact version
+	}
+
+	// Construct version constraints to be >= given version, and < given version's last part + 1.
+	// For example, given a version number of 3.10.x, constraints should be >= 3.10, < 3.11.
+	// Given 2.x, constraints should be >= 2, < 3.
+	requirements := []bpModel.VersionRequirement{}
+	parts := strings.Split(version, ".")
+	for i, part := range parts {
+		if part != "x" && part != "X" {
+			continue
+		}
+		if i == 0 {
+			return nil, locale.NewInputError("err_version_wildcard_start", "A version number cannot start with a wildcard")
+		}
+		requirements = append(requirements, bpModel.VersionRequirement{
+			bpModel.VersionRequirementComparatorKey: "gte",
+			bpModel.VersionRequirementVersionKey:    strings.Join(parts[:i], "."),
+		})
+		previousPart, err := strconv.Atoi(parts[i-1])
+		if err != nil {
+			return nil, locale.WrapInputError(err, "err_version_number_expected", "Version parts are expected to be numeric")
+		}
+		parts[i-1] = strconv.Itoa(previousPart + 1)
+		requirements = append(requirements, bpModel.VersionRequirement{
+			bpModel.VersionRequirementComparatorKey: "lt",
+			bpModel.VersionRequirementVersionKey:    strings.Join(parts[:i], "."),
+		})
+	}
+	return requirements, nil
 }

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -235,7 +235,7 @@ type StageCommitParams struct {
 	Project              string
 	ParentCommit         string
 	RequirementName      string
-	RequirementVersion   string
+	RequirementVersion   []bpModel.VersionRequirement
 	RequirementNamespace Namespace
 	Operation            bpModel.Operation
 	TimeStamp            strfmt.DateTime
@@ -256,15 +256,9 @@ func (bp *BuildPlanner) StageCommit(params StageCommitParams) (strfmt.UUID, erro
 		}
 	} else {
 		requirement := bpModel.Requirement{
-			Namespace: params.RequirementNamespace.String(),
-			Name:      params.RequirementName,
-		}
-
-		if params.RequirementVersion != "" {
-			requirement.VersionRequirement = []bpModel.VersionRequirement{{
-				bpModel.VersionRequirementComparatorKey: bpModel.ComparatorEQ,
-				bpModel.VersionRequirementVersionKey:    params.RequirementVersion,
-			}}
+			Namespace:          params.RequirementNamespace.String(),
+			Name:               params.RequirementName,
+			VersionRequirement: params.RequirementVersion,
 		}
 
 		err = expression.UpdateRequirement(params.Operation, requirement)

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -55,6 +55,9 @@ func GetRequirement(commitID strfmt.UUID, namespace Namespace, requirement strin
 // "python >=3.x.y,<3.x.y+1". In these cases, return 3.x.y.
 // For other cases, return an error.
 func getVersionFromConstraints(constraints mono_models.Constraints) (string, error) {
+	if len(constraints) == 0 {
+		return "", nil // could be auto, or the Platform did not specify one
+	}
 	if len(constraints) != 2 {
 		return "", errs.New("Unrecognized constraint")
 	}

--- a/pkg/platform/model/vcs.go
+++ b/pkg/platform/model/vcs.go
@@ -565,7 +565,7 @@ func CommitInitial(hostPlatform string, langName, langVersion string) (strfmt.UU
 	var changes []*mono_models.CommitChangeEditable
 
 	if langName != "" {
-		versionConstraints, err := versionStringToConstraints(langVersion)
+		versionConstraints, err := VersionStringToConstraints(langVersion)
 		if err != nil {
 			return "", errs.Wrap(err, "Could not process version string into constraints")
 		}
@@ -604,7 +604,7 @@ func isWildcardVersion(version string) bool {
 	return strings.Index(version, "x") >= 0 || strings.Index(version, "X") >= 0
 }
 
-func versionStringToConstraints(version string) ([]*mono_models.Constraint, error) {
+func VersionStringToConstraints(version string) ([]*mono_models.Constraint, error) {
 	if !isWildcardVersion(version) {
 		return []*mono_models.Constraint{{Comparator: "eq", Version: version}}, nil // exact version
 	}

--- a/pkg/platform/model/vcs.go
+++ b/pkg/platform/model/vcs.go
@@ -445,20 +445,6 @@ func AddChangeset(parentCommitID strfmt.UUID, commitMessage string, changeset Ch
 	return res.Payload, nil
 }
 
-// AddCommit creates a new commit with a single change. This is lower level than Commit{X} functions.
-func AddCommit(parentCommitID strfmt.UUID, commitMessage string, operation Operation, namespace Namespace, requirement string, version string) (*mono_models.Commit, error) {
-	changeset := []*mono_models.CommitChangeEditable{
-		{
-			Operation:         string(operation),
-			Namespace:         namespace.String(),
-			Requirement:       requirement,
-			VersionConstraint: version,
-		},
-	}
-
-	return AddChangeset(parentCommitID, commitMessage, changeset)
-}
-
 func UpdateBranchForProject(pj ProjectInfo, commitID strfmt.UUID) error {
 	pjm, err := FetchProjectByName(pj.Owner(), pj.Name())
 	if err != nil {
@@ -526,29 +512,6 @@ func DeleteBranch(branchID strfmt.UUID) error {
 	return nil
 }
 
-// CommitPackage commits a package to an existing parent commit
-func CommitPackage(parentCommitID strfmt.UUID, operation Operation, packageName string, namespace Namespace, packageVersion string) (strfmt.UUID, error) {
-	var message string
-	switch operation {
-	case OperationAdded:
-		message = "commit_message_added_package"
-	case OperationUpdated:
-		message = "commit_message_updated_package"
-	case OperationRemoved:
-		message = "commit_message_removed_package"
-	}
-
-	commit, err := AddCommit(
-		parentCommitID, locale.Tr(message, packageName, packageVersion),
-		operation, namespace,
-		packageName, packageVersion,
-	)
-	if err != nil {
-		return "", err
-	}
-	return commit.CommitID, nil
-}
-
 // UpdateProjectBranchCommitByName updates the vcs branch for a project given by its namespace with a new commitID
 func UpdateProjectBranchCommit(pj ProjectInfo, commitID strfmt.UUID) error {
 	pjm, err := FetchProjectByName(pj.Owner(), pj.Name())
@@ -602,14 +565,9 @@ func CommitInitial(hostPlatform string, langName, langVersion string) (strfmt.UU
 	var changes []*mono_models.CommitChangeEditable
 
 	if langName != "" {
-		// Construct version constraints to be >= given version, and < given version's last part + 1.
-		// For example, given a version number of 3.10, constraints should be >= 3.10, < 3.11.
-		// Given 2, constraints should be >= 2, < 3.
-		versionConstraints := []*mono_models.Constraint{&mono_models.Constraint{Comparator: "gte", Version: langVersion}}
-		versionParts := strings.Split(langVersion, ".")
-		if lastPart, err := strconv.Atoi(versionParts[len(versionParts)-1]); err == nil {
-			versionParts[len(versionParts)-1] = strconv.Itoa(lastPart + 1)
-			versionConstraints = append(versionConstraints, &mono_models.Constraint{Comparator: "lt", Version: strings.Join(versionParts, ".")})
+		versionConstraints, err := versionStringToConstraints(langVersion)
+		if err != nil {
+			return "", errs.Wrap(err, "Could not process version string into constraints")
 		}
 		c := &mono_models.CommitChangeEditable{
 			Operation:          string(OperationAdded),
@@ -621,10 +579,9 @@ func CommitInitial(hostPlatform string, langName, langVersion string) (strfmt.UU
 	}
 
 	c := &mono_models.CommitChangeEditable{
-		Operation:         string(OperationAdded),
-		Namespace:         NewNamespacePlatform().String(),
-		Requirement:       platformID,
-		VersionConstraint: "",
+		Operation:   string(OperationAdded),
+		Namespace:   NewNamespacePlatform().String(),
+		Requirement: platformID,
 	}
 	changes = append(changes, c)
 
@@ -641,6 +598,38 @@ func CommitInitial(hostPlatform string, langName, langVersion string) (strfmt.UU
 	}
 
 	return res.Payload.CommitID, nil
+}
+
+func isWildcardVersion(version string) bool {
+	return strings.Index(version, "x") >= 0 || strings.Index(version, "X") >= 0
+}
+
+func versionStringToConstraints(version string) ([]*mono_models.Constraint, error) {
+	if !isWildcardVersion(version) {
+		return []*mono_models.Constraint{{Comparator: "eq", Version: version}}, nil // exact version
+	}
+
+	// Construct version constraints to be >= given version, and < given version's last part + 1.
+	// For example, given a version number of 3.10.x, constraints should be >= 3.10, < 3.11.
+	// Given 2.x, constraints should be >= 2, < 3.
+	constraints := []*mono_models.Constraint{}
+	parts := strings.Split(version, ".")
+	for i, part := range parts {
+		if part != "x" && part != "X" {
+			continue
+		}
+		if i == 0 {
+			return nil, locale.NewInputError("err_version_wildcard_start", "A version number cannot start with a wildcard")
+		}
+		constraints = append(constraints, &mono_models.Constraint{Comparator: "gte", Version: strings.Join(parts[:i], ".")})
+		previousPart, err := strconv.Atoi(parts[i-1])
+		if err != nil {
+			return nil, locale.WrapInputError(err, "err_version_number_expected", "Version parts are expected to be numeric")
+		}
+		parts[i-1] = strconv.Itoa(previousPart + 1)
+		constraints = append(constraints, &mono_models.Constraint{Comparator: "lt", Version: strings.Join(parts[:i], ".")})
+	}
+	return constraints, nil
 }
 
 type indexedCommits map[string]string // key == commit id / val == parent id
@@ -689,23 +678,6 @@ func (cs indexedCommits) countBetween(first, last string) (int, error) {
 	}
 
 	return ct, nil
-}
-
-// CommitRequirement commits a single requirement to the platform
-func CommitRequirement(commitID strfmt.UUID, op Operation, name, version string, word int, namespace Namespace) (strfmt.UUID, error) {
-	msgL10nKey := commitMessage(op, name, version, namespace, word)
-	msg := locale.Tr(msgL10nKey, name, version)
-
-	name, version, err := ResolveRequirementNameAndVersion(name, version, word, namespace)
-	if err != nil {
-		return "", errs.Wrap(err, "Could not resolve requirement name and version")
-	}
-
-	commit, err := AddCommit(commitID, msg, op, namespace, name, version)
-	if err != nil {
-		return "", errs.Wrap(err, "Could not add changeset")
-	}
-	return commit.CommitID, nil
 }
 
 func commitMessage(op Operation, name, version string, namespace Namespace, word int) string {

--- a/pkg/platform/model/vcs_test.go
+++ b/pkg/platform/model/vcs_test.go
@@ -152,7 +152,7 @@ func (suite *VCSTestSuite) TestVersionStringToConstraints() {
 	}
 
 	for _, tt := range tests {
-		got, err := VersionStringToConstraints(tt.version)
+		got, err := versionStringToConstraints(tt.version)
 		suite.NoError(err)
 		suite.Equal(tt.want, got)
 	}

--- a/pkg/platform/model/vcs_test.go
+++ b/pkg/platform/model/vcs_test.go
@@ -152,7 +152,7 @@ func (suite *VCSTestSuite) TestVersionStringToConstraints() {
 	}
 
 	for _, tt := range tests {
-		got, err := versionStringToConstraints(tt.version)
+		got, err := VersionStringToConstraints(tt.version)
 		suite.NoError(err)
 		suite.Equal(tt.want, got)
 	}

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -53,6 +53,7 @@ func (suite *InitIntegrationTestSuite) TestInit_DisambiguatePython() {
 func (suite *InitIntegrationTestSuite) TestInit_PartialVersions() {
 	suite.OnlyRunForTags(tagsuite.Init)
 	suite.runInitTest(false, "python@3.10", "python3")
+	suite.runInitTest(false, "python@3.10.x", "python3")
 	suite.runInitTest(false, "python@2", "python2")
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2011" title="DX-2011" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2011</a>  We can install requirements with wildcard version matching
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

