### PR TITLE
Remote installer should send a sessionToken to analytics.

### DIFF
--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -95,6 +95,12 @@ func main() {
 		return
 	}
 
+	// Store sessionToken to config
+	err = cfg.Set(anaConst.CfgSessionToken, "remote_"+constants.RemoteInstallerVersion)
+	if err != nil {
+		logging.Error("Unable to set session token: " + errs.JoinMessage(err))
+	}
+
 	an = sync.New(anaConst.SrcStateRemoteInstaller, cfg, nil, out)
 
 	// Set up prompter

--- a/test/integration/remote_installer_int_test.go
+++ b/test/integration/remote_installer_int_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	anaConst "github.com/ActiveState/cli/internal/analytics/constants"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/exeutils"
@@ -88,6 +89,19 @@ func (suite *RemoteInstallIntegrationTestSuite) TestInstall() {
 			}
 			cp.Expect("Built")
 			cp.ExpectExitCode(0)
+
+			// Verify analytics reported the correct sessionToken.
+			sessionTokenFound := false
+			events := parseAnalyticsEvents(suite, ts)
+			suite.Require().NotEmpty(events)
+			for _, event := range events {
+				if event.Category == anaConst.CatUpdates && event.Dimensions != nil {
+					suite.Assert().Contains(*event.Dimensions.SessionToken, constants.RemoteInstallerVersion)
+					sessionTokenFound = true
+					break
+				}
+			}
+			suite.Assert().True(sessionTokenFound, "sessionToken was not found in analytics")
 		})
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2237" title="DX-2237" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2237</a>  The remote installer supports a session token
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
