### PR TITLE
Propagate-PR failures should link to their runs.

### DIFF
--- a/.github/workflows/propagate.yml
+++ b/.github/workflows/propagate.yml
@@ -89,6 +89,13 @@ jobs:
                     "type": "mrkdwn",
                     "text": "Propagate-PR failed for *<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>*\nFailure should be addressed by *${{ github.event.pull_request.user.login }}*"
                   }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Failed job: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2203" title="DX-2203" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2203</a>  Propagate-PR failure message includes link to failed job
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
