### PR TITLE
Better formatting for multi-line error messages

### DIFF
--- a/internal/runbits/errors/errors.go
+++ b/internal/runbits/errors/errors.go
@@ -45,7 +45,7 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 	if errors.As(o.error, &userFacingError) {
 		message := userFacingError.UserError()
 		if f == output.PlainFormatName {
-			outLines = append(outLines, fmt.Sprintf(" [NOTICE][ERROR]x[/RESET] %s", message))
+			outLines = append(outLines, formatMessage(message)...)
 		} else {
 			outLines = append(outLines, message)
 		}
@@ -59,7 +59,7 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 		for _, errv := range rerrs {
 			message := trimError(locale.ErrorMessage(errv))
 			if f == output.PlainFormatName {
-				outLines = append(outLines, fmt.Sprintf(" [NOTICE][ERROR]x[/RESET] %s", message))
+				outLines = append(outLines, formatMessage(message)...)
 			} else {
 				outLines = append(outLines, message)
 			}
@@ -80,6 +80,20 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 		}
 	}
 	return strings.Join(outLines, "\n")
+}
+
+func formatMessage(message string) []string {
+	var output []string
+	lines := strings.Split(message, "\n")
+	for i, line := range lines {
+		if i == 0 {
+			output = append(output, fmt.Sprintf(" [NOTICE][ERROR]x[/RESET] %s", line))
+		} else {
+			output = append(output, fmt.Sprintf("  %s", line))
+		}
+	}
+
+	return output
 }
 
 func getErrorTips(err error) []string {

--- a/internal/runbits/errors/errors.go
+++ b/internal/runbits/errors/errors.go
@@ -82,6 +82,9 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 	return strings.Join(outLines, "\n")
 }
 
+// formatMessage formats the error message for plain output. It adds a
+// x prefix to the first line and indents the rest of the lines to match
+// the indentation of the first line.
 func formatMessage(message string) []string {
 	var output []string
 	lines := strings.Split(message, "\n")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2278" title="DX-2278" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2278</a>  We have a better way of showing multi line errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
After trying to find a solution in the `output` package, it turns out this can be more easily, and simply, accomplished by modifying how the error messages are marshalled.