### PR TITLE
Platform signup URL should be constructed based on any host override.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -291,8 +291,8 @@ const DateTimeFormatUser = "2 Jan 2006 15:04"
 // DateTimeFormatRecord is the datetime format we use when recording for internal use
 const DateTimeFormatRecord = "Mon Jan 2 2006 15:04:05 -0700 MST"
 
-// PlatformSignupURL is the account creation url used by the platform
-const PlatformSignupURL = "https://platform.activestate.com" + "/create-account"
+// PlatformSignupPath is the account creation path used by the platform
+const PlatformSignupPath = "/create-account"
 
 // DocumentationURL is the url for the state tool documentation
 const DocumentationURL = "http://docs.activestate.com/platform/state/"

--- a/internal/runbits/auth/login.go
+++ b/internal/runbits/auth/login.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -222,9 +223,14 @@ func authenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 			return errs.Wrap(err, "Verification URL is not valid")
 		}
 
-		signupURL, err := url.Parse(constants.PlatformSignupURL)
+		apiHost := constants.DefaultAPIHost
+		if hostOverride := os.Getenv(constants.APIHostEnvVarName); hostOverride != "" {
+			apiHost = hostOverride
+		}
+		fullURL := "https://" + apiHost + constants.PlatformSignupPath
+		signupURL, err := url.Parse(fullURL)
 		if err != nil {
-			return errs.Wrap(err, "constants.PlatformSignupURL is not valid")
+			return errs.Wrap(err, "Platform signup URL '%s' is not valid", fullURL)
 		}
 		query := signupURL.Query()
 		query.Add("nextRoute", parsedURL.RequestURI())

--- a/internal/runbits/auth/login.go
+++ b/internal/runbits/auth/login.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -14,6 +13,7 @@ import (
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
+	"github.com/ActiveState/cli/pkg/platform/api"
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	secretsapi "github.com/ActiveState/cli/pkg/platform/api/secrets"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
@@ -223,15 +223,7 @@ func authenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 			return errs.Wrap(err, "Verification URL is not valid")
 		}
 
-		apiHost := constants.DefaultAPIHost
-		if hostOverride := os.Getenv(constants.APIHostEnvVarName); hostOverride != "" {
-			apiHost = hostOverride
-		}
-		fullURL := "https://" + apiHost + constants.PlatformSignupPath
-		signupURL, err := url.Parse(fullURL)
-		if err != nil {
-			return errs.Wrap(err, "Platform signup URL '%s' is not valid", fullURL)
-		}
+		signupURL := api.GetURL(constants.PlatformSignupPath)
 		query := signupURL.Query()
 		query.Add("nextRoute", parsedURL.RequestURI())
 		signupURL.RawQuery = query.Encode()

--- a/internal/runbits/auth/login.go
+++ b/internal/runbits/auth/login.go
@@ -223,7 +223,7 @@ func authenticateWithBrowser(out output.Outputer, auth *authentication.Auth, pro
 			return errs.Wrap(err, "Verification URL is not valid")
 		}
 
-		signupURL := api.GetURL(constants.PlatformSignupPath)
+		signupURL := api.GetPlatformURL(constants.PlatformSignupPath)
 		query := signupURL.Query()
 		query.Add("nextRoute", parsedURL.RequestURI())
 		signupURL.RawQuery = query.Encode()

--- a/internal/runners/tutorial/tutorial.go
+++ b/internal/runners/tutorial/tutorial.go
@@ -159,7 +159,7 @@ func (t *Tutorial) authFlow() error {
 		}
 	case signUpBrowser:
 		t.analytics.EventWithLabel(anaConsts.CatTutorial, "authentication-action", "sign-up-browser")
-		signupURL := api.GetURL(constants.PlatformSignupPath).String()
+		signupURL := api.GetPlatformURL(constants.PlatformSignupPath).String()
 		err := open.Run(signupURL)
 		if err != nil {
 			return locale.WrapInputError(err, "err_tutorial_browser", "Could not open browser, please manually navigate to {{.V0}}.", signupURL)

--- a/internal/runners/tutorial/tutorial.go
+++ b/internal/runners/tutorial/tutorial.go
@@ -158,9 +158,10 @@ func (t *Tutorial) authFlow() error {
 		}
 	case signUpBrowser:
 		t.analytics.EventWithLabel(anaConsts.CatTutorial, "authentication-action", "sign-up-browser")
-		err := open.Run(constants.PlatformSignupURL)
+		signupURL := "https://" + constants.DefaultAPIHost + constants.PlatformSignupPath
+		err := open.Run(signupURL)
 		if err != nil {
-			return locale.WrapInputError(err, "err_tutorial_browser", "Could not open browser, please manually navigate to {{.V0}}.", constants.PlatformSignupURL)
+			return locale.WrapInputError(err, "err_tutorial_browser", "Could not open browser, please manually navigate to {{.V0}}.", signupURL)
 		}
 		t.outputer.Notice(locale.Tl("tutorial_signing_ready", "[NOTICE]Please sign in once you have finished signing up via your browser.[/RESET]"))
 		if err := runbits.Invoke(t.outputer, "auth"); err != nil {

--- a/internal/runners/tutorial/tutorial.go
+++ b/internal/runners/tutorial/tutorial.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/pkg/platform/api"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 )
 
@@ -158,7 +159,7 @@ func (t *Tutorial) authFlow() error {
 		}
 	case signUpBrowser:
 		t.analytics.EventWithLabel(anaConsts.CatTutorial, "authentication-action", "sign-up-browser")
-		signupURL := "https://" + constants.DefaultAPIHost + constants.PlatformSignupPath
+		signupURL := api.GetURL(constants.PlatformSignupPath).String()
 		err := open.Run(signupURL)
 		if err != nil {
 			return locale.WrapInputError(err, "err_tutorial_browser", "Could not open browser, please manually navigate to {{.V0}}.", signupURL)

--- a/pkg/platform/api/settings.go
+++ b/pkg/platform/api/settings.go
@@ -136,3 +136,17 @@ func getProjectHost(service Service) *string {
 
 	return &url.Host
 }
+
+// GetURL returns a generic Platform URL for the given path.
+// This is for retrieving non-service URLs (e.g. signup URL).
+func GetURL(path string) *url.URL {
+	host := constants.DefaultAPIHost
+	if hostOverride := os.Getenv(constants.APIHostEnvVarName); hostOverride != "" {
+		host = hostOverride
+	}
+	return &url.URL{
+		Scheme: "https",
+		Host:   host,
+		Path:   path,
+	}
+}

--- a/pkg/platform/api/settings.go
+++ b/pkg/platform/api/settings.go
@@ -137,9 +137,9 @@ func getProjectHost(service Service) *string {
 	return &url.Host
 }
 
-// GetURL returns a generic Platform URL for the given path.
+// GetPlatformURL returns a generic Platform URL for the given path.
 // This is for retrieving non-service URLs (e.g. signup URL).
-func GetURL(path string) *url.URL {
+func GetPlatformURL(path string) *url.URL {
 	host := constants.DefaultAPIHost
 	if hostOverride := os.Getenv(constants.APIHostEnvVarName); hostOverride != "" {
 		host = hostOverride


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2326" title="DX-2326" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2326</a>  `state auth signup` does not honour `ACTIVESTATE_API_HOST` like `state auth` does
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
