### PR TITLE
Only run Target GitHub Action on PR creation.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,9 +17,6 @@ jobs:
     name: Target & Verify PR
     runs-on: ubuntu-20.04
     env:
-      ACTIVESTATE_CI: true
-      ACTIVESTATE_CLI_DISABLE_RUNTIME: true
-      SHELL: bash
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_USERNAME: ${{ secrets.JIRA_EMAIL }}
       JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
@@ -43,21 +40,6 @@ jobs:
         name: Install State Tool
         uses: ActiveState/setup-state-tool@v1
 
-      - # === Setup ===
-        name: Setup
-        shell: bash
-        run: |
-          bin=$(pwd)/.github/deps/${{ runner.os }}/bin
-          echo "Adding $bin to PATH"
-          echo "$bin" >> $GITHUB_PATH
-          ls -ahl $bin
-          printenv
-
-      - # === Install Deps ===
-        name: Install Deps
-        shell: bash
-        run: state run install-deps
-
       - # === Preprocess ===
         name: Preprocess
         shell: bash
@@ -65,6 +47,7 @@ jobs:
 
       - # === Set Target PR & FixVersion ===
         name: Set Target PR and FixVersion
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
         shell: bash
         run: go run scripts/ci/target-version-pr/main.go ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1743" title="DX-1743" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1743</a>  Revisit target & Verify
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Even though the last AC says only Verify should be required, I did not split up Target & Verify into separate actions because Verify implicitly depends on Target and I saw no easy way to make them sequential if they're separate actions (especially if Target is conditional). Instead, I just made Target only run on create, as specified in the ACs. This effectively makes it so that only Verify is required for merge.