### PR TITLE
Remove test accidentally restored during a merge.

### DIFF
--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -291,45 +291,6 @@ six==1.14.0
 `
 )
 
-func (suite *PackageIntegrationTestSuite) TestPackage_import() {
-	suite.OnlyRunForTags(tagsuite.Package)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
-	username, _ := ts.CreateNewUser()
-	namespace := fmt.Sprintf("%s/%s", username, "Python3")
-
-	cp := ts.Spawn("init", "--language", "python", namespace, ts.Dirs.Work)
-	cp.Expect("successfully initialized")
-	cp.ExpectExitCode(0)
-
-	reqsFilePath := filepath.Join(cp.WorkDirectory(), reqsFileName)
-
-	suite.Run("invalid requirements.txt", func() {
-		ts.SetT(suite.T())
-		ts.PrepareFile(reqsFilePath, badReqsData)
-
-		cp := ts.Spawn("import", "requirements.txt")
-		cp.ExpectNotExitCode(0)
-	})
-
-	suite.Run("valid requirements.txt", func() {
-		ts.SetT(suite.T())
-		ts.PrepareFile(reqsFilePath, reqsData)
-
-		cp := ts.Spawn("import", "requirements.txt")
-		cp.ExpectExitCode(0)
-
-		cp = ts.Spawn("push")
-		cp.ExpectExitCode(0)
-
-		cp = ts.Spawn("import", "requirements.txt")
-		cp.Expect("Are you sure")
-		cp.SendLine("n")
-		cp.ExpectNotExitCode(0)
-	})
-}
-
 func (suite *PackageIntegrationTestSuite) TestPackage_detached_operation() {
 	suite.OnlyRunForTags(tagsuite.Package)
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2310" title="DX-2310" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2310</a>  Nightly failure: TestPackageIntegrationTestSuite/TestPackage_import/valid_requirements.txt
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This test was moved to import_int_test.go in a previous commit.