### PR TITLE
Update failure analytics events should set target version, not version.

### DIFF
--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -78,21 +78,21 @@ func autoUpdate(args []string, cfg *config.Instance, an analytics.Dispatcher, ou
 	if err != nil {
 		if os.IsPermission(err) {
 			an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, &dimensions.Values{
-				Version: ptr.To(up.Version),
-				Error:   ptr.To("Could not update the state tool due to insufficient permissions."),
+				TargetVersion: ptr.To(up.Version),
+				Error:         ptr.To("Could not update the state tool due to insufficient permissions."),
 			})
 			return false, locale.WrapInputError(err, locale.Tl("auto_update_permission_err", "", constants.DocumentationURL, errs.JoinMessage(err)))
 		}
 		if errs.Matches(err, &updater.ErrorInProgress{}) {
 			an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, &dimensions.Values{
-				Version: ptr.To(up.Version),
-				Error:   ptr.To(anaConst.UpdateErrorInProgress),
+				TargetVersion: ptr.To(up.Version),
+				Error:         ptr.To(anaConst.UpdateErrorInProgress),
 			})
 			return false, nil
 		}
 		an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, &dimensions.Values{
-			Version: ptr.To(up.Version),
-			Error:   ptr.To(anaConst.UpdateErrorInstallFailed),
+			TargetVersion: ptr.To(up.Version),
+			Error:         ptr.To(anaConst.UpdateErrorInstallFailed),
 		})
 		return false, locale.WrapError(err, locale.T("auto_update_failed"))
 	}

--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -109,14 +109,14 @@ func autoUpdate(args []string, cfg *config.Instance, an analytics.Dispatcher, ou
 			msg = anaConst.UpdateErrorRelaunch
 		}
 		an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateRelaunch, anaConst.UpdateLabelFailed, &dimensions.Values{
-			Version: ptr.To(up.Version),
-			Error:   ptr.To(msg),
+			TargetVersion: ptr.To(up.Version),
+			Error:         ptr.To(msg),
 		})
 		return true, errs.Silence(errs.WrapExitCode(err, code))
 	}
 
 	an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateRelaunch, anaConst.UpdateLabelSuccess, &dimensions.Values{
-		Version: ptr.To(up.Version),
+		TargetVersion: ptr.To(up.Version),
 	})
 	return true, nil
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2144" title="DX-2144" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2144</a>  Update events incorrectly setting the target_version
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
