### PR TITLE
Executor messaging error checks should only fail on our CI, not generic CI

### DIFF
--- a/cmd/state-exec/condition.go
+++ b/cmd/state-exec/condition.go
@@ -2,7 +2,7 @@ package main
 
 import "os"
 
-// onCI is copied from the internal/condition package (to minimize depdencies).
-func onCI() bool {
-	return os.Getenv("CI") != "" || os.Getenv("BUILDER_OUTPUT") != ""
+// inActiveStateCI is copied from the internal/condition package (to minimize dependencies).
+func inActiveStateCI() bool {
+	return os.Getenv("ACTIVESTATE_CI") == "true"
 }

--- a/cmd/state-exec/main.go
+++ b/cmd/state-exec/main.go
@@ -87,7 +87,7 @@ func run() error {
 	if err := sendMsgToService(meta.SockPath, hb); err != nil {
 		logr.Debug("                 sock - error: %v", err)
 
-		if onCI() { // halt control flow on CI only
+		if inActiveStateCI() { // halt control flow on CI only
 			return fmt.Errorf("cannot send message to service (this error is handled in CI only): %w", err)
 		}
 	}
@@ -108,7 +108,7 @@ func run() error {
 	if err := sendMsgToService(meta.SockPath, msg); err != nil {
 		logr.Debug("                 sock - error: %v", err)
 
-		if onCI() { // halt control flow on CI only
+		if inActiveStateCI() { // halt control flow on CI only
 			return fmt.Errorf("cannot send message to service (this error is handled in CI only): %w", err)
 		}
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2268" title="DX-2268" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2268</a>  Update executor logic to only halt on ActiveState CI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
