### PR TITLE
Use `$script.name.path()` in activestate.yaml files.

### DIFF
--- a/activestate.generators.yaml
+++ b/activestate.generators.yaml
@@ -45,10 +45,10 @@ scripts:
     language: bash
     description: Generates all api clients
     value: |
-      $scripts.generate-api-client
-      $scripts.generate-secrets-client
-      $scripts.generate-headchef-client
-      $scripts.generate-inventory-client
+      $scripts.generate-api-client.path()
+      $scripts.generate-secrets-client.path()
+      $scripts.generate-headchef-client.path()
+      $scripts.generate-inventory-client.path()
   - name: generate-locale
     language: bash
     description: Detects new localisation calls and generates placeholder entries in en-us.yaml
@@ -70,7 +70,7 @@ scripts:
       export GOARCH=${1:-amd64}
       $constants.SET_ENV
 
-      $scripts.generate-payload
+      $scripts.generate-payload.path()
 
       echo "# Create update dir"
       mkdir -p ./build/update

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -295,7 +295,7 @@ scripts:
     language: bash
     description: Builds the State Tool and runs it with `--help`
     value: |
-      $scripts.build
+      $scripts.build.path()
       build/state --help
   - name: debug
     language: bash
@@ -409,8 +409,8 @@ events:
   - name: activate
     if: ne .Shell "cmd"
     value: |
-      $scripts.install-deps-dev
-      $scripts.install-deps
+      $scripts.install-deps-dev.path()
+      $scripts.install-deps.path()
   - name: file-changed
     scope: ["internal/locale/locales"]
     value: build


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2071" title="DX-2071" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2071</a>  Use .path() for calls to scripts in the various asy files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Scripts should be invoked like bash script files, not expanded inline.