### PR TITLE
Stop fetching org info upon `state auth`.

### DIFF
--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
@@ -9,7 +8,6 @@ import (
 	"github.com/ActiveState/cli/internal/prompt"
 	authlet "github.com/ActiveState/cli/pkg/cmdlets/auth"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
-	"github.com/ActiveState/cli/pkg/platform/model"
 )
 
 type Auth struct {
@@ -72,37 +70,12 @@ func (a *Auth) Run(params *AuthParams) error {
 	}
 
 	username := a.Auth.WhoAmI()
-	organization, err := model.FetchOrgByURLName(username, a.Auth)
-	if err != nil {
-		return errs.Wrap(err, "Could not fetch organizations")
-	}
-
-	tiers, err := model.FetchTiers()
-	if err != nil {
-		return errs.Wrap(err, "Could not fetch tiers")
-	}
-
-	tier := organization.Tier
-	privateProjects := false
-	for _, t := range tiers {
-		if tier == t.Name && t.RequiresPayment {
-			privateProjects = true
-			break
-		}
-	}
-
 	a.Outputer.Print(output.Prepare(
 		locale.T("logged_in_as", map[string]string{"Name": username}),
 		&struct {
-			Username        string `json:"username,omitempty"`
-			URLName         string `json:"urlname,omitempty"`
-			Tier            string `json:"tier,omitempty"`
-			PrivateProjects bool   `json:"privateProjects"`
+			Username string `json:"username"`
 		}{
 			username,
-			organization.URLname,
-			tier,
-			privateProjects,
 		},
 	))
 

--- a/test/integration/auth_int_test.go
+++ b/test/integration/auth_int_test.go
@@ -87,20 +87,13 @@ func (suite *AuthIntegrationTestSuite) ensureLogout(ts *e2e.Session) {
 }
 
 type userJSON struct {
-	Username        string `json:"username,omitempty"`
-	URLName         string `json:"urlname,omitempty"`
-	Tier            string `json:"tier,omitempty"`
-	PrivateProjects bool   `json:"privateProjects"`
+	Username string `json:"username,omitempty"`
 }
 
 func (suite *AuthIntegrationTestSuite) authOutput(method string) {
-	user := userJSON{
-		Username:        e2e.PersistentUsername,
-		URLName:         e2e.PersistentUsername,
-		Tier:            "free",
-		PrivateProjects: false,
-	}
-	data, err := json.Marshal(user)
+	data, err := json.Marshal(userJSON{
+		Username: e2e.PersistentUsername,
+	})
 	suite.Require().NoError(err)
 
 	ts := e2e.New(suite.T(), false)
@@ -109,7 +102,7 @@ func (suite *AuthIntegrationTestSuite) authOutput(method string) {
 	expected := string(data)
 	ts.LoginAsPersistentUser()
 	cp := ts.Spawn(tagsuite.Auth, "--output", method)
-	cp.Expect("false}")
+	cp.Expect(`"}`)
 	cp.ExpectExitCode(0)
 	suite.Contains(cp.Output(), fmt.Sprintf("%s", string(expected)))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2305" title="DX-2305" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2305</a>  state tool fails to auth if you sign-up via state auth
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
With personal orgs going away, providing this information in JSON format no longer makes sense.