### PR TITLE
Fixed commit date display in `state history`.

### DIFF
--- a/pkg/cmdlets/commit/commit.go
+++ b/pkg/cmdlets/commit/commit.go
@@ -74,8 +74,7 @@ func newCommitOutput(commit *mono_models.Commit, orgs []gmodel.Organization, isL
 		StructuredChanges: structuredChanges,
 	}
 
-	commitOutput.Date = commit.AtTime.String()
-	dt, err := time.Parse(time.RFC3339, commit.AtTime.String())
+	dt, err := time.Parse(time.RFC3339, commit.Added.String())
 	if err != nil {
 		multilog.Error("Could not parse commit time: %v", err)
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2196" title="DX-2196" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2196</a>  Commit date field is incorrect in `state history` output
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
