### PR TITLE
For checkout/activate, when given a commitID, fetch the branch it belongs to.

### DIFF
--- a/internal/runbits/checkout/checkout.go
+++ b/internal/runbits/checkout/checkout.go
@@ -85,6 +85,19 @@ func (r *Checkout) Run(ns *project.Namespaced, branchName, cachePath, targetPath
 			return "", locale.WrapError(err, "err_fetch_branch", "", branchName)
 		}
 		commitID = branch.CommitID
+	} else {
+		// It's possible the given commitID does not belong to the default project branch.
+		// If so, find the correct branch.
+		for _, branch := range pj.Branches {
+			belongs, err := model.CommitBelongsToBranch(ns.Owner, ns.Project, branch.Label, *commitID)
+			if err != nil {
+				return "", errs.Wrap(err, "Could not determine if the given commitID belongs to a project branch")
+			}
+			if belongs {
+				branchName = branch.Label
+				break
+			}
+		}
 	}
 
 	if commitID == nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2328" title="DX-2328" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2328</a>  PULL is failed if during `activate` we checked out using commitID from different branch of the project
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
