### PR TITLE
Lock down loop variables for use in goroutine closures.

### DIFF
--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -909,13 +909,15 @@ func (s *Setup) fetchAndInstallArtifactsFromDir(installFunc artifactInstaller) (
 			installedArtifacts[i] = artifactID
 
 			// Submit the artifact for setup and install.
-			wp.Submit(func() {
-				as := alternative.NewArtifactSetup(artifactID, s.store) // offline installer artifacts are in this format
-				err = installFunc(artifactID, filename, as)
-				if err != nil {
-					errors <- locale.WrapError(err, "artifact_setup_failed", "", artifactID.String(), "")
-				}
-			})
+			func(filename string, artifactID strfmt.UUID) {
+				wp.Submit(func() {
+					as := alternative.NewArtifactSetup(artifactID, s.store) // offline installer artifacts are in this format
+					err = installFunc(artifactID, filename, as)
+					if err != nil {
+						errors <- locale.WrapError(err, "artifact_setup_failed", "", artifactID.String(), "")
+					}
+				})
+			}(filename, artifactID) // avoid referencing loop variables inside goroutine closures
 		}
 
 		wp.StopWait()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2094" title="DX-2094" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2094</a>  Runtime setup from artifact directory should wrap workerpool.Submit() function in a closure call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Otherwise the installFunc will get confused and start referencing the wrong artifact IDs.

This is defensive programming in the event this is refactored down the road.