### PR TITLE
Remove TestStateTrayRemoval

### DIFF
--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -8,9 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ActiveState/cli/internal/condition"
@@ -18,7 +16,6 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/fileutils"
-	"github.com/ActiveState/cli/internal/httputil"
 	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/subshell"
@@ -191,66 +188,6 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 	cp.ExpectExit()
 	suite.Assert().Contains(cp.Output(), "Need More Help?",
 		"error tips should be displayed in shell created by installer")
-}
-
-func (suite *InstallerIntegrationTestSuite) TestStateTrayRemoval() {
-	suite.OnlyRunForTags(tagsuite.Installer, tagsuite.Critical)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
-	dir := installationDir(ts)
-
-	// Install a release version that still has state-tray.
-	version := "0.35.0-SHAb78e2a4"
-	var cp *e2e.SpawnedCmd
-	if runtime.GOOS != "windows" {
-		oneLiner := fmt.Sprintf("sh <(curl -q https://platform.activestate.com/dl/cli/pdli01/install.sh) -f -n -t %s -v %s", dir, version)
-		cp = ts.SpawnCmdWithOpts(
-			"bash", e2e.OptArgs("-c", oneLiner),
-			e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
-		)
-	} else {
-		b, err := httputil.GetDirect("https://platform.activestate.com/dl/cli/pdli01/install.ps1")
-		suite.Require().NoError(err)
-
-		ps1File := filepath.Join(ts.Dirs.Work, "install.ps1")
-		suite.Require().NoError(fileutils.WriteFile(ps1File, b))
-
-		cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.OptArgs(ps1File, "-f", "-n", "-t", dir, "-v", version),
-			e2e.OptAppendEnv("SHELL="),
-			e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
-		)
-	}
-	cp.Expect("Installation Complete", termtest.OptExpectTimeout(5*time.Minute))
-
-	// Verify state-tray is there.
-	svcExec, err := installation.ServiceExecFromDir(dir)
-	suite.Require().NoError(err)
-	trayExec := strings.Replace(svcExec, constants.StateSvcCmd, "state-tray", 1)
-	suite.FileExists(trayExec)
-	updateDialogExec := strings.Replace(svcExec, constants.StateSvcCmd, "state-update-dialog", 1)
-	// suite.FileExists(updateDialogExec) // this is not actually installed...
-
-	// Run the installer, which should remove state-tray and clean up after it.
-	cp = ts.SpawnCmdWithOpts(
-		suite.installerExe,
-		e2e.OptArgs("-f", "-n", "-t", dir),
-		e2e.OptAppendEnv(constants.UpdateBranchEnvVarName+"=release"),
-		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
-	)
-	cp.Expect("Installing", termtest.OptExpectTimeout(10*time.Second))
-	cp.Expect("Done", termtest.OptExpectTimeout(30*time.Second))
-
-	// Verify state-tray is no longer there.
-	suite.NoFileExists(trayExec)
-	suite.NoFileExists(updateDialogExec)
-
-	// Verify state can still be run and has a newly updated version.
-	stateExec, err := installation.StateExecFromDir(dir)
-	suite.Require().NoError(err)
-	cp = ts.SpawnCmdWithOpts(stateExec, e2e.OptArgs("--version"))
-	suite.Assert().NotContains(cp.Output(), version)
-	cp.ExpectExitCode(0)
 }
 
 func (suite *InstallerIntegrationTestSuite) TestInstallerOverwriteServiceApp() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2260" title="DX-2260" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2260</a>  Nightly Failure: Update TestStateTrayRemoval to be an installer test instead
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Turns out it was failing on an install of state tool v0.35. We were testing an update flow of sorts which needed an older state tool. Obviously not worth addressing going forward.