### PR TITLE
Add more logging to help debug random panic for buildplans that result in nil environment definitions.

### DIFF
--- a/pkg/platform/runtime/store/store.go
+++ b/pkg/platform/runtime/store/store.go
@@ -239,6 +239,14 @@ func (s *Store) updateEnviron(orderedArtifacts []artifact.ArtifactID, artifacts 
 		}
 	}
 
+	if rtGlobal == nil {
+		// Returning nil will end up causing a nil-pointer-exception panic in setup.Update().
+		// There is additional logging of the buildplan there that may help diagnose why this is happening.
+		logging.Error("There were artifacts returned, but none of them ended up being stored/installed.")
+		logging.Error("Artifacts returned: %v", orderedArtifacts)
+		logging.Error("Artifacts stored: %v", artifacts)
+	}
+
 	return rtGlobal, nil
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2302" title="DX-2302" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2302</a>  Panic during runtime update: runtime error: invalid memory address or nil pointer dereference, build plan
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This continues to be a random issue.

This PR doesn't solve the problem. It just adds more logging around why the environment definition might be nil. It complements the existing panic catcher that logs the buildplan that triggered the panic.
