### PR TITLE
Enrich service wait up/down errors with more debug info.

### DIFF
--- a/cmd/state-svc/autostart/autostart.go
+++ b/cmd/state-svc/autostart/autostart.go
@@ -13,7 +13,7 @@ import (
 var Options = autostart.Options{
 	Name:           constants.SvcAppName,
 	LaunchFileName: constants.SvcLaunchFileName,
-	Args:           []string{"start", "--startup"},
+	Args:           []string{"start", "--autostart"},
 }
 
 func RegisterConfigListener(cfg *config.Instance) error {

--- a/cmd/state-svc/autostart/autostart.go
+++ b/cmd/state-svc/autostart/autostart.go
@@ -13,7 +13,7 @@ import (
 var Options = autostart.Options{
 	Name:           constants.SvcAppName,
 	LaunchFileName: constants.SvcLaunchFileName,
-	Args:           []string{"start"},
+	Args:           []string{"start", "--startup"},
 }
 
 func RegisterConfigListener(cfg *config.Instance) error {

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -138,7 +138,7 @@ func run(cfg *config.Instance) error {
 				logging.Debug("Running CmdStart")
 				argText := "svc-start:cli"
 				if autostart {
-					argText += "-autostart"
+					argText = "svc-start:auto"
 				}
 				return runStart(out, argText)
 			},

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -122,16 +122,25 @@ func run(cfg *config.Instance) error {
 	)
 
 	var foregroundArgText string
+	var startup bool
 
 	cmd.AddChildren(
 		captain.NewCommand(
 			cmdStart,
 			"",
 			"Start the ActiveState Service (Background)",
-			p, nil, nil,
+			p,
+			[]*captain.Flag{
+				{Name: "startup", Value: &startup}, // differentiate between autostart and cli invocation
+			},
+			nil,
 			func(ccmd *captain.Command, args []string) error {
 				logging.Debug("Running CmdStart")
-				return runStart(out, "svc-start:cli")
+				argText := "svc-start:cli"
+				if startup {
+					argText = "svc-start:startup"
+				}
+				return runStart(out, argText)
 			},
 		),
 		captain.NewCommand(

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -122,7 +122,7 @@ func run(cfg *config.Instance) error {
 	)
 
 	var foregroundArgText string
-	var startup bool
+	var autostart bool
 
 	cmd.AddChildren(
 		captain.NewCommand(
@@ -131,14 +131,14 @@ func run(cfg *config.Instance) error {
 			"Start the ActiveState Service (Background)",
 			p,
 			[]*captain.Flag{
-				{Name: "startup", Value: &startup}, // differentiate between autostart and cli invocation
+				{Name: "autostart", Value: &autostart, Hidden: true}, // differentiate between autostart and cli invocation
 			},
 			nil,
 			func(ccmd *captain.Command, args []string) error {
 				logging.Debug("Running CmdStart")
 				argText := "svc-start:cli"
-				if startup {
-					argText = "svc-start:startup"
+				if autostart {
+					argText += "-autostart"
 				}
 				return runStart(out, argText)
 			},

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -23,6 +23,10 @@ func NewClient(n *SockPath) *Client {
 	}
 }
 
+func (c *Client) SockPath() *SockPath {
+	return c.sockpath
+}
+
 func (c *Client) Request(ctx context.Context, key string) (string, error) {
 	spath := c.sockpath.String()
 	conn, err := c.dialer.DialContext(ctx, network, spath)

--- a/internal/svcctl/debugdata.go
+++ b/internal/svcctl/debugdata.go
@@ -20,6 +20,8 @@ const (
 )
 
 type debugData struct {
+	argText string
+
 	sockInfo    *fileInfo
 	sockDirInfo *fileInfo
 	sockDirList []string
@@ -33,11 +35,12 @@ type debugData struct {
 	waitDur      time.Duration
 }
 
-func newDebugData(ipComm IPCommunicator, kind execKind) *debugData {
+func newDebugData(ipComm IPCommunicator, kind execKind, argText string) *debugData {
 	sock := ipComm.SockPath().String()
 	sockDir := filepath.Dir(sock)
 
 	return &debugData{
+		argText:     argText,
 		sockInfo:    newFileInfo(sock),
 		sockDirInfo: newFileInfo(sockDir),
 		sockDirList: fileutils.ListDirSimple(sockDir, false),
@@ -61,6 +64,7 @@ func (d *debugData) Error() string {
 	}
 
 	return fmt.Sprintf(strings.TrimSpace(`
+Arg Text      : %s
 Sock Info     : %s
 Sock Dir Info : %s
 Sock Dir List : %s
@@ -70,6 +74,7 @@ Wait Start    : %s
 Wait Duration : %s
 Wait Log: %s
 `),
+		d.argText,
 		strings.ReplaceAll(d.sockInfo.LogString(), "\n", "\n  "),
 		strings.ReplaceAll(d.sockDirInfo.LogString(), "\n", "\n  "),
 		sockDirList,

--- a/internal/svcctl/debugdata.go
+++ b/internal/svcctl/debugdata.go
@@ -1,0 +1,139 @@
+package svcctl
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/logging"
+)
+
+type execKind string
+
+const (
+	startSvc execKind = "Start"
+	stopSvc  execKind = "Stop"
+)
+
+type debugData struct {
+	sockInfo    *fileInfo
+	sockDirInfo *fileInfo
+	sockDirList []string
+
+	execStart time.Time
+	execDur   time.Duration
+	execKind  execKind
+
+	waitStart    time.Time
+	waitAttempts []*waitAttempt
+	waitDur      time.Duration
+}
+
+func newDebugData(ipComm IPCommunicator, kind execKind) *debugData {
+	sock := ipComm.SockPath().String()
+	sockDir := filepath.Dir(sock)
+
+	return &debugData{
+		sockInfo:    newFileInfo(sock),
+		sockDirInfo: newFileInfo(sockDir),
+		sockDirList: fileutils.ListDirSimple(sockDir, false),
+		execStart:   time.Now(),
+		execKind:    kind,
+	}
+}
+
+func (d *debugData) Error() string {
+	var sockDirList string
+	for _, entry := range d.sockDirList {
+		sockDirList += "\n  " + entry
+	}
+	if sockDirList == "" {
+		sockDirList = "No entries found"
+	}
+
+	var attemptsMsg string
+	for _, wa := range d.waitAttempts {
+		attemptsMsg += "\n  " + wa.LogString()
+	}
+
+	return fmt.Sprintf(strings.TrimSpace(`
+Sock Info     : %s
+Sock Dir Info : %s
+Sock Dir List : %s
+%s Start    : %s
+%s Duration : %s
+Wait Start    : %s
+Wait Duration : %s
+Wait Log: %s
+`),
+		strings.ReplaceAll(d.sockInfo.LogString(), "\n", "\n  "),
+		strings.ReplaceAll(d.sockDirInfo.LogString(), "\n", "\n  "),
+		sockDirList,
+		d.execKind, d.execStart,
+		d.execKind, d.execDur,
+		d.waitStart,
+		d.waitDur,
+		attemptsMsg,
+	)
+}
+
+func (d *debugData) startWait() {
+	d.execDur = time.Since(d.execStart)
+	logging.Debug("Exec time before wait was %v", d.execDur)
+	d.waitStart = time.Now()
+}
+
+func (d *debugData) addWaitAttempt(start time.Time, iter int, timeout time.Duration) {
+	attempt := &waitAttempt{
+		waitStart: d.waitStart,
+		start:     start,
+		iter:      iter,
+		timeout:   timeout,
+	}
+	d.waitAttempts = append(d.waitAttempts, attempt)
+	logging.Debug("%s", attempt)
+}
+
+func (d *debugData) stopWait() {
+	d.waitDur = time.Since(d.waitStart)
+	logging.Debug("Wait duration: %s", d.waitDur)
+}
+
+type fileInfo struct {
+	path string
+	fs.FileInfo
+	osFIErr error
+}
+
+func newFileInfo(path string) *fileInfo {
+	fi := &fileInfo{path: path}
+	fi.FileInfo, fi.osFIErr = os.Stat(path)
+	return fi
+}
+
+func (f *fileInfo) LogString() string {
+	if f.osFIErr != nil {
+		return fmt.Sprintf("Path: %s Error: %s", f.path, f.osFIErr)
+	}
+	return fmt.Sprintf("Path: %s Size: %d Mode: %s ModTime: %s", f.path, f.Size(), f.Mode(), f.ModTime())
+}
+
+type waitAttempt struct {
+	waitStart time.Time
+	start     time.Time
+	iter      int
+	timeout   time.Duration
+}
+
+func (a *waitAttempt) String() string {
+	return fmt.Sprintf("Attempt %2d at %10s with timeout %v",
+		a.iter, a.start.Sub(a.waitStart).Round(time.Microsecond), a.timeout)
+}
+
+func (a *waitAttempt) LogString() string {
+	return fmt.Sprintf("%2d: %10s/%v", a.iter, a.start.Sub(a.waitStart).Round(time.Microsecond), a.timeout)
+}

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -154,7 +154,7 @@ func startAndWait(ctx context.Context, ipComm IPCommunicator, exec, argText stri
 		args = args[:len(args)-1]
 	}
 
-	debugInfo := newDebugData(ipComm, startSvc)
+	debugInfo := newDebugData(ipComm, startSvc, argText)
 
 	if _, err := exeutils.ExecuteAndForget(exec, args); err != nil {
 		return locale.WrapError(err, "svcctl_cannot_exec_and_forget", "Cannot execute service in background: {{.V0}}", err.Error())
@@ -212,7 +212,7 @@ func waitUp(ctx context.Context, ipComm IPCommunicator, debugInfo *debugData) er
 }
 
 func stopAndWait(ctx context.Context, ipComm IPCommunicator) error {
-	debugInfo := newDebugData(ipComm, stopSvc)
+	debugInfo := newDebugData(ipComm, stopSvc, "")
 
 	if err := ipComm.StopServer(ctx); err != nil {
 		return locale.WrapError(err, "svcctl_stop_req_failed", "Service stop request failed")

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -40,6 +40,7 @@ type IPCommunicator interface {
 	Requester
 	PingServer(context.Context) (time.Duration, error)
 	StopServer(context.Context) error
+	SockPath() *ipc.SockPath
 }
 
 func NewIPCSockPathFromGlobals() *ipc.SockPath {
@@ -153,12 +154,14 @@ func startAndWait(ctx context.Context, ipComm IPCommunicator, exec, argText stri
 		args = args[:len(args)-1]
 	}
 
+	debugInfo := newDebugData(ipComm, startSvc)
+
 	if _, err := exeutils.ExecuteAndForget(exec, args); err != nil {
 		return locale.WrapError(err, "svcctl_cannot_exec_and_forget", "Cannot execute service in background: {{.V0}}", err.Error())
 	}
 
 	logging.Debug("Waiting for service")
-	if err := waitUp(ctx, ipComm); err != nil {
+	if err := waitUp(ctx, ipComm, debugInfo); err != nil {
 		return locale.WrapError(err, "svcctl_wait_startup_failed", "Waiting for service startup confirmation failed")
 	}
 
@@ -169,19 +172,23 @@ var (
 	waitTimeoutL10nKey = "svcctl_wait_timeout"
 )
 
-func waitUp(ctx context.Context, ipComm IPCommunicator) error {
+func waitUp(ctx context.Context, ipComm IPCommunicator, debugInfo *debugData) error {
+	debugInfo.startWait()
+	defer debugInfo.stopWait()
+
 	start := time.Now()
 	for try := 1; try <= pingRetryIterations; try++ {
 		select {
 		case <-ctx.Done():
-			return locale.WrapError(ctx.Err(), waitTimeoutL10nKey, "", time.Since(start).String(), "1", constants.ForumsURL)
+			err := locale.WrapError(ctx.Err(), waitTimeoutL10nKey, "", time.Since(start).String(), "1", constants.ForumsURL)
+			return errs.Pack(err, debugInfo)
 		default:
 		}
 
 		tryStart := time.Now()
 		timeout := time.Millisecond * time.Duration(try*try)
 
-		logging.Debug("Attempt: %d, timeout: %v, total: %v", try, timeout, time.Since(start))
+		debugInfo.addWaitAttempt(tryStart, try, timeout)
 		if err := ping(ctx, ipComm, timeout); err != nil {
 			// Timeout does not reveal enough info, try again.
 			// We don't need to sleep for this type of error because,
@@ -190,7 +197,8 @@ func waitUp(ctx context.Context, ipComm IPCommunicator) error {
 				continue
 			}
 			if !errors.Is(err, ctlErrNotUp) {
-				return locale.WrapError(err, "svcctl_ping_failed", "Ping encountered unexpected failure: {{.V0}}", err.Error())
+				err := locale.WrapError(err, "svcctl_ping_failed", "Ping encountered unexpected failure: {{.V0}}", err.Error())
+				return errs.Pack(err, debugInfo)
 			}
 			elapsed := time.Since(tryStart)
 			time.Sleep(timeout - elapsed)
@@ -199,35 +207,42 @@ func waitUp(ctx context.Context, ipComm IPCommunicator) error {
 		return nil
 	}
 
-	return locale.NewError(waitTimeoutL10nKey, "", time.Since(start).Round(time.Millisecond).String(), "2", constants.ForumsURL)
+	err := locale.NewError(waitTimeoutL10nKey, "", time.Since(start).Round(time.Millisecond).String(), "2", constants.ForumsURL)
+	return errs.Pack(err, debugInfo)
 }
 
 func stopAndWait(ctx context.Context, ipComm IPCommunicator) error {
+	debugInfo := newDebugData(ipComm, stopSvc)
+
 	if err := ipComm.StopServer(ctx); err != nil {
 		return locale.WrapError(err, "svcctl_stop_req_failed", "Service stop request failed")
 	}
 
 	logging.Debug("Waiting for service to die")
-	if err := waitDown(ctx, ipComm); err != nil {
+	if err := waitDown(ctx, ipComm, debugInfo); err != nil {
 		return locale.WrapError(err, "svcctl_wait_shutdown_failed", "Waiting for service shutdown confirmation failed")
 	}
 
 	return nil
 }
 
-func waitDown(ctx context.Context, ipComm IPCommunicator) error {
+func waitDown(ctx context.Context, ipComm IPCommunicator, debugInfo *debugData) error {
+	debugInfo.startWait()
+	defer debugInfo.stopWait()
+
 	start := time.Now()
 	for try := 1; try <= pingRetryIterations; try++ {
 		select {
 		case <-ctx.Done():
-			return locale.WrapError(ctx.Err(), waitTimeoutL10nKey, "", time.Since(start).String(), "3", constants.ForumsURL)
+			err := locale.WrapError(ctx.Err(), waitTimeoutL10nKey, "", time.Since(start).String(), "3", constants.ForumsURL)
+			return errs.Pack(err, debugInfo)
 		default:
 		}
 
 		tryStart := time.Now()
 		timeout := time.Millisecond * time.Duration(try*try)
 
-		logging.Debug("Attempt: %d, timeout: %v, total: %v", try, timeout, time.Since(start))
+		debugInfo.addWaitAttempt(tryStart, try, timeout)
 		if err := ping(ctx, ipComm, timeout); err != nil {
 			// Timeout does not reveal enough info, try again.
 			// We don't need to sleep for this type of error because,
@@ -242,14 +257,16 @@ func waitDown(ctx context.Context, ipComm IPCommunicator) error {
 				return nil
 			}
 			if !errors.Is(err, ctlErrTempNotUp) {
-				return locale.WrapError(err, "svcctl_ping_failed", "Ping encountered unexpected failure: {{.V0}}", err.Error())
+				err := locale.WrapError(err, "svcctl_ping_failed", "Ping encountered unexpected failure: {{.V0}}", err.Error())
+				return errs.Pack(err, debugInfo)
 			}
 		}
 		elapsed := time.Since(tryStart)
 		time.Sleep(timeout - elapsed)
 	}
 
-	return locale.NewError(waitTimeoutL10nKey, "", time.Since(start).Round(time.Millisecond).String(), "4", constants.ForumsURL)
+	err := locale.NewError(waitTimeoutL10nKey, "", time.Since(start).Round(time.Millisecond).String(), "4", constants.ForumsURL)
+	return errs.Pack(err, debugInfo)
 }
 
 func ping(ctx context.Context, ipComm IPCommunicator, timeout time.Duration) error {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1954" title="DX-1954" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1954</a>  Improve wait up/down and enrich content of svc wait up/down error message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This should help with rollbar reports.

This is based on work done in the https://github.com/ActiveState/cli/commits/green/upg_svc_wait.DX-1824 branch: https://github.com/ActiveState/cli/pull/2739/files

I omitted the wait up/down pacing (https://github.com/ActiveState/cli/pull/2739/commits/c1920bb1d130ef07c8eab04774ca68a7f33ad2bf) because that's additional complication for little gain from what little I understood of it. Maintenance going forward may be a burden.