### PR TITLE
Do not report existing state-svc instance in use errors to Rollbar.

### DIFF
--- a/cmd/state-svc/service.go
+++ b/cmd/state-svc/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/ipc"
+	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/svcctl"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
@@ -61,7 +62,7 @@ func (s *service) Start() error {
 	err = s.ipcSrv.Start()
 	if err != nil {
 		if errors.Is(err, ipc.ErrInUse) {
-			return errs.Wrap(err, "An existing server instance appears to be in use")
+			return locale.WrapInputError(err, "err_service_ipc_in_use", "An existing server instance appears to be in use")
 		}
 		return errs.Wrap(err, "Failed to start server")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2216" title="DX-2216" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2216</a>  Mark `flisten in use` for state-svc as an input error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
