### PR TITLE
Update shell rcfiles to indicate the user is already in an activated state.

### DIFF
--- a/internal/assets/contents/shells/bashrc_append.sh
+++ b/internal/assets/contents/shells/bashrc_append.sh
@@ -6,4 +6,7 @@ export {{$K}}="{{$V}}:$PATH"
 export {{$K}}="{{$V}}"
 {{- end}}
 {{- end}}
+if [[ ! -z "${{.ActivatedEnv}}" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ]]; then
+  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+fi
 # {{.Stop}}

--- a/internal/assets/contents/shells/fishrc_append.fish
+++ b/internal/assets/contents/shells/fishrc_append.fish
@@ -6,8 +6,7 @@ set -xg {{$K}} "{{$V}}:$PATH"
 set -xg {{$K}} "{{$V}}"
 {{- end}}
 {{- end}}
-if test ! -z "${{.ActivatedEnv}}"
-  and test -f "${{.ActivatedEnv}}/{{.ConfigFile}}"
+if test ! -z "${{.ActivatedEnv}}"; test -f "${{.ActivatedEnv}}/{{.ConfigFile}}"
   echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
 end
 # {{.Stop}}

--- a/internal/assets/contents/shells/fishrc_append.fish
+++ b/internal/assets/contents/shells/fishrc_append.fish
@@ -6,4 +6,8 @@ set -xg {{$K}} "{{$V}}:$PATH"
 set -xg {{$K}} "{{$V}}"
 {{- end}}
 {{- end}}
+if test ! -z "${{.ActivatedEnv}}"
+  and test -f "${{.ActivatedEnv}}/{{.ConfigFile}}"
+  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+end
 # {{.Stop}}

--- a/internal/assets/contents/shells/tcshrc_append.sh
+++ b/internal/assets/contents/shells/tcshrc_append.sh
@@ -5,4 +5,7 @@ setenv {{$K}} "{{$V}}:$PATH"
 {{- else}}
 {{- end}}
 {{- end}}
+if ( "${{.ActivatedEnv}}" != "" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ) then
+  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+endif
 # {{.Stop}}

--- a/internal/assets/contents/shells/zshrc_append.sh
+++ b/internal/assets/contents/shells/zshrc_append.sh
@@ -6,4 +6,7 @@ export {{$K}}="{{$V}}:$PATH"
 export {{$K}}="{{$V}}"
 {{- end}}
 {{- end}}
+if [[ ! -z "${{.ActivatedEnv}}" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ]]; then
+  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+fi
 # {{.Stop}}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -73,6 +73,9 @@ const ActivatedStateEnvVarName = "ACTIVESTATE_ACTIVATED"
 // ActivatedStateIDEnvVarName is the name of the environment variable that is set when in an activated state, its value will be a unique id identifying a specific instance of an activated state
 const ActivatedStateIDEnvVarName = "ACTIVESTATE_ACTIVATED_ID"
 
+// ActivatedStateProjectEnvVarName is the name of the environment variable that specifies the activated state's org/project namespace.
+const ActivatedStateNamespaceEnvVarName = "ACTIVESTATE_ACTIVATED_NAMESPACE"
+
 // ForwardedStateEnvVarName is the name of the environment variable that is set when in an activated state, its value will be the path of the project
 const ForwardedStateEnvVarName = "ACTIVESTATE_FORWARDED"
 

--- a/internal/runbits/activation/activation.go
+++ b/internal/runbits/activation/activation.go
@@ -39,7 +39,7 @@ func ActivateAndWait(
 		}
 	}
 
-	ve, err := venv.GetEnv(false, true, projectDir)
+	ve, err := venv.GetEnv(false, true, projectDir, proj.Namespace().String())
 	if err != nil {
 		return locale.WrapError(err, "error_could_not_activate_venv", "Could not retrieve environment information.")
 	}

--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -136,7 +136,7 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 	}
 	venv := virtualenvironment.New(rt)
 
-	env, err := venv.GetEnv(true, false, projectDir)
+	env, err := venv.GetEnv(true, false, projectDir, projectNamespace)
 	if err != nil {
 		return locale.WrapError(err, "err_exec_env", "Could not retrieve environment information for your runtime")
 	}

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -1,8 +1,11 @@
 package shell
 
 import (
+	"os"
+
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -84,7 +87,9 @@ func (u *Shell) Run(params *Params) error {
 	}
 
 	if process.IsActivated(u.config) {
-		return locale.NewInputError("err_shell_already_active", "", proj.NamespaceString(), proj.Dir())
+		activatedProjectNamespace := os.Getenv(constants.ActivatedStateNamespaceEnvVarName)
+		activatedProjectDir := os.Getenv(constants.ActivatedStateEnvVarName)
+		return locale.NewInputError("err_shell_already_active", "", activatedProjectNamespace, activatedProjectDir)
 	}
 
 	u.out.Notice(locale.Tl("shell_project_statement", "",

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -1,11 +1,8 @@
 package shell
 
 import (
-	"os"
-
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -87,9 +84,7 @@ func (u *Shell) Run(params *Params) error {
 	}
 
 	if process.IsActivated(u.config) {
-		activatedProjectNamespace := os.Getenv(constants.ActivatedStateNamespaceEnvVarName)
-		activatedProjectDir := os.Getenv(constants.ActivatedStateEnvVarName)
-		return locale.NewInputError("err_shell_already_active", "", activatedProjectNamespace, activatedProjectDir)
+		return locale.NewInputError("err_shell_already_active", "", proj.NamespaceString(), proj.Dir())
 	}
 
 	u.out.Notice(locale.Tl("shell_project_statement", "",

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -81,7 +81,7 @@ func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
 	venv := virtualenvironment.New(rt)
 
 	projDir := filepath.Dir(s.project.Source().Path())
-	env, err := venv.GetEnv(true, true, projDir)
+	env, err := venv.GetEnv(true, true, projDir, s.project.Namespace().String())
 	if err != nil {
 		return errs.Wrap(err, "Could not get venv environment")
 	}
@@ -91,7 +91,7 @@ func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
 	}
 
 	// search the "clean" path first (PATHS that are set by venv)
-	env, err = venv.GetEnv(false, true, "")
+	env, err = venv.GetEnv(false, true, "", "")
 	if err != nil {
 		return errs.Wrap(err, "Could not get venv environment")
 	}

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -73,9 +73,12 @@ func WriteRcFile(rcTemplateName string, path string, data RcIdentification, env 
 	}
 
 	rcData := map[string]interface{}{
-		"Start": data.Start,
-		"Stop":  data.Stop,
-		"Env":   env,
+		"Start":                 data.Start,
+		"Stop":                  data.Stop,
+		"Env":                   env,
+		"ActivatedEnv":          constants.ActivatedStateEnvVarName,
+		"ConfigFile":            constants.ConfigFileName,
+		"ActivatedNamespaceEnv": constants.ActivatedStateNamespaceEnvVarName,
 	}
 
 	if err := CleanRcFile(path, data); err != nil {

--- a/internal/subshell/sscommon/rcfile_test.go
+++ b/internal/subshell/sscommon/rcfile_test.go
@@ -45,18 +45,18 @@ func TestWriteRcFile(t *testing.T) {
 		env            map[string]string
 	}
 
-	zsh := fmt.Sprintf(
-		`export PATH="foo:$PATH"
-if [[ ! -z "$%s" && -f "$%s/%s" ]]; then
+	fish := fmt.Sprintf(
+		`set -xg PATH "foo:$PATH"
+if test ! -z "$%s"; test -f "$%s/%s"
   echo "State Tool is operating on project $%s, located at $%s"
-fi`,
+end`,
 		constants.ActivatedStateEnvVarName,
 		constants.ActivatedStateEnvVarName,
 		constants.ConfigFileName,
 		constants.ActivatedStateNamespaceEnvVarName,
 		constants.ActivatedStateEnvVarName)
 	if runtime.GOOS == "windows" {
-		zsh = strings.ReplaceAll(zsh, "\n", "\r\n")
+		fish = strings.ReplaceAll(fish, "\n", "\r\n")
 	}
 
 	tests := []struct {
@@ -68,26 +68,26 @@ fi`,
 		{
 			"Write RC to empty file",
 			args{
-				"zshrc_append.sh",
+				"fishrc_append.fish",
 				fakeFileWithContents("", "", ""),
 				map[string]string{
 					"PATH": "foo",
 				},
 			},
 			nil,
-			fakeContents("", zsh, ""),
+			fakeContents("", fish, ""),
 		},
 		{
 			"Write RC update",
 			args{
-				"zshrc_append.sh",
+				"fishrc_append.fish",
 				fakeFileWithContents("before", "SOMETHING ELSE", "after"),
 				map[string]string{
 					"PATH": "foo",
 				},
 			},
 			nil,
-			fakeContents(strings.Join([]string{"before", "after"}, fileutils.LineEnd), zsh, ""),
+			fakeContents(strings.Join([]string{"before", "after"}, fileutils.LineEnd), fish, ""),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/virtualenvironment/virtualenvironment.go
+++ b/internal/virtualenvironment/virtualenvironment.go
@@ -29,7 +29,7 @@ func New(runtime *runtime.Runtime) *VirtualEnvironment {
 }
 
 // GetEnv returns a map of the cumulative environment variables for all active virtual environments
-func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir string) (map[string]string, error) {
+func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir, namespace string) (map[string]string, error) {
 	envMap := make(map[string]string)
 
 	// Source runtime environment information
@@ -44,6 +44,7 @@ func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir 
 	if projectDir != "" {
 		envMap[constants.ActivatedStateEnvVarName] = projectDir
 		envMap[constants.ActivatedStateIDEnvVarName] = v.activationID
+		envMap[constants.ActivatedStateNamespaceEnvVarName] = namespace
 
 		// Get project from explicitly defined configuration file
 		configFile := filepath.Join(projectDir, constants.ConfigFileName)

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -289,14 +289,15 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
+	if runtime.GOOS == "darwin" && condition.OnCI() {
+		os.Setenv("SHELL", "zsh") // GitHub actions runs on bash, so override with zsh
+		defer os.Unsetenv("SHELL")
+	}
 	cfg, err := config.New()
 	suite.Require().NoError(err)
-	if runtime.GOOS == "darwin" && condition.OnCI() {
-		cfg.Set(subshell.ConfigKeyShell, "zsh") // GitHub actions runs on bash, so override with zsh
-	}
 
 	os.Setenv(constants.HomeEnvVarName, ts.Dirs.HomeDir)
-	defer func() { os.Unsetenv(constants.HomeEnvVarName) }()
+	defer os.Unsetenv(constants.HomeEnvVarName)
 	ss := subshell.New(cfg)
 	err = subshell.ConfigureAvailableShells(ss, cfg, nil, sscommon.InstallID, true) // mimic installer
 	suite.Require().NoError(err)

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -266,6 +266,8 @@ func (suite *ShellIntegrationTestSuite) SetupRCFile(ts *e2e.Session) {
 	rcFile, err := subshell.RcFile()
 	suite.Require().NoError(err)
 
+	err = fileutils.TouchFileUnlessExists(rcFile)
+	suite.Require().NoError(err)
 	err = fileutils.CopyFile(rcFile, filepath.Join(ts.Dirs.HomeDir, filepath.Base(rcFile)))
 	suite.Require().NoError(err)
 

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
@@ -288,6 +289,9 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 
 	cfg, err := config.New()
 	suite.Require().NoError(err)
+	if runtime.GOOS == "darwin" && condition.OnCI() {
+		cfg.Set(subshell.ConfigKeyShell, "zsh") // GitHub actions runs on bash, so override with zsh
+	}
 
 	os.Setenv(constants.HomeEnvVarName, ts.Dirs.HomeDir)
 	defer func() { os.Unsetenv(constants.HomeEnvVarName) }()

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -297,9 +297,9 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 	if runtime.GOOS != "darwin" || !condition.OnCI() {
 		ss = subshell.New(cfg)
 	} else {
-		os.Setenv("SHELL", "zsh")
+		cfg.Set(subshell.ConfigKeyShell, "zsh")
 		ss = subshell.New(cfg)
-		os.Unsetenv("SHELL")
+		cfg.Set(subshell.ConfigKeyShell, "")
 		env = append(env, "SHELL=zsh")
 	}
 

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/subshell"
-	"github.com/ActiveState/cli/internal/subshell/bash"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/internal/subshell/zsh"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -289,12 +289,15 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 	cfg, err := config.New()
 	suite.Require().NoError(err)
 
+	os.Setenv(constants.HomeEnvVarName, ts.Dirs.HomeDir)
+	defer func() { os.Unsetenv(constants.HomeEnvVarName) }()
 	ss := subshell.New(cfg)
 	err = subshell.ConfigureAvailableShells(ss, cfg, nil, sscommon.InstallID, true) // mimic installer
 	suite.Require().NoError(err)
 
 	rcFile, err := ss.RcFile()
 	suite.Require().NoError(err)
+	suite.Require().Equal(filepath.Dir(rcFile), ts.Dirs.HomeDir, "rc file not in test suite homedir")
 	suite.Require().FileExists(rcFile)
 	suite.Require().Contains(string(fileutils.ReadFileUnsafe(rcFile)), "State Tool is operating on project")
 
@@ -304,21 +307,12 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.WithArgs("shell", "small-python"),
-		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
-	)
+		e2e.AppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
 	cp.Expect("Activated")
 	suite.Assert().NotContains(cp.TrimmedSnapshot(), "State Tool is operating on project")
+	cp.SendLine(fmt.Sprintf(`export HOME="%s"`, ts.Dirs.HomeDir)) // some shells do not forward this
 
-	binary := ss.Binary() // platform-specific shell (zsh on macOS, bash on Linux, etc.)
-	// Cannot run bare binary because it will not load the rcFile in ts.Dirs.HomeDir.
-	// Instead, tell the shell to load rcFile. This is not needed in a non-test environment.
-	switch ss.Shell() {
-	case bash.Name:
-		binary = fmt.Sprintf("%s --rcfile %s", binary, rcFile)
-	case zsh.Name:
-		binary = fmt.Sprintf("ZDOTDIR=%s %s", filepath.Dir(rcFile), binary)
-	}
-	cp.SendLine(binary)
+	cp.SendLine(ss.Binary()) // platform-specific shell (zsh on macOS, bash on Linux, etc.)
 	cp.ExpectLongString("State Tool is operating on project ActiveState-CLI/small-python")
 	cp.SendLine("exit") // subshell within a subshell
 	cp.SendLine("exit")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2045" title="DX-2045" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2045</a>  As a user I can expect to always see a clear indication that I am in a virtual environment
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The PS1 prompt is only changed for the immediate subshell. Nested subshells do not inherit it, so it was not clear the user is still in an activated state.

cmd.exe does not need this because its PS1 equivalent is unmodified when opening another shell within a shell. I've also added a comment to the JIRA ticket explaining why I don't want to satisfy the Windows AC.