### PR TITLE
Re-enable edit test on Windows.

### DIFF
--- a/test/integration/edit_int_test.go
+++ b/test/integration/edit_int_test.go
@@ -92,10 +92,6 @@ func (suite *EditIntegrationTestSuite) TestEdit_NonInteractive() {
 
 func (suite *EditIntegrationTestSuite) TestEdit_UpdateCorrectPlatform() {
 	suite.OnlyRunForTags(tagsuite.Edit)
-	if runtime.GOOS == "windows" {
-		// https://www.pivotaltracker.com/story/show/174477457
-		suite.T().Skipf("Skipping on windows due to random failures")
-	}
 
 	ts, env := suite.setup()
 	defer ts.Close()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-292" title="DX-292" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-292</a>  Fix `TestEdit_UpdateCorrectPlatform` on Windows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I've run the tests a few times and they're passing for now. This may have been fixed with the termtest update.