### PR TITLE
Revert: Update shell rcfiles to indicate the user is already in an activated state (v42).

### DIFF
--- a/internal/assets/contents/shells/bashrc_append.sh
+++ b/internal/assets/contents/shells/bashrc_append.sh
@@ -6,7 +6,4 @@ export {{$K}}="{{$V}}:$PATH"
 export {{$K}}="{{$V}}"
 {{- end}}
 {{- end}}
-if [[ ! -z "${{.ActivatedEnv}}" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ]]; then
-  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
-fi
 # {{.Stop}}

--- a/internal/assets/contents/shells/fishrc_append.fish
+++ b/internal/assets/contents/shells/fishrc_append.fish
@@ -6,7 +6,4 @@ set -xg {{$K}} "{{$V}}:$PATH"
 set -xg {{$K}} "{{$V}}"
 {{- end}}
 {{- end}}
-if test ! -z "${{.ActivatedEnv}}"; test -f "${{.ActivatedEnv}}/{{.ConfigFile}}"
-  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
-end
 # {{.Stop}}

--- a/internal/assets/contents/shells/tcshrc_append.sh
+++ b/internal/assets/contents/shells/tcshrc_append.sh
@@ -5,7 +5,4 @@ setenv {{$K}} "{{$V}}:$PATH"
 {{- else}}
 {{- end}}
 {{- end}}
-if ( "${{.ActivatedEnv}}" != "" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ) then
-  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
-endif
 # {{.Stop}}

--- a/internal/assets/contents/shells/zshrc_append.sh
+++ b/internal/assets/contents/shells/zshrc_append.sh
@@ -6,7 +6,4 @@ export {{$K}}="{{$V}}:$PATH"
 export {{$K}}="{{$V}}"
 {{- end}}
 {{- end}}
-if [[ ! -z "${{.ActivatedEnv}}" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ]]; then
-  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
-fi
 # {{.Stop}}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -83,9 +83,6 @@ const ActivatedStateEnvVarName = "ACTIVESTATE_ACTIVATED"
 // ActivatedStateIDEnvVarName is the name of the environment variable that is set when in an activated state, its value will be a unique id identifying a specific instance of an activated state
 const ActivatedStateIDEnvVarName = "ACTIVESTATE_ACTIVATED_ID"
 
-// ActivatedStateProjectEnvVarName is the name of the environment variable that specifies the activated state's org/project namespace.
-const ActivatedStateNamespaceEnvVarName = "ACTIVESTATE_ACTIVATED_NAMESPACE"
-
 // ForwardedStateEnvVarName is the name of the environment variable that is set when in an activated state, its value will be the path of the project
 const ForwardedStateEnvVarName = "ACTIVESTATE_FORWARDED"
 

--- a/internal/runbits/activation/activation.go
+++ b/internal/runbits/activation/activation.go
@@ -39,7 +39,7 @@ func ActivateAndWait(
 		}
 	}
 
-	ve, err := venv.GetEnv(false, true, projectDir, proj.Namespace().String())
+	ve, err := venv.GetEnv(false, true, projectDir)
 	if err != nil {
 		return locale.WrapError(err, "error_could_not_activate_venv", "Could not retrieve environment information.")
 	}

--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -142,7 +142,7 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 	}
 	venv := virtualenvironment.New(rt)
 
-	env, err := venv.GetEnv(true, false, projectDir, projectNamespace)
+	env, err := venv.GetEnv(true, false, projectDir)
 	if err != nil {
 		return locale.WrapError(err, "err_exec_env", "Could not retrieve environment information for your runtime")
 	}

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -1,11 +1,8 @@
 package shell
 
 import (
-	"os"
-
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -93,9 +90,7 @@ func (u *Shell) Run(params *Params) error {
 	}
 
 	if process.IsActivated(u.config) {
-		activatedProjectNamespace := os.Getenv(constants.ActivatedStateNamespaceEnvVarName)
-		activatedProjectDir := os.Getenv(constants.ActivatedStateEnvVarName)
-		return locale.NewInputError("err_shell_already_active", "", activatedProjectNamespace, activatedProjectDir)
+		return locale.NewInputError("err_shell_already_active", "", proj.NamespaceString(), proj.Dir())
 	}
 
 	u.out.Notice(locale.Tl("shell_project_statement", "",

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -85,7 +85,7 @@ func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
 	venv := virtualenvironment.New(rt)
 
 	projDir := filepath.Dir(s.project.Source().Path())
-	env, err := venv.GetEnv(true, true, projDir, s.project.Namespace().String())
+	env, err := venv.GetEnv(true, true, projDir)
 	if err != nil {
 		return errs.Wrap(err, "Could not get venv environment")
 	}
@@ -95,7 +95,7 @@ func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
 	}
 
 	// search the "clean" path first (PATHS that are set by venv)
-	env, err = venv.GetEnv(false, true, "", "")
+	env, err = venv.GetEnv(false, true, "")
 	if err != nil {
 		return errs.Wrap(err, "Could not get venv environment")
 	}

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -73,12 +73,9 @@ func WriteRcFile(rcTemplateName string, path string, data RcIdentification, env 
 	}
 
 	rcData := map[string]interface{}{
-		"Start":                 data.Start,
-		"Stop":                  data.Stop,
-		"Env":                   env,
-		"ActivatedEnv":          constants.ActivatedStateEnvVarName,
-		"ConfigFile":            constants.ConfigFileName,
-		"ActivatedNamespaceEnv": constants.ActivatedStateNamespaceEnvVarName,
+		"Start": data.Start,
+		"Stop":  data.Stop,
+		"Env":   env,
 	}
 
 	if err := CleanRcFile(path, data); err != nil {

--- a/internal/subshell/sscommon/rcfile_test.go
+++ b/internal/subshell/sscommon/rcfile_test.go
@@ -3,7 +3,6 @@ package sscommon
 import (
 	"fmt"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -44,25 +43,10 @@ func TestWriteRcFile(t *testing.T) {
 		path           string
 		env            map[string]string
 	}
-
-	fish := fmt.Sprintf(
-		`set -xg PATH "foo:$PATH"
-if test ! -z "$%s"; test -f "$%s/%s"
-  echo "State Tool is operating on project $%s, located at $%s"
-end`,
-		constants.ActivatedStateEnvVarName,
-		constants.ActivatedStateEnvVarName,
-		constants.ConfigFileName,
-		constants.ActivatedStateNamespaceEnvVarName,
-		constants.ActivatedStateEnvVarName)
-	if runtime.GOOS == "windows" {
-		fish = strings.ReplaceAll(fish, "\n", "\r\n")
-	}
-
 	tests := []struct {
 		name         string
 		args         args
-		want         error
+		want error
 		wantContents string
 	}{
 		{
@@ -75,7 +59,7 @@ end`,
 				},
 			},
 			nil,
-			fakeContents("", fish, ""),
+			fakeContents("", `set -xg PATH "foo:$PATH"`, ""),
 		},
 		{
 			"Write RC update",
@@ -87,7 +71,7 @@ end`,
 				},
 			},
 			nil,
-			fakeContents(strings.Join([]string{"before", "after"}, fileutils.LineEnd), fish, ""),
+			fakeContents(strings.Join([]string{"before", "after"}, fileutils.LineEnd), `set -xg PATH "foo:$PATH"`, ""),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/virtualenvironment/virtualenvironment.go
+++ b/internal/virtualenvironment/virtualenvironment.go
@@ -29,7 +29,7 @@ func New(runtime *runtime.Runtime) *VirtualEnvironment {
 }
 
 // GetEnv returns a map of the cumulative environment variables for all active virtual environments
-func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir, namespace string) (map[string]string, error) {
+func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir string) (map[string]string, error) {
 	envMap := make(map[string]string)
 
 	// Source runtime environment information
@@ -44,7 +44,6 @@ func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir,
 	if projectDir != "" {
 		envMap[constants.ActivatedStateEnvVarName] = projectDir
 		envMap[constants.ActivatedStateIDEnvVarName] = v.activationID
-		envMap[constants.ActivatedStateNamespaceEnvVarName] = namespace
 
 		// Get project from explicitly defined configuration file
 		configFile := filepath.Join(projectDir, constants.ConfigFileName)

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/subshell"
-	"github.com/ActiveState/cli/internal/subshell/bash"
-	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/internal/subshell/zsh"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -267,8 +265,6 @@ func (suite *ShellIntegrationTestSuite) SetupRCFile(ts *e2e.Session) {
 	rcFile, err := subshell.RcFile()
 	suite.Require().NoError(err)
 
-	err = fileutils.TouchFileUnlessExists(rcFile)
-	suite.Require().NoError(err)
 	err = fileutils.CopyFile(rcFile, filepath.Join(ts.Dirs.HomeDir, filepath.Base(rcFile)))
 	suite.Require().NoError(err)
 
@@ -280,53 +276,6 @@ func (suite *ShellIntegrationTestSuite) SetupRCFile(ts *e2e.Session) {
 
 	err = fileutils.CopyFile(rcFile, filepath.Join(ts.Dirs.HomeDir, filepath.Base(zshRcFile)))
 	suite.Require().NoError(err)
-}
-
-func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
-	if runtime.GOOS == "windows" {
-		return // cmd.exe does not have an RC file to check for nested shells in
-	}
-	suite.OnlyRunForTags(tagsuite.Shell)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
-	var ss subshell.SubShell
-	var rcFile string
-	env := []string{"ACTIVESTATE_CLI_DISABLE_RUNTIME=false"}
-	switch runtime.GOOS {
-	case "darwin":
-		ss = &zsh.SubShell{}
-		ss.SetBinary("zsh")
-		rcFile = filepath.Join(ts.Dirs.HomeDir, ".zshrc")
-		suite.Require().NoError(sscommon.WriteRcFile("zshrc_append.sh", rcFile, sscommon.DefaultID, nil))
-		env = append(env, "SHELL=zsh") // override since CI tests are running on bash
-	case "linux":
-		ss = &bash.SubShell{}
-		ss.SetBinary("bash")
-		rcFile = filepath.Join(ts.Dirs.HomeDir, ".bashrc")
-		suite.Require().NoError(sscommon.WriteRcFile("bashrc_append.sh", rcFile, sscommon.DefaultID, nil))
-	default:
-		suite.Fail("Unsupported OS")
-	}
-	suite.Require().Equal(filepath.Dir(rcFile), ts.Dirs.HomeDir, "rc file not in test suite homedir")
-	suite.Require().Contains(string(fileutils.ReadFileUnsafe(rcFile)), "State Tool is operating on project")
-
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
-
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "small-python"),
-		e2e.OptAppendEnv(env...))
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-	suite.Assert().NotContains(cp.Output(), "State Tool is operating on project")
-	cp.SendLine(fmt.Sprintf(`export HOME="%s"`, ts.Dirs.HomeDir)) // some shells do not forward this
-
-	cp.SendLine(ss.Binary()) // platform-specific shell (zsh on macOS, bash on Linux, etc.)
-	cp.Expect("State Tool is operating on project ActiveState-CLI/small-python")
-	cp.SendLine("exit") // subshell within a subshell
-	cp.SendLine("exit")
-	cp.ExpectExitCode(0)
 }
 
 func (suite *ShellIntegrationTestSuite) TestRuby() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2239" title="DX-2239" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2239</a>  Remove virtual environment indication
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

It's broken :(