### PR TITLE
Fix JSON messages in history

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1344,6 +1344,8 @@ namespace_label_platform:
   other: "Platform"
 namespace_label_preplatform:
   other: "Bits"
+namespace_label_packager:
+  other: "Docker/Installer packagers"
 print_commit:
   other: "[NOTICE]commit {{.V0}}[/RESET]"
 print_commit_author:

--- a/pkg/cmdlets/commit/commit.go
+++ b/pkg/cmdlets/commit/commit.go
@@ -105,6 +105,13 @@ func FormatChanges(commit *mono_models.Commit) ([]string, []*requirementChange) 
 			versionConstraints = ""
 		}
 
+		// This is a temporary fix until we start getting history in the form of build expressions
+		if model.NamespaceMatch(change.Namespace, model.NamespaceBuildFlagsMatch) &&
+			(strings.Contains(change.Requirement, "docker") || strings.Contains(change.Requirement, "installer")) {
+			requirement = locale.T("namespace_label_packager")
+			versionConstraints = ""
+		}
+
 		var result, oldConstraints, newConstraints string
 		switch change.Operation {
 		case string(model.OperationAdded):

--- a/pkg/cmdlets/commit/commit.go
+++ b/pkg/cmdlets/commit/commit.go
@@ -106,6 +106,7 @@ func FormatChanges(commit *mono_models.Commit) ([]string, []*requirementChange) 
 		}
 
 		// This is a temporary fix until we start getting history in the form of build expressions
+		// https://activestatef.atlassian.net/browse/DX-2197
 		if model.NamespaceMatch(change.Namespace, model.NamespaceBuildFlagsMatch) &&
 			(strings.Contains(change.Requirement, "docker") || strings.Contains(change.Requirement, "installer")) {
 			requirement = locale.T("namespace_label_packager")

--- a/pkg/platform/model/vcs.go
+++ b/pkg/platform/model/vcs.go
@@ -85,6 +85,9 @@ const (
 
 	// NamespaceSharedMatch is the namespace used for shared requirements (usually runtime libraries)
 	NamespaceSharedMatch = `^shared$`
+
+	// NamespaceBuildFlagsMatch is the namespace used for passing build flags
+	NamespaceBuildFlagsMatch = `^build-flags$`
 )
 
 type TrackingType string


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2195" title="DX-2195" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2195</a>  Running `state history` in dashboard-created Windows project shows JSON in "changes" section
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This change isn't ideal but it will work for now until we can get the history in the format of a build expression. Asked the Dashboard squad how they are handling this. Here is their changeset: https://github.com/ActiveState/TheHomeRepot/pull/11922/files.

Here is an example of the updated output:

```
█ Viewing Project History

Operating on project mitchell-as/docker, located at C:\Users\Mike\work\testing\docker.

Here are the most recent changes made to this project.

  Commit     a518738b-402b-404b-805f-97f9276f2cdf
  Author     mitchell-as
  Date       01 Sep 23 16:41 UTC
  Message    Not provided.
  Changes     - + Docker/Installer packagers
              - + python 3.10.12
              - + Platform
```