### PR TITLE
Revert: Build scripts should use buildexpression types.

### DIFF
--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -57,6 +57,11 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 			return false, nil // nothing to do
 		}
 		logging.Debug("Merging changes")
+		expr, err = script.ToBuildExpression()
+		if err != nil {
+			return false, errs.Wrap(err, "Unable to translate local build script to build expression")
+		}
+
 		out.Notice(locale.Tl("buildscript_update", "Updating project to reflect build script changes..."))
 
 		localCommitID, err := localcommit.Get(proj.Dir())
@@ -69,7 +74,7 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 			Owner:        proj.Owner(),
 			Project:      proj.Name(),
 			ParentCommit: localCommitID.String(),
-			Expression:   script.Expr,
+			Expression:   expr,
 		})
 		if err != nil {
 			return false, errs.Wrap(err, "Could not update project to reflect build script changes.")

--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -1,11 +1,9 @@
 package buildscript
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
-	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,16 +29,11 @@ in:
 	runtime`))
 	require.NoError(t, err)
 
-	// Make a copy of the original expression.
-	bytes, err := json.Marshal(script.Expr)
-	require.NoError(t, err)
-	expr, err := buildexpression.New(bytes)
+	expr, err := script.ToBuildExpression()
 	require.NoError(t, err)
 
-	// Modify the build script.
-	(*script.Expr.Let.Assignments[0].Value.Ap.Arguments[0].Assignment.Value.List)[0].Str = ptr.To(`77777`)
+	(*script.Let.Assignments[0].Value.FuncCall.Arguments[0].Assignment.Value.List)[0].Str = ptr.To(`"77777"`)
 
-	// Generate the difference between the modified script and the original expression.
 	result, err := generateDiff(script, expr)
 	require.NoError(t, err)
 	assert.Equal(t, `let:

--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -227,7 +227,10 @@ func (p *Pull) mergeBuildScript(strategies *mono_models.MergeStrategies, remoteC
 	}
 
 	// Get the local and remote build expressions to merge.
-	exprA := script.Expr
+	exprA, err := script.ToBuildExpression()
+	if err != nil {
+		return errs.Wrap(err, "Unable to transform local buildscript into buildexpression")
+	}
 	bp := model.NewBuildPlannerModel(p.auth)
 	exprB, err := bp.GetBuildExpression(p.project.Owner(), p.project.Name(), remoteCommit.String())
 	if err != nil {

--- a/pkg/platform/runtime/buildexpression/buildexpression.go
+++ b/pkg/platform/runtime/buildexpression/buildexpression.go
@@ -302,10 +302,6 @@ func newValue(path []string, valueInterface interface{}) (*Value, error) {
 	case float64:
 		value.Float = ptr.To(v)
 
-	case nil:
-		// An empty value is interpreted as JSON null.
-		value.Null = &Null{}
-
 	default:
 		logging.Debug("Unknown type: %T at path %s", v, strings.Join(path, "."))
 		// An empty value is interpreted as JSON null.

--- a/pkg/platform/runtime/buildscript/buildexpression.go
+++ b/pkg/platform/runtime/buildscript/buildexpression.go
@@ -1,0 +1,228 @@
+package buildscript
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/multilog"
+	"github.com/ActiveState/cli/internal/rtutils/ptr"
+	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
+)
+
+const SolveFunction = "solve"
+const SolveLegacyFunction = "solve_legacy"
+const MergeFunction = "merge"
+
+func NewScriptFromBuildExpression(expr *buildexpression.BuildExpression) (*Script, error) {
+	data, err := json.Marshal(expr)
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to marshal buildexpression to JSON")
+	}
+
+	m := make(map[string]interface{})
+	err = json.Unmarshal(data, &m)
+	if err != nil { // this really should not happen
+		return nil, errs.Wrap(err, "Could not unmarshal buildexpression")
+	}
+
+	letValue, ok := m["let"]
+	if !ok {
+		return nil, errs.New("Build expression has no 'let' key")
+	}
+	letMap, ok := letValue.(map[string]interface{})
+	if !ok {
+		return nil, errs.New("'let' key is not a JSON object")
+	}
+	inValue, ok := letMap["in"]
+	if !ok {
+		return nil, errs.New("Build expression's 'let' object has no 'in' key")
+	}
+	delete(letMap, "in") // prevent duplication of "in" field when writing the build script
+
+	let, err := newLet(letMap)
+	if err != nil {
+		return nil, errs.Wrap(err, "Could not parse 'let' key")
+	}
+
+	in, err := newIn(inValue)
+	if err != nil {
+		return nil, errs.Wrap(err, "Could not parse 'in' key's value: %v", inValue)
+	}
+
+	return &Script{let, in}, nil
+}
+
+func newLet(m map[string]interface{}) (*Let, error) {
+	assignments, err := newAssignments(m)
+	if err != nil {
+		return nil, errs.Wrap(err, "Could not parse 'let' key")
+	}
+	return &Let{Assignments: *assignments}, nil
+}
+
+func isFunction(name string) bool {
+	return name == SolveFunction || name == SolveLegacyFunction || name == MergeFunction
+}
+
+func newValue(valueInterface interface{}, preferIdent bool) (*Value, error) {
+	value := &Value{}
+
+	switch v := valueInterface.(type) {
+	case map[string]interface{}:
+		// Examine keys first to see if this is a function call.
+		for key := range v {
+			if isFunction(key) {
+				f, err := newFuncCall(v)
+				if err != nil {
+					return nil, errs.Wrap(err, "Could not parse '%s' function's value: %v", key, v)
+				}
+				value.FuncCall = f
+			}
+		}
+
+		if value.FuncCall == nil {
+			// It's not a function call, but an object.
+			object, err := newAssignments(v)
+			if err != nil {
+				return nil, errs.Wrap(err, "Could not parse object: %v", v)
+			}
+			value.Object = object
+		}
+
+	case []interface{}:
+		values := []*Value{}
+		for _, item := range v {
+			value, err := newValue(item, false)
+			if err != nil {
+				return nil, errs.Wrap(err, "Could not parse list: %v", v)
+			}
+			values = append(values, value)
+		}
+		value.List = &values
+
+	case string:
+		if preferIdent {
+			value.Ident = &v
+		} else {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, errs.Wrap(err, "Could not marshal string '%s'", v)
+			}
+			value.Str = ptr.To(string(b))
+		}
+
+	case float64:
+		value.Number = ptr.To(v)
+
+	default:
+		// An empty value is interpreted as JSON null.
+		value.Null = &Null{}
+	}
+
+	return value, nil
+}
+
+func newFuncCall(m map[string]interface{}) (*FuncCall, error) {
+	// Look in the given object for the function's name and argument object or list.
+	var name string
+	var argsInterface interface{}
+	for key, value := range m {
+		if isFunction(key) {
+			name = key
+			argsInterface = value
+			break
+		}
+	}
+
+	args := []*Value{}
+
+	switch v := argsInterface.(type) {
+	case map[string]interface{}:
+		for key, valueInterface := range v {
+			value, err := newValue(valueInterface, name == MergeFunction)
+			if err != nil {
+				return nil, errs.Wrap(err, "Could not parse '%s' function's argument '%s': %v", name, key, valueInterface)
+			}
+			args = append(args, &Value{Assignment: &Assignment{Key: key, Value: value}})
+		}
+		sort.SliceStable(args, func(i, j int) bool { return args[i].Assignment.Key < args[j].Assignment.Key })
+
+	case []interface{}:
+		for _, item := range v {
+			value, err := newValue(item, false)
+			if err != nil {
+				return nil, errs.Wrap(err, "Could not parse '%s' function's argument list item: %v", name, item)
+			}
+			args = append(args, value)
+		}
+
+	default:
+		return nil, errs.New("Function '%s' expected to be object or list", name)
+	}
+
+	return &FuncCall{Name: name, Arguments: args}, nil
+}
+
+func newAssignments(m map[string]interface{}) (*[]*Assignment, error) {
+	assignments := []*Assignment{}
+	for key, valueInterface := range m {
+		value, err := newValue(valueInterface, false)
+		if err != nil {
+			return nil, errs.Wrap(err, "Could not parse '%s' key's value: %v", key, valueInterface)
+		}
+		assignments = append(assignments, &Assignment{Key: key, Value: value})
+	}
+	sort.SliceStable(assignments, func(i, j int) bool { return assignments[i].Key < assignments[j].Key })
+	return &assignments, nil
+}
+
+func newIn(inValue interface{}) (*In, error) {
+	in := &In{}
+
+	switch v := inValue.(type) {
+	case map[string]interface{}:
+		f, err := newFuncCall(v)
+		if err != nil {
+			return nil, errs.Wrap(err, "'in' object is not a function call")
+		}
+		in.FuncCall = f
+
+	case string:
+		in.Name = ptr.To(strings.TrimPrefix(v, "$"))
+
+	default:
+		return nil, errs.New("'in' value expected to be a function call or string")
+	}
+
+	return in, nil
+}
+
+func (s *Script) EqualsBuildExpressionBytes(exprBytes []byte) bool {
+	expr, err := buildexpression.New(exprBytes)
+	if err != nil {
+		multilog.Error("Unable to create buildexpression from incoming JSON: %v", err)
+		return false
+	}
+	return s.EqualsBuildExpression(expr)
+}
+
+func (s *Script) EqualsBuildExpression(expr *buildexpression.BuildExpression) bool {
+	myJson, err := json.Marshal(s)
+	if err != nil {
+		multilog.Error("Unable to marshal this buildscript to JSON: %v", err)
+		return false
+	}
+	otherScript, err := NewScriptFromBuildExpression(expr)
+	if err != nil {
+		multilog.Error("Unable to transform buildexpression to buildscript: %v", err)
+		return false
+	}
+	otherJson, err := json.Marshal(otherScript)
+	if err != nil {
+		multilog.Error("Unable to marshal other buildscript to JSON: %v", err)
+		return false
+	}
+	return string(myJson) == string(otherJson)
+}

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -12,18 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// toBuildExpression converts given script constructed by Participle into a buildexpression.
-// This function should not be used to convert an arbitrary script to buildexpression.
-// NewScript*() populates the expr field with the equivalent build expression.
-// This function exists solely for testing that functionality.
-func toBuildExpression(script *Script) (*buildexpression.BuildExpression, error) {
-	bytes, err := json.Marshal(script)
-	if err != nil {
-		return nil, err
-	}
-	return buildexpression.New(bytes)
-}
-
 func TestBasic(t *testing.T) {
 	script, err := NewScript([]byte(
 		`let:
@@ -49,9 +37,6 @@ func TestBasic(t *testing.T) {
 in:
   runtime
 `))
-	require.NoError(t, err)
-
-	expr, err := toBuildExpression(script)
 	require.NoError(t, err)
 
 	assert.Equal(t, &Script{
@@ -88,12 +73,10 @@ in:
 			},
 		},
 		&In{Name: ptr.To("runtime")},
-		expr,
 	}, script)
 }
 
-func NoTestComplex(t *testing.T) {
-	t.Skip("Multiple solve notes are not supported now") // DX-2238
+func TestComplex(t *testing.T) {
 	script, err := NewScript([]byte(
 		`let:
     linux_runtime = solve(
@@ -114,14 +97,11 @@ func NoTestComplex(t *testing.T) {
     )
 
 in:
-    merge(
+   merge(
         win_installer(win_runtime),
         tar_installer(linux_runtime)
     )
 `))
-	require.NoError(t, err)
-
-	expr, err := toBuildExpression(script)
 	require.NoError(t, err)
 
 	assert.Equal(t, &Script{
@@ -165,7 +145,6 @@ in:
 			{FuncCall: &FuncCall{"win_installer", []*Value{{Ident: ptr.To("win_runtime")}}}},
 			{FuncCall: &FuncCall{"tar_installer", []*Value{{Ident: ptr.To("linux_runtime")}}}},
 		}}},
-		expr,
 	}, script)
 }
 
@@ -196,9 +175,6 @@ in:
 
 func TestExample(t *testing.T) {
 	script, err := NewScript([]byte(example))
-	require.NoError(t, err)
-
-	expr, err := toBuildExpression(script)
 	require.NoError(t, err)
 
 	assert.Equal(t, &Script{
@@ -241,7 +217,6 @@ func TestExample(t *testing.T) {
 			},
 		},
 		&In{Name: ptr.To("runtime")},
-		expr,
 	}, script)
 }
 
@@ -249,8 +224,8 @@ func TestString(t *testing.T) {
 	script, err := NewScript([]byte(
 		`let:
     runtime = solve(
-        platforms=["12345", "67890"],
-        requirements=[{name="language/python"}]
+        requirements=[{name="language/python"}],
+        platforms=["12345", "67890"]
     )
 in:
     runtime
@@ -260,14 +235,14 @@ in:
 	assert.Equal(t,
 		`let:
 	runtime = solve(
-		platforms = [
-			"12345",
-			"67890"
-		],
 		requirements = [
 			{
 				name = "language/python"
 			}
+		],
+		platforms = [
+			"12345",
+			"67890"
 		]
 	)
 
@@ -387,7 +362,8 @@ func TestBuildExpression(t *testing.T) {
 	script, err := NewScriptFromBuildExpression(expr)
 	require.NoError(t, err)
 	require.NotNil(t, script)
-	//newExpr := script.Expr
+	//newExpr, err := script.ToBuildExpression()
+	//require.NoError(t, err)
 	exprBytes, err := json.Marshal(expr)
 	require.NoError(t, err)
 	//newExprBytes, err := json.Marshal(newExpr)
@@ -403,12 +379,12 @@ func TestBuildExpression(t *testing.T) {
 	// Verify null JSON value is handled correctly.
 	var null *string
 	nullHandled := false
-	for _, assignment := range script.Expr.Let.Assignments {
-		if assignment.Name == "runtime" {
-			args := assignment.Value.Ap.Arguments
+	for _, assignment := range script.Let.Assignments {
+		if assignment.Key == "runtime" {
+			args := assignment.Value.FuncCall.Arguments
 			require.NotNil(t, args)
 			for _, arg := range args {
-				if arg.Assignment != nil && arg.Assignment.Name == "solver_version" {
+				if arg.Assignment != nil && arg.Assignment.Key == "solver_version" {
 					assert.Equal(t, null, arg.Assignment.Value.Str)
 					nullHandled = true
 				}

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -6,11 +6,19 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
 )
 
-// MarshalJSON marshals the Participle-produced Script into an equivalent buildexpression.
-// Users of buildscripts do not need to do this manually; the Expr field contains the
-// equivalent buildexpression.
+func (s *Script) ToBuildExpression() (*buildexpression.BuildExpression, error) {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to marshal buildscript into JSON")
+	}
+	return buildexpression.New(data)
+}
+
 func (s *Script) MarshalJSON() ([]byte, error) {
 	m := make(map[string]interface{})
 	let := make(map[string]interface{})
@@ -71,8 +79,6 @@ func (f *FuncCall) MarshalJSON() ([]byte, error) {
 		switch {
 		case argument.Assignment != nil:
 			args[argument.Assignment.Key] = argument.Assignment.Value
-		case argument.FuncCall != nil:
-			args[argument.FuncCall.Name] = argument.FuncCall.Arguments
 		default:
 			return nil, errors.New(fmt.Sprintf("Cannot marshal %v (arg %v)", f, argument))
 		}

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -133,7 +133,6 @@ func (suite *PullIntegrationTestSuite) TestPull_RestoreNamespace() {
 }
 
 func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
-	suite.T().Skip("Skipping since build script/build expression equality cannot be easily computed") // DX-2221
 	suite.OnlyRunForTags(tagsuite.Pull)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1961" title="DX-1961" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1961</a>  Unify BuildPlanner and Local Order Build Expression types
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
A few tests that rely on build script/build expression equality break because incoming build expressions are not ordered.