### PR TITLE
Use constants for environment variable names in integration tests.

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -178,7 +178,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 	projectName := "Python-LinuxWorks"
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "cli-integration-tests/"+projectName, "--path="+ts.Dirs.Work),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 
 	if runtime.GOOS == "linux" {
@@ -226,7 +226,7 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptAppendEnv(extraEnv...),
 	)
 
@@ -278,7 +278,7 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 	cp = ts.SpawnCmdWithOpts(
 		executor,
 		e2e.OptArgs("-c", "import sys; print(sys.copyright);"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("ActiveState Software Inc.", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -296,7 +296,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_PythonPath() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
@@ -376,9 +376,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePerl() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/Perl"),
-		e2e.OptAppendEnv(
-			"ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
-		),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 
 	cp.Expect("Downloading", termtest.OptExpectTimeout(40*time.Second))
@@ -512,7 +510,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_FromCache() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/small-python", "--path", ts.Dirs.Work),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Downloading")
 	cp.Expect("Installing")
@@ -525,7 +523,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_FromCache() {
 	// next activation is cached
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/small-python", "--path", ts.Dirs.Work),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 
 	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
@@ -666,7 +664,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateArtifactsCached() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
@@ -695,7 +693,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateArtifactsCached() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace),
 		e2e.OptAppendEnv(
-			"ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
+			constants.DisableRuntime+"=false",
 			"VERBOSE=true", // Necessary to assert "Fetched cached artifact"
 		),
 	)

--- a/test/integration/bundle_int_test.go
+++ b/test/integration/bundle_int_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ActiveState/termtest"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 )
@@ -223,7 +224,7 @@ func (suite *BundleIntegrationTestSuite) TestJSON() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("bundles", "install", "Testing", "--output", "json"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect(`"name":"Testing"`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -231,7 +232,7 @@ func (suite *BundleIntegrationTestSuite) TestJSON() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("bundles", "uninstall", "Testing", "-o", "editor"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect(`"name":"Testing"`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -33,7 +33,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckout() {
 	// Checkout and verify.
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/Python-3.9", "."),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	suite.Require().True(fileutils.DirExists(ts.Dirs.Work), "state checkout should have created "+ts.Dirs.Work)
@@ -66,7 +66,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckout() {
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("checkout", "ActiveState-CLI/Python-3.9", "."),
 			e2e.OptAppendEnv(
-				"ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
+				constants.DisableRuntime+"=false",
 				"VERBOSE=true", // Necessary to assert "Fetched cached artifact"
 			),
 		)
@@ -91,7 +91,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutNonEmptyDir() {
 	// Checkout and verify.
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/Python3", tmpdir),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=true"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("already a project checked out at")
 	cp.ExpectExitCode(1)
@@ -104,7 +104,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutNonEmptyDir() {
 	suite.Require().NoError(os.Remove(filepath.Join(tmpdir, constants.ConfigFileName)))
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/Python3", tmpdir),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=true"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
@@ -178,7 +178,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutCustomRTPath() {
 	// Checkout and verify.
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/Python3", fmt.Sprintf("--runtime-path=%s", customRTPath)),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 
@@ -194,7 +194,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutCustomRTPath() {
 	// Verify that state exec works with custom cache.
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("exec", "python3", "--", "-c", "import sys;print(sys.executable)"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptWD(filepath.Join(ts.Dirs.Work, "Python3")),
 	)
 	if runtime.GOOS == "windows" {

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -31,7 +31,7 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 			"ActiveState-CLI/Commit-Test-A#7a1b416e-c17f-4d4a-9e27-cbad9e8f5655",
 			".",
 		),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)

--- a/test/integration/deploy_int_test.go
+++ b/test/integration/deploy_int_test.go
@@ -37,7 +37,7 @@ func (suite *DeployIntegrationTestSuite) deploy(ts *e2e.Session, prj string, tar
 	case "windows":
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", prj, "--path", targetPath),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	case "darwin":
 		// On MacOS the command is the same as Linux, however some binaries
@@ -45,13 +45,13 @@ func (suite *DeployIntegrationTestSuite) deploy(ts *e2e.Session, prj string, tar
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", prj, "--path", targetPath, "--force"),
 			e2e.OptAppendEnv("SHELL=bash"),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	default:
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", prj, "--path", targetPath),
 			e2e.OptAppendEnv("SHELL=bash"),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	}
 
@@ -98,13 +98,14 @@ func (suite *DeployIntegrationTestSuite) TestDeployPerl() {
 			"cmd.exe",
 			e2e.OptArgs("/k", filepath.Join(targetPath, "bin", "shell.bat")),
 			e2e.OptAppendEnv("PATHEXT=.COM;.EXE;.BAT;.LNK", "SHELL="),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	} else {
 		cp = ts.SpawnCmdWithOpts(
 			"/bin/bash",
 			e2e.OptAppendEnv("PROMPT_COMMAND="),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+		)
 		cp.SendLine(fmt.Sprintf("source %s\n", filepath.Join(targetPath, "bin", "shell.sh")))
 	}
 
@@ -174,13 +175,14 @@ func (suite *DeployIntegrationTestSuite) TestDeployPython() {
 			"cmd.exe",
 			e2e.OptArgs("/k", filepath.Join(targetPath, "bin", "shell.bat")),
 			e2e.OptAppendEnv("PATHEXT=.COM;.EXE;.BAT;.LNK", "SHELL="),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	} else {
 		cp = ts.SpawnCmdWithOpts(
 			"/bin/bash",
 			e2e.OptAppendEnv("PROMPT_COMMAND="),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+		)
 		cp.SendLine(fmt.Sprintf("source %s\n", filepath.Join(targetPath, "bin", "shell.sh")))
 	}
 
@@ -242,7 +244,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployInstall() {
 func (suite *DeployIntegrationTestSuite) InstallAndAssert(ts *e2e.Session, targetPath string) {
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "install", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 
 	cp.Expect("Installing Runtime")
@@ -270,7 +272,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 	// Install step is required
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
@@ -280,12 +282,12 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath),
 			e2e.OptAppendEnv("SHELL=bash"),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	} else {
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	}
 
@@ -296,7 +298,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 	if runtime.GOOS == "windows" {
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath, "--user"),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 		cp.Expect("Configuring shell", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectExitCode(0)
@@ -346,7 +348,7 @@ func (suite *DeployIntegrationTestSuite) TestDeploySymlink() {
 	// Install step is required
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
@@ -355,12 +357,12 @@ func (suite *DeployIntegrationTestSuite) TestDeploySymlink() {
 	if runtime.GOOS != "darwin" {
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	} else {
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath, "--force"),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	}
 
@@ -387,7 +389,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployReport() {
 	// Install step is required
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "report", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
@@ -395,7 +397,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployReport() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "report", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Deployment Information")
 	cp.Expect(targetID.String()) // expect bin dir
@@ -426,7 +428,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployTwice() {
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath),
 		e2e.OptAppendEnv(fmt.Sprintf("PATH=%s", pathDir)), // Avoid conflicts
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectExitCode(0)
 
@@ -439,7 +441,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployTwice() {
 	cpx := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath),
 		e2e.OptAppendEnv(fmt.Sprintf("PATH=%s", pathDir)), // Avoid conflicts
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cpx.ExpectExitCode(0)
 }
@@ -465,7 +467,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployUninstall() {
 	// Uninstall deployed runtime.
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "uninstall", "--path", filepath.Join(ts.Dirs.Work, "target")),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Uninstall Deployed Runtime")
 	cp.Expect("Successful")
@@ -476,7 +478,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployUninstall() {
 	// Trying to uninstall again should fail
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "uninstall", "--path", filepath.Join(ts.Dirs.Work, "target")),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("no deployed runtime")
 	cp.ExpectExitCode(1)
@@ -485,7 +487,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployUninstall() {
 	// Trying to uninstall in a non-deployment directory should fail.
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "uninstall"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("no deployed runtime")
 	cp.ExpectExitCode(1)
@@ -494,7 +496,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployUninstall() {
 	// Trying to uninstall in a non-deployment directory should not delete that directory.
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "uninstall", "--path", ts.Dirs.Work),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("no deployed runtime")
 	cp.ExpectExitCode(1)

--- a/test/integration/edit_int_test.go
+++ b/test/integration/edit_int_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -79,7 +80,7 @@ func (suite *EditIntegrationTestSuite) TestEdit_NonInteractive() {
 	}
 	ts, env := suite.setup()
 	defer ts.Close()
-	extraEnv := e2e.OptAppendEnv("ACTIVESTATE_NONINTERACTIVE=true")
+	extraEnv := e2e.OptAppendEnv(constants.NonInteractiveEnvVarName + "=true")
 
 	cp := ts.SpawnWithOpts(e2e.OptArgs("scripts", "edit", "test-script"), env, extraEnv)
 	cp.Expect("Watching file changes")

--- a/test/integration/exec_int_test.go
+++ b/test/integration/exec_int_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -181,7 +182,7 @@ func (suite *ExecIntegrationTestSuite) TestExecWithPath() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("exec", "--path", pythonDir, "which", "python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Operating on project ActiveState-CLI/Python-3.9", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectRe(regexp.MustCompile("cache/[0-9A-Fa-f]+/usr/bin/python3").String())
@@ -189,7 +190,7 @@ func (suite *ExecIntegrationTestSuite) TestExecWithPath() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("exec", "echo", "python3", "--path", pythonDir, "--", "--path", "doesNotExist", "--", "extra"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("python3 --path doesNotExist -- extra")
 	cp.ExpectExitCode(0)

--- a/test/integration/executor_int_test.go
+++ b/test/integration/executor_int_test.go
@@ -35,7 +35,7 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorForwards() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
@@ -62,7 +62,7 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorExitCode() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()

--- a/test/integration/export_int_test.go
+++ b/test/integration/export_int_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/termtest"
@@ -87,7 +88,7 @@ func (suite *ExportIntegrationTestSuite) TestExport_Env() {
 	ts.PrepareProject("ActiveState-CLI/Export", "5397f645-da8a-4591-b106-9d7fa99545fe")
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("export", "env"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect(`PATH: `, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -107,13 +108,13 @@ func (suite *ExportIntegrationTestSuite) TestJSON() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python", "."),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("export", "env", "-o", "json"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 	AssertValidJSON(suite.T(), cp)

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -115,7 +115,7 @@ func (suite *InitIntegrationTestSuite) TestInit_InferLanguageFromUse() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -93,14 +93,14 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 			if runtime.GOOS != "windows" {
 				cp = ts.SpawnCmdWithOpts(
 					"bash", e2e.OptArgs(argsWithActive...),
-					e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+					e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 					e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.AppInstallDirOverrideEnvVarName, appInstallDir)),
 					e2e.OptAppendEnv(fmt.Sprintf("%s=FOO", constants.OverrideSessionTokenEnvVarName)),
 				)
 			} else {
 				cp = ts.SpawnCmdWithOpts("powershell.exe", e2e.OptArgs(argsWithActive...),
 					e2e.OptAppendEnv("SHELL="),
-					e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+					e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 					e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.AppInstallDirOverrideEnvVarName, appInstallDir)),
 					e2e.OptAppendEnv(fmt.Sprintf("%s=FOO", constants.OverrideSessionTokenEnvVarName)),
 				)

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -421,7 +421,7 @@ func (suite *PackageIntegrationTestSuite) TestInstall_Empty() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("install", "JSON"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Installing Package")
 	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
@@ -464,7 +464,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("install", "Text-CSV", "--output", "editor"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect(`{"name":"Text-CSV"`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -477,7 +477,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("uninstall", "Text-CSV", "-o", "json"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect(`{"name":"Text-CSV"`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -506,7 +506,7 @@ func (suite *PackageIntegrationTestSuite) TestNormalize() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("install", "Charset_normalizer"),
 		e2e.OptWD(dir),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("charset-normalizer")
 	cp.Expect("is different")
@@ -526,7 +526,7 @@ func (suite *PackageIntegrationTestSuite) TestNormalize() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("install", "charset-normalizer"),
 		e2e.OptWD(anotherDir),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("charset-normalizer")
 	cp.ExpectExitCode(0)

--- a/test/integration/performance_int_test.go
+++ b/test/integration/performance_int_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/exeutils"
 	"github.com/ActiveState/termtest"
@@ -54,7 +55,7 @@ func performanceTest(commands []string, expect string, samples int, maxTime time
 	for x := 0; x < samples+1; x++ {
 		opts := []e2e.SpawnOptSetter{
 			e2e.OptArgs(commands...),
-			e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_UPDATES=true", "ACTIVESTATE_PROFILE=true"),
+			e2e.OptAppendEnv(constants.DisableUpdates+"=true", constants.ProfileEnvVarName+"=true"),
 		}
 		termtestLogs := &bytes.Buffer{}
 		if verbose {

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -50,7 +50,7 @@ func (suite *PrepareIntegrationTestSuite) TestPrepare() {
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("_prepare"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.AutostartPathOverrideEnvVarName, autostartDir)),
-		// e2e.OptAppendEnv(fmt.Sprintf("ACTIVESTATE_CLI_CONFIGDIR=%s", ts.Dirs.Work)),
+		// e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.ConfigEnvVarName, ts.Dirs.Work)),
 	)
 	cp.ExpectExitCode(0)
 
@@ -119,7 +119,7 @@ func (suite *PrepareIntegrationTestSuite) AssertConfig(target string) {
 
 func (suite *PrepareIntegrationTestSuite) TestResetExecutors() {
 	suite.OnlyRunForTags(tagsuite.Prepare)
-	ts := e2e.New(suite.T(), true, "ACTIVESTATE_CLI_DISABLE_RUNTIME=false")
+	ts := e2e.New(suite.T(), true, constants.DisableRuntime+"=false")
 	err := ts.ClearCache()
 	suite.Require().NoError(err)
 	defer ts.Close()

--- a/test/integration/progress_int_test.go
+++ b/test/integration/progress_int_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"testing"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -20,7 +21,7 @@ func (suite *ProgressIntegrationTestSuite) TestProgress() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect(locale.T("setup_runtime"))
 	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
@@ -29,7 +30,7 @@ func (suite *ProgressIntegrationTestSuite) TestProgress() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python", "small-python2", "--non-interactive"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect(locale.T("setup_runtime"))
 	cp.Expect("...")

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -146,7 +146,7 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("install", "requests"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Package added", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)

--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -225,7 +225,7 @@ func (suite *PushIntegrationTestSuite) TestCarlisle() {
 		e2e.OptArgs(
 			"activate", suite.baseProject,
 			"--path", wd),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	// The activestate.yaml on Windows runs custom activation to set shortcuts and file associations.
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
@@ -240,7 +240,8 @@ func (suite *PushIntegrationTestSuite) TestCarlisle() {
 	cp = ts.SpawnWithOpts(e2e.OptArgs(
 		"install", suite.extraPackage),
 		e2e.OptWD(wd),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
 	switch runtime.GOOS {
 	case "darwin":
 		cp.ExpectRe("added|being built", e2e.RuntimeSourcingTimeoutOpt) // while cold storage is off

--- a/test/integration/refresh_int_test.go
+++ b/test/integration/refresh_int_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/stretchr/testify/suite"
@@ -22,7 +23,7 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("refresh"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Setting Up Runtime")
 	cp.Expect("Runtime updated", e2e.RuntimeSourcingTimeoutOpt)
@@ -30,7 +31,7 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("exec", "--", "python3", "-c", "import requests"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("ModuleNotFoundError")
 	cp.ExpectExitCode(1)
@@ -38,7 +39,7 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 	suite.PrepareActiveStateYAML(ts, "ActiveState-CLI/Branches", "secondbranch", "46c83477-d580-43e2-a0c6-f5d3677517f1")
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("refresh"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Setting Up Runtime")
 	cp.Expect("Runtime updated", e2e.RuntimeSourcingTimeoutOpt)
@@ -46,7 +47,7 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("exec", "--", "python3", "-c", "import requests"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/stretchr/testify/suite"
@@ -51,7 +52,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	// Verify that argparse still exists (it was not reverted along with urllib3).
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell", "Revert"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("python3")

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ActiveState/termtest"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -292,7 +293,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate"),
 		e2e.OptAppendEnv(
-			"ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
+			constants.DisableRuntime+"=false",
 			"PERL_VERSION=does_not_exist",
 		),
 	)

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/exeutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -87,7 +88,7 @@ func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/test-interrupt-small-python#863c45e2-3626-49b6-893c-c15e85a17241", "."),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 
@@ -99,8 +100,8 @@ func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("pull"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false",
-			"ACTIVESTATE_CLI_RUNTIME_SETUP_WAIT=true"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false",
+			constants.RuntimeSetupWaitEnvVarName+"=true"),
 	)
 	time.Sleep(30 * time.Second)
 	cp.SendCtrlC() // cancel pull/update

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -88,7 +88,7 @@ func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
 	// Use.
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -188,7 +188,7 @@ func (suite *ShellIntegrationTestSuite) TestDefaultNoLongerExists() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -226,7 +226,7 @@ func (suite *ShellIntegrationTestSuite) TestUseShellUpdates() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
 		e2e.OptAppendEnv("SHELL=bash"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)

--- a/test/integration/shells_int_test.go
+++ b/test/integration/shells_int_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 )
@@ -34,7 +35,7 @@ func (suite *ShellsIntegrationTestSuite) TestShells() {
 	// Checkout the first instance. It doesn't matter which shell is used.
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -54,7 +55,7 @@ func (suite *ShellsIntegrationTestSuite) TestShells() {
 
 			// There are 2 or more instances checked out, so we should get a prompt in whichever shell we
 			// use.
-			cp = ts.SpawnShellWithOpts(shell, e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"))
+			cp = ts.SpawnShellWithOpts(shell, e2e.OptAppendEnv(constants.DisableRuntime+"=false"))
 			cp.SendLine(e2e.QuoteCommand(shell, ts.ExecutablePath(), "shell", "small-python"))
 			cp.Expect("Multiple project paths")
 

--- a/test/integration/show_int_test.go
+++ b/test/integration/show_int_test.go
@@ -26,7 +26,7 @@ func (suite *ShowIntegrationTestSuite) TestShow() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
 

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -51,13 +51,13 @@ func (suite *UpdateIntegrationTestSuite) env(disableUpdates, forceUpdate bool) [
 	env := []string{}
 
 	if disableUpdates {
-		env = append(env, "ACTIVESTATE_CLI_DISABLE_UPDATES=true")
+		env = append(env, constants.DisableUpdates+"=true")
 	} else {
-		env = append(env, "ACTIVESTATE_CLI_DISABLE_UPDATES=false")
+		env = append(env, constants.DisableUpdates+"=false")
 	}
 
 	if forceUpdate {
-		env = append(env, "ACTIVESTATE_FORCE_UPDATE=true")
+		env = append(env, constants.ForceUpdateEnvVarName+"=true")
 	}
 
 	dir, err := ioutil.TempDir("", "system*")
@@ -296,7 +296,7 @@ func (suite *UpdateIntegrationTestSuite) testAutoUpdate(ts *e2e.Session, baseDir
 		e2e.OptArgs("--version"),
 		e2e.OptAppendEnv(suite.env(false, true)...),
 		e2e.OptAppendEnv(fmt.Sprintf("HOME=%s", fakeHome)),
-		e2e.OptAppendEnv("ACTIVESTATE_TEST_AUTO_UPDATE=true"),
+		e2e.OptAppendEnv(constants.TestAutoUpdateEnvVarName + "=true"),
 	}
 	if opts != nil {
 		spawnOpts = append(spawnOpts, opts...)
@@ -361,7 +361,7 @@ func (suite *UpdateIntegrationTestSuite) TestAutoUpdateToCurrent() {
 
 	suite.installLatestReleaseVersion(ts, installDir)
 
-	suite.testAutoUpdate(ts, installDir, e2e.OptAppendEnv(fmt.Sprintf("ACTIVESTATE_CLI_UPDATE_BRANCH=%s", constants.BranchName)))
+	suite.testAutoUpdate(ts, installDir, e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.UpdateBranchEnvVarName, constants.BranchName)))
 }
 
 func (suite *UpdateIntegrationTestSuite) TestUpdateToCurrent() {
@@ -379,5 +379,5 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateToCurrent() {
 
 	suite.installLatestReleaseVersion(ts, installDir)
 
-	suite.testUpdate(ts, installDir, e2e.OptAppendEnv(fmt.Sprintf("ACTIVESTATE_CLI_UPDATE_BRANCH=%s", constants.BranchName)))
+	suite.testUpdate(ts, installDir, e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.UpdateBranchEnvVarName, constants.BranchName)))
 }

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/subshell"
@@ -35,7 +36,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 	// Use.
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -55,7 +56,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 	// Use it.
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "ActiveState-CLI/Python-3.9"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -68,7 +69,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 	// Switch back using just the project name.
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -100,7 +101,7 @@ func (suite *UseIntegrationTestSuite) TestUseCwd() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use"),
 		e2e.OptWD(pythonDir),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -131,7 +132,7 @@ func (suite *UseIntegrationTestSuite) TestReset() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -186,7 +187,7 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -236,7 +237,7 @@ func (suite *UseIntegrationTestSuite) TestSetupNotice() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Setting Up Runtime")
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
@@ -253,7 +254,7 @@ func (suite *UseIntegrationTestSuite) TestSetupNotice() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "Python3"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Setting Up Runtime")
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
@@ -272,7 +273,7 @@ func (suite *UseIntegrationTestSuite) TestJSON() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use", "-o", "json"),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect(`"namespace":`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.Expect(`"path":`)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2159" title="DX-2159" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2159</a>  Integration tests that define environment variables should use their constants instead of typing them in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
