### PR TITLE
Add a version field to buildscripts.

### DIFF
--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -30,7 +30,9 @@ func TestDiff(t *testing.T) {
 	)
 
 in:
-	runtime`))
+	runtime
+
+version: 1`))
 	require.NoError(t, err)
 
 	// Make a copy of the original expression.
@@ -64,7 +66,9 @@ in:
 	)
 
 in:
-	runtime`, result)
+	runtime
+
+version: 1`, result)
 }
 
 // TestRealWorld tests a real-world case where:
@@ -130,5 +134,7 @@ func TestRealWorld(t *testing.T) {
 	)
 
 in:
-	runtime`, result)
+	runtime
+
+version: 1`, result)
 }

--- a/internal/runbits/buildscript/testdata/buildscript1.yaml
+++ b/internal/runbits/buildscript/testdata/buildscript1.yaml
@@ -34,3 +34,5 @@ let:
 
 in:
 	runtime
+
+version: 1

--- a/internal/runbits/buildscript/testdata/buildscript2.yaml
+++ b/internal/runbits/buildscript/testdata/buildscript2.yaml
@@ -40,3 +40,5 @@ let:
 
 in:
 	runtime
+
+version: 1

--- a/pkg/platform/runtime/buildexpression/merge/merge_test.go
+++ b/pkg/platform/runtime/buildexpression/merge/merge_test.go
@@ -32,7 +32,9 @@ func TestMergeAdd(t *testing.T) {
 	)
 
 in:
-	runtime`))
+	runtime
+
+version: 1`))
 	require.NoError(t, err)
 	bytes, err := json.Marshal(scriptA)
 	require.NoError(t, err)
@@ -59,7 +61,9 @@ in:
 	)
 
 in:
-	runtime`))
+	runtime
+
+version: 1`))
 	require.NoError(t, err)
 	bytes, err = json.Marshal(scriptB)
 	require.NoError(t, err)
@@ -104,7 +108,9 @@ in:
 	)
 
 in:
-	runtime`, mergedScript.String())
+	runtime
+
+version: 1`, mergedScript.String())
 }
 
 func TestMergeRemove(t *testing.T) {
@@ -132,7 +138,9 @@ func TestMergeRemove(t *testing.T) {
 	)
 
 in:
-	runtime`))
+	runtime
+
+version: 1`))
 	require.NoError(t, err)
 	bytes, err := json.Marshal(scriptA)
 	require.NoError(t, err)
@@ -159,7 +167,9 @@ in:
 	)
 
 in:
-	runtime`))
+	runtime
+
+version: 1`))
 	require.NoError(t, err)
 	bytes, err = json.Marshal(scriptB)
 	require.NoError(t, err)
@@ -200,7 +210,9 @@ in:
 	)
 
 in:
-	runtime`, mergedScript.String())
+	runtime
+
+version: 1`, mergedScript.String())
 }
 
 func TestMergeConflict(t *testing.T) {
@@ -220,7 +232,9 @@ func TestMergeConflict(t *testing.T) {
 	)
 
 in:
-	runtime`))
+	runtime
+
+version: 1`))
 	require.NoError(t, err)
 	bytes, err := json.Marshal(scriptA)
 	require.NoError(t, err)
@@ -246,7 +260,9 @@ in:
 	)
 
 in:
-	runtime`))
+	runtime
+
+version: 1`))
 	require.NoError(t, err)
 	bytes, err = json.Marshal(scriptB)
 	require.NoError(t, err)

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -48,6 +48,7 @@ func TestBasic(t *testing.T) {
   )
 in:
   runtime
+version: 1
 `))
 	require.NoError(t, err)
 
@@ -89,6 +90,7 @@ in:
 		},
 		&In{Name: ptr.To("runtime")},
 		expr,
+		1,
 	}, script)
 }
 
@@ -117,6 +119,8 @@ in:
         win_installer(win_runtime),
         tar_installer(linux_runtime)
     )
+
+version: 1
 `))
 	require.NoError(t, err)
 
@@ -165,6 +169,7 @@ in:
 			{FuncCall: &FuncCall{"tar_installer", []*Value{{Ident: ptr.To("linux_runtime")}}}},
 		}}},
 		expr,
+		1,
 	}, script)
 }
 
@@ -191,7 +196,8 @@ const example = `let:
     solver_version = 0
   )
 in:
-  runtime`
+  runtime
+version: 1`
 
 func TestExample(t *testing.T) {
 	script, err := NewScript([]byte(example))
@@ -241,6 +247,7 @@ func TestExample(t *testing.T) {
 		},
 		&In{Name: ptr.To("runtime")},
 		expr,
+		1,
 	}, script)
 }
 
@@ -253,6 +260,7 @@ func TestString(t *testing.T) {
     )
 in:
     runtime
+version: 1
 `))
 	require.NoError(t, err)
 
@@ -271,7 +279,9 @@ in:
 	)
 
 in:
-	runtime`, script.String())
+	runtime
+
+version: 1`, script.String())
 }
 
 func TestRoundTrip(t *testing.T) {
@@ -304,6 +314,7 @@ func TestJson(t *testing.T) {
     )
 in:
     runtime
+version: 1
 `))
 	require.NoError(t, err)
 
@@ -386,6 +397,7 @@ func TestBuildExpression(t *testing.T) {
 	script, err := NewScriptFromBuildExpression(expr)
 	require.NoError(t, err)
 	require.NotNil(t, script)
+	assert.Equal(t, CurrentVersion, script.Version)
 	newExpr := script.Expr
 	exprBytes, err := json.Marshal(expr)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2245" title="DX-2245" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2245</a>  Buildscripts have a version field
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This PR is targeted at the temporary branch that re-enables localorders.