### PR TITLE
Drop VSCode-specific flag.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -279,14 +279,6 @@ func newStateCommand(globals *globalOptions, prime *primer.Values) *captain.Comm
 				Value:       &globals.Output,
 			},
 			{
-				/* This option is only used for the vscode extension: It prevents the integrated terminal to close immediately after an error occurs, such that the user can read the message */
-				Name:        "confirm-exit-on-error", // Name and Shorthand should be kept in sync with cmd/state/output.go
-				Description: "prompts the user to press enter before exiting, when an error occurs",
-				Persist:     true,
-				Hidden:      true, // No need to add this to help messages
-				Value:       &opts.ConfirmExit,
-			},
-			{
 				Name:        "non-interactive", // Name and Shorthand should be kept in sync with cmd/state/output.go
 				Description: locale.T("flag_state_non_interactive_description"),
 				Shorthand:   "n",

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -107,17 +104,6 @@ func main() {
 		exitCode, err = cmdletErrors.ParseUserFacing(err)
 		if err != nil {
 			out.Error(err)
-		}
-
-		// If a state tool error occurs in a VSCode integrated terminal, we want
-		// to pause and give time to the user to read the error message.
-		// But not, if we exit, because the last command in the activated sub-shell failed.
-		var eerr *exec.ExitError
-		isExitError := errors.As(err, &eerr)
-		if !isExitError && outFlags.ConfirmExit {
-			out.Print(locale.T("confirm_exit_on_error_prompt"))
-			br := bufio.NewReader(os.Stdin)
-			br.ReadLine()
 		}
 	}
 }

--- a/cmd/state/main_test.go
+++ b/cmd/state/main_test.go
@@ -15,45 +15,44 @@ type MainTestSuite struct {
 
 func (suite *MainTestSuite) TestOutputer() {
 	{
-		outputer, err := initOutput(outputFlags{"", false, false, false}, "", "")
+		outputer, err := initOutput(outputFlags{"", false, false}, "", "")
 		suite.Require().NoError(err, errs.JoinMessage(err))
 		suite.Equal(output.PlainFormatName, outputer.Type(), "Returns Plain outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{string(output.PlainFormatName), false, false, false}, "", "")
+		outputer, err := initOutput(outputFlags{string(output.PlainFormatName), false, false}, "", "")
 		suite.Require().NoError(err)
 		suite.Equal(output.PlainFormatName, outputer.Type(), "Returns Plain outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{string(output.JSONFormatName), false, false, false}, "", "")
+		outputer, err := initOutput(outputFlags{string(output.JSONFormatName), false, false}, "", "")
 		suite.Require().NoError(err)
 		suite.Equal(output.JSONFormatName, outputer.Type(), "Returns JSON outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{"", false, false, false}, string(output.JSONFormatName), "")
+		outputer, err := initOutput(outputFlags{"", false, false}, string(output.JSONFormatName), "")
 		suite.Require().NoError(err)
 		suite.Equal(output.JSONFormatName, outputer.Type(), "Returns JSON outputer")
 	}
 
 	{
-		outputer, err := initOutput(outputFlags{"", false, false, false}, string(output.EditorFormatName), "")
+		outputer, err := initOutput(outputFlags{"", false, false}, string(output.EditorFormatName), "")
 		suite.Require().NoError(err)
 		suite.Equal(output.EditorFormatName, outputer.Type(), "Returns JSON outputer")
 	}
 }
 
 func (suite *MainTestSuite) TestParseOutputFlags() {
-	suite.Equal(outputFlags{"plain", false, false, false}, parseOutputFlags([]string{"state", "foo", "-o", "plain"}))
-	suite.Equal(outputFlags{"json", false, false, false}, parseOutputFlags([]string{"state", "foo", "--output", "json"}))
-	suite.Equal(outputFlags{"json", false, false, false}, parseOutputFlags([]string{"state", "foo", "-o", "json"}))
-	suite.Equal(outputFlags{"editor", false, false, false}, parseOutputFlags([]string{"state", "foo", "--output", "editor"}))
-	suite.Equal(outputFlags{"", true, false, false}, parseOutputFlags([]string{"state", "foo", "--mono"}))
-	suite.Equal(outputFlags{"", false, true, false}, parseOutputFlags([]string{"state", "foo", "--confirm-exit-on-error"}))
-	suite.Equal(outputFlags{"", false, false, true}, parseOutputFlags([]string{"state", "foo", "--non-interactive"}))
-	suite.Equal(outputFlags{"", false, false, true}, parseOutputFlags([]string{"state", "foo", "-n"}))
+	suite.Equal(outputFlags{"plain", false, false}, parseOutputFlags([]string{"state", "foo", "-o", "plain"}))
+	suite.Equal(outputFlags{"json", false, false}, parseOutputFlags([]string{"state", "foo", "--output", "json"}))
+	suite.Equal(outputFlags{"json", false, false}, parseOutputFlags([]string{"state", "foo", "-o", "json"}))
+	suite.Equal(outputFlags{"editor", false, false}, parseOutputFlags([]string{"state", "foo", "--output", "editor"}))
+	suite.Equal(outputFlags{"", true, false}, parseOutputFlags([]string{"state", "foo", "--mono"}))
+	suite.Equal(outputFlags{"", false, true}, parseOutputFlags([]string{"state", "foo", "--non-interactive"}))
+	suite.Equal(outputFlags{"", false, true}, parseOutputFlags([]string{"state", "foo", "-n"}))
 }
 
 func (suite *MainTestSuite) TestDisableColors() {

--- a/cmd/state/output.go
+++ b/cmd/state/output.go
@@ -19,7 +19,6 @@ type outputFlags struct {
 	// These should be kept in sync with cmd/state/internal/cmdtree (output flag)
 	Output         string `short:"o" long:"output"`
 	Mono           bool   `long:"mono"`
-	ConfirmExit    bool   `long:"confirm-exit-on-error"`
 	NonInteractive bool   `short:"n" long:"non-interactive"`
 }
 

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1569,8 +1569,6 @@ deploy_usable_path:
     Please ensure '[NOTICE]{{.V0}}[/RESET]' exists and is on your PATH.
 script_watcher_watch_file:
   other: "Watching file changes at: [NOTICE]{{.V0}}[/RESET]"
-confirm_exit_on_error_prompt:
-  other: Press enter to continue...
 tutorial_newproject_intro:
   other: |
     The State Tool lets you create and maintain a set of virtual environments (eg., one per project), allowing you to


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2262" title="DX-2262" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2262</a>  Drop `confirm-exit-on-error` flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It's no longer needed.