### PR TITLE
Disable terminal echo while State Tool is running (except for prompts).

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -98,6 +98,14 @@ func main() {
 	setPrinterColors(outFlags)
 
 	isInteractive := strings.ToLower(os.Getenv(constants.NonInteractiveEnvVarName)) != "true" && out.Config().Interactive
+	if isInteractive {
+		// Disable terminal echo while State Tool is running.
+		// Other than prompts (which temporarily re-enable echo), user typing should not interfere with
+		// output (e.g. runtime progress bars).
+		subshell.TurnOffEcho(cfg)
+		defer subshell.TurnOnEcho(cfg)
+	}
+
 	// Run our main command logic, which is logic that defers to the error handling logic below
 	err = run(os.Args, isInteractive, cfg, out)
 	if err != nil {

--- a/internal/osutils/termecho/termecho.go
+++ b/internal/osutils/termecho/termecho.go
@@ -1,9 +1,0 @@
-package termecho
-
-func Off() error {
-	return toggle(false)
-}
-
-func On() error {
-	return toggle(true)
-}

--- a/internal/runbits/runtime/progress/progress.go
+++ b/internal/runbits/runtime/progress/progress.go
@@ -7,17 +7,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/vbauerster/mpb/v7"
+	"golang.org/x/net/context"
+
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/multilog"
-	"github.com/ActiveState/cli/internal/osutils/termecho"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/pkg/platform/runtime/artifact"
 	"github.com/ActiveState/cli/pkg/platform/runtime/setup/events"
-	"github.com/go-openapi/strfmt"
-	"github.com/vbauerster/mpb/v7"
-	"golang.org/x/net/context"
 )
 
 type step struct {
@@ -89,10 +89,6 @@ type ProgressDigester struct {
 }
 
 func NewProgressIndicator(w io.Writer, out output.Outputer) *ProgressDigester {
-	err := termecho.Off()
-	if err != nil {
-		multilog.Error("Unable to turn off terminal echoing: %v", errs.JoinMessage(err))
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &ProgressDigester{
 		mainProgress: mpb.NewWithContext(
@@ -383,11 +379,6 @@ Still expecting:
 
 	// Blank line to separate progress from rest of output
 	p.out.Notice("")
-
-	err := termecho.On()
-	if err != nil {
-		multilog.Error("Unable to turn terminal echoing back on: %v", errs.JoinMessage(err))
-	}
 
 	return nil
 }

--- a/internal/subshell/subshell.go
+++ b/internal/subshell/subshell.go
@@ -237,3 +237,11 @@ func DetectShell(cfg sscommon.Configurable) (string, string) {
 
 	return name, path
 }
+
+func TurnOffEcho(cfg sscommon.Configurable) error {
+	return toggleEcho(cfg, false)
+}
+
+func TurnOnEcho(cfg sscommon.Configurable) error {
+	return toggleEcho(cfg, true)
+}

--- a/internal/subshell/termecho_darwin.go
+++ b/internal/subshell/termecho_darwin.go
@@ -1,4 +1,4 @@
-package termecho
+package subshell
 
 import "golang.org/x/sys/unix"
 

--- a/internal/subshell/termecho_linux.go
+++ b/internal/subshell/termecho_linux.go
@@ -1,4 +1,4 @@
-package termecho
+package subshell
 
 import "golang.org/x/sys/unix"
 

--- a/internal/subshell/termecho_unix.go
+++ b/internal/subshell/termecho_unix.go
@@ -1,16 +1,17 @@
 //go:build linux || darwin
 // +build linux darwin
 
-package termecho
+package subshell
 
 import (
 	"os"
 
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"golang.org/x/sys/unix"
 )
 
-func toggle(on bool) error {
+func toggleEcho(cfg sscommon.Configurable, on bool) error {
 	fd := int(os.Stdin.Fd())
 	termios, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	if err != nil {

--- a/internal/subshell/termecho_windows.go
+++ b/internal/subshell/termecho_windows.go
@@ -1,19 +1,22 @@
-package termecho
+package subshell
 
 import (
 	"os"
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
+	"github.com/ActiveState/cli/internal/subshell/cmd"
+	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"golang.org/x/sys/windows"
 )
 
-func toggle(on bool) error {
+func toggleEcho(cfg sscommon.Configurable, on bool) error {
 	fd := windows.Handle(os.Stdin.Fd())
 	var mode uint32
 	err := windows.GetConsoleMode(fd, &mode)
 	if err != nil {
-		if shell := os.Getenv("SHELL"); shell != "" {
+		shell, _ := DetectShell(cfg)
+		if shell != cmd.Name {
 			logging.Debug("Cannot turn off terminal echo in %s", shell)
 			return nil
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2214" title="DX-2214" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2214</a>  As a user I can't interfere with State Tool by pressing keys during read-only actions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
