### PR TITLE
Fix runtime timeout on analytics executor test

### DIFF
--- a/test/integration/analytics_int_test.go
+++ b/test/integration/analytics_int_test.go
@@ -238,7 +238,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestExecEvents() {
 		e2e.OptAppendEnv(env...),
 	)
 
-	cp.Expect("DONE")
+	cp.Expect("DONE", e2e.RuntimeSourcingTimeoutOpt)
 
 	time.Sleep(sleepTime)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2252" title="DX-2252" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2252</a>  TestAnalyticsIntegrationTestSuite/TestExecEvents timing out on nightly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
