### PR TITLE
Emphasize named things in error messages.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -760,7 +760,7 @@ field_localized_field:
 err_could_not_marshal_print:
   other: "Could not marshal the value being printed, please check the error log for more information."
 err_no_structured_output:
-  other: "This command does not support the {{.V0}} output format. Please try again without that output flag."
+  other: "This command does not support the '{{.V0}}' output format. Please try again without that output flag."
 err_main_outputer:
   other: "Could not create output writer, please contact developers if this problem persists. Error: {{.V0}}"
 field_name:
@@ -1101,9 +1101,9 @@ err_fetch_project:
 err_set_default_branch:
   other: Could not update project field with branch, please manually set the `branch={{.V0}}` query parameter on the project field in your activestate.yaml.
 artifact_download_failed:
-  other: Failed to download artifact {{.V0}} ({{.V1}})
+  other: Failed to download artifact '{{.V0}}' ({{.V1}})
 artifact_setup_failed:
-  other: Failed to install artifact {{.V0}} ({{.V1}})
+  other: Failed to install artifact '{{.V0}}' ({{.V1}})
 err_stored_artifacts:
   other: Could not unmarshal stored artifacts, your install may be corrupted.
 err_fetch_branch:

--- a/internal/runners/initialize/rationalize.go
+++ b/internal/runners/initialize/rationalize.go
@@ -52,7 +52,7 @@ func rationalizeError(namespace *project.Namespaced, rerr *error) {
 		case bpModel.AlreadyExistsErrorType:
 			*rerr = errs.WrapUserFacing(
 				pcErr,
-				locale.Tl("err_create_project_exists", "The project {{.V0}} already exists under {{.V1}}", namespace.Project, namespace.Owner),
+				locale.Tl("err_create_project_exists", "The project '{{.V0}}' already exists under '{{.V1}}'", namespace.Project, namespace.Owner),
 				errs.SetInput(),
 			)
 		case bpModel.ForbiddenErrorType:
@@ -63,7 +63,7 @@ func rationalizeError(namespace *project.Namespaced, rerr *error) {
 		case bpModel.NotFoundErrorType:
 			*rerr = errs.WrapUserFacing(
 				pcErr,
-				locale.Tl("err_create_project_not_found", "Could not create project because the organization {{.V0}} was not found.", namespace.Owner),
+				locale.Tl("err_create_project_not_found", "Could not create project because the organization '{{.V0}}' was not found.", namespace.Owner),
 				errs.SetInput(),
 				errs.SetTips(locale.T("err_init_authenticated")))
 		}

--- a/internal/runners/scripts/edit.go
+++ b/internal/runners/scripts/edit.go
@@ -266,7 +266,7 @@ func verifyPathEditor(editor string) (string, error) {
 
 	_, err := os.Stat(editor)
 	if err != nil {
-		return "", locale.WrapInputError(err, "error_edit_stat_editor", "Failed to find editor {{.V0}} on file system.", editor)
+		return "", locale.WrapInputError(err, "error_edit_stat_editor", "Failed to find editor '{{.V0}}' on file system.", editor)
 	}
 
 	return editor, nil

--- a/internal/runners/swtch/switch.go
+++ b/internal/runners/swtch/switch.go
@@ -139,7 +139,7 @@ func resolveIdentifier(project *mono_models.Project, idParam string) (identifier
 
 	branch, err := model.BranchForProjectByName(project, idParam)
 	if err != nil {
-		return nil, locale.WrapError(err, "err_identifier_branch", "Could not get branch {{.V0}} for current project", idParam)
+		return nil, locale.WrapError(err, "err_identifier_branch", "Could not get branch '{{.V0}}' for current project", idParam)
 
 	}
 

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -190,7 +190,7 @@ func (s *ScriptRun) Run(script *project.Script, args []string) error {
 			err = locale.WrapInputError(
 				err,
 				"err_run_script",
-				"Script execution fell back to {{.V0}} after {{.V1}} was not detected in your project or system. Please ensure your script is compatible with one, or more, of: {{.V0}}, {{.V1}}",
+				"Script execution fell back to '{{.V0}}' after '{{.V1}}' was not detected in your project or system. Please ensure your script is compatible with one, or more, of: {{.V0}}, {{.V1}}",
 				lang.String(),
 				strings.Join(attempted, ", "),
 			)

--- a/pkg/platform/runtime/buildplan/buildplan.go
+++ b/pkg/platform/runtime/buildplan/buildplan.go
@@ -190,7 +190,7 @@ func buildTerminals(nodeID strfmt.UUID, lookup map[strfmt.UUID]interface{}, resu
 	}
 
 	if !model.IsSuccessArtifactStatus(targetArtifact.Status) {
-		return locale.NewError("err_artifact_failed", "Artifact {{.V0}} failed to build", trimDisplayName(targetArtifact.DisplayName))
+		return locale.NewError("err_artifact_failed", "Artifact '{{.V0}}' failed to build", trimDisplayName(targetArtifact.DisplayName))
 	}
 
 	if model.IsStateToolArtifact(targetArtifact.MimeType) {

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -148,7 +148,7 @@ func (suite *InitIntegrationTestSuite) TestInit_AlreadyExists() {
 	ts.LoginAsPersistentUser()
 
 	cp := ts.Spawn("init", fmt.Sprintf("%s/test-project", e2e.PersistentUsername), "--language", "python@3")
-	cp.Expect("The project test-project already exists under cli-integration-tests")
+	cp.Expect("The project 'test-project' already exists under 'cli-integration-tests'")
 	cp.ExpectExitCode(1)
 }
 

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -250,7 +250,7 @@ func (suite *ShellIntegrationTestSuite) TestJSON() {
 	defer ts.Close()
 
 	cp := ts.Spawn("shell", "--output", "json")
-	cp.Expect(`"error":"This command does not support the json output format`)
+	cp.Expect(`"error":"This command does not support the 'json' output format`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 }


### PR DESCRIPTION
Not adorning them can easily cause confusion.