### PR TITLE
state-svc reports its log file as an absolute, not relative path.

### DIFF
--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -195,12 +195,12 @@ func runForeground(cfg *config.Instance, an *anaSync.Client, auth *authenticatio
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logFile := logging.FilePath()
-	logging.Debug("Logging to %q", logFile)
+	logFileName := logging.FileName()
+	logging.Debug("Logging to %q", logging.FilePathFor(logFileName))
 	stopTimer := logging.StartRotateLogTimer()
 	defer stopTimer()
 
-	p := NewService(ctx, cfg, an, auth, logFile)
+	p := NewService(ctx, cfg, an, auth, logFileName)
 
 	if argText != "" {
 		argText = fmt.Sprintf(" (invoked by %q)", argText)

--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -72,6 +72,9 @@ func FilePath() string {
 }
 
 func FilePathFor(filename string) string {
+	if filepath.IsAbs(filename) {
+		return filename
+	}
 	return filepath.Join(datadir, "logs", filename)
 }
 

--- a/internal/logging/defaults.go
+++ b/internal/logging/defaults.go
@@ -72,9 +72,6 @@ func FilePath() string {
 }
 
 func FilePathFor(filename string) string {
-	if filepath.IsAbs(filename) {
-		return filename
-	}
 	return filepath.Join(datadir, "logs", filename)
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2301" title="DX-2301" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2301</a>  `state-svc status` log path is corrupted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
