### PR TITLE
Fix some update analytics.

### DIFF
--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -73,30 +73,14 @@ func autoUpdate(svc *model.SvcModel, args []string, cfg *config.Instance, an ana
 
 	err = up.InstallBlocking("")
 	if err != nil {
+		if errs.Matches(err, &updater.ErrorInProgress{}) {
+			return false, nil // ignore
+		}
 		if os.IsPermission(err) {
-			an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, &dimensions.Values{
-				TargetVersion: ptr.To(avUpdate.Version),
-				Error:         ptr.To("Could not update the state tool due to insufficient permissions."),
-			})
 			return false, locale.WrapInputError(err, locale.Tl("auto_update_permission_err", "", constants.DocumentationURL, errs.JoinMessage(err)))
 		}
-		if errs.Matches(err, &updater.ErrorInProgress{}) {
-			an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, &dimensions.Values{
-				TargetVersion: ptr.To(avUpdate.Version),
-				Error:         ptr.To(anaConst.UpdateErrorInProgress),
-			})
-			return false, nil
-		}
-		an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, &dimensions.Values{
-			TargetVersion: ptr.To(avUpdate.Version),
-			Error:         ptr.To(anaConst.UpdateErrorInstallFailed),
-		})
 		return false, locale.WrapError(err, locale.T("auto_update_failed"))
 	}
-
-	an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateInstall, anaConst.UpdateLabelSuccess, &dimensions.Values{
-		TargetVersion: ptr.To(avUpdate.Version),
-	})
 
 	out.Notice(locale.Tr("auto_update_relaunch"))
 	out.Notice("") // Ensure output doesn't stick to our messaging

--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -94,6 +94,10 @@ func autoUpdate(svc *model.SvcModel, args []string, cfg *config.Instance, an ana
 		return false, locale.WrapError(err, locale.T("auto_update_failed"))
 	}
 
+	an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateInstall, anaConst.UpdateLabelSuccess, &dimensions.Values{
+		TargetVersion: ptr.To(avUpdate.Version),
+	})
+
 	out.Notice(locale.Tr("auto_update_relaunch"))
 	out.Notice("") // Ensure output doesn't stick to our messaging
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -132,7 +132,7 @@ func (u *UpdateInstaller) DownloadAndUnpack() (string, error) {
 	tmpDir, err := os.MkdirTemp("", "state-update")
 	if err != nil {
 		msg := anaConst.UpdateErrorTempDir
-		u.analyticsEvent(anaConst.ActUpdateDownload, anaConst.UpdateLabelFailed, u.AvailableUpdate.Version, msg)
+		u.analyticsEvent(anaConst.ActUpdateDownload, anaConst.UpdateLabelFailed, msg)
 		return "", errs.Wrap(err, msg)
 	}
 
@@ -149,13 +149,13 @@ func (u *UpdateInstaller) prepareInstall(installTargetPath string, args []string
 	if err != nil {
 		return "", nil, err
 	}
-	u.analyticsEvent(anaConst.ActUpdateDownload, anaConst.UpdateLabelSuccess, u.AvailableUpdate.Version, "")
+	u.analyticsEvent(anaConst.ActUpdateDownload, anaConst.UpdateLabelSuccess, "")
 
 	installerPath := filepath.Join(sourcePath, InstallerName)
 	logging.Debug("Using installer: %s", installerPath)
 	if !fileutils.FileExists(installerPath) {
 		msg := anaConst.UpdateErrorNoInstaller
-		u.analyticsEvent(anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, u.AvailableUpdate.Version, msg)
+		u.analyticsEvent(anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, msg)
 		return "", nil, errs.Wrap(err, msg)
 	}
 
@@ -163,7 +163,7 @@ func (u *UpdateInstaller) prepareInstall(installTargetPath string, args []string
 		installTargetPath, err = installation.InstallPathFromExecPath()
 		if err != nil {
 			msg := anaConst.UpdateErrorInstallPath
-			u.analyticsEvent(anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, u.AvailableUpdate.Version, msg)
+			u.analyticsEvent(anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, msg)
 			return "", nil, errs.Wrap(err, msg)
 		}
 	}
@@ -173,8 +173,23 @@ func (u *UpdateInstaller) prepareInstall(installTargetPath string, args []string
 	return installerPath, args, nil
 }
 
-func (u *UpdateInstaller) InstallBlocking(installTargetPath string, args ...string) error {
+func (u *UpdateInstaller) InstallBlocking(installTargetPath string, args ...string) (rerr error) {
 	logging.Debug("InstallBlocking path: %s, args: %v", installTargetPath, args)
+
+	// Report any failure to analytics.
+	defer func() {
+		if rerr == nil {
+			return
+		}
+		switch {
+		case os.IsPermission(rerr):
+			u.analyticsEvent(anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, "Could not update the state tool due to insufficient permissions.")
+		case errs.Matches(rerr, &ErrorInProgress{}):
+			u.analyticsEvent(anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, anaConst.UpdateErrorInProgress)
+		default:
+			u.analyticsEvent(anaConst.ActUpdateInstall, anaConst.UpdateLabelFailed, anaConst.UpdateErrorInstallFailed)
+		}
+	}()
 
 	err := checkAdmin()
 	if errors.Is(err, errPrivilegeMistmatch) {
@@ -215,6 +230,8 @@ func (u *UpdateInstaller) InstallBlocking(installTargetPath string, args ...stri
 	if err != nil {
 		return errs.Wrap(err, "Could not run installer")
 	}
+
+	u.analyticsEvent(anaConst.ActUpdateInstall, anaConst.UpdateLabelSuccess, "")
 
 	return nil
 }
@@ -259,9 +276,9 @@ func (u *UpdateInstaller) InstallWithProgress(installTargetPath string, progress
 	return proc, nil
 }
 
-func (u *UpdateInstaller) analyticsEvent(action, label, version, msg string) {
+func (u *UpdateInstaller) analyticsEvent(action, label, msg string) {
 	dims := &dimensions.Values{
-		TargetVersion: ptr.To(version),
+		TargetVersion: ptr.To(u.AvailableUpdate.Version),
 	}
 
 	if msg != "" {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -277,8 +277,9 @@ func (u *UpdateInstaller) InstallWithProgress(installTargetPath string, progress
 }
 
 func (u *UpdateInstaller) analyticsEvent(action, label, msg string) {
-	dims := &dimensions.Values{
-		TargetVersion: ptr.To(u.AvailableUpdate.Version),
+	dims := &dimensions.Values{}
+	if u.AvailableUpdate != nil {
+		dims.TargetVersion = ptr.To(u.AvailableUpdate.Version)
 	}
 
 	if msg != "" {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -149,7 +149,7 @@ func (u *UpdateInstaller) prepareInstall(installTargetPath string, args []string
 	if err != nil {
 		return "", nil, err
 	}
-	u.analyticsEvent(anaConst.ActUpdateDownload, "success", u.AvailableUpdate.Version, "")
+	u.analyticsEvent(anaConst.ActUpdateDownload, anaConst.UpdateLabelSuccess, u.AvailableUpdate.Version, "")
 
 	installerPath := filepath.Join(sourcePath, InstallerName)
 	logging.Debug("Using installer: %s", installerPath)
@@ -268,5 +268,5 @@ func (u *UpdateInstaller) analyticsEvent(action, label, version, msg string) {
 		dims.Error = ptr.To(msg)
 	}
 
-	u.an.EventWithLabel(anaConst.CatUpdates, anaConst.ActUpdateDownload, label, dims)
+	u.an.EventWithLabel(anaConst.CatUpdates, action, label, dims)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2128" title="DX-2128" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2128</a>  Fix update metrics not firing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The install success event was not being fired, so I added that.

However,
- The download event is fired here via autoUpdate() -> InstallBlocking() -> prepareInstall(): https://github.com/ActiveState/cli/blob/30a336cb4185db84569a7fbab6dadee5c4ec4719/internal/updater/updater.go#L152
- The relaunch event is fired here via autoUpdate(): https://github.com/ActiveState/cli/blob/30a336cb4185db84569a7fbab6dadee5c4ec4719/cmd/state/autoupdate.go#L115-L117

What can prevent these events from firing successfully are:
- The "should-autoupdate" "disabled-config" event is fired: https://github.com/ActiveState/cli/blob/30a336cb4185db84569a7fbab6dadee5c4ec4719/cmd/state/autoupdate.go#L61-L67
- The "install" "failure" event is fired (e.g. insufficient permissions, update in progress, etc.): https://github.com/ActiveState/cli/blob/30a336cb4185db84569a7fbab6dadee5c4ec4719/cmd/state/autoupdate.go#L74-L95
- The "relaunch" "failure" event is fired: https://github.com/ActiveState/cli/blob/30a336cb4185db84569a7fbab6dadee5c4ec4719/cmd/state/autoupdate.go#L100-L113

I don't have permission to view the tableau report, but this is what I gleaned looking at the code.