### PR TITLE
Improve messaging around failed installations possibly being caused by antivirus false-positives.

### DIFF
--- a/internal/installation/paths.go
+++ b/internal/installation/paths.go
@@ -26,6 +26,12 @@ type InstallMarkerMeta struct {
 	Version string `json:"version"`
 }
 
+type StateExeDoesNotExistError struct{ *errs.WrapperError }
+
+func IsStateExeDoesNotExistError(err error) bool {
+	return errs.Matches(err, &StateExeDoesNotExistError{})
+}
+
 func DefaultInstallPath() (string, error) {
 	return InstallPathForBranch(constants.BranchName)
 }
@@ -84,7 +90,7 @@ func InstallPathFromReference(dir string) (string, error) {
 
 	stateExe := filepath.Join(binPath, cmdName)
 	if !fileutils.TargetExists(stateExe) {
-		return "", errs.New("Installation bin directory does not contain %s", stateExe)
+		return "", &StateExeDoesNotExistError{errs.New("Installation bin directory does not contain %s", stateExe)}
 	}
 
 	return filepath.Dir(binPath), nil

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1996,7 +1996,7 @@ err_autostart_app:
   other: Could not create new autostart app
 err_install_state_exe_does_not_exist:
   other: |
-    Could not install State Tool. One or more of the installed executables appears to have been deleted during installation. Please check with your antivirus to see if it might’ve triggered a false-positive.
+    Could not install State Tool. One or more of the installed executables appears to have been deleted during installation. Please check with your antivirus to see if it might have triggered a false-positive.
 
     Please consider letting us know what antivirus you are running so that we can address this false-positive: [ACTIONABLE]{{.V0}}[/RESET].
 

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1994,6 +1994,13 @@ svcctl_file_not_found:
     If this problem persists please report it on our forums: [ACTIONABLE]{{.V0}}[/RESET]
 err_autostart_app:
   other: Could not create new autostart app
+err_install_state_exe_does_not_exist:
+  other: |
+    Could not install State Tool. One or more of the installed executables appears to have been deleted during installation. Please check with your antivirus to see if it might’ve triggered a false-positive.
+
+    Please consider letting us know what antivirus you are running so that we can address this false-positive: [ACTIONABLE]{{.V0}}[/RESET].
+
+    Note the source code of the State Tool is open source, and you can review it yourself should you have concerns: [ACTIONABLE]https://github.com/ActiveState/cli[/RESET]
 install_remote_title:
   other: This will install the State Tool
 err_already_checked_out:

--- a/internal/runners/prepare/prepare.go
+++ b/internal/runners/prepare/prepare.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/globaldefault"
+	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/installation/storage"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -113,6 +114,9 @@ func (r *Prepare) Run(cmd *captain.Command) error {
 	// OS specific preparations
 	err := r.prepareOS()
 	if err != nil {
+		if installation.IsStateExeDoesNotExistError(err) && runtime.GOOS == "windows" {
+			return locale.WrapInputError(err, "err_install_state_exe_does_not_exist", "", constants.ForumsURL)
+		}
 		return errs.Wrap(err, "Could not prepare OS")
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2100" title="DX-2100" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2100</a>  Autostart creation failing on Windows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
