### PR TITLE
Support a master State Tool versions list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,6 +415,10 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
+      - # === Install State Tool ===
+        name: Install State Tool
+        uses: ActiveState/setup-state-tool@v1
+
       - # === Setup ===
         name: Setup
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,6 @@ jobs:
       SHELL: bash
       GITHUB_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 10
-    if: contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref) || startsWith(github.event.pull_request.head.ref, 'version/')
 
     # === Deploy Steps ===
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -465,6 +465,11 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           mask-aws-account-id: true
 
+      - # === Generate updated master versions.json if necessary ===
+        name: Generate version list
+        shell: bash
+        run: state run generate-versions-list
+
       - # === Deploy ===
         name: Deploy
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,6 +401,7 @@ jobs:
       SHELL: bash
       GITHUB_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 10
+    if: contains(fromJSON('["refs/heads/master", "refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref) || startsWith(github.event.pull_request.head.ref, 'version/')
 
     # === Deploy Steps ===
     steps:

--- a/activestate.generators.yaml
+++ b/activestate.generators.yaml
@@ -129,13 +129,3 @@ scripts:
       $constants.SET_ENV
 
       go run scripts/ci/update-version-list/main.go ./build/update
-  - name: generate-test-versions-list
-    language: bash
-    description: Generates test versions.json
-    value: |
-      set -e
-      $constants.SET_ENV
-
-      $scripts.generate-test-update
-
-      go run scripts/ci/update-version-list/main.go ./build/test-update

--- a/activestate.generators.yaml
+++ b/activestate.generators.yaml
@@ -59,7 +59,7 @@ scripts:
     value: |
       set -e
       $constants.SET_ENV
-      
+
       echo "# Generate payload"
       go run ./scripts/ci/payload-generator/main.go "$@"
   - name: generate-update
@@ -120,3 +120,22 @@ scripts:
       go run scripts/ci/payload-generator/main.go -b ${TEST_CHANNEL} -v ${TEST_VERSION}
       copy_test_payload
       go run scripts/ci/update-generator/main.go -b ${TEST_CHANNEL} -v ${TEST_VERSION} -o ${TEST_ARCHIVE_DIR}
+  - name: generate-versions-list
+    language: bash
+    standalone: true
+    description: Generates master versions.json from S3 and info.json's from generate-update
+    value: |
+      set -e
+      $constants.SET_ENV
+
+      go run scripts/ci/update-version-list/main.go ./build/update
+  - name: generate-test-versions-list
+    language: bash
+    description: Generates test versions.json
+    value: |
+      set -e
+      $constants.SET_ENV
+
+      $scripts.generate-test-update
+
+      go run scripts/ci/update-version-list/main.go ./build/test-update

--- a/scripts/ci/update-version-list/main.go
+++ b/scripts/ci/update-version-list/main.go
@@ -21,7 +21,7 @@ const S3Bucket = "update/state/"
 const VersionsJson = "versions.json"
 
 // Valid channels to update the master version file with.
-var ValidChannels = []string{"master", "beta", "release", "LTS"}
+var ValidChannels = []string{"beta", "release", "LTS"}
 
 func init() {
 	if !condition.OnCI() {

--- a/scripts/ci/update-version-list/main.go
+++ b/scripts/ci/update-version-list/main.go
@@ -21,7 +21,7 @@ const S3Bucket = "update/state/"
 const VersionsJson = "versions.json"
 
 // Valid channels to update the master version file with.
-var ValidChannels = []string{"master", "beta", "release", "LTS"}
+var ValidChannels = []string{"master", "beta", "release", "LTS", "mitchell"}
 
 func init() {
 	if !condition.OnCI() {

--- a/scripts/ci/update-version-list/main.go
+++ b/scripts/ci/update-version-list/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/thoas/go-funk"
+
+	"github.com/ActiveState/cli/internal/condition"
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/httputil"
+)
+
+// Where the master version file lives on S3.
+const S3PrefixURL = "https://state-tool.s3.amazonaws.com/"
+const S3Bucket = "update/state/"
+const VersionsJson = "versions.json"
+
+// Valid channels to update the master version file with.
+var ValidChannels = []string{"master", "beta", "release", "LTS"}
+
+func init() {
+	if !condition.OnCI() {
+		// Allow testing with artifacts produced by `state run generate-test-update`
+		ValidChannels = append(ValidChannels, "test-channel")
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatalf("Usage: %s <build-dir>", os.Args[0])
+	}
+
+	// Fetch the current master list from S3.
+	versions := []map[string]string{}
+	fmt.Printf("Fetching master %s file from S3\n", VersionsJson)
+	bytes, err := httputil.Get(S3PrefixURL + S3Bucket + VersionsJson)
+	if err != nil {
+		log.Fatalf("Failed to fetch file: %s", err.Error())
+	}
+	err = json.Unmarshal(bytes, &versions)
+	if err != nil {
+		log.Fatalf("Failed to decode JSON: %s", err.Error())
+	}
+
+	// Find info.json files to add to the master list and add them.
+	updated := false
+	buildDir := os.Args[1]
+	fmt.Printf("Searching for info.json files in %s\n", buildDir)
+	files, err := fileutils.ListDir(buildDir, false)
+	if err != nil {
+		log.Fatalf("Failed to search %s: %s", buildDir, err.Error())
+	}
+	for _, file := range files {
+		if file.Name() != "info.json" {
+			continue
+		}
+		channel := strings.Split(file.RelativePath(), string(filepath.Separator))[0]
+		if !funk.Contains(ValidChannels, channel) {
+			continue
+		}
+		fmt.Printf("Found %s\n", file.RelativePath())
+		bytes, err := fileutils.ReadFile(file.Path())
+		if err != nil {
+			log.Fatalf("Unable to read file: %s", err.Error())
+		}
+		info := map[string]string{}
+		err = json.Unmarshal(bytes, &info)
+		if err != nil {
+			log.Fatalf("Unable to decode JSON: %s", err.Error())
+		}
+		info["path"] = S3PrefixURL + S3Bucket + info["path"] // convert relative path to full URL
+		versions = append(versions, info)
+		updated = true
+	}
+
+	if !updated {
+		fmt.Println("No updates found.")
+		return
+	}
+
+	// Write the updated list to disk. The s3-deployer script should pick it up and upload it.
+	localVersionsJson := filepath.Join(buildDir, VersionsJson)
+	fmt.Printf("Writing updated %s locally to %s\n", VersionsJson, localVersionsJson)
+	bytes, err = json.Marshal(versions)
+	if err != nil {
+		log.Fatalf("Failed to encode JSON: %s", err.Error())
+	}
+	err = fileutils.WriteFile(localVersionsJson, bytes)
+	if err != nil {
+		log.Fatalf("Failed to write file: %s", err.Error())
+	}
+}

--- a/scripts/ci/update-version-list/main.go
+++ b/scripts/ci/update-version-list/main.go
@@ -21,7 +21,7 @@ const S3Bucket = "update/state/"
 const VersionsJson = "versions.json"
 
 // Valid channels to update the master version file with.
-var ValidChannels = []string{"master", "beta", "release", "LTS", "mitchell"}
+var ValidChannels = []string{"master", "beta", "release", "LTS"}
 
 func init() {
 	if !condition.OnCI() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1960" title="DX-1960" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1960</a>  As a devops engineer I can find links for State Tool install archives and their checksums
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The master version list is located here: https://state-tool.s3.amazonaws.com/update/state/versions.json

I tested this on CI temporarily allowing for PR releases to deploy and it worked. The version list was updated here: https://github.com/ActiveState/cli/actions/runs/6499308092/job/17652710058?pr=2814#step:12:30 and uploaded to S3 here: https://github.com/ActiveState/cli/actions/runs/6499308092/job/17652710058?pr=2814#step:13:53. I double-checked the file on S3 and it was indeed updated and the links valid. Since then I've reverted to "release" and "beta" channel versions starting at v0.40.0.

I've excluded "master" channel from this list because it would be unnecessary pollution in my opinion. Let me know if I should include them. Only "beta", "release", and "LTS" channels will show up in the new master list.
