### PR TITLE
Detecting the current project should fall back on the activated one within a shell.

### DIFF
--- a/internal/virtualenvironment/virtualenvironment.go
+++ b/internal/virtualenvironment/virtualenvironment.go
@@ -42,14 +42,12 @@ func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir,
 	}
 
 	if projectDir != "" {
-		configFile := filepath.Join(projectDir, constants.ConfigFileName)
-
 		envMap[constants.ActivatedStateEnvVarName] = projectDir
-		envMap[constants.ProjectEnvVarName] = configFile
 		envMap[constants.ActivatedStateIDEnvVarName] = v.activationID
 		envMap[constants.ActivatedStateNamespaceEnvVarName] = namespace
 
 		// Get project from explicitly defined configuration file
+		configFile := filepath.Join(projectDir, constants.ConfigFileName)
 		pj, err := project.Parse(configFile)
 		if err != nil {
 			return envMap, locale.WrapError(err, "err_parse_project", "", configFile)

--- a/internal/virtualenvironment/virtualenvironment.go
+++ b/internal/virtualenvironment/virtualenvironment.go
@@ -42,12 +42,14 @@ func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir,
 	}
 
 	if projectDir != "" {
+		configFile := filepath.Join(projectDir, constants.ConfigFileName)
+
 		envMap[constants.ActivatedStateEnvVarName] = projectDir
+		envMap[constants.ProjectEnvVarName] = configFile
 		envMap[constants.ActivatedStateIDEnvVarName] = v.activationID
 		envMap[constants.ActivatedStateNamespaceEnvVarName] = namespace
 
 		// Get project from explicitly defined configuration file
-		configFile := filepath.Join(projectDir, constants.ConfigFileName)
 		pj, err := project.Parse(configFile)
 		if err != nil {
 			return envMap, locale.WrapError(err, "err_parse_project", "", configFile)

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -752,6 +752,7 @@ func GetProjectFilePath() (string, error) {
 	lookup := []func() (string, error){
 		getProjectFilePathFromEnv,
 		getProjectFilePathFromWd,
+		getProjectFilePathFromShell,
 		getProjectFilePathFromDefault,
 	}
 	for _, getProjectFilePath := range lookup {
@@ -790,6 +791,18 @@ func getProjectFilePathFromWd() (string, error) {
 	}
 
 	return path, nil
+}
+
+func getProjectFilePathFromShell() (string, error) {
+	projectFilePath := os.Getenv(constants.ActivatedStateEnvVarName)
+	if projectFilePath != "" {
+		configFile := filepath.Join(projectFilePath, constants.ConfigFileName)
+		if fileutils.FileExists(configFile) {
+			return configFile, nil
+		}
+		return "", &ErrorNoProject{locale.NewInputError("err_shell_no_projectfile", "The project for the shell you are in no longer exists.")}
+	}
+	return "", nil
 }
 
 func getProjectFilePathFromDefault() (_ string, rerr error) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2109" title="DX-2109" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2109</a>  Despite activated project `state` commands still error `To run this command you need to be in an existing project.`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

If the working directory does not contain a project, fall back on the activated project (if there is one).