### PR TITLE
Fix typo in hello cmd e2e test

### DIFF
--- a/test/integration/hello_int_example_test.go
+++ b/test/integration/hello_int_example_test.go
@@ -31,7 +31,7 @@ func (suite *HelloIntegrationTestSuite) TestHello() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("_hello", "")
-	cp.Expect("Cannot say Hello")
+	cp.Expect("Cannot say hello")
 	cp.Expect("No name provided")
 	cp.ExpectNotExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2053" title="DX-2053" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2053</a>  TestHello failing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
