### PR TITLE
Reduce log spam.

### DIFF
--- a/pkg/platform/api/buildplanner/request/commit.go
+++ b/pkg/platform/api/buildplanner/request/commit.go
@@ -1,9 +1,6 @@
 package request
 
-import "github.com/ActiveState/cli/internal/logging"
-
 func BuildPlanByCommitID(commitID string) *buildPlanByCommitID {
-	logging.Debug("BuildPlanByCommitID")
 	bp := &buildPlanByCommitID{map[string]interface{}{
 		"commitID": commitID,
 	}}

--- a/pkg/platform/api/buildplanner/request/project.go
+++ b/pkg/platform/api/buildplanner/request/project.go
@@ -1,9 +1,6 @@
 package request
 
-import "github.com/ActiveState/cli/internal/logging"
-
 func BuildPlanByProject(organization, project, commitID string) *buildPlanByProject {
-	logging.Debug("BuildPlanByProject")
 	bp := &buildPlanByProject{map[string]interface{}{
 		"organization": organization,
 		"project":      project,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2313" title="DX-2313" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2313</a>  Clear the state log
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


We developers shouldn't have to worry about debug logging. This PR fixes some egregious log spam, but I filed https://activestatef.atlassian.net/browse/DX-2330 to turn off debug-logging in end-user builds to address other examples of spammy log entries pointed out in this PR's ticket.