### PR TITLE
Added commitID for activation tests that immediately run `state pull` to update.

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -423,6 +423,7 @@ version: %s
 `, constants.BranchName, constants.Version))
 
 	ts.PrepareActiveStateYAML(content)
+	ts.PrepareCommitIdFile("59404293-e5a9-4fd0-8843-77cd4761b5b5")
 
 	// Pull to ensure we have an up to date config file
 	cp := ts.Spawn("pull")
@@ -453,7 +454,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_NamespaceWins() {
 	suite.Require().NoError(err)
 
 	// Create the project file at the root of the temp dir
-	ts.PrepareProject("ActiveState-CLI/Python3", "")
+	ts.PrepareProject("ActiveState-CLI/Python3", "59404293-e5a9-4fd0-8843-77cd4761b5b5")
 
 	// Pull to ensure we have an up to date config file
 	cp := ts.Spawn("pull")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2308" title="DX-2308" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2308</a>  Nightly failure: Activation errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The commitID doesn't matter, but it ought to be specified. Projects without commitIDs don't exist in the real world as far as I can tell.