### PR TITLE
State revert uses the build planner

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1715,7 +1715,7 @@ err_user_network_solution:
 err_revert_get_commit:
   other: "Could not fetch commit details for commit with ID: {{.V0}}"
 err_revert_commit:
-  other: "Could not revert{{.V0}} commit: {{.V1}}"
+  other: "Could not revert {{.V0}} commit: {{.V1}}"
 install_initial_success:
   other: "An activestate.yaml has been created at: {{.V0}}."
 err_package_info_no_packages:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1703,7 +1703,7 @@ err_user_network_solution:
 err_revert_get_commit:
   other: "Could not fetch commit details for commit with ID: {{.V0}}"
 err_revert_commit:
-  other: "Could not revert {{.V0}} commit: {{.V1}}"
+  other: "Could not revert{{.V0}} commit: {{.V1}}"
 install_initial_success:
   other: "An activestate.yaml has been created at: {{.V0}}."
 err_package_info_no_packages:

--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -75,7 +75,6 @@ func (r *Revert) Run(params *Params) error {
 	revertParams := revertParams{
 		organization:   r.project.Owner(),
 		project:        r.project.Name(),
-		branch:         r.project.BranchName(),
 		parentCommitID: latestCommit.String(),
 		revertCommitID: params.CommitID,
 	}
@@ -126,11 +125,6 @@ func (r *Revert) Run(params *Params) error {
 			locale.T("tip_private_project_auth"))
 	}
 
-	err = runbits.RefreshRuntime(r.auth, r.out, r.analytics, r.project, revertCommit, true, target.TriggerRevert, r.svcModel)
-	if err != nil {
-		return locale.WrapError(err, "err_refresh_runtime")
-	}
-
 	err = commitmediator.Set(r.project, revertCommit.String())
 	if err != nil {
 		return errs.Wrap(err, "Unable to set local commit")
@@ -158,13 +152,12 @@ type revertFunc func(params revertParams, bp *model.BuildPlanner) (strfmt.UUID, 
 type revertParams struct {
 	organization   string
 	project        string
-	branch         string
 	parentCommitID string
 	revertCommitID string
 }
 
 func (r *Revert) revertCommit(params revertParams, bp *model.BuildPlanner) (strfmt.UUID, error) {
-	newCommitID, err := bp.RevertCommit(params.organization, params.project, params.branch, params.revertCommitID)
+	newCommitID, err := bp.RevertCommit(params.organization, params.project, params.parentCommitID, params.revertCommitID)
 	if err != nil {
 		return "", errs.Wrap(err, "could not revert commit")
 	}

--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -158,7 +158,7 @@ type revertParams struct {
 func (r *Revert) revertCommit(params revertParams, bp *model.BuildPlanner) (strfmt.UUID, error) {
 	newCommitID, err := bp.RevertCommit(params.organization, params.project, params.parentCommitID, params.revertCommitID)
 	if err != nil {
-		return "", errs.Wrap(err, "could not revert commit")
+		return "", errs.Wrap(err, "Could not revert commit")
 	}
 
 	return newCommitID, nil
@@ -167,7 +167,7 @@ func (r *Revert) revertCommit(params revertParams, bp *model.BuildPlanner) (strf
 func (r *Revert) revertToCommit(params revertParams, bp *model.BuildPlanner) (strfmt.UUID, error) {
 	buildExpression, err := bp.GetBuildExpression(params.organization, params.project, params.revertCommitID)
 	if err != nil {
-		return "", errs.Wrap(err, "could not get build expression")
+		return "", errs.Wrap(err, "Could not get build expression")
 	}
 
 	stageCommitParams := model.StageCommitParams{
@@ -180,7 +180,7 @@ func (r *Revert) revertToCommit(params revertParams, bp *model.BuildPlanner) (st
 
 	newCommitID, err := bp.StageCommit(stageCommitParams)
 	if err != nil {
-		return "", errs.Wrap(err, "could not stage commit")
+		return "", errs.Wrap(err, "Could not stage commit")
 	}
 
 	return newCommitID, nil

--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -79,8 +79,10 @@ func (r *Revert) Run(params *Params) error {
 		revertCommitID: params.CommitID,
 	}
 	revertFunc := r.revertCommit
+	preposition := ""
 	if params.To {
 		revertFunc = r.revertToCommit
+		preposition = " to" // need leading whitespace
 	}
 
 	targetCommit, err := model.GetCommitWithinCommitHistory(latestCommit, strfmt.UUID(targetCommitID))
@@ -99,10 +101,7 @@ func (r *Revert) Run(params *Params) error {
 			return locale.WrapError(err, "err_revert_get_organizations", "Could not get organizations for current user")
 		}
 	}
-	preposition := ""
-	if params.To {
-		preposition = " to" // need leading whitespace
-	}
+
 	if !r.out.Type().IsStructured() {
 		r.out.Print(locale.Tl("revert_info", "You are about to revert{{.V0}} the following commit:", preposition))
 		commit.PrintCommit(r.out, targetCommit, orgs)

--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -44,6 +44,7 @@ const (
 	BuildLogRecipeID = "RECIPE_ID"
 	BuildRequestID   = "BUILD_REQUEST_ID"
 
+	// Version Comparators
 	ComparatorEQ  string = "eq"
 	ComparatorGT         = "gt"
 	ComparatorGTE        = "gte"
@@ -51,14 +52,20 @@ const (
 	ComparatorLTE        = "lte"
 	ComparatorNE         = "ne"
 
+	// Version Requirement keys
 	VersionRequirementComparatorKey = "comparator"
 	VersionRequirementVersionKey    = "version"
 
+	// MIME types
 	XArtifactMimeType            = "application/x.artifact"
 	XActiveStateArtifactMimeType = "application/x-activestate-artifacts"
 	XCamelInstallerMimeType      = "application/x-camel-installer"
 	XGozipInstallerMimeType      = "application/x-gozip-installer"
 	XActiveStateBuilderMimeType  = "application/x-activestate-builder"
+
+	// RevertCommit strategies
+	RevertCommitStrategyForce   = "Force"
+	RevertCommitStrategyDefault = "Default"
 
 	// Error types
 	ErrorType                        = "Error"
@@ -378,6 +385,18 @@ type projectCreated struct {
 
 type CreateProjectResult struct {
 	ProjectCreated *projectCreated `json:"createProject"`
+}
+
+type RevertedCommit struct {
+	Type           string      `json:"__typename"`
+	Commit         *Commit     `json:"commit"`
+	CommonAncestor strfmt.UUID `json:"commonAncestorID"`
+	ConflictPaths  []string    `json:"conflictPaths"`
+	*Error
+}
+
+type RevertCommitResult struct {
+	RevertedCommit *RevertedCommit `json:"revertCommit"`
 }
 
 // Error contains an error message.

--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -415,7 +415,7 @@ type CreateProjectResult struct {
 	ProjectCreated *projectCreated `json:"createProject"`
 }
 
-type RevertedCommit struct {
+type revertedCommit struct {
 	Type           string      `json:"__typename"`
 	Commit         *Commit     `json:"commit"`
 	CommonAncestor strfmt.UUID `json:"commonAncestorID"`
@@ -424,7 +424,7 @@ type RevertedCommit struct {
 }
 
 type RevertCommitResult struct {
-	RevertedCommit *RevertedCommit `json:"revertCommit"`
+	RevertedCommit *revertedCommit `json:"revertCommit"`
 }
 
 type mergedCommit struct {

--- a/pkg/platform/api/buildplanner/request/revertcommit.go
+++ b/pkg/platform/api/buildplanner/request/revertcommit.go
@@ -1,0 +1,78 @@
+package request
+
+import "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
+
+func RevertCommit(organization, project, branch, commitID string) *revertCommit {
+	return &revertCommit{map[string]interface{}{
+		"organization": organization,
+		"project":      project,
+		"branch":       branch,
+		"commitId":     commitID,
+		// Currently, we use the force strategy for all revert commits.
+		// This is because we don't have a way to show the user the conflicts
+		// and let them resolve them yet.
+		// https://activestatef.atlassian.net/browse/AR-80?focusedCommentId=46998
+		"strategy": model.RevertCommitStrategyForce,
+	}}
+}
+
+type revertCommit struct {
+	vars map[string]interface{}
+}
+
+func (r *revertCommit) Query() string {
+	return `
+mutation ($organization: String!, $project: String!, $commitId: String!, $branch: String!, $strategy: RevertStrategy) {
+  revertCommit(
+    input: {organization: $organization, project: $project, commitId: $commitId, branch: $branch, strategy: $strategy}
+  ) {
+    ... on RevertedCommit {
+      __typename
+      commit {
+        __typename
+        commitId
+      }
+    }
+    ... on RevertConflict {
+      __typename
+      message
+      branchName
+      conflictPaths
+    }
+    ... on CommitHasNoParent {
+      __typename
+      message
+    }
+    ... on NotFound {
+      __typename
+      message
+      mayNeedAuthentication
+    }
+    ... on ParseError {
+      __typename
+      message
+      path
+    }
+    ... on ValidationError {
+      __typename
+      message
+    }
+    ... on Forbidden {
+      __typename
+      message
+    }
+    ... on HeadOnBranchMoved {
+      __typename
+      message
+    }
+    ... on NoChangeSinceLastCommit {
+      message
+      commitId
+    }
+  }
+}`
+}
+
+func (r *revertCommit) Vars() map[string]interface{} {
+	return r.vars
+}

--- a/pkg/platform/api/buildplanner/request/revertcommit.go
+++ b/pkg/platform/api/buildplanner/request/revertcommit.go
@@ -2,11 +2,11 @@ package request
 
 import "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
 
-func RevertCommit(organization, project, branch, commitID string) *revertCommit {
+func RevertCommit(organization, project, targetVcsRef, commitID string) *revertCommit {
 	return &revertCommit{map[string]interface{}{
 		"organization": organization,
 		"project":      project,
-		"branch":       branch,
+		"targetVcsRef": targetVcsRef,
 		"commitId":     commitID,
 		// Currently, we use the force strategy for all revert commits.
 		// This is because we don't have a way to show the user the conflicts
@@ -22,9 +22,9 @@ type revertCommit struct {
 
 func (r *revertCommit) Query() string {
 	return `
-mutation ($organization: String!, $project: String!, $commitId: String!, $branch: String!, $strategy: RevertStrategy) {
+mutation ($organization: String!, $project: String!, $commitId: String!, $targetVcsRef: String!, $strategy: RevertStrategy) {
   revertCommit(
-    input: {organization: $organization, project: $project, commitId: $commitId, branch: $branch, strategy: $strategy}
+    input: {organization: $organization, project: $project, commitId: $commitId, targetVcsRef: $targetVcsRef, strategy: $strategy}
   ) {
     ... on RevertedCommit {
       __typename
@@ -36,7 +36,8 @@ mutation ($organization: String!, $project: String!, $commitId: String!, $branch
     ... on RevertConflict {
       __typename
       message
-      branchName
+      commitId
+      targetCommitId
       conflictPaths
     }
     ... on CommitHasNoParent {

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -400,7 +400,7 @@ func (bp *BuildPlanner) RevertCommit(organization, project, parentCommitID, comm
 	resp := &bpModel.RevertCommitResult{}
 	err := bp.client.Run(request.RevertCommit(organization, project, parentCommitID, commitID), resp)
 	if err != nil {
-		return "", processBuildPlannerError(err, "failed to revert commit")
+		return "", processBuildPlannerError(err, "Failed to revert commit")
 	}
 
 	if resp.RevertedCommit == nil {

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -395,10 +395,10 @@ func (bp *BuildPlanner) CreateProject(params *CreateProjectParams) (strfmt.UUID,
 	return resp.ProjectCreated.Commit.CommitID, nil
 }
 
-func (bp *BuildPlanner) RevertCommit(organization, project, branch, commitID string) (strfmt.UUID, error) {
+func (bp *BuildPlanner) RevertCommit(organization, project, parentCommitID, commitID string) (strfmt.UUID, error) {
 	logging.Debug("RevertCommit, organization: %s, project: %s, commitID: %s", organization, project, commitID)
 	resp := &bpModel.RevertCommitResult{}
-	err := bp.client.Run(request.RevertCommit(organization, project, branch, commitID), resp)
+	err := bp.client.Run(request.RevertCommit(organization, project, parentCommitID, commitID), resp)
 	if err != nil {
 		return "", processBuildPlannerError(err, "failed to revert commit")
 	}

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -115,10 +115,12 @@ func (suite *RevertIntegrationTestSuite) TestRevertTo() {
 		e2e.OptArgs("history"),
 		e2e.OptWD(wd),
 	)
+	cp.Expect("Revert to commit " + commitID)
 	cp.Expect("- argparse") // effectively reverting previous commit
 	cp.Expect("+ argparse") // commit being effectively reverted
 	cp.Expect("+ urllib3")  // commit reverted to
 	cp.Expect("+ python")   // initial commit
+	fmt.Println("Output: ", cp.Snapshot())
 }
 
 func (suite *RevertIntegrationTestSuite) TestRevertTo_failsOnCommitNotInHistory() {

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -42,7 +42,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 		e2e.OptArgs("history"),
 		e2e.OptWD(wd),
 	)
-	cp.Expect("Revert commit " + commitID)
+	cp.Expect("Reverted commit " + commitID)
 	cp.Expect("- urllib3")
 	cp.Expect("+ argparse") // parent commit
 	cp.Expect("+ urllib3")  // commit whose changes were just reverted
@@ -83,7 +83,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert_failsOnCommitNotInHistory() 
 	cp.Expect(fmt.Sprintf("Operating on project %s", namespace))
 	cp.SendLine("Y")
 	cp.Expect(commitID)
-	cp.Expect("The commit being reverted is not within the current commit's history")
+	cp.Expect("The target commit is not within the current commit's history")
 	cp.ExpectNotExitCode(0)
 }
 
@@ -115,7 +115,6 @@ func (suite *RevertIntegrationTestSuite) TestRevertTo() {
 		e2e.OptArgs("history"),
 		e2e.OptWD(wd),
 	)
-	cp.Expect("Reverting to commit " + commitID)
 	cp.Expect("- argparse") // effectively reverting previous commit
 	cp.Expect("+ argparse") // commit being effectively reverted
 	cp.Expect("+ urllib3")  // commit reverted to

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -42,7 +42,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 		e2e.OptArgs("history"),
 		e2e.OptWD(wd),
 	)
-	cp.Expect("Reverted commit " + commitID)
+	cp.Expect("Reverted commit for commit " + commitID)
 	cp.Expect("- urllib3")
 	cp.Expect("+ argparse") // parent commit
 	cp.Expect("+ urllib3")  // commit whose changes were just reverted

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -120,7 +120,6 @@ func (suite *RevertIntegrationTestSuite) TestRevertTo() {
 	cp.Expect("+ argparse") // commit being effectively reverted
 	cp.Expect("+ urllib3")  // commit reverted to
 	cp.Expect("+ python")   // initial commit
-	fmt.Println("Output: ", cp.Snapshot())
 }
 
 func (suite *RevertIntegrationTestSuite) TestRevertTo_failsOnCommitNotInHistory() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2226" title="DX-2226" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2226</a>  `state revert --to` uses the BuildPlanner
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
