### PR TITLE
Added tests for Ruby support.

### DIFF
--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -643,6 +643,29 @@ func (suite *PackageIntegrationTestSuite) TestUpdate() {
 	cp.ExpectExitCode(0)
 }
 
+func (suite *PackageIntegrationTestSuite) TestRuby() {
+	if runtime.GOOS == "darwin" {
+		return // Ruby support is not yet enabled on the Platform
+	}
+	suite.OnlyRunForTags(tagsuite.Package)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Ruby-3.2.2", ".")
+	cp.Expect("Checked out project")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("install", "rake")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("exec", "rake", "--", "--version"),
+		e2e.AppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.ExpectRe(`rake, version \d+\.\d+\.\d+`)
+	cp.ExpectExitCode(0)
+}
+
 func TestPackageIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(PackageIntegrationTestSuite))
 }

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/subshell/bash"
@@ -325,6 +326,29 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 	cp.SendLine("exit") // subshell within a subshell
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
+}
+
+func (suite *ShellIntegrationTestSuite) TestRuby() {
+	if runtime.GOOS == "darwin" {
+		return // Ruby support is not yet enabled on the Platform
+	}
+	suite.OnlyRunForTags(tagsuite.Shell)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Ruby-3.2.2")
+	cp.Expect("Checked out project")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.WithArgs("shell", "Ruby-3.2.2"),
+		e2e.AppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("Activated")
+	cp.WaitForInput()
+	cp.SendLine("ruby -v")
+	cp.Expect("3.2.2")
+	cp.Expect("ActiveState")
 }
 
 func TestShellIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2181" title="DX-2181" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2181</a>  State Tool Fully Supports Ruby
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


State Tool's recommended Ruby version is already 3.2.2.
