### PR TITLE
Support number values in buildscripts.

### DIFF
--- a/pkg/platform/runtime/buildscript/buildexpression.go
+++ b/pkg/platform/runtime/buildscript/buildexpression.go
@@ -113,6 +113,9 @@ func newValue(valueInterface interface{}, preferIdent bool) (*Value, error) {
 			value.Str = ptr.To(string(b))
 		}
 
+	case float64:
+		value.Number = ptr.To(v)
+
 	default:
 		// An empty value is interpreted as JSON null.
 		value.Null = &Null{}

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -3,6 +3,7 @@ package buildscript
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -28,6 +29,7 @@ type Value struct {
 	FuncCall *FuncCall `parser:"@@"`
 	List     *[]*Value `parser:"| '[' (@@ (',' @@)* ','?)? ']'"`
 	Str      *string   `parser:"| @String"`
+	Number   *float64  `parser:"| (@Float | @Int)"`
 	Null     *Null     `parser:"| @@"`
 
 	Assignment *Assignment    `parser:"| @@"`                        // only in FuncCall
@@ -108,6 +110,9 @@ func (v *Value) String() string {
 
 	case v.Str != nil:
 		return *v.Str
+
+	case v.Number != nil:
+		return strconv.FormatFloat(*v.Number, 'G', -1, 64)
 
 	case v.Null != nil:
 		return "null"

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -112,7 +112,7 @@ func (v *Value) String() string {
 		return *v.Str
 
 	case v.Number != nil:
-		return strconv.FormatFloat(*v.Number, 'G', -1, 64)
+		return strconv.FormatFloat(*v.Number, 'G', -1, 64) // 64-bit float with minimum digits on display
 
 	case v.Null != nil:
 		return "null"

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -167,7 +167,8 @@ const example = `let:
           }
         ]
       }
-    ]
+    ],
+    solver_version = 0
   )
 in:
   runtime`
@@ -207,6 +208,9 @@ func TestExample(t *testing.T) {
 									}}},
 								}},
 							}},
+						}},
+						{Assignment: &Assignment{
+							"solver_version", &Value{Number: ptr.To(float64(0))},
 						}},
 					}},
 				}},

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -54,6 +54,8 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 		return json.Marshal(list)
 	case v.Str != nil:
 		return json.Marshal(strings.Trim(*v.Str, `"`))
+	case v.Number != nil:
+		return json.Marshal(*v.Number)
 	case v.Null != nil:
 		return json.Marshal(nil)
 	case v.Assignment != nil:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2106" title="DX-2106" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2106</a>  Nightly failure: TestPullIntegrationTestSuite/TestPull_Merge
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

A recent change to fix buildexpression parser errors (supporting ints/floats) bubbled up to buildscripts, so now they have to support ints/floats. Whenever we get around to unifying their datastructures, issues like this should go away. For now, we have to manually intercede.
