### PR TITLE
Use correct project and directory in "already active shell" error message.

### DIFF
--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -1,8 +1,11 @@
 package shell
 
 import (
+	"os"
+
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -84,7 +87,9 @@ func (u *Shell) Run(params *Params) error {
 	}
 
 	if process.IsActivated(u.config) {
-		return locale.NewInputError("err_shell_already_active", "", proj.NamespaceString(), proj.Dir())
+		activatedProjectNamespace := os.Getenv(constants.ActivatedStateNamespaceEnvVarName)
+		activatedProjectDir := os.Getenv(constants.ActivatedStateEnvVarName)
+		return locale.NewInputError("err_shell_already_active", "", activatedProjectNamespace, activatedProjectDir)
 	}
 
 	u.out.Notice(locale.Tl("shell_project_statement", "",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2136" title="DX-2136" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2136</a>  Despite we are in the `PROJECT_A` subshell the message says we are in the `PROJECT_B` shell.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

