### PR TITLE
Revert inclusion of build artifacts from event handling

### DIFF
--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -485,7 +485,7 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 	)
 
 	artifactsToInstall := []artifact.ArtifactID{}
-	buildtimeArtifacts := runtimeArtifacts
+	// buildtimeArtifacts := runtimeArtifacts
 	if buildResult.BuildReady {
 		// If the build is already done we can just look at the downloadable artifacts as they will be a fully accurate
 		// prediction of what we will be installing.
@@ -501,13 +501,6 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 			if _, alreadyInstalled := alreadyInstalled[a.ArtifactID]; !alreadyInstalled {
 				artifactsToInstall = append(artifactsToInstall, a.ArtifactID)
 			}
-		}
-
-		// We also caclulate the artifacts to be built which includes more than the runtime artifacts.
-		// This is used to determine if we need to show the "build in progress" screen.
-		buildtimeArtifacts, err = buildplan.BuildtimeArtifacts(buildResult.Build, false)
-		if err != nil {
-			return nil, nil, errs.Wrap(err, "Could not get buildtime artifacts")
 		}
 	}
 
@@ -525,7 +518,7 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 		ArtifactNames: artifactNames,
 		LogFilePath:   logFilePath,
 		ArtifactsToBuild: func() []artifact.ArtifactID {
-			return artifact.ArtifactIDsFromBuildPlanMap(buildtimeArtifacts) // This does not account for cached builds
+			return artifact.ArtifactIDsFromBuildPlanMap(runtimeArtifacts) // This does not account for cached builds
 		}(),
 		// Yes these have the same value; this is intentional.
 		// Separating these out just allows us to be more explicit and intentional in our event handling logic.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2186" title="DX-2186" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2186</a>  Install/Uninstall package finished with `Progress Bar` ERROR in the log 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This reverses the meaningful change from https://github.com/ActiveState/cli/pull/2696. I've opted to keep the function that calculates the build dependencies as it will give us a starting point when we revisit the issue.

Tested this build with an in-progress Perl build and did not see the incorrect building number.