### PR TITLE
Fix failing integration tests due to expect mismatch

### DIFF
--- a/test/integration/bundle_int_test.go
+++ b/test/integration/bundle_int_test.go
@@ -80,7 +80,7 @@ func (suite *BundleIntegrationTestSuite) TestBundle_project_invalid() {
 	defer ts.Close()
 
 	cp := ts.Spawn("bundles", "--namespace", "junk/junk")
-	cp.Expect("The requested project junk/junk could not be found")
+	cp.Expect("The requested project junk does not exist under junk")
 	cp.ExpectExitCode(1)
 }
 

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -88,7 +88,7 @@ func (suite *PackageIntegrationTestSuite) TestPackages_project_invalid() {
 	defer ts.Close()
 
 	cp := ts.Spawn("packages", "--namespace", "junk/junk")
-	cp.Expect("The requested project junk/junk could not be found")
+	cp.Expect("The requested project junk does not exist under junk")
 	cp.ExpectExitCode(1)
 }
 

--- a/test/integration/projects_int_test.go
+++ b/test/integration/projects_int_test.go
@@ -148,7 +148,7 @@ func (suite *ProjectsIntegrationTestSuite) TestEdit_Visibility() {
 	ts.LogoutUser()
 
 	cp = ts.Spawn("checkout", namespace)
-	cp.Expect("Could not checkout")
+	cp.Expect("does not exist under ActiveState-CLI")
 	cp.ExpectExitCode(1)
 
 	ts.LoginAsPersistentUser()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2247" title="DX-2247" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2247</a>  Nightly failures due to outdated expect string
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
