### PR TITLE
Integration tests now fail if there are log errors unless the test opts out.

### DIFF
--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -145,6 +145,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallIncompatible() {
 	// Assert output
 	cp.Expect("not compatible")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *InstallerIntegrationTestSuite) TestInstallNoErrorTips() {
@@ -164,6 +165,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallNoErrorTips() {
 
 	cp.ExpectExitCode(1)
 	suite.Assert().NotContains(cp.Output(), "Need More Help?", "error tips should not be displayed when invoking installer")
+	ts.IgnoreLogErrors()
 }
 
 func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {

--- a/cmd/state-svc/test/integration/svc_int_test.go
+++ b/cmd/state-svc/test/integration/svc_int_test.go
@@ -43,6 +43,7 @@ func (suite *SvcIntegrationTestSuite) TestStartStop() {
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.OptArgs("status"))
 	cp.Expect("Service cannot be reached")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.OptArgs("start"))
 	cp.Expect("Starting")
@@ -91,6 +92,7 @@ func (suite *SvcIntegrationTestSuite) TestSignals() {
 
 	suite.OnlyRunForTags(tagsuite.Service)
 	ts := e2e.New(suite.T(), false)
+	ts.IgnoreLogErrors()
 	defer ts.Close()
 
 	// SIGINT (^C)
@@ -145,6 +147,7 @@ func (suite *SvcIntegrationTestSuite) TestStartDuplicateErrorOutput() {
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.OptArgs("foreground"))
 	cp.Expect("An existing server instance appears to be in use")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	cp = ts.SpawnCmdWithOpts(ts.SvcExe, e2e.OptArgs("stop"))
 	cp.ExpectExitCode(0)

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -201,6 +201,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 			suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
 		}
 	}
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ActivateIntegrationTestSuite) assertCompletedStatusBarReport(snapshot string) {
@@ -553,6 +554,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateCommitURL() {
 	cp := ts.Spawn("activate")
 	cp.Expect("Cannot activate a headless project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ActivateIntegrationTestSuite) TestActivate_AlreadyActive() {

--- a/test/integration/analytics_int_test.go
+++ b/test/integration/analytics_int_test.go
@@ -496,6 +496,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestInputError() {
 
 	cp := ts.Spawn("clean", "uninstall", "badarg", "--mono")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	events := parseAnalyticsEvents(suite, ts)
 	suite.assertSequentialEvents(events)

--- a/test/integration/auth_int_test.go
+++ b/test/integration/auth_int_test.go
@@ -78,6 +78,7 @@ func (suite *AuthIntegrationTestSuite) loginFlags(ts *e2e.Session, username stri
 	cp := ts.Spawn(tagsuite.Auth, "--username", username, "--password", "bad-password")
 	cp.Expect("You are not authorized, did you provide valid login credentials?")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *AuthIntegrationTestSuite) ensureLogout(ts *e2e.Session) {

--- a/test/integration/bundle_int_test.go
+++ b/test/integration/bundle_int_test.go
@@ -83,6 +83,7 @@ func (suite *BundleIntegrationTestSuite) TestBundle_project_invalid() {
 	cp := ts.Spawn("bundles", "--namespace", "junk/junk")
 	cp.Expect("The requested project junk does not exist under junk")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *BundleIntegrationTestSuite) TestBundle_searchSimple() {
@@ -131,6 +132,7 @@ func (suite *BundleIntegrationTestSuite) TestBundle_searchWithExactTermWrongTerm
 	cp := ts.Spawn("bundles", "search", "xxxUtilitiesxxx", "--exact-term")
 	cp.Expect("No bundles in our catalog match")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *BundleIntegrationTestSuite) TestBundle_searchWithLang() {
@@ -153,6 +155,7 @@ func (suite *BundleIntegrationTestSuite) TestBundle_searchWithWrongLang() {
 	cp := ts.Spawn("bundles", "search", "Utilities", "--language=python")
 	cp.Expect("No bundles in our catalog match")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *BundleIntegrationTestSuite) TestBundle_searchWithBadLang() {
@@ -164,6 +167,7 @@ func (suite *BundleIntegrationTestSuite) TestBundle_searchWithBadLang() {
 	cp := ts.Spawn("bundles", "search", "Utilities", "--language=bad")
 	cp.Expect("Cannot obtain search")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *BundleIntegrationTestSuite) TestBundle_detached_operation() {
@@ -198,6 +202,7 @@ func (suite *BundleIntegrationTestSuite) TestBundle_detached_operation() {
 		cp := ts.Spawn("bundles", "install", "Utilities@0.7.6")
 		cp.ExpectRe("(?:bundle updated|being built)")
 		cp.ExpectExitCode(1)
+		ts.IgnoreLogErrors()
 	})
 	*/
 

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -96,6 +96,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutNonEmptyDir() {
 	)
 	cp.Expect("already a project checked out at")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -164,6 +165,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutWithFlags() {
 	cp = ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/Python-3.9", branchPath, "--branch", "doesNotExist"))
 	cp.Expect("This project has no branch with label matching doesNotExist")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *CheckoutIntegrationTestSuite) TestCheckoutCustomRTPath() {
@@ -217,6 +219,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutNotFound() {
 	cp.Expect("does not exist under")         // error
 	cp.Expect("If this is a private project") // tip
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -236,6 +239,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutAlreadyCheckedOut() {
 	cp = ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/small-python"))
 	cp.Expect("already a project checked out at")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *CheckoutIntegrationTestSuite) TestJSON() {
@@ -252,6 +256,7 @@ func (suite *CheckoutIntegrationTestSuite) TestJSON() {
 	cp.Expect(`"tips":["If this is a private project`) // tip
 	cp.ExpectNotExitCode(0)
 	AssertValidJSON(suite.T(), cp)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *CheckoutIntegrationTestSuite) TestCheckoutCaseInsensitive() {

--- a/test/integration/condition_int_test.go
+++ b/test/integration/condition_int_test.go
@@ -111,6 +111,7 @@ func (suite *ConditionIntegrationTestSuite) TestConditionSyntaxError() {
 	)
 	cp.Expect(`not defined`) // for now we aren't passing the error up the chain, so invalid syntax will lead to empty result
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ConditionIntegrationTestSuite) PrepareActiveStateYAML(ts *e2e.Session) {

--- a/test/integration/config_int_test.go
+++ b/test/integration/config_int_test.go
@@ -21,6 +21,7 @@ func (suite *ConfigIntegrationTestSuite) TestConfig() {
 	cp := ts.Spawn("config", "set", "invalid++", "value")
 	cp.Expect("Invalid")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	cp = ts.Spawn("config", "set", constants.UnstableConfig, "true")
 	cp.Expect("Successfully")

--- a/test/integration/cve_int_test.go
+++ b/test/integration/cve_int_test.go
@@ -97,6 +97,7 @@ func (suite *CveIntegrationTestSuite) TestCveInvalidProject() {
 	cp.Expect("Found no project with specified organization and name")
 
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *CveIntegrationTestSuite) TestJSON() {

--- a/test/integration/deploy_int_test.go
+++ b/test/integration/deploy_int_test.go
@@ -276,6 +276,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 	)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 	suite.InstallAndAssert(ts, targetPath)
 
 	if runtime.GOOS != "windows" {
@@ -352,6 +353,7 @@ func (suite *DeployIntegrationTestSuite) TestDeploySymlink() {
 	)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 	suite.InstallAndAssert(ts, targetPath)
 
 	if runtime.GOOS != "darwin" {
@@ -393,6 +395,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployReport() {
 	)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 	suite.InstallAndAssert(ts, targetPath)
 
 	cp = ts.SpawnWithOpts(
@@ -482,6 +485,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployUninstall() {
 	)
 	cp.Expect("no deployed runtime")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 	suite.True(fileutils.IsDir(ts.Dirs.Work), "Work dir was unexpectedly deleted")
 
 	// Trying to uninstall in a non-deployment directory should fail.

--- a/test/integration/errors_int_test.go
+++ b/test/integration/errors_int_test.go
@@ -23,6 +23,7 @@ func (suite *ErrorsIntegrationTestSuite) TestTips() {
 	cp.Expect("Run →")
 	cp.Expect("Ask For Help →")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ErrorsIntegrationTestSuite) TestMultiError() {
@@ -33,6 +34,7 @@ func (suite *ErrorsIntegrationTestSuite) TestMultiError() {
 	cp := ts.Spawn("__test", "multierror")
 	cp.ExpectRe(`\s+x error1\s+\s+x error2\s+x error3\s+x error4\s+█\s+Need More Help`)
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func TestErrorsIntegrationTestSuite(t *testing.T) {

--- a/test/integration/export_int_test.go
+++ b/test/integration/export_int_test.go
@@ -56,6 +56,7 @@ func (suite *ExportIntegrationTestSuite) TestExport_InvalidPlatform() {
 	ts.PrepareProject("cli-integration-tests/Export", "")
 	cp := ts.Spawn("export", "recipe", "--platform", "junk")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ExportIntegrationTestSuite) TestExport_ConfigDir() {
@@ -66,6 +67,7 @@ func (suite *ExportIntegrationTestSuite) TestExport_ConfigDir() {
 	ts.PrepareProject("cli-integration-tests/Export", "")
 	cp := ts.Spawn("export", "config", "--filter", "junk")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ExportIntegrationTestSuite) TestExport_Config() {

--- a/test/integration/fork_int_test.go
+++ b/test/integration/fork_int_test.go
@@ -37,6 +37,7 @@ func (suite *ForkIntegrationTestSuite) TestFork() {
 	cp = ts.Spawn("fork", "ActiveState-CLI/Python3", "--name", "Test-Python3", "--org", username)
 	cp.Expect(`You already have a project with the name`)
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ForkIntegrationTestSuite) TestFork_FailNameExists() {
@@ -48,6 +49,7 @@ func (suite *ForkIntegrationTestSuite) TestFork_FailNameExists() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("fork", "ActiveState-CLI/Python3", "--org", e2e.PersistentUsername))
 	cp.Expect("You already have a project with the name 'Python3'", termtest.OptExpectTimeout(30*time.Second))
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func TestForkIntegrationTestSuite(t *testing.T) {

--- a/test/integration/hello_int_example_test.go
+++ b/test/integration/hello_int_example_test.go
@@ -29,6 +29,7 @@ func (suite *HelloIntegrationTestSuite) TestHello() {
 	cp = ts.Spawn("_hello", "")
 	cp.Expect("Cannot say hello because no name was provided")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 
 	cp = ts.Spawn("_hello", "Person", "--extra")
 	cp.Expect("Project: ActiveState-CLI/small-python")

--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -86,6 +86,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		cp.Expect("already exists")
 		cp.ExpectNotExitCode(0)
 	})
+	ts.IgnoreLogErrors()
 }
 
 func TestImportIntegrationTestSuite(t *testing.T) {

--- a/test/integration/info_int_test.go
+++ b/test/integration/info_int_test.go
@@ -44,6 +44,7 @@ func (suite *InfoIntegrationTestSuite) TestInfo_UnavailableVersion() {
 	cp := ts.Spawn("info", "pylint@9.9.9", "--language", "python")
 	cp.Expect("Could not find version 9.9.9 for package pylint")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *InfoIntegrationTestSuite) TestJSON() {
@@ -62,6 +63,7 @@ func (suite *InfoIntegrationTestSuite) TestJSON() {
 	cp.Expect(`"error":`)
 	cp.ExpectExitCode(1)
 	AssertValidJSON(suite.T(), cp)
+	ts.IgnoreLogErrors()
 }
 
 func TestInfoIntegrationTestSuite(t *testing.T) {

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -100,6 +100,7 @@ func (suite *InitIntegrationTestSuite) TestInit_NoLanguage() {
 
 	cp := ts.Spawn("init", "test-user/test-project")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *InitIntegrationTestSuite) TestInit_InferLanguageFromUse() {

--- a/test/integration/install_int_test.go
+++ b/test/integration/install_int_test.go
@@ -35,6 +35,7 @@ func (suite *InstallIntegrationTestSuite) TestInstall_InvalidCommit() {
 	//cp.Expect("Could not find or read the commit file") // re-enable in DX-2307
 	cp.Expect("Invalid commit ID") // remove in DX-2307
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	// Re-enable in DX-2307.
 	//if strings.Count(cp.Snapshot(), " x ") != 1 {
@@ -52,6 +53,7 @@ func (suite *InstallIntegrationTestSuite) TestInstall_NoMatches_NoAlternatives()
 	cp.Expect("No results found for search term")
 	cp.Expect("find alternatives") // This verifies no alternatives were found
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(strings.ReplaceAll(cp.Snapshot(), " x Failed", ""), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -68,6 +70,7 @@ func (suite *InstallIntegrationTestSuite) TestInstall_NoMatches_Alternatives() {
 	cp.Expect("No results found for search term")
 	cp.Expect("did you mean") // This verifies alternatives were found
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(strings.ReplaceAll(cp.Snapshot(), " x Failed", ""), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -83,6 +86,7 @@ func (suite *InstallIntegrationTestSuite) TestInstall_BuildPlannerError() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("install", "trender@999.0"), e2e.OptAppendEnv(constants.DisableRuntime+"=true"))
 	cp.Expect("Could not plan build, platform responded with", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(strings.ReplaceAll(cp.Snapshot(), " x Failed", ""), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -185,6 +185,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall_NonEmptyTarget() {
 	// because of powershell.
 	// Since we asserted the expected error above we don't need to go on a wild goose chase here.
 	cp.ExpectExit()
+	ts.IgnoreLogErrors()
 }
 
 func (suite *InstallScriptsIntegrationTestSuite) TestInstall_VersionDoesNotExist() {
@@ -206,6 +207,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall_VersionDoesNotExist
 		cp.Expect("Could not download")
 	}
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 // scriptPath returns the path to an installation script copied to targetDir, if useTestUrl is true, the install script is modified to download from the local test server instead

--- a/test/integration/invite_int_test.go
+++ b/test/integration/invite_int_test.go
@@ -23,6 +23,7 @@ func (suite *InviteIntegrationTestSuite) TestInvite_NotAuthenticated() {
 	cp := ts.Spawn("invite", "test-user@test.com")
 	cp.Expect("You need to authenticate")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func TestInviteIntegrationTestSuite(t *testing.T) {

--- a/test/integration/languages_int_test.go
+++ b/test/integration/languages_int_test.go
@@ -40,6 +40,7 @@ func (suite *LanguagesIntegrationTestSuite) TestLanguages_listNoCommitID() {
 
 	cp := ts.Spawn("languages")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *LanguagesIntegrationTestSuite) TestLanguages_install() {
@@ -59,6 +60,7 @@ func (suite *LanguagesIntegrationTestSuite) TestLanguages_install() {
 	cp = ts.Spawn("languages", "install", "python")
 	cp.Expect("Language: python is already installed")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	cp = ts.Spawn("languages", "install", "python@3.9.16")
 	cp.Expect("Language added: python@3.9.16")

--- a/test/integration/msg_int_test.go
+++ b/test/integration/msg_int_test.go
@@ -28,9 +28,8 @@ func (suite *MsgIntegrationTestSuite) TestMessage_None() {
 	cp.Expect("Usage:")
 	cp.ExpectExitCode(0)
 
-	// Since message failures should fail silently without impacting the user we need to check the logs for any
-	// potential issues.
-	ts.DetectLogErrors()
+	// Note: since message failures should fail silently without impacting the user we need to check
+	// the logs for any potential issues. This is done automatically by ts.Close().
 }
 
 func (suite *MsgIntegrationTestSuite) TestMessage_Basic() {
@@ -167,6 +166,7 @@ func (suite *MsgIntegrationTestSuite) TestMessage_Basic_InterruptExit() {
 	cp.ExpectExitCode(1)
 	suite.Require().Contains(cp.Snapshot(), "This is a simple message")
 	suite.Require().NotContains(cp.Output(), "Usage:")
+	ts.IgnoreLogErrors()
 }
 
 func TestMsgIntegrationTestSuite(t *testing.T) {

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -89,6 +89,7 @@ func (suite *PackageIntegrationTestSuite) TestPackages_project_invalid() {
 	cp := ts.Spawn("packages", "--namespace", "junk/junk")
 	cp.Expect("The requested project junk does not exist under junk")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) TestPackage_listingWithCommitValid() {
@@ -114,6 +115,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_listingWithCommitInvalid()
 	cp := ts.Spawn("packages", "--commit", "junk")
 	cp.Expect("Cannot obtain")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) TestPackage_listingWithCommitUnknown() {
@@ -126,6 +128,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_listingWithCommitUnknown()
 	cp := ts.Spawn("packages", "--commit", "00010001-0001-0001-0001-000100010001")
 	cp.Expect("No data")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) TestPackage_listingWithCommitValidNoPackages() {
@@ -185,6 +188,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_searchWithExactTermWrongTe
 	cp := ts.Spawn("search", "Requests", "--exact-term")
 	cp.Expect("No packages in our catalog match")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	cp = ts.Spawn("search", "xxxrequestsxxx", "--exact-term")
 	cp.Expect("No packages in our catalog match")
@@ -232,6 +236,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_searchWithWrongLang() {
 	cp := ts.Spawn("search", "xxxjunkxxx", "--language=perl")
 	cp.Expect("No packages in our catalog match")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) TestPackage_searchWithBadLang() {
@@ -243,6 +248,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_searchWithBadLang() {
 	cp := ts.Spawn("search", "numpy", "--language=bad")
 	cp.Expect("Cannot obtain search")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) TestPackage_info() {
@@ -270,6 +276,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_infoWrongCase() {
 	cp := ts.Spawn("info", "Pexpect")
 	cp.Expect("No packages in our catalog are an exact match")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 const (
@@ -393,6 +400,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_Duplicate() {
 	cp = ts.Spawn("install", "requests") // install again
 	cp.Expect("No new changes to commit")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) PrepareActiveStateYAML(ts *e2e.Session) {
@@ -419,6 +427,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_UninstallDoesNotExist() {
 	cp := ts.Spawn("uninstall", "doesNotExist")
 	cp.Expect("Error occurred while trying to create a commit")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) TestJSON() {
@@ -527,6 +536,7 @@ func (suite *PackageIntegrationTestSuite) TestInstall_InvalidVersion() {
 	// We only assert the state tool curated part of the error as the underlying build planner error may change
 	cp.Expect("Could not plan build")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) TestUpdate_InvalidVersion() {
@@ -550,6 +560,7 @@ func (suite *PackageIntegrationTestSuite) TestUpdate_InvalidVersion() {
 	// We only assert the state tool curated part of the error as the underlying build planner error may change
 	cp.Expect("Could not plan build")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *PackageIntegrationTestSuite) TestUpdate() {

--- a/test/integration/pjfile_int_test.go
+++ b/test/integration/pjfile_int_test.go
@@ -33,6 +33,7 @@ languages:
 		e2e.OptArgs("scripts"),
 	)
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func TestPjFileIntegrationTestSuite(t *testing.T) {

--- a/test/integration/projects_int_test.go
+++ b/test/integration/projects_int_test.go
@@ -150,6 +150,7 @@ func (suite *ProjectsIntegrationTestSuite) TestEdit_Visibility() {
 	cp = ts.Spawn("checkout", namespace)
 	cp.Expect("does not exist under ActiveState-CLI")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	ts.LoginAsPersistentUser()
 

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -56,6 +56,7 @@ func (suite *PullIntegrationTestSuite) TestPullSetProject() {
 	cp.SendLine("n")
 	cp.Expect("Pull aborted by user")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 
 	cp = ts.Spawn("pull", "--non-interactive", "--set-project", "ActiveState-CLI/small-python-fork")
 	cp.Expect("activestate.yaml has been updated")
@@ -74,6 +75,7 @@ func (suite *PullIntegrationTestSuite) TestPullSetProjectUnrelated() {
 	cp.SendLine("n")
 	cp.Expect("Pull aborted by user")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 
 	cp = ts.Spawn("pull", "--non-interactive", "--set-project", "ActiveState-CLI/Python3")
 	cp.Expect("Could not detect common parent")
@@ -106,6 +108,7 @@ func (suite *PullIntegrationTestSuite) TestPull_Merge() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("push"), e2e.OptWD(wd))
 	cp.Expect("Your project has new changes available")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	cp = ts.SpawnWithOpts(e2e.OptArgs("pull"), e2e.OptWD(wd))
 	cp.Expect("Merging history")
@@ -132,6 +135,7 @@ func (suite *PullIntegrationTestSuite) TestPull_RestoreNamespace() {
 	cp := ts.Spawn("pull", "--non-interactive", "--set-project", "ActiveState-CLI/Python3")
 	cp.Expect("Could not detect common parent")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 
 	// Verify namespace is unchanged.
 	cp = ts.Spawn("show")
@@ -168,6 +172,7 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	cp = ts.Spawn("pull")
 	cp.Expect("Unable to automatically merge build scripts")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 
 	_, err = buildscript.NewScriptFromProject(proj, nil)
 	suite.Assert().Error(err)

--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -223,6 +223,7 @@ func (suite *PushIntegrationTestSuite) TestPush_NoProject() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("push"))
 	cp.Expect("No project found")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -240,6 +241,7 @@ func (suite *PushIntegrationTestSuite) TestPush_NoAuth() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("push"))
 	cp.Expect("you need to be authenticated")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -259,6 +261,7 @@ func (suite *PushIntegrationTestSuite) TestPush_NoChanges() {
 	cp = ts.SpawnWithOpts(e2e.OptArgs("push"))
 	cp.Expect("no local changes to push")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -279,6 +282,7 @@ func (suite *PushIntegrationTestSuite) TestPush_NameInUse() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("push", "-n", "ActiveState-CLI/push-error-test"))
 	cp.Expect("already in use")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -304,6 +308,7 @@ func (suite *PushIntegrationTestSuite) TestPush_Aborted() {
 	cp.SendLine("n")
 	cp.Expect("Project creation aborted by user", termtest.OptExpectTimeout(5*time.Second))
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -324,6 +329,7 @@ func (suite *PushIntegrationTestSuite) TestPush_InvalidHistory() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("push", "ActiveState-CLI/push-error-test"))
 	cp.Expect("commit history does not match")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -343,6 +349,7 @@ func (suite *PushIntegrationTestSuite) TestPush_PullNeeded() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("push"))
 	cp.Expect("changes available that need to be merged")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	if strings.Count(cp.Snapshot(), " x ") != 1 {
 		suite.Fail("Expected exactly ONE error message, got: ", cp.Snapshot())
@@ -372,6 +379,7 @@ func (suite *PushIntegrationTestSuite) TestPush_Outdated() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("push"), e2e.OptWD(wd))
 	cp.Expect("Your project has new changes available")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func TestPushIntegrationTestSuite(t *testing.T) {

--- a/test/integration/refresh_int_test.go
+++ b/test/integration/refresh_int_test.go
@@ -35,6 +35,7 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 	)
 	cp.Expect("ModuleNotFoundError")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	suite.PrepareActiveStateYAML(ts, "ActiveState-CLI/Branches", "secondbranch", "46c83477-d580-43e2-a0c6-f5d3677517f1")
 	cp = ts.SpawnWithOpts(

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -86,6 +86,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert_failsOnCommitNotInHistory() 
 	cp.Expect(commitID)
 	cp.Expect("The target commit is not within the current commit's history")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *RevertIntegrationTestSuite) TestRevertTo() {
@@ -143,6 +144,7 @@ func (suite *RevertIntegrationTestSuite) TestRevertTo_failsOnCommitNotInHistory(
 	cp.Expect(commitID)
 	cp.Expect("The target commit is not")
 	cp.ExpectNotExitCode(0)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *RevertIntegrationTestSuite) TestJSON() {

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -197,6 +197,7 @@ func (suite *RunIntegrationTestSuite) TestTwoInterrupts() {
 	cp.SendCtrlC()
 	suite.expectTerminateBatchJob(cp)
 	cp.ExpectExitCode(123)
+	ts.IgnoreLogErrors()
 	suite.Require().NotContains(
 		cp.Output(), "not printed after second interrupt",
 	)

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -71,6 +71,7 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 		cp.Expect("Cannot find the Python-3.9 project")
 		cp.ExpectExitCode(1)
 	}
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
@@ -199,6 +200,7 @@ func (suite *ShellIntegrationTestSuite) TestDefaultNoLongerExists() {
 	cp = ts.SpawnWithOpts(e2e.OptArgs("shell"))
 	cp.Expect("Cannot find your project")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *ShellIntegrationTestSuite) TestUseShellUpdates() {

--- a/test/integration/switch_int_test.go
+++ b/test/integration/switch_int_test.go
@@ -102,6 +102,7 @@ func (suite *SwitchIntegrationTestSuite) TestSwitch_CommitID_NotInHistory() {
 	cp.Expect("Commit does not belong")
 	if runtime.GOOS != "windows" {
 		cp.ExpectExitCode(1)
+		ts.IgnoreLogErrors()
 	}
 
 	// Check that branch and commitID were not updated

--- a/test/integration/update_lock_int_test.go
+++ b/test/integration/update_lock_int_test.go
@@ -106,6 +106,7 @@ func (suite *UpdateIntegrationTestSuite) TestLockedChannel() {
 				cp = ts.SpawnWithOpts(e2e.OptArgs("--version"), e2e.OptAppendEnv(suite.env(true, false)...))
 				cp.Expect("This project is locked at State Tool version")
 				cp.ExpectExitCode(1)
+				ts.IgnoreLogErrors()
 				return
 			}
 		})
@@ -161,6 +162,7 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateLockedConfirmation() {
 				cp.Expect("Cancelling")
 			}
 			cp.ExpectNotExitCode(0)
+			ts.IgnoreLogErrors()
 		})
 	}
 }

--- a/test/integration/use_int_test.go
+++ b/test/integration/use_int_test.go
@@ -83,6 +83,7 @@ func (suite *UseIntegrationTestSuite) TestUse() {
 	cp = ts.SpawnWithOpts(e2e.OptArgs("use", "NotCheckedOut"))
 	cp.Expect("Cannot find the NotCheckedOut project.")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *UseIntegrationTestSuite) TestUseCwd() {
@@ -114,6 +115,7 @@ func (suite *UseIntegrationTestSuite) TestUseCwd() {
 	)
 	cp.Expect("Unable to use project")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 }
 
 func (suite *UseIntegrationTestSuite) TestReset() {
@@ -153,6 +155,7 @@ func (suite *UseIntegrationTestSuite) TestReset() {
 	cp.SendLine("n")
 	cp.Expect("Reset aborted by user")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	cp = ts.SpawnWithOpts(e2e.OptArgs("use", "reset", "--non-interactive"))
 	cp.Expect("Stopped using your project runtime")
@@ -179,6 +182,7 @@ func (suite *UseIntegrationTestSuite) TestShow() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("use", "show"))
 	cp.Expect("No project is being used")
 	cp.ExpectExitCode(1)
+	ts.IgnoreLogErrors()
 
 	cp = ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/Python3"))
 	cp.Expect("Skipping runtime setup")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1813" title="DX-1813" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1813</a>  We check for log errors / panics on most tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
