### PR TITLE
Add error tips to structured/JSON output.

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -251,7 +251,9 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 		if childCmd != nil {
 			cmdName = childCmd.JoinedSubCommandNames() + " "
 		}
-		err = errs.AddTips(err, locale.Tl("err_tip_run_help", "Run → [ACTIONABLE]`state {{.V0}}--help`[/RESET] for general help", cmdName))
+		if !out.Type().IsStructured() {
+			err = errs.AddTips(err, locale.Tl("err_tip_run_help", "Run → [ACTIONABLE]`state {{.V0}}--help`[/RESET] for general help", cmdName))
+		}
 		cmdletErrors.ReportError(err, cmds.Command(), an)
 	}
 

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -65,7 +65,8 @@ func (f *JSON) Fprint(writer io.Writer, value interface{}) {
 }
 
 type StructuredError struct {
-	Error string `json:"error"`
+	Error string   `json:"error"`
+	Tips  []string `json:"tips,omitempty"`
 }
 
 // Error will marshal and print the given value to the error writer
@@ -120,11 +121,11 @@ func toStructuredError(v interface{}) StructuredError {
 	case StructuredError:
 		return vv
 	case error:
-		return StructuredError{locale.JoinedErrorMessage(vv)}
+		return StructuredError{Error: locale.JoinedErrorMessage(vv)}
 	case string:
-		return StructuredError{vv}
+		return StructuredError{Error: vv}
 	}
 	message := fmt.Sprintf("Not a recognized error format: %v", v)
 	multilog.Error(message)
-	return StructuredError{message}
+	return StructuredError{Error: message}
 }

--- a/internal/output/mediator.go
+++ b/internal/output/mediator.go
@@ -56,7 +56,7 @@ func mediatorValue(v interface{}, format Format) interface{} {
 		if vt, ok := v.(StructuredMarshaller); ok {
 			return vt.MarshalStructured(format)
 		}
-		return StructuredError{locale.Tr("err_no_structured_output", string(format))}
+		return StructuredError{Error: locale.Tr("err_no_structured_output", string(format))}
 	}
 	if vt, ok := v.(Marshaller); ok {
 		return vt.MarshalOutput(format)

--- a/internal/output/mediator_test.go
+++ b/internal/output/mediator_test.go
@@ -67,7 +67,7 @@ func Test_mediatorValue(t *testing.T) {
 				"unstructured",
 				JSONFormatName,
 			},
-			StructuredError{locale.Tr("err_no_structured_output", string(JSONFormatName))},
+			StructuredError{Error: locale.Tr("err_no_structured_output", string(JSONFormatName))},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmdlets/errors/errors.go
+++ b/pkg/cmdlets/errors/errors.go
@@ -85,12 +85,15 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 func getErrorTips(err error) []string {
 	errorTips := []string{}
 	for _, err := range errs.Unpack(err) {
-		if v, ok := err.(ErrorTips); ok {
-			for _, tip := range v.ErrorTips() {
-				if !funk.Contains(errorTips, tip) {
-					errorTips = append(errorTips, tip)
-				}
+		v, ok := err.(ErrorTips)
+		if !ok {
+			continue
+		}
+		for _, tip := range v.ErrorTips() {
+			if funk.Contains(errorTips, tip) {
+				continue
 			}
+			errorTips = append(errorTips, tip)
 		}
 	}
 	return errorTips

--- a/pkg/cmdlets/errors/errors.go
+++ b/pkg/cmdlets/errors/errors.go
@@ -67,17 +67,7 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 	}
 
 	// Concatenate error tips
-	errorTips := []string{}
-	err := o.error
-	for _, err := range errs.Unpack(err) {
-		if v, ok := err.(ErrorTips); ok {
-			for _, tip := range v.ErrorTips() {
-				if !funk.Contains(errorTips, tip) {
-					errorTips = append(errorTips, tip)
-				}
-			}
-		}
-	}
+	errorTips := getErrorTips(o.error)
 	errorTips = append(errorTips, locale.Tl("err_help_forum", "Ask For Help → [ACTIONABLE]{{.V0}}[/RESET]", constants.ForumsURL))
 
 	// Print tips
@@ -92,6 +82,20 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 	return strings.Join(outLines, "\n")
 }
 
+func getErrorTips(err error) []string {
+	errorTips := []string{}
+	for _, err := range errs.Unpack(err) {
+		if v, ok := err.(ErrorTips); ok {
+			for _, tip := range v.ErrorTips() {
+				if !funk.Contains(errorTips, tip) {
+					errorTips = append(errorTips, tip)
+				}
+			}
+		}
+	}
+	return errorTips
+}
+
 func (o *OutputError) MarshalStructured(f output.Format) interface{} {
 	var userFacingError errs.UserFacingError
 	var message string
@@ -100,7 +104,7 @@ func (o *OutputError) MarshalStructured(f output.Format) interface{} {
 	} else {
 		message = locale.JoinedErrorMessage(o.error)
 	}
-	return output.StructuredError{message}
+	return output.StructuredError{message, getErrorTips(o.error)}
 }
 
 func trimError(msg string) string {

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -244,6 +244,12 @@ func (suite *CheckoutIntegrationTestSuite) TestJSON() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/small-python", "-o", "json"))
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
+
+	cp = ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/Bogus-Project-That-Doesnt-Exist", "-o", "json"))
+	cp.Expect("does not exist")                        // error
+	cp.Expect(`"tips":["If this is a private project`) // tip
+	cp.ExpectNotExitCode(0)
+	AssertValidJSON(suite.T(), cp)
 }
 
 func (suite *CheckoutIntegrationTestSuite) TestCheckoutCaseInsensitive() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2284" title="DX-2284" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2284</a>  When `-o json` used the `If this is a private project you may need to authenticate with 'state auth'` is missing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
For example, this suggests to authenticate prior to checking out a private project.