### PR TITLE
Fixed failing test.

### DIFF
--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -192,7 +192,7 @@ func (suite *PushIntegrationTestSuite) TestPush_NoPermission_NewProject() {
 
 	cp = ts.SpawnWithOpts(e2e.OptArgs("push"))
 	cp.Expect("not authorized")
-	cp.Expect("(y/N)")
+	cp.Expect("(Y/n)")
 	cp.SendLine("y")
 	cp.Expect("Who would you like the owner of this project to be?")
 	cp.SendEnter()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2254" title="DX-2254" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2254</a>  TestPushIntegrationTestSuite/TestPush_NoPermission_NewProject  failing nightly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Updated test based on changes here: https://github.com/ActiveState/cli/commit/20b5cfab167d9d66279df6a6f0b990340c533e9f