### PR TITLE
Removed inapplicable shell test.

### DIFF
--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/subshell"
-	"github.com/ActiveState/cli/internal/subshell/bash"
-	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/internal/subshell/zsh"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -278,53 +276,6 @@ func (suite *ShellIntegrationTestSuite) SetupRCFile(ts *e2e.Session) {
 
 	err = fileutils.CopyFile(rcFile, filepath.Join(ts.Dirs.HomeDir, filepath.Base(zshRcFile)))
 	suite.Require().NoError(err)
-}
-
-func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
-	if runtime.GOOS == "windows" {
-		return // cmd.exe does not have an RC file to check for nested shells in
-	}
-	suite.OnlyRunForTags(tagsuite.Shell)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
-	var ss subshell.SubShell
-	var rcFile string
-	env := []string{"ACTIVESTATE_CLI_DISABLE_RUNTIME=false"}
-	switch runtime.GOOS {
-	case "darwin":
-		ss = &zsh.SubShell{}
-		ss.SetBinary("zsh")
-		rcFile = filepath.Join(ts.Dirs.HomeDir, ".zshrc")
-		suite.Require().NoError(sscommon.WriteRcFile("zshrc_append.sh", rcFile, sscommon.DefaultID, nil))
-		env = append(env, "SHELL=zsh") // override since CI tests are running on bash
-	case "linux":
-		ss = &bash.SubShell{}
-		ss.SetBinary("bash")
-		rcFile = filepath.Join(ts.Dirs.HomeDir, ".bashrc")
-		suite.Require().NoError(sscommon.WriteRcFile("bashrc_append.sh", rcFile, sscommon.DefaultID, nil))
-	default:
-		suite.Fail("Unsupported OS")
-	}
-	suite.Require().Equal(filepath.Dir(rcFile), ts.Dirs.HomeDir, "rc file not in test suite homedir")
-	suite.Require().Contains(string(fileutils.ReadFileUnsafe(rcFile)), "State Tool is operating on project")
-
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
-
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "small-python"),
-		e2e.OptAppendEnv(env...))
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-	suite.Assert().NotContains(cp.Output(), "State Tool is operating on project")
-	cp.SendLine(fmt.Sprintf(`export HOME="%s"`, ts.Dirs.HomeDir)) // some shells do not forward this
-
-	cp.SendLine(ss.Binary()) // platform-specific shell (zsh on macOS, bash on Linux, etc.)
-	cp.Expect("State Tool is operating on project ActiveState-CLI/small-python")
-	cp.SendLine("exit") // subshell within a subshell
-	cp.SendLine("exit")
-	cp.ExpectExitCode(0)
 }
 
 func (suite *ShellIntegrationTestSuite) TestRuby() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2255" title="DX-2255" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2255</a>  TestShellIntegrationTestSuite/TestNestedShellNotification  failing nightly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Its underlying feature was reverted.

This test was accidentally re-introduced by https://github.com/ActiveState/cli/pull/2791