### PR TITLE
Increase default timeout for runtime sourcing to 3 minutes

### DIFF
--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -66,7 +66,9 @@ var (
 	PersistentPassword string
 	PersistentToken    string
 
-	defaultTimeout = 40 * time.Second
+	defaultTimeout            = 40 * time.Second
+	RuntimeSourcingTimeout    = 3 * time.Minute
+	RuntimeSourcingTimeoutOpt = termtest.OptExpectTimeout(3 * time.Minute)
 )
 
 func init() {

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -183,7 +183,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 
 	if runtime.GOOS == "linux" {
 		cp.Expect("Creating a Virtual Environment")
-		cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+		cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectInput(termtest.OptExpectTimeout(40 * time.Second))
 		cp.SendLine("exit")
 		cp.ExpectExitCode(0)
@@ -226,7 +226,7 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 		e2e.OptAppendEnv(extraEnv...),
 	)
 
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	// ensure that shell is functional
 	cp.ExpectInput()
 
@@ -295,7 +295,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_PythonPath() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	// ensure that shell is functional
 	cp.ExpectInput()
 
@@ -351,7 +351,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_SpaceInCacheDir() {
 		e2e.OptArgs("activate", "ActiveState-CLI/Python3"),
 	)
 
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("python3 --version")
 	cp.Expect("Python 3.")
 
@@ -379,7 +379,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePerl() {
 
 	cp.Expect("Downloading", termtest.OptExpectTimeout(40*time.Second))
 	cp.Expect("Installing", termtest.OptExpectTimeout(140*time.Second))
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 
 	suite.assertCompletedStatusBarReport(cp.Output())
 
@@ -511,7 +511,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_FromCache() {
 	)
 	cp.Expect("Downloading")
 	cp.Expect("Installing")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 
 	suite.assertCompletedStatusBarReport(cp.Output())
 	cp.SendLine("exit")
@@ -547,7 +547,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateCommitURL() {
 
 	// Ensure we have the most up to date version of the project before activating
 	cp := ts.Spawn("activate")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 }
@@ -664,7 +664,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateArtifactsCached() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 
@@ -696,7 +696,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateArtifactsCached() {
 	)
 
 	cp.Expect("Fetched cached artifact")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 }

--- a/test/integration/analytics_int_test.go
+++ b/test/integration/analytics_int_test.go
@@ -77,7 +77,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestHeartbeats() {
 	}
 
 	cp.Expect("Creating a Virtual Environment")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(120 * time.Second))
 
 	time.Sleep(time.Second) // Ensure state-svc has time to report events
@@ -525,7 +525,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestAttempts() {
 	)
 
 	cp.Expect("Creating a Virtual Environment")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(120 * time.Second))
 
 	cp.SendLine("python3 --version")
@@ -568,7 +568,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestHeapEvents() {
 	)
 
 	cp.Expect("Creating a Virtual Environment")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(120 * time.Second))
 
 	time.Sleep(time.Second) // Ensure state-svc has time to report events

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -7,9 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -37,7 +35,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckout() {
 		e2e.OptArgs("checkout", "ActiveState-CLI/Python-3.9", "."),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Checked out project", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	suite.Require().True(fileutils.DirExists(ts.Dirs.Work), "state checkout should have created "+ts.Dirs.Work)
 	suite.Require().True(fileutils.FileExists(filepath.Join(ts.Dirs.Work, constants.ConfigFileName)), "ActiveState-CLI/Python3 was not checked out properly")
 
@@ -72,8 +70,8 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckout() {
 				"VERBOSE=true", // Necessary to assert "Fetched cached artifact"
 			),
 		)
-		cp.Expect("Fetched cached artifact", termtest.OptExpectTimeout(120*time.Second)) // Comes from log, which is why we're using VERBOSE=true
-		cp.Expect("Checked out project", termtest.OptExpectTimeout(120*time.Second))
+		cp.Expect("Fetched cached artifact", e2e.RuntimeSourcingTimeoutOpt) // Comes from log, which is why we're using VERBOSE=true
+		cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectExitCode(0)
 	})
 }
@@ -178,7 +176,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutCustomRTPath() {
 		e2e.OptArgs("checkout", "ActiveState-CLI/Python3", fmt.Sprintf("--runtime-path=%s", customRTPath)),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Checked out project", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 
 	pythonExe := filepath.Join(setup.ExecDir(customRTPath), "python3"+exeutils.Extension)
 	suite.Require().True(fileutils.DirExists(customRTPath))

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
@@ -12,7 +11,6 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
 	"github.com/ActiveState/cli/pkg/project"
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -35,7 +33,7 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 		),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Checked out", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	proj, err := project.FromPath(ts.Dirs.Work)

--- a/test/integration/deploy_int_test.go
+++ b/test/integration/deploy_int_test.go
@@ -248,8 +248,8 @@ func (suite *DeployIntegrationTestSuite) InstallAndAssert(ts *e2e.Session, targe
 	)
 
 	cp.Expect("Installing Runtime")
-	cp.Expect("Installing", termtest.OptExpectTimeout(120*time.Second))
-	cp.Expect("Installation completed", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Installing", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Installation completed", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/executor_int_test.go
+++ b/test/integration/executor_int_test.go
@@ -4,9 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -39,7 +37,7 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorForwards() {
 		e2e.OptArgs("shell", "ActiveState-CLI/Python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 
 	cp.SendLine("python3 -c \"import sys; print(sys.copyright)\"")
@@ -66,7 +64,7 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorExitCode() {
 		e2e.OptArgs("shell", "ActiveState-CLI/Python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 
 	cp.SendLine("python3 -c \"exit(42)\"")

--- a/test/integration/export_int_test.go
+++ b/test/integration/export_int_test.go
@@ -109,7 +109,7 @@ func (suite *ExportIntegrationTestSuite) TestJSON() {
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python", "."),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.ExpectExitCode(0, termtest.OptExpectTimeout(120*time.Second))
+	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("export", "env", "-o", "json"),

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -463,7 +463,7 @@ func (suite *PackageIntegrationTestSuite) TestInstall_Empty() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Installing Package")
-	cp.ExpectExitCode(0, termtest.OptExpectTimeout(120*time.Second))
+	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 
 	configFilepath := filepath.Join(ts.Dirs.Work, constants.ConfigFileName)
 	suite.Require().FileExists(configFilepath)
@@ -505,7 +505,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 		e2e.OptArgs("install", "Text-CSV", "--output", "editor"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect(`{"name":"Text-CSV"`, termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect(`{"name":"Text-CSV"`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -7,9 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 
 	svcApp "github.com/ActiveState/cli/cmd/state-svc/app"
@@ -132,7 +130,7 @@ func (suite *PrepareIntegrationTestSuite) TestResetExecutors() {
 	cp.Expect("This project will always be available for use")
 	cp.Expect("Downloading")
 	cp.Expect("Installing")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -164,7 +162,7 @@ func (suite *PrepareIntegrationTestSuite) TestResetExecutors() {
 	err = os.RemoveAll(projectExecDir)
 
 	cp = ts.Spawn("activate")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("which python3")
 	cp.SendLine("python3 --version")
 	cp.Expect("ActiveState")

--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -228,7 +228,7 @@ func (suite *PushIntegrationTestSuite) TestCarlisle() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	// The activestate.yaml on Windows runs custom activation to set shortcuts and file associations.
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -107,7 +107,7 @@ func (suite *RunIntegrationTestSuite) TestInActivatedEnv() {
 	suite.createProjectFile(ts, 3)
 
 	cp := ts.Spawn("activate")
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
 
 	cp.SendLine(fmt.Sprintf("%s run testMultipleLanguages", ts.Exe))
@@ -144,7 +144,7 @@ func (suite *RunIntegrationTestSuite) TestScriptBashSubshell() {
 	suite.createProjectFile(ts, 3)
 
 	cp := ts.SpawnWithOpts(e2e.OptArgs("activate"), e2e.OptAppendEnv("SHELL=bash"))
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
 
 	cp.SendLine("helloWorld")
@@ -296,7 +296,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
 			"PERL_VERSION=does_not_exist",
 		),
 	)
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
 
 	cp.SendLine("perl -MEnglish -e 'print $PERL_VERSION'")

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -6,9 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ActiveState/cli/internal/config"
@@ -94,7 +92,7 @@ func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
 		e2e.OptArgs("use", "ActiveState-CLI/small-python"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
@@ -320,7 +318,7 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell", "small-python"),
 		e2e.OptAppendEnv(env...))
-	cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	suite.Assert().NotContains(cp.Output(), "State Tool is operating on project")
 	cp.SendLine(fmt.Sprintf(`export HOME="%s"`, ts.Dirs.HomeDir)) // some shells do not forward this
 

--- a/test/integration/shells_int_test.go
+++ b/test/integration/shells_int_test.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -62,7 +60,7 @@ func (suite *ShellsIntegrationTestSuite) TestShells() {
 
 			// Just pick the first one and verify the selection prompt works.
 			cp.SendEnter()
-			cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+			cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 
 			// Verify that the command prompt contains the right info, except for tcsh, whose prompt does
 			// not behave like other shells'.

--- a/test/integration/softlimit_int_test.go
+++ b/test/integration/softlimit_int_test.go
@@ -2,9 +2,7 @@ package integration
 
 import (
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -44,7 +42,7 @@ func (suite *SoftLimitIntegrationTestSuite) TestCheckout() {
 			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
 		)
 		cp.Expect("You've reached your runtime limit")
-		cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+		cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectInput()
 		cp.SendLine("exit 0")
 		cp.ExpectExitCode(0)
@@ -57,7 +55,7 @@ func (suite *SoftLimitIntegrationTestSuite) TestCheckout() {
 			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
 		)
 		cp.Expect("You've reached your runtime limit")
-		cp.Expect("Activated", termtest.OptExpectTimeout(120*time.Second))
+		cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectInput()
 		cp.SendLine("exit 0")
 		cp.ExpectExitCode(0)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2217" title="DX-2217" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2217</a>  Nightly failures due to timeouts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
