### PR TITLE
Fixed failing test.

### DIFF
--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -264,7 +264,7 @@ func (suite *PackageIntegrationTestSuite) TestPackage_info() {
 	cp.Expect("Version")
 	cp.Expect("Available")
 	cp.Expect("What's next?")
-	cp.Expect("run `state install")
+	cp.Expect("run 'state install")
 	cp.ExpectExitCode(0)
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2333" title="DX-2333" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2333</a>  Nightly failure: TestPackageIntegrationTestSuite/TestPackage_info
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The recent change to use quotes instead of backticks will cause a nightly failure tonight unless this PR gets merged.