### PR TITLE
`state update` should use a consistent channel if none was given.

### DIFF
--- a/internal/runners/update/update.go
+++ b/internal/runners/update/update.go
@@ -55,7 +55,8 @@ func New(prime primeable) *Update {
 
 func (u *Update) Run(params *Params) error {
 	// Check for available update
-	upd, err := u.svc.CheckUpdate(context.Background(), params.Channel, "")
+	channel := fetchChannel(params.Channel, false)
+	upd, err := u.svc.CheckUpdate(context.Background(), channel, "")
 	if err != nil {
 		return errs.AddTips(locale.WrapError(
 			err, "err_update_fetch",
@@ -69,7 +70,7 @@ func (u *Update) Run(params *Params) error {
 	if !update.ShouldInstall() {
 		logging.Debug("No update found")
 		u.out.Print(output.Prepare(
-			locale.Tr("update_none_found", params.Channel),
+			locale.Tr("update_none_found", channel),
 			&struct{}{},
 		))
 		return nil
@@ -79,10 +80,10 @@ func (u *Update) Run(params *Params) error {
 
 	// Handle switching channels
 	var installPath string
-	if params.Channel != "" && params.Channel != constants.BranchName {
-		installPath, err = installation.InstallPathForBranch(params.Channel)
+	if channel != constants.BranchName {
+		installPath, err = installation.InstallPathForBranch(channel)
 		if err != nil {
-			return locale.WrapError(err, "err_update_install_path", "Could not get installation path for branch {{.V0}}", params.Channel)
+			return locale.WrapError(err, "err_update_install_path", "Could not get installation path for branch {{.V0}}", channel)
 		}
 	}
 
@@ -100,7 +101,7 @@ func (u *Update) Run(params *Params) error {
 	}
 
 	message := ""
-	if params.Channel != constants.BranchName {
+	if channel != constants.BranchName {
 		message = locale.Tl("update_switch_channel", "[NOTICE]Please start a new shell for the update to take effect.[/RESET]")
 	}
 	u.out.Print(output.Prepare(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2283" title="DX-2283" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2283</a>  v0.42 Confusing message when `state update` executed and no new update is available.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

