### PR TITLE
Delete a remotely created project if runtime setup fails.

### DIFF
--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -234,6 +234,11 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 
 	err = runbits.RefreshRuntime(r.auth, r.out, r.analytics, proj, commitID, true, target.TriggerInit, r.svcModel)
 	if err != nil {
+		logging.Debug("Deleting remotely created project due to runtime setup error")
+		err2 := model.DeleteProject(namespace.Owner, namespace.Project, r.auth)
+		if err2 != nil {
+			multilog.Error("Error deleting remotely created project after runtime setup error: %v", errs.JoinMessage(err2))
+		}
 		return locale.WrapError(err, "err_init_refresh", "Could not setup runtime after init")
 	}
 

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -238,6 +238,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		err2 := model.DeleteProject(namespace.Owner, namespace.Project, r.auth)
 		if err2 != nil {
 			multilog.Error("Error deleting remotely created project after runtime setup error: %v", errs.JoinMessage(err2))
+			return locale.WrapError(err, "err_init_refresh_delete_project", "Could not setup runtime after init, and could not delete newly created Platform project. Please delete it manually before trying again")
 		}
 		return locale.WrapError(err, "err_init_refresh", "Could not setup runtime after init")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2093" title="DX-2093" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2093</a>  init project with `--language python@3.9` cause actual creation of the project in the platform
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
