### PR TITLE
Attempt to trap "flisten in use" errors on CI for further debugging.

### DIFF
--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -527,8 +527,9 @@ func (s *Session) Close() error {
 	}
 
 	// Trap "flisten in use" errors to help debug DX-2090.
-	svcLogContents := s.SvcLog()
-	require.NotContains(s.t, svcLogContents, "flisten in use", "Found flisten in use error in state-svc log file, contents:\n%s", svcLogContents)
+	if contents := s.SvcLog(); strings.Contains(contents, "flisten in use") {
+		s.t.Fatal(s.DebugMessage("Found 'flisten in use' error in state-svc log file"))
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2090" title="DX-2090" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2090</a>  state-svc: An existing server instance appears to be in use: flisten in use
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
