### PR TITLE
Integration tests that create users should use a better password.

### DIFF
--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -337,12 +337,12 @@ func (s *Session) LogoutUser() {
 	p.ExpectExitCode(0)
 }
 
-func (s *Session) CreateNewUser() string {
+func (s *Session) CreateNewUser() (string, string) {
 	uid, err := uuid.NewRandom()
 	require.NoError(s.t, err)
 
 	username := fmt.Sprintf("user-%s", uid.String()[0:8])
-	password := username
+	password := uid.String()[8:]
 	email := fmt.Sprintf("%s@test.tld", username)
 
 	p := s.Spawn(tagsuite.Auth, "signup", "--prompt")
@@ -363,7 +363,7 @@ func (s *Session) CreateNewUser() string {
 
 	s.users = append(s.users, username)
 
-	return username
+	return username, password
 }
 
 // NotifyProjectCreated indicates that the given project was created on the Platform and needs to

--- a/test/integration/auth_int_test.go
+++ b/test/integration/auth_int_test.go
@@ -33,9 +33,9 @@ func (suite *AuthIntegrationTestSuite) TestAuth() {
 	suite.OnlyRunForTags(tagsuite.Auth, tagsuite.Critical)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	username := ts.CreateNewUser()
+	username, password := ts.CreateNewUser()
 	ts.LogoutUser()
-	suite.interactiveLogin(ts, username)
+	suite.interactiveLogin(ts, username, password)
 	ts.LogoutUser()
 	suite.loginFlags(ts, username)
 	suite.ensureLogout(ts)
@@ -58,12 +58,12 @@ func (suite *AuthIntegrationTestSuite) TestAuthToken() {
 	suite.ensureLogout(ts)
 }
 
-func (suite *AuthIntegrationTestSuite) interactiveLogin(ts *e2e.Session, username string) {
+func (suite *AuthIntegrationTestSuite) interactiveLogin(ts *e2e.Session, username, password string) {
 	cp := ts.Spawn(tagsuite.Auth, "--prompt")
 	cp.Expect("username:")
 	cp.Send(username)
 	cp.Expect("password:")
-	cp.Send(username)
+	cp.Send(password)
 	cp.Expect("logged in", 40*time.Second)
 	cp.ExpectExitCode(0)
 

--- a/test/integration/fork_int_test.go
+++ b/test/integration/fork_int_test.go
@@ -26,7 +26,7 @@ func (suite *ForkIntegrationTestSuite) TestFork() {
 	ts := e2e.New(suite.T(), false)
 	defer suite.cleanup(ts)
 
-	username := ts.CreateNewUser()
+	username, _ := ts.CreateNewUser()
 
 	cp := ts.Spawn("fork", "ActiveState-CLI/Python3", "--name", "Test-Python3", "--org", username)
 	cp.Expect("fork has been successfully created")

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -294,7 +294,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_import() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	username := ts.CreateNewUser()
+	username, _ := ts.CreateNewUser()
 	namespace := fmt.Sprintf("%s/%s", username, "Python3")
 
 	cp := ts.Spawn("init", "--language", "python", namespace, ts.Dirs.Work)
@@ -375,7 +375,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_operation() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	username := ts.CreateNewUser()
+	username, _ := ts.CreateNewUser()
 	namespace := fmt.Sprintf("%s/%s", username, "python3-pkgtest")
 
 	cp := ts.Spawn("fork", "ActiveState-CLI/Packages", "--org", username, "--name", "python3-pkgtest")

--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -158,7 +158,7 @@ func (suite *PushIntegrationTestSuite) TestPush_NoPermission_NewProject() {
 	suite.OnlyRunForTags(tagsuite.Push)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	username := ts.CreateNewUser()
+	username, _ := ts.CreateNewUser()
 	pname := strutils.UUID()
 
 	cp := ts.SpawnWithOpts(e2e.WithArgs("activate", suite.baseProject, "--path", ts.Dirs.Work))

--- a/test/integration/vscode_int_test.go
+++ b/test/integration/vscode_int_test.go
@@ -17,7 +17,7 @@ func (suite *PushIntegrationTestSuite) TestInitAndPush_VSCode() {
 
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	username := ts.CreateNewUser()
+	username, _ := ts.CreateNewUser()
 
 	namespace := fmt.Sprintf("%s/%s", username, "Perl")
 	cp := ts.Spawn(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2078" title="DX-2078" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2078</a>  Nightly failure: Signup-related tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Passwords can no longer contain usernames.