### PR TITLE
Added version flags to state-svc and state-installer.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -46,6 +46,7 @@ type Params struct {
 	isUpdate        bool
 	activate        *project.Namespaced
 	activateDefault *project.Namespaced
+	showVersion     bool
 }
 
 func newParams() *Params {
@@ -184,11 +185,16 @@ func main() {
 				Hidden:    true, // Since we already expose the path as an argument, let's not confuse the user
 				Value:     &params.path,
 			},
+			{
+				Name:      "version",
+				Shorthand: "v",
+				Value:     &params.showVersion,
+			},
 			// The remaining flags are for backwards compatibility (ie. we don't want to error out when they're provided)
 			{Name: "nnn", Shorthand: "n", Hidden: true, Value: &garbageBool}, // don't prompt; useless cause we don't prompt anyway
 			{Name: "channel", Hidden: true, Value: &garbageString},
 			{Name: "bbb", Shorthand: "b", Hidden: true, Value: &garbageString},
-			{Name: "vvv", Shorthand: "v", Hidden: true, Value: &garbageString},
+			{Name: "vvv", Hidden: true, Value: &garbageString},
 			{Name: "source-path", Hidden: true, Value: &garbageString},
 		},
 		[]*captain.Argument{
@@ -226,6 +232,20 @@ func main() {
 }
 
 func execute(out output.Outputer, cfg *config.Instance, an analytics.Dispatcher, args []string, params *Params) error {
+	if params.showVersion {
+		vd := installation.VersionData{
+			"CLI Installer",
+			constants.LibraryLicense,
+			constants.Version,
+			constants.BranchName,
+			constants.RevisionHash,
+			constants.Date,
+			constants.OnCI == "true",
+		}
+		out.Print(locale.T("version_info", vd))
+		return nil
+	}
+
 	an.Event(anaConst.CatInstallerFunnel, "exec")
 
 	if params.path == "" {

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/events"
+	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/ipc"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -114,9 +115,34 @@ func run(cfg *config.Instance) error {
 
 	p := primer.New(nil, out, nil, nil, nil, nil, cfg, nil, nil, an)
 
+	showVersion := false
 	cmd := captain.NewCommand(
-		path.Base(os.Args[0]), "", "", p, nil, nil,
+		path.Base(os.Args[0]),
+		"",
+		"",
+		p,
+		[]*captain.Flag{
+			{
+				Name:      "version",
+				Shorthand: "v",
+				Value:     &showVersion,
+			},
+		},
+		nil,
 		func(ccmd *captain.Command, args []string) error {
+			if showVersion {
+				vd := installation.VersionData{
+					"CLI Service",
+					constants.LibraryLicense,
+					constants.Version,
+					constants.BranchName,
+					constants.RevisionHash,
+					constants.Date,
+					constants.OnCI == "true",
+				}
+				out.Print(locale.T("version_info", vd))
+				return nil
+			}
 			out.Print(ccmd.UsageText())
 			return nil
 		},

--- a/internal/installation/versiondata.go
+++ b/internal/installation/versiondata.go
@@ -1,6 +1,7 @@
 package installation
 
 type VersionData struct {
+	Name       string `json:"name"`
 	License    string `json:"license"`
 	Version    string `json:"version"`
 	Branch     string `json:"branch"`

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -35,7 +35,7 @@ confirm_update_unlocked_version_prompt:
   other: "Are you sure you want to unlock the State Tool version from your project?"
 version_info:
   other: |
-    ActiveState CLI by ActiveState Software Inc.
+    ActiveState {{.Name}} by ActiveState Software Inc.
     License [NOTICE]{{.License}}[/RESET]
     Version [NOTICE]{{.Version}}[/RESET]
     Revision [NOTICE]{{.Revision}}[/RESET]

--- a/internal/runners/state/state.go
+++ b/internal/runners/state/state.go
@@ -56,6 +56,7 @@ func (s *State) Run(usageFunc func() error) error {
 	if s.opts.Version {
 		checker.RunUpdateNotifier(s.an, s.svcMdl, s.out)
 		vd := installation.VersionData{
+			"CLI",
 			constants.LibraryLicense,
 			constants.Version,
 			constants.BranchName,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-31" title="DX-31" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-31</a>  All of our executables support the `--version` flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
