### PR TITLE
Drop check for "flisten in use"

### DIFF
--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -575,11 +575,6 @@ func (s *Session) Close() error {
 		}
 	}
 
-	// Trap "flisten in use" errors to help debug DX-2090.
-	if contents := s.SvcLog(); strings.Contains(contents, "flisten in use") {
-		s.t.Fatal(s.DebugMessage("Found 'flisten in use' error in state-svc log file"))
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2218" title="DX-2218" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2218</a>  Nightly failure: TestSingleSvc
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It was diagnosed, we don't need it anymore.