### PR TITLE
Create buildscripts at request time if they do not exist.

### DIFF
--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -39,8 +39,8 @@ func getBuildExpression(proj *project.Project, customCommit *strfmt.UUID, auth *
 // commit with them in order to update the remote one.
 func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, auth *authentication.Auth) (synced bool, err error) {
 	logging.Debug("Synchronizing local build script using commit %s", commitID)
-	script, err := buildscript.NewScriptFromProjectDir(proj.Dir())
-	if err != nil && !buildscript.IsDoesNotExistError(err) {
+	script, err := buildscript.NewScriptFromProjectDir(proj.Dir(), auth)
+	if err != nil {
 		return false, errs.Wrap(err, "Could not get local build script")
 	}
 
@@ -89,7 +89,7 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		synced = true
 	}
 
-	if err := buildscript.UpdateOrCreate(proj.Dir(), expr); err != nil {
+	if err := buildscript.UpdateOrCreate(proj.Dir(), expr, auth); err != nil {
 		return false, errs.Wrap(err, "Could not update local build script.")
 	}
 

--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -39,7 +39,7 @@ func getBuildExpression(proj *project.Project, customCommit *strfmt.UUID, auth *
 // commit with them in order to update the remote one.
 func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, auth *authentication.Auth) (synced bool, err error) {
 	logging.Debug("Synchronizing local build script using commit %s", commitID)
-	script, err := buildscript.NewScriptFromProjectDir(proj.Dir(), auth)
+	script, err := buildscript.NewScriptFromProject(proj, auth)
 	if err != nil {
 		return false, errs.Wrap(err, "Could not get local build script")
 	}
@@ -89,7 +89,7 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		synced = true
 	}
 
-	if err := buildscript.UpdateOrCreate(proj.Dir(), expr, auth); err != nil {
+	if err := buildscript.Update(proj, expr, auth); err != nil {
 		return false, errs.Wrap(err, "Could not update local build script.")
 	}
 

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -285,7 +285,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 			return errs.Wrap(err, "Could not get remote build expr")
 		}
 
-		err = buildscript.UpdateOrCreate(pj.Dir(), expr, r.Auth)
+		err = buildscript.Update(pj, expr, r.Auth)
 		if err != nil {
 			return locale.WrapError(err, "err_update_build_script")
 		}

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -285,7 +285,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(requirementName, requ
 			return errs.Wrap(err, "Could not get remote build expr")
 		}
 
-		err = buildscript.UpdateOrCreate(pj.Dir(), expr)
+		err = buildscript.UpdateOrCreate(pj.Dir(), expr, r.Auth)
 		if err != nil {
 			return locale.WrapError(err, "err_update_build_script")
 		}

--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -219,8 +219,8 @@ func (p *Pull) performMerge(strategies *mono_models.MergeStrategies, remoteCommi
 // mergeBuildScript merges the local build script with the remote buildexpression (not script) for a
 // given UUID, performing the given merge strategy (e.g. from model.MergeCommit).
 func (p *Pull) mergeBuildScript(strategies *mono_models.MergeStrategies, remoteCommit strfmt.UUID) error {
-	// Verify we have a build script to merge.
-	script, err := buildscript.NewScriptFromProjectDir(p.project.Dir(), p.auth)
+	// Get the build script to merge.
+	script, err := buildscript.NewScriptFromProject(p.project, p.auth)
 	if err != nil {
 		return errs.Wrap(err, "Could not get local build script")
 	}
@@ -250,7 +250,7 @@ func (p *Pull) mergeBuildScript(strategies *mono_models.MergeStrategies, remoteC
 	}
 
 	// Write the merged build expression as a local build script.
-	return buildscript.UpdateOrCreate(p.project.Dir(), mergedExpr, p.auth)
+	return buildscript.Update(p.project, mergedExpr, p.auth)
 }
 
 func resolveRemoteProject(prj *project.Project, overwrite string) (*project.Namespaced, error) {

--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -220,7 +220,7 @@ func (p *Pull) performMerge(strategies *mono_models.MergeStrategies, remoteCommi
 // given UUID, performing the given merge strategy (e.g. from model.MergeCommit).
 func (p *Pull) mergeBuildScript(strategies *mono_models.MergeStrategies, remoteCommit strfmt.UUID) error {
 	// Verify we have a build script to merge.
-	script, err := buildscript.NewScriptFromProjectDir(p.project.Dir())
+	script, err := buildscript.NewScriptFromProjectDir(p.project.Dir(), p.auth)
 	if err != nil {
 		return errs.Wrap(err, "Could not get local build script")
 	}
@@ -250,7 +250,7 @@ func (p *Pull) mergeBuildScript(strategies *mono_models.MergeStrategies, remoteC
 	}
 
 	// Write the merged build expression as a local build script.
-	return buildscript.UpdateOrCreate(p.project.Dir(), mergedExpr)
+	return buildscript.UpdateOrCreate(p.project.Dir(), mergedExpr, p.auth)
 }
 
 func resolveRemoteProject(prj *project.Project, overwrite string) (*project.Namespaced, error) {

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -257,7 +257,7 @@ func TestRoundTrip(t *testing.T) {
 	tmpfile.Write([]byte(script.String()))
 	tmpfile.Close()
 
-	roundTripScript, err := newScriptFromFile(tmpfile.Name())
+	roundTripScript, err := newScriptFromFile(tmpfile.Name(), nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, script, roundTripScript)

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -257,7 +257,7 @@ func TestRoundTrip(t *testing.T) {
 	tmpfile.Write([]byte(script.String()))
 	tmpfile.Close()
 
-	roundTripScript, err := newScriptFromFile(tmpfile.Name(), nil)
+	roundTripScript, err := newScriptFromFile(tmpfile.Name(), "", "", nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, script, roundTripScript)

--- a/pkg/platform/runtime/buildscript/file.go
+++ b/pkg/platform/runtime/buildscript/file.go
@@ -9,37 +9,57 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/logging"
+	"github.com/ActiveState/cli/pkg/localcommit"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
+	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
-type DoesNotExistError struct{ error }
-
-func IsDoesNotExistError(err error) bool {
-	return errs.Matches(err, &DoesNotExistError{})
+func NewScriptFromProjectDir(dir string, auth *authentication.Auth) (*Script, error) {
+	return newScriptFromFile(filepath.Join(dir, constants.BuildScriptFileName), auth)
 }
 
-func NewScriptFromProjectDir(dir string) (*Script, error) {
-	return newScriptFromFile(filepath.Join(dir, constants.BuildScriptFileName))
-}
-
-func newScriptFromFile(path string) (*Script, error) {
-	data, err := fileutils.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, &DoesNotExistError{errs.New("Build script '%s' does not exist", path)}
-		}
+func newScriptFromFile(path string, auth *authentication.Auth) (*Script, error) {
+	if data, err := fileutils.ReadFile(path); err == nil {
+		return NewScript(data)
+	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, errs.Wrap(err, "Could not read build script")
 	}
-	return NewScript(data)
+
+	logging.Debug("Build script does not exist. Creating one.")
+	dir := filepath.Dir(path)
+	pjf, err := projectfile.FromPath(dir)
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to read the project")
+	}
+	commitId, err := localcommit.Get(dir)
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to get the local commit ID")
+	}
+	buildplanner := model.NewBuildPlannerModel(auth)
+	expr, err := buildplanner.GetBuildExpression(pjf.Owner(), pjf.Name(), commitId.String())
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to get the remote build expression")
+	}
+	script, err := NewScriptFromBuildExpression(expr)
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to convert build expression to build script")
+	}
+	err = fileutils.WriteFile(path, []byte(script.String()))
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to write build script")
+	}
+	return script, nil
 }
 
-func UpdateOrCreate(dir string, newExpr *buildexpression.BuildExpression) error {
+func UpdateOrCreate(dir string, newExpr *buildexpression.BuildExpression, auth *authentication.Auth) error {
 	// If a build script exists, check to see if an update is needed.
-	script, err := NewScriptFromProjectDir(dir)
-	if err != nil && !IsDoesNotExistError(err) {
+	script, err := NewScriptFromProjectDir(dir, auth)
+	if err != nil {
 		return errs.Wrap(err, "Could not read build script")
 	}
-	if script != nil && script.EqualsBuildExpression(newExpr) {
+	if script.EqualsBuildExpression(newExpr) {
 		return nil
 	}
 

--- a/pkg/platform/runtime/buildscript/file.go
+++ b/pkg/platform/runtime/buildscript/file.go
@@ -13,14 +13,24 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
-	"github.com/ActiveState/cli/pkg/projectfile"
+	"github.com/ActiveState/cli/pkg/project"
 )
 
-func NewScriptFromProjectDir(dir string, auth *authentication.Auth) (*Script, error) {
-	return newScriptFromFile(filepath.Join(dir, constants.BuildScriptFileName), auth)
+type targeter interface { // note: cannot import runtime/setup.Targeter due to import cycle
+	ProjectDir() string
+	Owner() string
+	Name() string
 }
 
-func newScriptFromFile(path string, auth *authentication.Auth) (*Script, error) {
+func NewScriptFromProject(proj *project.Project, auth *authentication.Auth) (*Script, error) {
+	return newScriptFromFile(filepath.Join(proj.Dir(), constants.BuildScriptFileName), proj.Owner(), proj.Name(), auth)
+}
+
+func NewScriptFromTarget(target targeter, auth *authentication.Auth) (*Script, error) {
+	return newScriptFromFile(filepath.Join(target.ProjectDir(), constants.BuildScriptFileName), target.Owner(), target.Name(), auth)
+}
+
+func newScriptFromFile(path, org, project string, auth *authentication.Auth) (*Script, error) {
 	if data, err := fileutils.ReadFile(path); err == nil {
 		return NewScript(data)
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -28,17 +38,12 @@ func newScriptFromFile(path string, auth *authentication.Auth) (*Script, error) 
 	}
 
 	logging.Debug("Build script does not exist. Creating one.")
-	dir := filepath.Dir(path)
-	pjf, err := projectfile.FromPath(dir)
-	if err != nil {
-		return nil, errs.Wrap(err, "Unable to read the project")
-	}
-	commitId, err := localcommit.Get(dir)
+	commitId, err := localcommit.Get(filepath.Dir(path))
 	if err != nil {
 		return nil, errs.Wrap(err, "Unable to get the local commit ID")
 	}
 	buildplanner := model.NewBuildPlannerModel(auth)
-	expr, err := buildplanner.GetBuildExpression(pjf.Owner(), pjf.Name(), commitId.String())
+	expr, err := buildplanner.GetBuildExpression(org, project, commitId.String())
 	if err != nil {
 		return nil, errs.Wrap(err, "Unable to get the remote build expression")
 	}
@@ -53,24 +58,27 @@ func newScriptFromFile(path string, auth *authentication.Auth) (*Script, error) 
 	return script, nil
 }
 
-func UpdateOrCreate(dir string, newExpr *buildexpression.BuildExpression, auth *authentication.Auth) error {
-	// If a build script exists, check to see if an update is needed.
-	script, err := NewScriptFromProjectDir(dir, auth)
-	if err != nil {
+func Update(proj *project.Project, newExpr *buildexpression.BuildExpression, auth *authentication.Auth) error {
+	if script, err := NewScriptFromProject(proj, auth); err == nil && !script.EqualsBuildExpression(newExpr) {
+		update(proj.Dir(), newExpr, auth)
+	} else if err != nil {
 		return errs.Wrap(err, "Could not read build script")
 	}
-	if script.EqualsBuildExpression(newExpr) {
-		return nil
-	}
+	return nil
+}
 
-	script, err = NewScriptFromBuildExpression(newExpr)
+func UpdateFromTarget(target targeter, newExpr *buildexpression.BuildExpression, auth *authentication.Auth) error {
+	return update(target.ProjectDir(), newExpr, auth)
+}
+
+func update(projectDir string, newExpr *buildexpression.BuildExpression, auth *authentication.Auth) error {
+	script, err := NewScriptFromBuildExpression(newExpr)
 	if err != nil {
 		return errs.Wrap(err, "Could not parse build expression")
 	}
 
 	logging.Debug("Writing build script")
-	err = fileutils.WriteFile(filepath.Join(dir, constants.BuildScriptFileName), []byte(script.String()))
-	if err != nil {
+	if err := fileutils.WriteFile(filepath.Join(projectDir, constants.BuildScriptFileName), []byte(script.String())); err != nil {
 		return errs.Wrap(err, "Could not write build script to file")
 	}
 	return nil

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -115,12 +115,9 @@ func (r *Runtime) validateCache() error {
 	}
 
 	// Check if local build script has changes that should be committed.
-	script, err := buildscript.NewScriptFromProjectDir(r.target.ProjectDir())
+	script, err := buildscript.NewScriptFromProjectDir(r.target.ProjectDir(), r.auth)
 	if err != nil {
-		if !buildscript.IsDoesNotExistError(err) {
-			return errs.Wrap(err, "Unable to get local build script")
-		}
-		return nil // build script does not exist, so there are no changes
+		return errs.Wrap(err, "Unable to get local build script")
 	}
 
 	commitID := r.target.CommitUUID().String()

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -115,7 +115,7 @@ func (r *Runtime) validateCache() error {
 	}
 
 	// Check if local build script has changes that should be committed.
-	script, err := buildscript.NewScriptFromTarget(r.target, r.auth)
+	script, err := buildscript.NewScriptFromProject(r.target, r.auth)
 	if err != nil {
 		return errs.Wrap(err, "Unable to get local build script")
 	}

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -115,7 +115,7 @@ func (r *Runtime) validateCache() error {
 	}
 
 	// Check if local build script has changes that should be committed.
-	script, err := buildscript.NewScriptFromProjectDir(r.target.ProjectDir(), r.auth)
+	script, err := buildscript.NewScriptFromTarget(r.target, r.auth)
 	if err != nil {
 		return errs.Wrap(err, "Unable to get local build script")
 	}

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -553,7 +553,7 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 	}
 
 	if s.target.ProjectDir() != "" {
-		if err := buildscript.UpdateOrCreate(s.target.ProjectDir(), buildResult.BuildExpression); err != nil {
+		if err := buildscript.UpdateOrCreate(s.target.ProjectDir(), buildResult.BuildExpression, s.auth); err != nil {
 			return nil, nil, errs.Wrap(err, "Could not save build script.")
 		}
 	}

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -553,7 +553,7 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 	}
 
 	if s.target.ProjectDir() != "" {
-		if err := buildscript.UpdateFromTarget(s.target, buildResult.BuildExpression, s.auth); err != nil {
+		if err := buildscript.Update(s.target, buildResult.BuildExpression, s.auth); err != nil {
 			return nil, nil, errs.Wrap(err, "Could not save build script.")
 		}
 	}

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -553,7 +553,7 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 	}
 
 	if s.target.ProjectDir() != "" {
-		if err := buildscript.UpdateOrCreate(s.target.ProjectDir(), buildResult.BuildExpression, s.auth); err != nil {
+		if err := buildscript.UpdateFromTarget(s.target, buildResult.BuildExpression, s.auth); err != nil {
 			return nil, nil, errs.Wrap(err, "Could not save build script.")
 		}
 	}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -210,6 +210,11 @@ func (p *Project) Dir() string {
 	return filepath.Dir(p.projectfile.Path())
 }
 
+// ProjectDir is an alias for Dir() to implement the runtime setup.Targeter interface.
+func (p *Project) ProjectDir() string {
+	return p.Dir()
+}
+
 func (p *Project) IsHeadless() bool {
 	match := projectfile.CommitURLRe.FindStringSubmatch(p.URL())
 	return len(match) > 1

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -210,7 +210,7 @@ func (p *Project) Dir() string {
 	return filepath.Dir(p.projectfile.Path())
 }
 
-// ProjectDir is an alias for Dir() to implement the runtime setup.Targeter interface.
+// ProjectDir is an alias for Dir() to satisfy interfaces that may also target the setup.Targeter interface.
 func (p *Project) ProjectDir() string {
 	return p.Dir()
 }

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -35,14 +35,14 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	cp.Expect("Checked out")
 	cp.ExpectExitCode(0)
 
-	_, err := buildscript.NewScriptFromProjectDir(ts.Dirs.Work)
+	_, err := buildscript.NewScriptFromProjectDir(ts.Dirs.Work, nil)
 	suite.Require().NoError(err) // verify validity
 
 	cp = ts.Spawn("commit")
 	cp.Expect("No change")
 	cp.ExpectExitCode(0)
 
-	_, err = buildscript.NewScriptFromProjectDir(ts.Dirs.Work)
+	_, err = buildscript.NewScriptFromProjectDir(ts.Dirs.Work, nil)
 	suite.Require().NoError(err) // verify validity
 
 	scriptPath := filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName)

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
+	"github.com/ActiveState/cli/pkg/project"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -35,14 +36,17 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	cp.Expect("Checked out")
 	cp.ExpectExitCode(0)
 
-	_, err := buildscript.NewScriptFromProjectDir(ts.Dirs.Work, nil)
+	proj, err := project.FromPath(ts.Dirs.Work)
+	suite.NoError(err, "Error loading project")
+
+	_, err = buildscript.NewScriptFromProject(proj, nil)
 	suite.Require().NoError(err) // verify validity
 
 	cp = ts.Spawn("commit")
 	cp.Expect("No change")
 	cp.ExpectExitCode(0)
 
-	_, err = buildscript.NewScriptFromProjectDir(ts.Dirs.Work, nil)
+	_, err = buildscript.NewScriptFromProject(proj, nil)
 	suite.Require().NoError(err) // verify validity
 
 	scriptPath := filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName)

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
+	"github.com/ActiveState/cli/pkg/project"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -149,14 +150,17 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	)
 	cp.ExpectExitCode(0)
 
-	_, err := buildscript.NewScriptFromProjectDir(ts.Dirs.Work, nil)
+	proj, err := project.FromPath(ts.Dirs.Work)
+	suite.NoError(err, "Error loading project")
+
+	_, err = buildscript.NewScriptFromProject(proj, nil)
 	suite.Require().NoError(err) // just verify it's a valid build script
 
 	cp = ts.Spawn("pull")
 	cp.Expect("Your local build script is different")
 	cp.ExpectNotExitCode(0)
 
-	_, err = buildscript.NewScriptFromProjectDir(ts.Dirs.Work, nil)
+	_, err = buildscript.NewScriptFromProject(proj, nil)
 	suite.Assert().Error(err)
 	bytes := fileutils.ReadFileUnsafe(filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName))
 	suite.Assert().Contains(string(bytes), "<<<<<<<", "No merge conflict markers are in build script")

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -149,14 +149,14 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	)
 	cp.ExpectExitCode(0)
 
-	_, err := buildscript.NewScriptFromProjectDir(ts.Dirs.Work)
+	_, err := buildscript.NewScriptFromProjectDir(ts.Dirs.Work, nil)
 	suite.Require().NoError(err) // just verify it's a valid build script
 
 	cp = ts.Spawn("pull")
 	cp.Expect("Your local build script is different")
 	cp.ExpectNotExitCode(0)
 
-	_, err = buildscript.NewScriptFromProjectDir(ts.Dirs.Work)
+	_, err = buildscript.NewScriptFromProjectDir(ts.Dirs.Work, nil)
 	suite.Assert().Error(err)
 	bytes := fileutils.ReadFileUnsafe(filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName))
 	suite.Assert().Contains(string(bytes), "<<<<<<<", "No merge conflict markers are in build script")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1997" title="DX-1997" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1997</a>  As a devx engineer I don't have to consider old state tool versions whenever working with local orders
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
