### PR TITLE
 No need to see if there were any buildexpression changes after the fact

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1718,8 +1718,6 @@ err_user_network_solution:
     If your issue persists consider reporting it on our forums at {{.V0}}.
 err_revert_get_commit:
   other: "Could not fetch commit details for commit with ID: {{.V0}}"
-err_revert_refresh:
-  other: Could not get revert commit to check if changes were indeed made
 err_revert_commit:
   other: "Could not revert{{.V0}} commit: {{.V1}}"
 install_initial_success:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2014" title="DX-2014" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2014</a>  We don't rely on GetRevertCommit for detecting order changes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

StageCommit will error if there are no changes.