### PR TITLE
Silence network timeout errors when checking for updates.

### DIFF
--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"encoding/json"
+	"net"
 	"net/url"
 	"os"
 	"runtime"
@@ -115,6 +116,10 @@ func (u *Checker) getUpdateInfo(desiredChannel, desiredVersion string) (*Availab
 			label = anaConst.UpdateLabelFailed
 			msg = anaConst.UpdateErrorFetch
 			err = errs.Wrap(err, "Could not fetch update info from %s", infoURL)
+			if e, ok := err.(net.Error); ok && e.Timeout() {
+				logging.Debug("Silencing network timeout error: %v", err)
+				err = errs.Silence(err)
+			}
 		}
 
 		u.an.EventWithLabel(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2288" title="DX-2288" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2288</a>  Silence "Could not poll update" error due to TLS timeout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
