### PR TITLE
Clarify why we normalize terminal line endings to '\n'.

### DIFF
--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -268,6 +268,7 @@ func (s *Session) SpawnCmdWithOpts(exe string, optSetters ...SpawnOptSetter) *Sp
 	// raw terminal output will contain "\r\n". Since our multi-line expectation messages often use
 	// '\n', normalize line endings to that for convenience, regardless of platform ('\n' for Linux
 	// and macOS, "\r\n" for Windows).
+	// More info: https://superuser.com/a/1774370
 	spawnOpts.TermtestOpts = append(spawnOpts.TermtestOpts,
 		termtest.OptNormalizedLineEnds(true),
 	)

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -263,9 +263,9 @@ func (s *Session) SpawnCmdWithOpts(exe string, optSetters ...SpawnOptSetter) *Sp
 		termtest.OptRows(30), // Needs to be able to accommodate most JSON output
 	)
 
-	// Work around issue where multiline values sometimes have the wrong line endings
-	// See for example TestBranch_List
-	// https://activestatef.atlassian.net/browse/DX-2169
+	// Multi-line expectation strings (e.g. TestBranch_List), as well as macOS and Linux, use '\n' to
+	// represent newlines. However, Windows uses '\r\n' to represent newlines. Normalize all line
+	// endings to be just '\n' or else the expectation will fail on Windows.
 	spawnOpts.TermtestOpts = append(spawnOpts.TermtestOpts,
 		termtest.OptNormalizedLineEnds(true),
 	)

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -263,9 +263,11 @@ func (s *Session) SpawnCmdWithOpts(exe string, optSetters ...SpawnOptSetter) *Sp
 		termtest.OptRows(30), // Needs to be able to accommodate most JSON output
 	)
 
-	// Multi-line expectation strings (e.g. TestBranch_List), as well as macOS and Linux, use '\n' to
-	// represent newlines. However, Windows uses '\r\n' to represent newlines. Normalize all line
-	// endings to be just '\n' or else the expectation will fail on Windows.
+	// TTYs output newlines in two steps: '\r' (CR) to move the caret to the beginning of the line,
+	// and '\n' (LF) to move the caret one line down. Terminal emulators do the same thing, so the
+	// raw terminal output will contain "\r\n". Since our multi-line expectation messages often use
+	// '\n', normalize line endings to that for convenience, regardless of platform ('\n' for Linux
+	// and macOS, "\r\n" for Windows).
 	spawnOpts.TermtestOpts = append(spawnOpts.TermtestOpts,
 		termtest.OptNormalizedLineEnds(true),
 	)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2169" title="DX-2169" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2169</a>  Figure out why termtest is using Windows line endings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

~~When I commented out the code as instructed in the ticket, I got test passes on macOS and Linux (was not able to reproduce the original failure), but failures on Windows.~~

~~It is quite possible that the original, multi-line expectation string in TestBranch_List was silently using CR+LF line endings. (That is, the test was originally written and committed on Windows with CR+LF line endings.) Switching to a quoted string with newline (LF) escapes silently fixed the problem on macOS and Linux, but still requires a fix for Windows, which uses CR+LF.~~

Long story short: terminal emulators are emulating old TTYs, which emit CR+LF for newlines. You can read more [here](https://unix.stackexchange.com/questions/343324/why-in-the-output-of-script-1-the-newline-is-cr-lf-dos-style) and [here](https://superuser.com/questions/714078/wrong-newline-character-over-serial-port-cr-instead-of-lf).