### PR TITLE
Always print auth URL

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -937,7 +937,7 @@ prompt_signup_browser_action:
 prompt_login_after_browser_signup:
   other: Please login once you've registered your account
 err_browser_open:
-  other: "Could not open your browser, please manually open the following URL in your browser: {{.V0}}"
+  other: "Could not open your browser, please manually open the following URL above."
 err_activate_auth_required:
   other: Activating a project requires you to be authenticated against the ActiveState Platform
 err_os_not_a_directory:
@@ -1032,6 +1032,10 @@ auth_device_verify_security_code:
 
     Please sign into the ActiveState Platform (if you have not already done so) and click "Authorize".
     After that, it may take a few seconds for the authorization process here to complete.
+
+    If the URL does not open automatically, please copy and paste it into your browser.
+
+        [ACTIONABLE]{{.V1}}[/RESET]
 auth_device_timeout:
   other: Authorization timeout. Please try again.
 auth_device_success:

--- a/internal/runners/learn/learn.go
+++ b/internal/runners/learn/learn.go
@@ -27,7 +27,7 @@ func (l *Learn) Run() error {
 	err := open.Run(constants.CheatSheetURL)
 	if err != nil {
 		logging.Warning("Could not open browser: %v", err)
-		l.out.Notice(locale.Tr("err_browser_open", constants.CheatSheetURL))
+		l.out.Notice(locale.Tr("err_browser_open"))
 	}
 
 	return nil

--- a/pkg/cmdlets/auth/login.go
+++ b/pkg/cmdlets/auth/login.go
@@ -235,7 +235,7 @@ func AuthenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 	if response.UserCode == nil {
 		return errs.New("Invalid response: Missing user code.")
 	}
-	out.Notice(locale.Tr("auth_device_verify_security_code", *response.UserCode))
+	out.Notice(locale.Tr("auth_device_verify_security_code", *response.UserCode, *response.VerificationURIComplete))
 
 	// Open URL in browser
 	if response.VerificationURIComplete == nil {
@@ -244,7 +244,7 @@ func AuthenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 	err = OpenURI(*response.VerificationURIComplete)
 	if err != nil {
 		logging.Warning("Could not open browser: %v", err)
-		out.Notice(locale.Tr("err_browser_open", *response.VerificationURIComplete))
+		out.Notice(locale.Tr("err_browser_open"))
 	}
 
 	var apiKey string


### PR DESCRIPTION
We were already printing the auth URL when we encountered an error on `Open()` however it appears on the system in the ticket that we did not encounter an error. It is likely because the process that the `Open()` function started did not exit non-zero. This updates the flow to always print the URL when attempting to open it.