### PR TITLE
Retry 502 (and other) status codes

### DIFF
--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"errors"
-	"net/http"
 	"os"
 	"regexp"
 	"strconv"
@@ -75,7 +74,7 @@ func NewBuildPlannerModel(auth *authentication.Auth) *BuildPlanner {
 	bpURL := api.GetServiceURL(api.ServiceBuildPlanner).String()
 	logging.Debug("Using build planner at: %s", bpURL)
 
-	client := gqlclient.NewWithOpts(bpURL, 0, graphql.WithHTTPClient(&http.Client{}))
+	client := gqlclient.NewWithOpts(bpURL, 0, graphql.WithHTTPClient(api.NewHTTPClient()))
 
 	if auth.Authenticated() {
 		client.SetTokenProvider(auth)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2030" title="DX-2030" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2030</a>  MAC OS - Installing `pytest` attempt failed with `x Failed to stage commit, error: Request failed: decoding response: EOF`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Our retry client already retries the 502 response code as well as other instances that could be useful for BuildPlanner requests.
