### PR TITLE
Add support for attachStagedCommit

### DIFF
--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -210,7 +210,11 @@ func (r *Push) Run(params PushParams) error {
 
 	// Update the project at the given commit id.
 	bp := model.NewBuildPlannerModel(r.auth)
-	err = bp.AttachStagedCommit(targetNamespace.Owner, targetNamespace.Project, branch.CommitID.String(), commitID.String(), branch.Label)
+	var branchCommitID string
+	if branch.CommitID != nil {
+		branchCommitID = branch.CommitID.String()
+	}
+	err = bp.AttachStagedCommit(targetNamespace.Owner, targetNamespace.Project, branchCommitID, commitID.String(), branch.Label)
 	if err != nil {
 		return locale.WrapError(err, "err_push_attach_staged_commit", "Failed to attach staged commit to project.")
 	}

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -209,8 +209,10 @@ func (r *Push) Run(params PushParams) error {
 	}
 
 	// Update the project at the given commit id.
-	bp := model.NewBuildPlannerModel(r.auth)
+	// Currently, the build planner doesn't support attaching a staged commit
+	// without a parent commit ID
 	if branch.CommitID != nil {
+		bp := model.NewBuildPlannerModel(r.auth)
 		logging.Debug("Attaching staged commit via build planner")
 		err = bp.AttachStagedCommit(targetNamespace.Owner, targetNamespace.Project, branch.CommitID.String(), commitID.String(), branch.Label)
 		if err != nil {

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -211,11 +211,13 @@ func (r *Push) Run(params PushParams) error {
 	// Update the project at the given commit id.
 	bp := model.NewBuildPlannerModel(r.auth)
 	if branch.CommitID != nil {
+		logging.Debug("Attaching staged commit via build planner")
 		err = bp.AttachStagedCommit(targetNamespace.Owner, targetNamespace.Project, branch.CommitID.String(), commitID.String(), branch.Label)
 		if err != nil {
 			return locale.WrapError(err, "err_push_attach_staged_commit", "Failed to attach staged commit to project.")
 		}
 	} else {
+		logging.Debug("Updating project branch commit via VCS")
 		err = model.UpdateProjectBranchCommitWithModel(targetPjm, branch.Label, commitID)
 		if err != nil {
 			if errs.Matches(err, &model.ErrUpdateBranchAuth{}) {

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -210,22 +210,21 @@ func (r *Push) Run(params PushParams) error {
 
 	// Update the project at the given commit id.
 	bp := model.NewBuildPlannerModel(r.auth)
-	var branchCommitID string
 	if branch.CommitID != nil {
-		branchCommitID = branch.CommitID.String()
+		err = bp.AttachStagedCommit(targetNamespace.Owner, targetNamespace.Project, branch.CommitID.String(), commitID.String(), branch.Label)
+		if err != nil {
+			return locale.WrapError(err, "err_push_attach_staged_commit", "Failed to attach staged commit to project.")
+		}
+	} else {
+		err = model.UpdateProjectBranchCommitWithModel(targetPjm, branch.Label, commitID)
+		if err != nil {
+			if errs.Matches(err, &model.ErrUpdateBranchAuth{}) {
+				return locale.WrapInputError(err, "push_project_branch_no_permission", "You do not have permission to push to {{.V0}}.", targetNamespace.String())
+			} else {
+				return locale.WrapError(err, "push_project_branch_commit_err", "Failed to update new project {{.V0}} to current commitID.", targetNamespace.String())
+			}
+		}
 	}
-	err = bp.AttachStagedCommit(targetNamespace.Owner, targetNamespace.Project, branchCommitID, commitID.String(), branch.Label)
-	if err != nil {
-		return locale.WrapError(err, "err_push_attach_staged_commit", "Failed to attach staged commit to project.")
-	}
-	// err = model.UpdateProjectBranchCommitWithModel(targetPjm, branch.Label, commitID)
-	// if err != nil {
-	// 	if errs.Matches(err, &model.ErrUpdateBranchAuth{}) {
-	// 		return locale.WrapInputError(err, "push_project_branch_no_permission", "You do not have permission to push to {{.V0}}.", targetNamespace.String())
-	// 	} else {
-	// 		return locale.WrapError(err, "push_project_branch_commit_err", "Failed to update new project {{.V0}} to current commitID.", targetNamespace.String())
-	// 	}
-	// }
 
 	// Write the project namespace to the as.yaml, if it changed
 	if r.project.Owner() != targetNamespace.Owner || r.project.Name() != targetNamespace.Project {

--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -343,6 +343,10 @@ type StageCommitResult struct {
 	Commit *Commit `json:"stageCommit"`
 }
 
+type AttachStagedCommitResult struct {
+	Commit *Commit `json:"attachStagedCommit"`
+}
+
 // Error contains an error message.
 type Error struct {
 	Message string `json:"message"`

--- a/pkg/platform/api/buildplanner/request/attachStagedCommit.go
+++ b/pkg/platform/api/buildplanner/request/attachStagedCommit.go
@@ -1,0 +1,197 @@
+package request
+
+func AttachStagedCommit(owner, project, parentCommit, stagedCommit, branch string) *buildPlanByAttachStagedCommit {
+	return &buildPlanByAttachStagedCommit{map[string]interface{}{
+		"organization": owner,
+		"project":      project,
+		"parentCommit": parentCommit,
+		"stagedCommit": stagedCommit,
+		"branchRef":    branch,
+	}}
+}
+
+type buildPlanByAttachStagedCommit struct {
+	vars map[string]interface{}
+}
+
+func (b *buildPlanByAttachStagedCommit) Query() string {
+	return `
+mutation ($organization: String!, $project: String!, $parentCommit: ID!, $stagedCommit: ID!, $branchRef: String!) {
+  attachStagedCommit(input: {organization: $organization, project: $project, parentCommitId: $parentCommit, stagedCommitId: $stagedCommit, branchRef: $branchRef}) {
+    ... on Commit {
+      __typename
+      expr
+      commitId
+      build {
+        __typename
+        ... on BuildStarted {
+          buildLogIds {
+            ... on AltBuildId {
+              id
+            }
+          }
+        }
+        ... on BuildStarted {
+          buildLogIds {
+            ... on AltBuildId {
+              id
+            }
+          }
+        }
+        ... on Build {
+          status
+          terminals {
+            tag
+            nodeIds
+          }
+          sources: nodes {
+            ... on Source {
+              nodeId
+              name
+              namespace
+              version
+            }
+          }
+          steps: steps {
+            ... on Step {
+              stepId
+              inputs {
+                tag
+                nodeIds
+              }
+              outputs
+            }
+          }
+          artifacts: nodes {
+            ... on ArtifactSucceeded {
+              __typename
+              nodeId
+              mimeType
+              generatedBy
+              runtimeDependencies
+              status
+              logURL
+              url
+              checksum
+            }
+            ... on ArtifactUnbuilt {
+              __typename
+              nodeId
+              mimeType
+              generatedBy
+              runtimeDependencies
+              status
+            }
+            ... on ArtifactStarted {
+              __typename
+              nodeId
+              mimeType
+              generatedBy
+              runtimeDependencies
+              status
+            }
+            ... on ArtifactTransientlyFailed {
+              __typename
+              nodeId
+              mimeType
+              generatedBy
+              runtimeDependencies
+              status
+              logURL
+              errors
+              attempts
+              nextAttemptAt
+            }
+            ... on ArtifactPermanentlyFailed {
+              __typename
+              nodeId
+              mimeType
+              generatedBy
+              runtimeDependencies
+              status
+              logURL
+              errors
+            }
+            ... on ArtifactFailed {
+              __typename
+              nodeId
+              mimeType
+              generatedBy
+              runtimeDependencies
+              status
+              logURL
+              errors
+            }
+          }
+        }
+        ... on PlanningError {
+          message
+          subErrors {
+            __typename
+            ... on GenericSolveError {
+              path
+              message
+              isTransient
+              validationErrors {
+                jsonPath
+                error
+              }
+            }
+            ... on RemediableSolveError {
+              path
+              message
+              isTransient
+              errorType
+              validationErrors {
+                jsonPath
+              }
+              suggestedRemediations {
+                remediationType
+                command
+                parameters
+              }
+            }
+          }
+        }
+      }
+    }
+    ... on ParseError {
+      __typename
+      message
+      path
+    }
+    ... on NotFound {
+      __typename
+      message
+      type
+      resource
+      mayNeedAuthentication
+    }
+    ... on Error {
+      __typename
+      message
+    }
+    ... on NoChangeSinceLastCommit {
+      __typename
+      commitId
+      message
+    }
+    ... on Forbidden {
+      __typename
+      operation
+      message
+      resource
+    }
+    ... on HeadOnBranchMoved {
+      __typename
+      commitId
+      branchId
+      message
+    }
+  }
+}`
+}
+
+func (b *buildPlanByAttachStagedCommit) Vars() map[string]interface{} {
+	return b.vars
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2133" title="DX-2133" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2133</a>  Use new AttachStagedCommit BuildPlanner mutation for `state push`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The BuildPlanner currently doesn't support attaching a commit that doesn't have a parent. This means that in some cases we are still using the old VCS API. I've filed a story with PB to address this.