### PR TITLE
Fixed filling OleError with error info.

### DIFF
--- a/internal/osutils/shortcut/shortcut_windows.go
+++ b/internal/osutils/shortcut/shortcut_windows.go
@@ -66,7 +66,7 @@ func (s *Shortcut) Enable() error {
 	logging.Debug("Creating Shortcut: %s", filename)
 	cs, err := oleutil.CallMethod(wshell, "CreateShortcut", filename)
 	if err != nil {
-		var oleErr *ole.OleError
+		oleErr := &ole.OleError{}
 		if errors.As(err, &oleErr) {
 			return errs.Wrap(err, "oleutil CreateShortcut returned error: %s, parent error: %s", oleErr.Description(), oleErr.SubError())
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2088" title="DX-2088" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2088</a>  Could not create start menu shortcut
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
An allocated struct is needed to fill in its fields.