### PR TITLE
Install scripts should always fetch and verify checksums.

### DIFF
--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -156,6 +156,10 @@ if (!$version) {
     $relUrl = $infoJson.Path
 } else {
     # If the user specified a full version, construct the installer URL.
+    if ($version -ne $infoJson.Version) {
+        Write-Error "Unknown version: $version"
+        exit 1
+    }
     $relUrl = "$script:CHANNEL/$versionNoSHA/windows-amd64/state-windows-amd64-$version.zip"
 }
 

--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -113,40 +113,50 @@ function error([string] $msg)
     Write-Host $msg -ForegroundColor Red
 }
 
-if (!$script:VERSION) {
+$version = $script:VERSION
+if (!$version) {
     # If the user did not specify a version, formulate a query to fetch the JSON info of the latest
     # version, including where it is.
     $jsonURL = "$script:BASEINFOURL/?channel=$script:CHANNEL&platform=windows&source=install"
-} elseif (!($script:VERSION | Select-String -Pattern "-SHA" -SimpleMatch)) {
+} elseif (!($version | Select-String -Pattern "-SHA" -SimpleMatch)) {
     # If the user specified a partial version (i.e. no SHA), formulate a query to fetch the JSON
     # info of that version's latest SHA, including where it is.
-    $jsonURL = "$script:BASEINFOURL/?channel=$script:CHANNEL&platform=windows&source=install&target-version=$script:VERSION"
+    $versionNoSHA = $version
+    $version = ""
+    $jsonURL = "$script:BASEINFOURL/?channel=$script:CHANNEL&platform=windows&source=install&target-version=$versionNoSHA"
+} else {
+    # If the user specified a full version with SHA, formulate a query to fetch the JSON info of
+    # that version.
+    $versionNoSHA = $version -replace "-SHA.*", ""
+    $jsonURL = "$script:BASEINFOURL/?channel=$script:CHANNEL&platform=windows&source=install&target-version=$versionNoSHA"
 }
 
-if ($jsonURL) {
+# Fetch version info.
+try {
+    $infoJson = ConvertFrom-Json -InputObject (download $jsonURL)
+} catch [System.Exception] {
+}
+if (!$infoJson) {
+    if (!$version) {
+        Write-Error "Unable to retrieve the latest version number"
+    } else {
+        Write-Error "Could not download a State Tool Installer for the given command line arguments"
+    }
+    Write-Error $_.Exception.Message
+    exit 1
+}
+
+# Extract checksum.
+$checksum = $infoJson.Sha256
+
+if (!$version) {
     # If the user specified no version or a partial version we need to use the json URL to get the
     # actual installer URL.
-    try {
-        $infoJson = ConvertFrom-Json -InputObject (download $jsonURL)
-    } catch [System.Exception] {
-    }
-    if (!$infoJson) {
-      if (!$script:VERSION) {
-        Write-Error "Unable to retrieve the latest version number"
-      } else {
-        Write-Error "Could not download a State Tool Installer for the given command line arguments"
-      }
-      Write-Error $_.Exception.Message
-      exit 1
-    }
     $version = $infoJson.Version
-    $checksum = $infoJson.Sha256
     $relUrl = $infoJson.Path
 } else {
-    # If the user specified a full version, strip the SHA to get the folder name of the installer
-    # URL. Then we can construct the installer URL.
-    $versionNoSHA = $script:VERSION -replace "-SHA.*", ""
-    $relUrl = "$script:CHANNEL/$versionNoSHA/windows-amd64/state-windows-amd64-$script:VERSION.zip"
+    # If the user specified a full version, construct the installer URL.
+    $relUrl = "$script:CHANNEL/$versionNoSHA/windows-amd64/state-windows-amd64-$version.zip"
 }
 
 # Fetch the requested or latest version.
@@ -167,9 +177,9 @@ catch [System.Exception]
     exit 1
 }
 
-# Verify checksum if possible.
+# Verify checksum.
 $hash = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash
-if ($checksum -and $hash -ne $checksum)
+if ($hash -ne $checksum)
 {
     Write-Warning "SHA256 sum did not match:"
     Write-Warning "Expected: $checksum"

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -148,10 +148,12 @@ if [ -z "$VERSION" ]; then
   RELURL=`cat $INSTALLERTMPDIR/info.json | sed -ne 's/.*"path":[ \t]*"\([^"]*\)".*/\1/p'`
 else
   # If the user specified a full version, construct the installer URL.
+  if [ "$VERSION" != "`cat $INSTALLERTMPDIR/info.json | sed -ne 's/.*"version":[ \t]*"\([^"]*\)".*/\1/p'`" ]; then
+    error "Unknown version: $VERSION"
+    exit 1
+  fi
   RELURL="$CHANNEL/$VERSIONNOSHA/$OS-amd64/state-$OS-amd64-$VERSION$DOWNLOADEXT"
 fi
-
-rm $INSTALLERTMPDIR/info.json
 
 # Fetch the requested or latest version.
 progress "Preparing Installer for State Tool Package Manager version $VERSION"

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -117,34 +117,41 @@ if [ -z "$VERSION" ]; then
 elif [ -z "`echo $VERSION | grep -o '\-SHA'`" ]; then
   # If the user specified a partial version (i.e. no SHA), formulate a query to fetch the JSON info
   # of that version's latest SHA, including where it is.
-  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS&target-version=$VERSION"
+  VERSIONNOSHA="$VERSION"
+  VERSION=""
+  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS&target-version=$VERSIONNOSHA"
+else
+  # If the user specified a full version with SHA, formulate a query to fetch the JSON info of that
+  # version.
+  VERSIONNOSHA="`echo $VERSION | sed 's/-SHA.*$//'`"
+  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS&target-version=$VERSIONNOSHA"
 fi
 
-if [ ! -z "$JSONURL" ]; then
+# Fetch version info.
+$FETCH $INSTALLERTMPDIR/info.json $JSONURL || exit 1
+if [ ! -z "`grep -o Invalid $INSTALLERTMPDIR/info.json`" ]; then
+	error "Could not download a State Tool installer for the given command line arguments"
+	exit 1
+fi
+
+# Extract checksum.
+SUM=`cat $INSTALLERTMPDIR/info.json | sed -ne 's/.*"sha256":[ \t]*"\([^"]*\)".*/\1/p'`
+
+if [ -z "$VERSION" ]; then
   # If the user specified no version or a partial version we need to use the json URL to get the
   # actual installer URL.
-  $FETCH $INSTALLERTMPDIR/info.json $JSONURL || exit 1
-  if [ ! -z "`grep -o Invalid $INSTALLERTMPDIR/info.json`" ]; then
-    error "Could not download a State Tool installer for the given command line arguments"
-    exit 1
-  fi
-
-  # Parse info.
   VERSION=`cat $INSTALLERTMPDIR/info.json | sed -ne 's/.*"version":[ \t]*"\([^"]*\)".*/\1/p'`
   if [ -z "$VERSION" ]; then
     error "Unable to retrieve the latest version number"
     exit 1
   fi
-  SUM=`cat $INSTALLERTMPDIR/info.json | sed -ne 's/.*"sha256":[ \t]*"\([^"]*\)".*/\1/p'`
   RELURL=`cat $INSTALLERTMPDIR/info.json | sed -ne 's/.*"path":[ \t]*"\([^"]*\)".*/\1/p'`
-  rm $INSTALLERTMPDIR/info.json
-
 else
-  # If the user specified a full version, strip the SHA to get the folder name of the installer URL.
-  # Then we can construct the installer URL.
-  VERSIONNOSHA="`echo $VERSION | sed 's/-SHA.*$//'`"
+  # If the user specified a full version, construct the installer URL.
   RELURL="$CHANNEL/$VERSIONNOSHA/$OS-amd64/state-$OS-amd64-$VERSION$DOWNLOADEXT"
 fi
+
+rm $INSTALLERTMPDIR/info.json
 
 # Fetch the requested or latest version.
 progress "Preparing Installer for State Tool Package Manager version $VERSION"
@@ -162,8 +169,8 @@ if [ $? -ne 0 -o \( "`echo $FETCH | grep -o 'curl'`" = "curl" -a ! -z "`grep -o 
   exit 1
 fi
 
-# Verify checksum if possible.
-if [ ! -z "$SUM" -a  "`$SHA256SUM -b $INSTALLERTMPDIR/$ARCHIVE | cut -d ' ' -f1`" != "$SUM" ]; then
+# Verify checksum.
+if [ "`$SHA256SUM -b $INSTALLERTMPDIR/$ARCHIVE | cut -d ' ' -f1`" != "$SUM" ]; then
   error "SHA256 sum did not match:"
   error "Expected: $SUM"
   error "Received: `$SHA256SUM -b $INSTALLERTMPDIR/$ARCHIVE | cut -d ' ' -f1`"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2266" title="DX-2266" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2266</a>  Install.ps1 and install.sh should ALWAYS verify the checksum
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
