### PR TITLE
Do not query for build when staging a commit

### DIFF
--- a/pkg/platform/api/buildplanner/request/stagecommit.go
+++ b/pkg/platform/api/buildplanner/request/stagecommit.go
@@ -18,149 +18,18 @@ type buildPlanByStageCommit struct {
 
 func (b *buildPlanByStageCommit) Query() string {
 	return `
-mutation ($organization: String!, $project: String!, $parentCommit: ID, $description: String!, $expr:BuildExpr!) {
-  stageCommit(input:{organization:$organization, project:$project, parentCommitId:$parentCommit, description:$description, expr:$expr}) {
+mutation ($organization: String!, $project: String!, $parentCommit: ID, $description: String!, $expr: BuildExpr!) {
+  stageCommit(
+    input: {organization: $organization, project: $project, parentCommitId: $parentCommit, description: $description, expr: $expr}
+  ) {
     ... on Commit {
       __typename
-			expr
+      expr
       commitId
-      build {
-        __typename
-        ... on BuildStarted {
-          buildLogIds {
-            ... on AltBuildId {
-              id
-            }
-          }
-        }
-        ... on BuildStarted {
-          buildLogIds {
-            ... on AltBuildId {
-              id
-            }
-          }
-        }
-        ... on Build {
-          status
-          terminals {
-            tag
-            nodeIds
-          }
-          sources: nodes {
-            ... on Source {
-              nodeId
-              name
-              namespace
-              version
-            }
-          }
-          steps: steps {
-            ... on Step {
-              stepId
-              inputs {
-                tag
-                nodeIds
-              }
-              outputs
-            }
-          }
-          artifacts: nodes {
-            ... on ArtifactSucceeded {
-              __typename
-              nodeId
-              mimeType
-              generatedBy
-              runtimeDependencies
-              status
-              logURL
-              url
-              checksum
-            }
-            ... on ArtifactUnbuilt {
-              __typename
-              nodeId
-              mimeType
-              generatedBy
-              runtimeDependencies
-              status
-            }
-            ... on ArtifactStarted {
-              __typename
-              nodeId
-              mimeType
-              generatedBy
-              runtimeDependencies
-              status
-            }
-            ... on ArtifactTransientlyFailed {
-              __typename
-              nodeId
-              mimeType
-              generatedBy
-              runtimeDependencies
-              status
-              logURL
-              errors
-              attempts
-              nextAttemptAt
-            }
-            ... on ArtifactPermanentlyFailed {
-              __typename
-              nodeId
-              mimeType
-              generatedBy
-              runtimeDependencies
-              status
-              logURL
-              errors
-            }
-            ... on ArtifactFailed {
-              __typename
-              nodeId
-              mimeType
-              generatedBy
-              runtimeDependencies
-              status
-              logURL
-              errors
-            }
-          }
-        }
-        ... on PlanningError {
-          message
-          subErrors {
-            __typename
-            ... on GenericSolveError {
-              path
-              message
-              isTransient
-              validationErrors {
-                jsonPath
-                error
-              }
-            }
-            ... on RemediableSolveError {
-              path
-              message
-              isTransient
-              errorType
-              validationErrors {
-                jsonPath
-              }
-              suggestedRemediations {
-                remediationType
-                command
-                parameters
-              }
-            }
-          }
-        }
-      }
     }
-    ... on ParseError {
+    ... on Error {
       __typename
       message
-      path
     }
     ... on NotFound {
       __typename
@@ -169,14 +38,10 @@ mutation ($organization: String!, $project: String!, $parentCommit: ID, $descrip
       resource
       mayNeedAuthentication
     }
-    ... on Error {
+    ... on ParseError {
       __typename
       message
-    }
-    ... on NoChangeSinceLastCommit {
-      __typename
-      commitId
-      message
+      path
     }
     ... on Forbidden {
       __typename
@@ -188,6 +53,11 @@ mutation ($organization: String!, $project: String!, $parentCommit: ID, $descrip
       __typename
       commitId
       branchId
+      message
+    }
+    ... on NoChangeSinceLastCommit {
+      __typename
+      commitId
       message
     }
   }

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -286,14 +286,6 @@ func (bp *BuildPlanner) StageCommit(params StageCommitParams) (strfmt.UUID, erro
 		return "", errs.New("Staged commit does not contain commitID")
 	}
 
-	if resp.Commit.Build == nil {
-		return "", errs.New("Commit does not contain build")
-	}
-
-	if bpModel.IsErrorResponse(resp.Commit.Build.Type) {
-		return "", bpModel.ProcessBuildError(resp.Commit.Build, "Could not get build from commit")
-	}
-
 	return resp.Commit.CommitID, nil
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2324" title="DX-2324" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2324</a>  We no longer ask for the build when staging a commit
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It turns out that while we are querying for the build when we stage a commit we are not using it so the changeset is fairly small.