### PR TITLE
Removed buildscript/buildexpression list sorting workarounds.

### DIFF
--- a/pkg/platform/runtime/buildexpression/buildexpression.go
+++ b/pkg/platform/runtime/buildexpression/buildexpression.go
@@ -910,17 +910,7 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 	case v.Ap != nil:
 		return json.Marshal(v.Ap)
 	case v.List != nil:
-		// Buildexpression list order does not matter, so sorting is necessary for
-		// comparisons. Go's JSON marshaling is deterministic, so utilize that.
-		// This should not be necessary when PB-4607 is implemented.
-		list := make([]*Value, len(*v.List))
-		copy(list, *v.List)
-		sort.SliceStable(list, func(i, j int) bool {
-			b1, err1 := json.Marshal(list[i])
-			b2, err2 := json.Marshal(list[j])
-			return err1 == nil && err2 == nil && string(b1) < string(b2)
-		})
-		return json.Marshal(list)
+		return json.Marshal(v.List)
 	case v.Str != nil:
 		return json.Marshal(strings.Trim(*v.Str, `"`))
 	case v.Null != nil:

--- a/pkg/platform/runtime/buildexpression/merge/merge_test.go
+++ b/pkg/platform/runtime/buildexpression/merge/merge_test.go
@@ -80,35 +80,6 @@ in:
 	mergedScript, err := buildscript.NewScriptFromBuildExpression(mergedExpr)
 	require.NoError(t, err)
 
-	// TODO: delete this block after DX-1939. Sorting requirements is needed until we have
-	// buildexpression hashes for comparing equality.
-	assert.Equal(t,
-		`let:
-	runtime = solve(
-		platforms = [
-			"12345",
-			"67890"
-		],
-		requirements = [
-			{
-				name = "JSON",
-				namespace = "language/perl"
-			},
-			{
-				name = "perl",
-				namespace = "language"
-			},
-			{
-				name = "DateTime",
-				namespace = "language/perl"
-			}
-		]
-	)
-
-in:
-	runtime`, mergedScript.String())
-	return
-
 	assert.Equal(t,
 		`let:
 	runtime = solve(
@@ -168,14 +139,12 @@ in:
 	exprA, err := buildexpression.New(bytes)
 	require.NoError(t, err)
 
-	// Note the intentional swap of platform order. Buildexpression list order does not matter.
-	// isAutoMergePossible() should still return true, and the original platforms will be used.
 	scriptB, err := buildscript.NewScript([]byte(
 		`let:
 	runtime = solve(
 		platforms = [
-			"67890",
-			"12345"
+			"12345",
+			"67890"
 		],
 		requirements = [
 			{
@@ -210,31 +179,6 @@ in:
 
 	mergedScript, err := buildscript.NewScriptFromBuildExpression(mergedExpr)
 	require.NoError(t, err)
-
-	// TODO: delete this block after DX-1939. Sorting requirements is needed until we have
-	// buildexpression hashes for comparing equality.
-	assert.Equal(t,
-		`let:
-	runtime = solve(
-		platforms = [
-			"12345",
-			"67890"
-		],
-		requirements = [
-			{
-				name = "DateTime",
-				namespace = "language/perl"
-			},
-			{
-				name = "perl",
-				namespace = "language"
-			}
-		]
-	)
-
-in:
-	runtime`, mergedScript.String())
-	return
 
 	assert.Equal(t,
 		`let:
@@ -320,16 +264,4 @@ func TestDeleteKey(t *testing.T) {
 	assert.True(t, deleteKey(&m, "quux"), "did not find quux")
 	_, exists := m["foo"].(map[string]interface{})["quux"]
 	assert.False(t, exists, "did not delete quux")
-}
-
-func TestSortLists(t *testing.T) {
-	m := map[string]interface{}{
-		"one": []interface{}{"foo", "bar", "baz"},
-		"two": map[string]interface{}{
-			"three": []interface{}{"foobar", "barfoo", "barbaz"},
-		},
-	}
-	sortLists(&m)
-	assert.Equal(t, []interface{}{"bar", "baz", "foo"}, m["one"])
-	assert.Equal(t, []interface{}{"barbaz", "barfoo", "foobar"}, m["two"].(map[string]interface{})["three"])
 }

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -98,8 +98,9 @@ func (s *Script) String() string {
 	buf.WriteString("let:\n")
 	for _, assignment := range s.Expr.Let.Assignments {
 		buf.WriteString(indent(assignmentString(assignment)))
+		buf.WriteString("\n")
 	}
-	buf.WriteString("\n\n")
+	buf.WriteString("\n")
 	buf.WriteString("in:\n")
 	switch {
 	case s.Expr.Let.In.FuncCall != nil:

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -386,14 +386,12 @@ func TestBuildExpression(t *testing.T) {
 	script, err := NewScriptFromBuildExpression(expr)
 	require.NoError(t, err)
 	require.NotNil(t, script)
-	//newExpr := script.Expr
+	newExpr := script.Expr
 	exprBytes, err := json.Marshal(expr)
 	require.NoError(t, err)
-	//newExprBytes, err := json.Marshal(newExpr)
-	//require.NoError(t, err)
-	// TODO: re-enable this test in DX-1939. Buildexpression equality is implicitly tested
-	// elsewhere, so temporarily disabling this explicit test is okay.
-	//assert.Equal(t, string(exprBytes), string(newExprBytes))
+	newExprBytes, err := json.Marshal(newExpr)
+	require.NoError(t, err)
+	assert.Equal(t, string(exprBytes), string(newExprBytes))
 
 	// Verify comparisons between buildscripts and buildexpressions is accurate.
 	assert.True(t, script.EqualsBuildExpression(expr))
@@ -415,49 +413,4 @@ func TestBuildExpression(t *testing.T) {
 		}
 	}
 	assert.True(t, nullHandled, "JSON null not encountered")
-}
-
-func TestJsonListEquality(t *testing.T) {
-	// When comparing buildscripts to buildexpressions, the former is converted to the latter
-	// via JSON marshaling. Since buildexpression list order does not matter (in addition to
-	// key-value order not mattering), test for list equality.
-	// This should not be necessary after DX-1939.
-
-	// Test that ["foo", "bar"] == ["bar", "foo"].
-	v1 := &Value{List: &[]*Value{
-		{Str: ptr.To(`"foo"`)},
-		{Str: ptr.To(`"bar"`)},
-	}}
-	v2 := &Value{List: &[]*Value{
-		{Str: ptr.To(`"bar"`)},
-		{Str: ptr.To(`"foo"`)},
-	}}
-
-	b1, err := json.Marshal(v1)
-	require.NoError(t, err)
-	b2, err := json.Marshal(v2)
-	require.NoError(t, err)
-
-	assert.Equal(t, string(b2), string(b1))
-
-	// Test that [{"name": "foo"}, {"name": "bar"}] == [{"name": "bar"}, {"name": "foo"}].
-	v1 = &Value{List: &[]*Value{
-		{Object: &[]*Assignment{
-			{"name", &Value{Str: ptr.To(`"foo"`)}},
-			{"name", &Value{Str: ptr.To(`"bar"`)}},
-		}},
-	}}
-	v2 = &Value{List: &[]*Value{
-		{Object: &[]*Assignment{
-			{"name", &Value{Str: ptr.To(`"foo"`)}},
-			{"name", &Value{Str: ptr.To(`"bar"`)}},
-		}},
-	}}
-
-	b1, err = json.Marshal(v1)
-	require.NoError(t, err)
-	b2, err = json.Marshal(v2)
-	require.NoError(t, err)
-
-	assert.Equal(t, string(b2), string(b1))
 }

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 )
 
@@ -33,17 +32,7 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 	case v.FuncCall != nil:
 		return json.Marshal(v.FuncCall)
 	case v.List != nil:
-		// Buildexpression list order does not matter, so sorting is necessary for
-		// comparisons. Go's JSON marshaling is deterministic, so utilize that.
-		// This should not be necessary when DX-1939 is implemented.
-		list := make([]*Value, len(*v.List))
-		copy(list, *v.List)
-		sort.SliceStable(list, func(i, j int) bool {
-			b1, err1 := json.Marshal(list[i])
-			b2, err2 := json.Marshal(list[j])
-			return err1 == nil && err2 == nil && string(b1) < string(b2)
-		})
-		return json.Marshal(list)
+		return json.Marshal(v.List)
 	case v.Str != nil:
 		return json.Marshal(strings.Trim(*v.Str, `"`))
 	case v.Number != nil:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1939" title="DX-1939" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1939</a>  As a user, I can modify my Build Script in my text editor and the state tool will pickup the changes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Buildexpressions from the Platforms should have the same list order.