### PR TITLE
Show indication the user is still in a `state shell` when starting a new shell within it.

### DIFF
--- a/internal/assets/contents/shells/bashrc_append.sh
+++ b/internal/assets/contents/shells/bashrc_append.sh
@@ -6,4 +6,7 @@ export {{$K}}="{{$V}}:$PATH"
 export {{$K}}="{{$V}}"
 {{- end}}
 {{- end}}
+if [[ ! -z "${{.ActivatedEnv}}" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ]]; then
+  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+fi
 # {{.Stop}}

--- a/internal/assets/contents/shells/fishrc_append.fish
+++ b/internal/assets/contents/shells/fishrc_append.fish
@@ -6,4 +6,7 @@ set -xg {{$K}} "{{$V}}:$PATH"
 set -xg {{$K}} "{{$V}}"
 {{- end}}
 {{- end}}
+if test ! -z "${{.ActivatedEnv}}"; test -f "${{.ActivatedEnv}}/{{.ConfigFile}}"
+  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+end
 # {{.Stop}}

--- a/internal/assets/contents/shells/tcshrc_append.sh
+++ b/internal/assets/contents/shells/tcshrc_append.sh
@@ -5,4 +5,7 @@ setenv {{$K}} "{{$V}}:$PATH"
 {{- else}}
 {{- end}}
 {{- end}}
+if ( "${{.ActivatedEnv}}" != "" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ) then
+  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+endif
 # {{.Stop}}

--- a/internal/assets/contents/shells/tcshrc_append.sh
+++ b/internal/assets/contents/shells/tcshrc_append.sh
@@ -5,7 +5,9 @@ setenv {{$K}} "{{$V}}:$PATH"
 {{- else}}
 {{- end}}
 {{- end}}
-if ( "${{.ActivatedEnv}}" != "" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ) then
-  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+if ( $?{{.ActivatedEnv}} ) then
+  if ( -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ) then
+    echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+  endif
 endif
 # {{.Stop}}

--- a/internal/assets/contents/shells/zshrc_append.sh
+++ b/internal/assets/contents/shells/zshrc_append.sh
@@ -6,4 +6,7 @@ export {{$K}}="{{$V}}:$PATH"
 export {{$K}}="{{$V}}"
 {{- end}}
 {{- end}}
+if [[ ! -z "${{.ActivatedEnv}}" && -f "${{.ActivatedEnv}}/{{.ConfigFile}}" ]]; then
+  echo "State Tool is operating on project ${{.ActivatedNamespaceEnv}}, located at ${{.ActivatedEnv}}"
+fi
 # {{.Stop}}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -93,7 +93,7 @@ const ActivatedStateEnvVarName = "ACTIVESTATE_ACTIVATED"
 // ActivatedStateIDEnvVarName is the name of the environment variable that is set when in an activated state, its value will be a unique id identifying a specific instance of an activated state
 const ActivatedStateIDEnvVarName = "ACTIVESTATE_ACTIVATED_ID"
 
-// ActivatedStateProjectEnvVarName is the name of the environment variable that specifies the activated state's org/project namespace.
+// ActivatedStateNamespaceEnvVarName is the name of the environment variable that specifies the activated state's org/project namespace.
 const ActivatedStateNamespaceEnvVarName = "ACTIVESTATE_ACTIVATED_NAMESPACE"
 
 // ForwardedStateEnvVarName is the name of the environment variable that is set when in an activated state, its value will be the path of the project

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -93,6 +93,9 @@ const ActivatedStateEnvVarName = "ACTIVESTATE_ACTIVATED"
 // ActivatedStateIDEnvVarName is the name of the environment variable that is set when in an activated state, its value will be a unique id identifying a specific instance of an activated state
 const ActivatedStateIDEnvVarName = "ACTIVESTATE_ACTIVATED_ID"
 
+// ActivatedStateProjectEnvVarName is the name of the environment variable that specifies the activated state's org/project namespace.
+const ActivatedStateNamespaceEnvVarName = "ACTIVESTATE_ACTIVATED_NAMESPACE"
+
 // ForwardedStateEnvVarName is the name of the environment variable that is set when in an activated state, its value will be the path of the project
 const ForwardedStateEnvVarName = "ACTIVESTATE_FORWARDED"
 

--- a/internal/runbits/activation/activation.go
+++ b/internal/runbits/activation/activation.go
@@ -39,7 +39,7 @@ func ActivateAndWait(
 		}
 	}
 
-	ve, err := venv.GetEnv(false, true, projectDir)
+	ve, err := venv.GetEnv(false, true, projectDir, proj.Namespace().String())
 	if err != nil {
 		return locale.WrapError(err, "error_could_not_activate_venv", "Could not retrieve environment information.")
 	}

--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -135,7 +135,7 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 	}
 	venv := virtualenvironment.New(rt)
 
-	env, err := venv.GetEnv(true, false, projectDir)
+	env, err := venv.GetEnv(true, false, projectDir, projectNamespace)
 	if err != nil {
 		return locale.WrapError(err, "err_exec_env", "Could not retrieve environment information for your runtime")
 	}

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -1,8 +1,11 @@
 package shell
 
 import (
+	"os"
+
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -87,7 +90,9 @@ func (u *Shell) Run(params *Params) error {
 	}
 
 	if process.IsActivated(u.config) {
-		return locale.NewInputError("err_shell_already_active", "", proj.NamespaceString(), proj.Dir())
+		activatedProjectNamespace := os.Getenv(constants.ActivatedStateNamespaceEnvVarName)
+		activatedProjectDir := os.Getenv(constants.ActivatedStateEnvVarName)
+		return locale.NewInputError("err_shell_already_active", "", activatedProjectNamespace, activatedProjectDir)
 	}
 
 	u.out.Notice(locale.Tl("shell_project_statement", "",

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -85,7 +85,7 @@ func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
 	venv := virtualenvironment.New(rt)
 
 	projDir := filepath.Dir(s.project.Source().Path())
-	env, err := venv.GetEnv(true, true, projDir)
+	env, err := venv.GetEnv(true, true, projDir, s.project.Namespace().String())
 	if err != nil {
 		return errs.Wrap(err, "Could not get venv environment")
 	}
@@ -95,7 +95,7 @@ func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
 	}
 
 	// search the "clean" path first (PATHS that are set by venv)
-	env, err = venv.GetEnv(false, true, "")
+	env, err = venv.GetEnv(false, true, "", "")
 	if err != nil {
 		return errs.Wrap(err, "Could not get venv environment")
 	}

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -73,9 +73,12 @@ func WriteRcFile(rcTemplateName string, path string, data RcIdentification, env 
 	}
 
 	rcData := map[string]interface{}{
-		"Start": data.Start,
-		"Stop":  data.Stop,
-		"Env":   env,
+		"Start":                 data.Start,
+		"Stop":                  data.Stop,
+		"Env":                   env,
+		"ActivatedEnv":          constants.ActivatedStateEnvVarName,
+		"ConfigFile":            constants.ConfigFileName,
+		"ActivatedNamespaceEnv": constants.ActivatedStateNamespaceEnvVarName,
 	}
 
 	if err := CleanRcFile(path, data); err != nil {

--- a/internal/subshell/sscommon/rcfile_test.go
+++ b/internal/subshell/sscommon/rcfile_test.go
@@ -3,6 +3,7 @@ package sscommon
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -43,10 +44,25 @@ func TestWriteRcFile(t *testing.T) {
 		path           string
 		env            map[string]string
 	}
+
+	fish := fmt.Sprintf(
+		`set -xg PATH "foo:$PATH"
+if test ! -z "$%s"; test -f "$%s/%s"
+  echo "State Tool is operating on project $%s, located at $%s"
+end`,
+		constants.ActivatedStateEnvVarName,
+		constants.ActivatedStateEnvVarName,
+		constants.ConfigFileName,
+		constants.ActivatedStateNamespaceEnvVarName,
+		constants.ActivatedStateEnvVarName)
+	if runtime.GOOS == "windows" {
+		fish = strings.ReplaceAll(fish, "\n", "\r\n")
+	}
+
 	tests := []struct {
 		name         string
 		args         args
-		want error
+		want         error
 		wantContents string
 	}{
 		{
@@ -59,7 +75,7 @@ func TestWriteRcFile(t *testing.T) {
 				},
 			},
 			nil,
-			fakeContents("", `set -xg PATH "foo:$PATH"`, ""),
+			fakeContents("", fish, ""),
 		},
 		{
 			"Write RC update",
@@ -71,7 +87,7 @@ func TestWriteRcFile(t *testing.T) {
 				},
 			},
 			nil,
-			fakeContents(strings.Join([]string{"before", "after"}, fileutils.LineEnd), `set -xg PATH "foo:$PATH"`, ""),
+			fakeContents(strings.Join([]string{"before", "after"}, fileutils.LineEnd), fish, ""),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/virtualenvironment/virtualenvironment.go
+++ b/internal/virtualenvironment/virtualenvironment.go
@@ -29,7 +29,7 @@ func New(runtime *runtime.Runtime) *VirtualEnvironment {
 }
 
 // GetEnv returns a map of the cumulative environment variables for all active virtual environments
-func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir string) (map[string]string, error) {
+func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir, namespace string) (map[string]string, error) {
 	envMap := make(map[string]string)
 
 	// Source runtime environment information
@@ -44,6 +44,7 @@ func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir 
 	if projectDir != "" {
 		envMap[constants.ActivatedStateEnvVarName] = projectDir
 		envMap[constants.ActivatedStateIDEnvVarName] = v.activationID
+		envMap[constants.ActivatedStateNamespaceEnvVarName] = namespace
 
 		// Get project from explicitly defined configuration file
 		configFile := filepath.Join(projectDir, constants.ConfigFileName)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2240" title="DX-2240" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2240</a>  Reimplement - As a user I can expect to always see a clear indication that I am in a virtual environment
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
