### PR TITLE
Guard against empty version requirement

### DIFF
--- a/pkg/platform/runtime/buildexpression/buildexpression.go
+++ b/pkg/platform/runtime/buildexpression/buildexpression.go
@@ -572,6 +572,10 @@ func (e *BuildExpression) addRequirement(requirement model.Requirement) error {
 
 	if requirement.VersionRequirement != nil {
 		for _, r := range requirement.VersionRequirement {
+			if r[RequirementComparatorKey] == "" || r[RequirementVersionKey] == "" {
+				continue
+			}
+
 			obj = append(obj, &Var{Name: RequirementVersionRequirementsKey, Value: &Value{List: &[]*Value{
 				{Object: &[]*Var{
 					{Name: RequirementComparatorKey, Value: &Value{Str: ptr.To(r[RequirementComparatorKey])}},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2054" title="DX-2054" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2054</a>  Build Expression includes empty version requirement
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I could not repro the error from the original ticket. From the rollbar report, the error did not occur frequently and hasn't happened in the last 4 days so it was likely from a test build. This error has also been updated on the Build Planner to be a parsing error, so we should see errors in the State Tool if it occurs. This PR adds an extra guard against the `VersionRequirement` field being populated when it shouldn't.