### PR TITLE
Handle user facing errors with structured output

### DIFF
--- a/pkg/cmdlets/errors/errors.go
+++ b/pkg/cmdlets/errors/errors.go
@@ -87,7 +87,14 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 }
 
 func (o *OutputError) MarshalStructured(f output.Format) interface{} {
-	return output.StructuredError{locale.JoinedErrorMessage(o.error)}
+	var userFacingError errs.UserFacingError
+	var message string
+	if errors.As(o.error, &userFacingError) {
+		message = userFacingError.UserError()
+	} else {
+		message = locale.JoinedErrorMessage(o.error)
+	}
+	return output.StructuredError{message}
 }
 
 func trimError(msg string) string {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2258" title="DX-2258" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2258</a>  User facing errors not surfaced when using json output
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
