### PR TITLE
Fix panic in buildexpression parser

### DIFF
--- a/pkg/platform/runtime/buildexpression/buildexpression.go
+++ b/pkg/platform/runtime/buildexpression/buildexpression.go
@@ -269,7 +269,11 @@ func newAp(path []string, m map[string]interface{}) (*Ap, error) {
 	var name string
 	var argsInterface interface{}
 	for key, value := range m {
-		if isAp(path, value.(map[string]interface{})) {
+		valueMap, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if isAp(path, valueMap) {
 			name = key
 			argsInterface = value
 			break


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2089" title="DX-2089" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2089</a>  build expression: Panic: interface conversion: interface {} is float64, not map[string]interface
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
