### PR TITLE
`state auth signup` sends the user to the signup page instead of the login page.

### DIFF
--- a/internal/runners/auth/signup.go
+++ b/internal/runners/auth/signup.go
@@ -30,7 +30,7 @@ func (s *Signup) Run(params *SignupParams) error {
 	}
 
 	if !params.Prompt {
-		return authlet.AuthenticateWithBrowser(s.Outputer, s.Auth, s.Prompter) // user can sign up from this page too
+		return authlet.SignupWithBrowser(s.Outputer, s.Auth, s.Prompter)
 	}
 	return authlet.Signup(s.Configurable, s.Outputer, s.Prompter, s.Auth)
 }

--- a/pkg/cmdlets/auth/login.go
+++ b/pkg/cmdlets/auth/login.go
@@ -1,8 +1,12 @@
 package auth
 
 import (
+	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
@@ -121,7 +125,7 @@ func RequireAuthentication(message string, cfg keypairs.Configurable, out output
 			return errs.Wrap(err, "Authenticate failed")
 		}
 	case locale.T("prompt_signup_browser_action"):
-		if err := AuthenticateWithBrowser(out, auth, prompt); err != nil { // user can sign up from this page too
+		if err := SignupWithBrowser(out, auth, prompt); err != nil {
 			return errs.Wrap(err, "Signup failed")
 		}
 	case locale.T("prompt_signup_action"):
@@ -226,22 +230,41 @@ func promptToken(credentials *mono_models.Credentials, out output.Outputer, prom
 func AuthenticateWithBrowser(out output.Outputer, auth *authentication.Auth, prompt prompt.Prompter) error {
 	logging.Debug("Authenticating with browser")
 
+	err := authenticateWithBrowser(out, auth, prompt, false)
+	if err != nil {
+		return errs.Wrap(err, "Error authenticating with browser")
+	}
+
+	out.Notice(locale.T("auth_device_success"))
+
+	return nil
+}
+
+// authenticateWithBrowser authenticates after signup if applicable.
+func authenticateWithBrowser(out output.Outputer, auth *authentication.Auth, prompt prompt.Prompter, signup bool) error {
 	response, err := model.RequestDeviceAuthorization()
 	if err != nil {
 		return locale.WrapError(err, "err_auth_device")
+	}
+
+	if response.VerificationURIComplete == nil {
+		return errs.New("Invalid response: Missing verification URL.")
+	}
+
+	verificationUrl := *response.VerificationURIComplete
+	if signup {
+		baseUrl := strings.TrimPrefix(*response.VerificationURIComplete, "https://"+constants.PlatformURL)
+		verificationUrl = fmt.Sprintf("%s?nextRoute=%s", constants.PlatformSignupURL, url.QueryEscape(baseUrl))
 	}
 
 	// Print code to user
 	if response.UserCode == nil {
 		return errs.New("Invalid response: Missing user code.")
 	}
-	out.Notice(locale.Tr("auth_device_verify_security_code", *response.UserCode, *response.VerificationURIComplete))
+	out.Notice(locale.Tr("auth_device_verify_security_code", *response.UserCode, verificationUrl))
 
 	// Open URL in browser
-	if response.VerificationURIComplete == nil {
-		return errs.New("Invalid response: Missing verification URL.")
-	}
-	err = OpenURI(*response.VerificationURIComplete)
+	err = OpenURI(verificationUrl)
 	if err != nil {
 		logging.Warning("Could not open browser: %v", err)
 		out.Notice(locale.Tr("err_browser_open"))
@@ -274,8 +297,6 @@ func AuthenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 	if err := auth.SaveToken(apiKey); err != nil {
 		return locale.WrapError(err, "err_auth_token", "Failed to create token after authenticating with browser.")
 	}
-
-	out.Notice(locale.T("auth_device_success"))
 
 	return nil
 }

--- a/pkg/cmdlets/auth/signup.go
+++ b/pkg/cmdlets/auth/signup.go
@@ -1,12 +1,13 @@
 package auth
 
 import (
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/prompt"
-
 	"github.com/ActiveState/cli/pkg/cmdlets/legalprompt"
 	"github.com/ActiveState/cli/pkg/platform/api"
 	"github.com/ActiveState/cli/pkg/platform/api/mono"
@@ -163,5 +164,18 @@ func UsernameValidator(val interface{}) error {
 	if err != nil || *res.Payload.Code != int64(200) {
 		return locale.NewError("err_username_taken")
 	}
+	return nil
+}
+
+func SignupWithBrowser(out output.Outputer, auth *authentication.Auth, prompt prompt.Prompter) error {
+	logging.Debug("Signing up with browser")
+
+	err := authenticateWithBrowser(out, auth, prompt, true)
+	if err != nil {
+		return errs.Wrap(err, "Error signing up with browser")
+	}
+
+	out.Notice(locale.Tl("auth_signup_success", "Successfully signed up and authorized this device"))
+
 	return nil
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2148" title="DX-2148" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2148</a>  As a user when I use the state auth signup command I want it to automatically open the account creation page instead of the login page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The idea is to share as much of the authentication with browser logic is possible, but account for the differences in URL.