### PR TITLE
Update runtime use tracking

### DIFF
--- a/pkg/platform/runtime/target/target.go
+++ b/pkg/platform/runtime/target/target.go
@@ -54,7 +54,8 @@ func NewExecTrigger(cmd string) Trigger {
 }
 
 func (t Trigger) IndicatesUsage() bool {
-	return !strings.EqualFold(string(t), string(TriggerRefresh))
+	// All triggers should indicate runtime use except for refreshing executors
+	return !strings.EqualFold(string(t), string(TriggerResetExec))
 }
 
 type ProjectTarget struct {

--- a/pkg/platform/runtime/target/target.go
+++ b/pkg/platform/runtime/target/target.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/go-openapi/strfmt"
-	"github.com/thoas/go-funk"
 )
 
 type Trigger string
@@ -50,40 +49,12 @@ const (
 	triggerUnknown            Trigger = "unknown"
 )
 
-// usageTriggers are triggers that indicate actual usage of the runtime (as oppose to simply making changes to the runtime)
-var usageTriggers = []Trigger{
-	TriggerActivate,
-	TriggerScript,
-	TriggerDeploy,
-	TriggerExec,
-	TriggerExecutor,
-	TriggerSwitch,
-	TriggerImport,
-	TriggerInit,
-	TriggerPackage,
-	TriggerPull,
-	TriggerReset,
-	TriggerRevert,
-	TriggerShell,
-	TriggerCheckout,
-	TriggerUse,
-	TriggerOfflineInstaller,
-	TriggerOfflineUninstaller,
-}
-
 func NewExecTrigger(cmd string) Trigger {
 	return Trigger(fmt.Sprintf("%s: %s", TriggerExec, cmd))
 }
 
 func (t Trigger) IndicatesUsage() bool {
-	if funk.Contains(usageTriggers, t) {
-		return true
-	}
-	return t.IsExecTrigger() && funk.Contains(usageTriggers, TriggerExec)
-}
-
-func (t Trigger) IsExecTrigger() bool {
-	return strings.HasPrefix(string(t), string(TriggerExec)+": ")
+	return !strings.EqualFold(string(t), string(TriggerRefresh))
 }
 
 type ProjectTarget struct {

--- a/pkg/platform/runtime/target/target_test.go
+++ b/pkg/platform/runtime/target/target_test.go
@@ -15,7 +15,7 @@ func TestTrigger_IndicatesUsage(t *testing.T) {
 		},
 		{
 			"Reset exec does not count as usage",
-			TriggerRefresh,
+			TriggerResetExec,
 			false,
 		},
 	}

--- a/pkg/platform/runtime/target/target_test.go
+++ b/pkg/platform/runtime/target/target_test.go
@@ -15,7 +15,7 @@ func TestTrigger_IndicatesUsage(t *testing.T) {
 		},
 		{
 			"Reset exec does not count as usage",
-			TriggerResetExec,
+			TriggerRefresh,
 			false,
 		},
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2162" title="DX-2162" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2162</a>  We track ALL runtime use as runtime use
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Decided to go with the simpler blacklist approach. This means we will have to be a little more careful calling `IndicatesUsage()`