### PR TITLE
Executors should only setup PATH again in activated state.

### DIFF
--- a/cmd/state-exec/meta_test.go
+++ b/cmd/state-exec/meta_test.go
@@ -9,8 +9,9 @@ import (
 func Test_transformedEnv(t *testing.T) {
 	I := string(os.PathListSeparator)
 	type args struct {
-		sourceEnv    []string
-		updatesToEnv []string
+		sourceEnv         []string
+		updatesToEnv      []string
+		onlyTransformPath bool
 	}
 	tests := []struct {
 		name string
@@ -20,31 +21,43 @@ func Test_transformedEnv(t *testing.T) {
 		{
 			"Simple append",
 			args{
-				sourceEnv:    []string{"A=1", "B=2"},
-				updatesToEnv: []string{"C=3"},
+				sourceEnv:         []string{"A=1", "B=2"},
+				updatesToEnv:      []string{"C=3"},
+				onlyTransformPath: false,
 			},
 			[]string{"A=1", "B=2", "C=3"},
 		},
 		{
 			"Path append",
 			args{
-				sourceEnv:    []string{"PATH=A" + I + "B"},
-				updatesToEnv: []string{"PATH=C"},
+				sourceEnv:         []string{"PATH=A" + I + "B"},
+				updatesToEnv:      []string{"PATH=C"},
+				onlyTransformPath: false,
 			},
 			[]string{"PATH=C" + I + "A" + I + "B"},
 		},
 		{
 			"Path append with missmatched casing",
 			args{
-				sourceEnv:    []string{"Path=A" + I + "B"},
-				updatesToEnv: []string{"PATH=C"},
+				sourceEnv:         []string{"Path=A" + I + "B"},
+				updatesToEnv:      []string{"PATH=C"},
+				onlyTransformPath: false,
 			},
 			[]string{"PATH=C" + I + "A" + I + "B"},
+		},
+		{
+			"Only update path",
+			args{
+				sourceEnv:         []string{"PATH=A", "B=2", "C=3"},
+				updatesToEnv:      []string{"PATH=D", "B=20", "C=30"},
+				onlyTransformPath: true,
+			},
+			[]string{"PATH=D" + I + "A", "B=2", "C=3"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := transformedEnv(tt.args.sourceEnv, tt.args.updatesToEnv); !reflect.DeepEqual(got, tt.want) {
+			if got := transformedEnv(tt.args.sourceEnv, tt.args.updatesToEnv, tt.args.onlyTransformPath); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("transformedEnv() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2068" title="DX-2068" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2068</a>  State tool "local" executors gobble up environment variables
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The other environment variables have already been set.

The first attempt at fixing this assumed that `PATH` modifications by `state shell` were complete. However, they were not. Executors also modify `PATH` based on meta information, so that absolutely needs to be done every time an executor is run. Any other environment variables are already set properly, so they can be ignored.