### PR TITLE
Allow installing overtop previous state tool as long as the branch matches

### DIFF
--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -49,7 +50,17 @@ func NewInstaller(cfg *config.Instance, out output.Outputer, payloadPath string,
 }
 
 func (i *Installer) Install() (rerr error) {
-	if err := fileutils.Touch(filepath.Join(i.path, installation.InstallDirMarker)); err != nil {
+	// Create install marker
+	installMarkerContents := installation.InstallMarkerMeta{
+		Branch:  constants.BranchName,
+		Version: constants.Version,
+	}
+	b, err := json.Marshal(installMarkerContents)
+	if err != nil {
+		return errs.Wrap(err, "Could not marshal install marker contents")
+	}
+
+	if err := fileutils.WriteFile(filepath.Join(i.path, installation.InstallDirMarker), b); err != nil {
 		return errs.Wrap(err, "Could not place install dir marker")
 	}
 
@@ -73,7 +84,7 @@ func (i *Installer) Install() (rerr error) {
 	}
 
 	// Detect if existing installation needs to be cleaned
-	err := detectCorruptedInstallDir(i.path)
+	err = detectCorruptedInstallDir(i.path)
 	if errors.Is(err, errCorruptedInstall) {
 		err = i.sanitizeInstallPath()
 		if err != nil {

--- a/internal/installation/paths.go
+++ b/internal/installation/paths.go
@@ -21,6 +21,11 @@ const (
 	InstallDirMarker = ".state_install_root"
 )
 
+type InstallMarkerMeta struct {
+	Branch  string `json:"branch"`
+	Version string `json:"version"`
+}
+
 func DefaultInstallPath() (string, error) {
 	return InstallPathForBranch(constants.BranchName)
 }

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -133,7 +133,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 			suite.assertCorrectVersion(ts, installDir, tt.Version, tt.Channel)
 			suite.DirExists(ts.Dirs.Config)
 
-			// Verify that we don't try to install it again
+			// Verify that can install overtop
 			if runtime.GOOS != "windows" {
 				cp = ts.SpawnCmdWithOpts("bash", e2e.WithArgs(argsPlain...))
 			} else {
@@ -141,7 +141,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 					e2e.AppendEnv("SHELL="),
 				)
 			}
-			cp.Expect("already installed")
+			cp.Expect("successfully installed")
 			cp.ExpectExitCode(0)
 		})
 	}

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -142,6 +142,8 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 				)
 			}
 			cp.Expect("successfully installed")
+			cp.WaitForInput()
+			cp.SendLine("exit")
 			cp.ExpectExitCode(0)
 		})
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2047" title="DX-2047" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2047</a>  If you run the installer and have a pre-existing installation it should not require --force if you are installing from the same branch.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
