### PR TITLE
Use installation package for directory determination.

### DIFF
--- a/internal/runners/clean/run_win.go
+++ b/internal/runners/clean/run_win.go
@@ -117,11 +117,14 @@ func removeInstall(logFile string, params *UninstallParams, cfg *config.Instance
 		return locale.WrapError(err, "err_state_exec")
 	}
 
-	// Schedule removal of the entire branch name directory.
+	// Schedule removal of the entire install directory.
 	// This is because Windows often thinks the installation.InstallDirMarker and
 	// constants.StateInstallerCmd files are still in use.
-	branchDir := filepath.Dir(filepath.Dir(stateExec))
-	paths := []string{stateExec, branchDir}
+	installDir, err := installation.InstallPathFromExecPath()
+	if err != nil {
+		return errs.Wrap(err, "Could not get installation path")
+	}
+	paths := []string{stateExec, installDir}
 	if params.All {
 		paths = append(paths, cfg.ConfigPath()) // also remove the config directory
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1699" title="DX-1699" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1699</a>  As a DevX engineer I can rely on the installation dir being retrieved consistenly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I searched the codebase for all uses of the `installation.*Exec()` methods and looked to see if they used `filepath.Dir()` or other filepath manipulations to produce some path that could be produced by any of the `installation.*()` methods and found none. This appeared to be a one-off due to my ignorance.