### PR TITLE
Set runtime source timeout for expects where runtime sourcing is enabled

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -280,7 +280,7 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 		e2e.OptArgs("-c", "import sys; print(sys.copyright);"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("ActiveState Software Inc.")
+	cp.Expect("ActiveState Software Inc.", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }
 
@@ -528,7 +528,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_FromCache() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 
-	cp.ExpectInput()
+	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 	suite.NotContains(cp.Output(), "Downloading")

--- a/test/integration/bundle_int_test.go
+++ b/test/integration/bundle_int_test.go
@@ -225,7 +225,7 @@ func (suite *BundleIntegrationTestSuite) TestJSON() {
 		e2e.OptArgs("bundles", "install", "Testing", "--output", "json"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect(`"name":"Testing"`)
+	cp.Expect(`"name":"Testing"`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
@@ -233,7 +233,7 @@ func (suite *BundleIntegrationTestSuite) TestJSON() {
 		e2e.OptArgs("bundles", "uninstall", "Testing", "-o", "editor"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect(`"name":"Testing"`)
+	cp.Expect(`"name":"Testing"`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 }

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -202,7 +202,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutCustomRTPath() {
 		suite.Require().NoError(err)
 		customRTPath = strings.ToLower(customRTPath)
 	}
-	cp.Expect(customRTPath)
+	cp.Expect(customRTPath, e2e.RuntimeSourcingTimeoutOpt)
 }
 
 func (suite *CheckoutIntegrationTestSuite) TestCheckoutNotFound() {

--- a/test/integration/deploy_int_test.go
+++ b/test/integration/deploy_int_test.go
@@ -7,9 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
@@ -57,12 +55,12 @@ func (suite *DeployIntegrationTestSuite) deploy(ts *e2e.Session, prj string, tar
 		)
 	}
 
-	cp.Expect("Installing", termtest.OptExpectTimeout(40*time.Second))
-	cp.Expect("Configuring", termtest.OptExpectTimeout(40*time.Second))
+	cp.Expect("Installing", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Configuring")
 	if runtime.GOOS != "windows" {
-		cp.Expect("Symlinking", termtest.OptExpectTimeout(30*time.Second))
+		cp.Expect("Symlinking")
 	}
-	cp.Expect("Deployment Information", termtest.OptExpectTimeout(60*time.Second))
+	cp.Expect("Deployment Information")
 	cp.Expect(targetID) // expect bin dir
 	if runtime.GOOS == "windows" {
 		cp.Expect("log out")
@@ -291,7 +289,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 		)
 	}
 
-	cp.Expect("Configuring shell", termtest.OptExpectTimeout(60*time.Second))
+	cp.Expect("Configuring shell", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 	suite.AssertConfig(ts, targetID.String())
 
@@ -300,7 +298,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 			e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath, "--user"),
 			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 		)
-		cp.Expect("Configuring shell", termtest.OptExpectTimeout(60*time.Second))
+		cp.Expect("Configuring shell", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectExitCode(0)
 
 		out, err := exec.Command("reg", "query", `HKCU\Environment`, "/v", "Path").Output()

--- a/test/integration/exec_int_test.go
+++ b/test/integration/exec_int_test.go
@@ -183,7 +183,7 @@ func (suite *ExecIntegrationTestSuite) TestExecWithPath() {
 		e2e.OptArgs("exec", "--path", pythonDir, "which", "python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Operating on project ActiveState-CLI/Python-3.9")
+	cp.Expect("Operating on project ActiveState-CLI/Python-3.9", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectRe(regexp.MustCompile("cache/[0-9A-Fa-f]+/usr/bin/python3").String())
 	cp.ExpectExitCode(0)
 

--- a/test/integration/export_int_test.go
+++ b/test/integration/export_int_test.go
@@ -89,7 +89,7 @@ func (suite *ExportIntegrationTestSuite) TestExport_Env() {
 		e2e.OptArgs("export", "env"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect(`PATH: `)
+	cp.Expect(`PATH: `, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	suite.Assert().NotContains(cp.Output(), "ACTIVESTATE_ACTIVATED")
@@ -115,7 +115,7 @@ func (suite *ExportIntegrationTestSuite) TestJSON() {
 		e2e.OptArgs("export", "env", "-o", "json"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.ExpectExitCode(0)
+	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 	AssertValidJSON(suite.T(), cp)
 
 	ts.LoginAsPersistentUser()

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -117,7 +117,7 @@ func (suite *InitIntegrationTestSuite) TestInit_InferLanguageFromUse() {
 		e2e.OptArgs("use", "Python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	pname := strutils.UUID()

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -6,9 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"time"
 
-	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/thoas/go-funk"
@@ -234,7 +232,7 @@ func scriptPath(t *testing.T, targetDir string) string {
 
 func expectStateToolInstallation(cp *e2e.SpawnedCmd) {
 	cp.Expect("Preparing Installer for State Tool Package Manager")
-	cp.Expect("Installation Complete", termtest.OptExpectTimeout(time.Minute))
+	cp.Expect("Installation Complete", e2e.RuntimeSourcingTimeoutOpt)
 }
 
 // assertBinDirContents checks if given files are or are not in the bin directory

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -518,7 +518,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 		e2e.OptArgs("uninstall", "Text-CSV", "-o", "json"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect(`{"name":"Text-CSV"`)
+	cp.Expect(`{"name":"Text-CSV"`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 }

--- a/test/integration/progress_int_test.go
+++ b/test/integration/progress_int_test.go
@@ -23,7 +23,7 @@ func (suite *ProgressIntegrationTestSuite) TestProgress() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect(locale.T("setup_runtime"))
-	cp.Expect("Checked out")
+	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
 	suite.Assert().NotContains(cp.Output(), "...")
 	cp.ExpectExitCode(0)
 
@@ -33,7 +33,7 @@ func (suite *ProgressIntegrationTestSuite) TestProgress() {
 	)
 	cp.Expect(locale.T("setup_runtime"))
 	cp.Expect("...")
-	cp.Expect("Checked out")
+	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -148,7 +148,7 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 		e2e.OptArgs("install", "requests"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Package added")
+	cp.Expect("Package added", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	proj, err := project.FromPath(ts.Dirs.Work)

--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -243,10 +243,10 @@ func (suite *PushIntegrationTestSuite) TestCarlisle() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
 	switch runtime.GOOS {
 	case "darwin":
-		cp.ExpectRe("added|being built", termtest.OptExpectTimeout(60*time.Second)) // while cold storage is off
+		cp.ExpectRe("added|being built", e2e.RuntimeSourcingTimeoutOpt) // while cold storage is off
 		cp.Wait()
 	default:
-		cp.Expect("added", termtest.OptExpectTimeout(60*time.Second))
+		cp.Expect("added", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectExitCode(0)
 	}
 

--- a/test/integration/refresh_int_test.go
+++ b/test/integration/refresh_int_test.go
@@ -25,7 +25,7 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Setting Up Runtime")
-	cp.Expect("Runtime updated")
+	cp.Expect("Runtime updated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
@@ -41,14 +41,14 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Setting Up Runtime")
-	cp.Expect("Runtime updated")
+	cp.Expect("Runtime updated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("exec", "--", "python3", "-c", "import requests"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.ExpectExitCode(0)
+	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 
 	cp = ts.Spawn("refresh")
 	suite.Assert().NotContains(cp.Output(), "Setting Up Runtime", "Unchanged runtime should not refresh")

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -53,7 +53,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 		e2e.OptArgs("shell", "Revert"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.ExpectInput()
+	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("python3")
 	cp.Expect("3.9.15")
 	cp.SendLine("import urllib3")

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -89,7 +89,7 @@ func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
 		e2e.OptArgs("checkout", "ActiveState-CLI/test-interrupt-small-python#863c45e2-3626-49b6-893c-c15e85a17241", "."),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Checked out project")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 
 	targetDir := target.ProjectDirToTargetDir(ts.Dirs.Work, ts.Dirs.Cache)
 	pythonExe := filepath.Join(setup.ExecDir(targetDir), "python3"+exeutils.Extension)

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -190,7 +190,7 @@ func (suite *ShellIntegrationTestSuite) TestDefaultNoLongerExists() {
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	err := os.RemoveAll(filepath.Join(ts.Dirs.Work, "Python3"))
@@ -228,7 +228,7 @@ func (suite *ShellIntegrationTestSuite) TestUseShellUpdates() {
 		e2e.OptAppendEnv("SHELL=bash"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	// Ensure both bash and zsh RC files are updated
@@ -294,7 +294,7 @@ func (suite *ShellIntegrationTestSuite) TestRuby() {
 		e2e.OptArgs("shell", "Ruby-3.2.2"),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	cp.SendLine("ruby -v")
 	cp.Expect("3.2.2")

--- a/test/integration/shells_int_test.go
+++ b/test/integration/shells_int_test.go
@@ -36,7 +36,7 @@ func (suite *ShellsIntegrationTestSuite) TestShells() {
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Checked out project")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	for _, shell := range shells {

--- a/test/integration/show_int_test.go
+++ b/test/integration/show_int_test.go
@@ -28,7 +28,7 @@ func (suite *ShowIntegrationTestSuite) TestShow() {
 		e2e.OptArgs("activate"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.ExpectInput()
+	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
 
 	cp = ts.Spawn("show")
 	cp.Expect(`Name`)

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -37,7 +37,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	// Verify runtime works.
@@ -57,7 +57,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.OptArgs("use", "ActiveState-CLI/Python-3.9"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	// Verify the new runtime works.
@@ -70,7 +70,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 		e2e.OptArgs("use", "Python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	// Verify the first runtime is set up correctly and usable.
@@ -102,7 +102,7 @@ func (suite *UseIntegrationTestSuite) TestUseCwd() {
 		e2e.OptWD(pythonDir),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	emptyDir := filepath.Join(ts.Dirs.Work, "EmptyDir")
@@ -133,7 +133,7 @@ func (suite *UseIntegrationTestSuite) TestReset() {
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	python3Exe := filepath.Join(ts.Dirs.DefaultBin, "python3"+osutils.ExeExt)
@@ -188,7 +188,7 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
@@ -239,7 +239,7 @@ func (suite *UseIntegrationTestSuite) TestSetupNotice() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Setting Up Runtime")
-	cp.Expect("Checked out project")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	suite.Require().NoError(os.RemoveAll(filepath.Join(ts.Dirs.Work, "Python3"))) // runtime marker still exists
@@ -256,7 +256,7 @@ func (suite *UseIntegrationTestSuite) TestSetupNotice() {
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
 	cp.Expect("Setting Up Runtime")
-	cp.Expect("Switched to project")
+	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }
 
@@ -274,7 +274,7 @@ func (suite *UseIntegrationTestSuite) TestJSON() {
 		e2e.OptArgs("use", "-o", "json"),
 		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
 	)
-	cp.Expect(`"namespace":`)
+	cp.Expect(`"namespace":`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.Expect(`"path":`)
 	cp.Expect(`"executables":`)
 	cp.ExpectExitCode(0)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2293" title="DX-2293" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2293</a>  Test Timeouts on Runtime sourcing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
