### PR TITLE
Don't add language templating to yaml if runtime is disabled

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -59,6 +59,9 @@ const DisableRuntime = "ACTIVESTATE_CLI_DISABLE_RUNTIME"
 // DisableUpdates is the env var used to disable automatic updates
 const DisableUpdates = "ACTIVESTATE_CLI_DISABLE_UPDATES"
 
+// DisableLanguageTemplates is the env var used to disable templating for new activestate.yaml files
+const DisableLanguageTemplates = "ACTIVESTATE_CLI_DISABLE_LANGUAGE_TEMPLATES"
+
 // UpdateBranchEnvVarName is the env var that is used to override which branch to pull the update from
 const UpdateBranchEnvVarName = "ACTIVESTATE_CLI_UPDATE_BRANCH"
 

--- a/pkg/cmdlets/git/test/integration/git_test.go
+++ b/pkg/cmdlets/git/test/integration/git_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/outputhelper"
 	gitlet "github.com/ActiveState/cli/pkg/cmdlets/git"
 	"github.com/ActiveState/cli/pkg/project"
-	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
 type GitTestSuite struct {
@@ -42,7 +41,7 @@ func (suite *GitTestSuite) BeforeTest(suiteName, testName string) {
 
 	projectURL := fmt.Sprintf("https://%s/%s/%s", constants.PlatformURL, "test-owner", "test-project")
 
-	_, err = projectfile.TestOnlyCreateWithProjectURL(projectURL, suite.dir)
+	err = fileutils.WriteFile(filepath.Join(suite.dir, "activestate.yaml"), []byte("project: "+projectURL))
 	suite.NoError(err, "could not create a projectfile")
 
 	err = fileutils.Touch(filepath.Join(suite.dir, "test-file"))

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -923,14 +923,6 @@ type CreateParams struct {
 	Cache      string
 }
 
-// TestOnlyCreateWithProjectURL a new activestate.yaml with default content
-func TestOnlyCreateWithProjectURL(projectURL, path string) (*Project, error) {
-	return createCustom(&CreateParams{
-		ProjectURL: projectURL,
-		Directory:  path,
-	}, language.Python3)
-}
-
 // Create will create a new activestate.yaml with a projectURL for the given details
 func Create(params *CreateParams) (*Project, error) {
 	lang := language.MakeByName(params.Language)

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -983,8 +983,9 @@ func createCustom(params *CreateParams, lang language.Language) (*Project, error
 		shell = "batch"
 	}
 
+	languageDisabled := os.Getenv(constants.DisableRuntime) == "true"
 	content := params.Content
-	if content == "" && lang != language.Unset && lang != language.Unknown {
+	if !languageDisabled && content == "" && lang != language.Unset && lang != language.Unknown {
 		tplName := "activestate.yaml." + strings.TrimRight(lang.String(), "23") + ".tpl"
 		template, err := assets.ReadFileBytes(tplName)
 		if err != nil {

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -983,7 +983,7 @@ func createCustom(params *CreateParams, lang language.Language) (*Project, error
 		shell = "batch"
 	}
 
-	languageDisabled := os.Getenv(constants.DisableRuntime) == "true"
+	languageDisabled := os.Getenv(constants.DisableLanguageTemplates) == "true"
 	content := params.Content
 	if !languageDisabled && content == "" && lang != language.Unset && lang != language.Unknown {
 		tplName := "activestate.yaml." + strings.TrimRight(lang.String(), "23") + ".tpl"

--- a/pkg/projectfile/projectfile_test.go
+++ b/pkg/projectfile/projectfile_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/language"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -314,17 +315,17 @@ func TestNewProjectfile(t *testing.T) {
 	assert.NoError(t, err, "Should be no error when getting a temp directory")
 	os.Chdir(dir)
 
-	pjFile, err := TestOnlyCreateWithProjectURL("https://platform.activestate.com/xowner/xproject", dir)
+	pjFile, err := testOnlyCreateWithProjectURL("https://platform.activestate.com/xowner/xproject", dir)
 	assert.NoError(t, err, "There should be no error when loading from a path")
 	assert.Equal(t, "activationMessage", pjFile.Scripts[0].Name)
 
-	_, err = TestOnlyCreateWithProjectURL("https://platform.activestate.com/xowner/xproject", "")
+	_, err = testOnlyCreateWithProjectURL("https://platform.activestate.com/xowner/xproject", "")
 	assert.Error(t, err, "We don't accept blank paths")
 
 	setCwd(t, "")
 	dir, err = os.Getwd()
 	assert.NoError(t, err, "Should be no error when getting the CWD")
-	_, err = TestOnlyCreateWithProjectURL("https://platform.activestate.com/xowner/xproject", dir)
+	_, err = testOnlyCreateWithProjectURL("https://platform.activestate.com/xowner/xproject", dir)
 	assert.Error(t, err, "Cannot create new project if existing as.yaml ...exists")
 }
 
@@ -467,6 +468,14 @@ languages:
 			}
 		})
 	}
+}
+
+// testOnlyCreateWithProjectURL a new activestate.yaml with default content
+func testOnlyCreateWithProjectURL(projectURL, path string) (*Project, error) {
+	return createCustom(&CreateParams{
+		ProjectURL: projectURL,
+		Directory:  path,
+	}, language.Python3)
 }
 
 func TestMigrateCommitFromASY(t *testing.T) {

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -466,6 +466,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_NamespaceWins() {
 	c2 := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/Python2"), // activate a different namespace
 		e2e.OptWD(targetPath),
+		e2e.OptAppendEnv(constants.DisableLanguageTemplates+"=true"),
 	)
 	c2.Expect("ActiveState-CLI/Python2")
 	c2.Expect("Activated")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2290" title="DX-2290" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2290</a>  Nightly failure on TestActivate_NamespaceWins 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Fixes CI failure due to python2 not existing