### PR TITLE
Update .golangci.yaml and fixed nil pointer dereference.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,12 +5,20 @@ run:
 linters-settings:
   errcheck:
     exclude-functions:
-      - (*github.com/ActiveState/termtest.ConsoleProcess).Expect
-      - (*github.com/ActiveState/termtest.ConsoleProcess).ExpectExitCode
-      - (*github.com/ActiveState/termtest.ConsoleProcess).ExpectNotExitCode
-      - (*github.com/ActiveState/termtest.ConsoleProcess).ExpectRe
-      - (*github.com/ActiveState/termtest.ConsoleProcess).Expect
-      - (*github.com/ActiveState/termtest.ConsoleProcess).WaitForInput
+      - (*github.com/ActiveState/termtest.TermTest).Expect
+      - (*github.com/ActiveState/termtest.TermTest).ExpectExitCode
+      - (*github.com/ActiveState/termtest.TermTest).ExpectNotExitCode
+      - (*github.com/ActiveState/termtest.TermTest).ExpectRe
+      - (*github.com/ActiveState/termtest.TermTest).Expect
+      - (*github.com/ActiveState/termtest.TermTest).WaitForInput
+      - (*github.com/ActiveState/termtest.TermTest).SendLine
+      - (*github.com/ActiveState/termtest.TermTest).ExpectInput
+      - (*github.com/ActiveState/termtest.TermTest).Wait
+      - (*github.com/ActiveState/logging.fileHandler).Printf
+      - (*github.com/ActiveState/logging.standardHandler).Printf
+  govet:
+    disable:
+      - composites
 
 # When issues occur with linting us the snippet below to help with debugging
 # linters:

--- a/internal/runbits/runtime/rationalize.go
+++ b/internal/runbits/runtime/rationalize.go
@@ -15,14 +15,14 @@ import (
 )
 
 func rationalizeError(auth *authentication.Auth, proj *project.Project, rerr *error) {
+	if rerr == nil {
+		return
+	}
 	var errNoMatchingPlatform *model.ErrNoMatchingPlatform
 	var errArtifactSetup *setup.ArtifactSetupErrors
 
 	isUpdateErr := errs.Matches(*rerr, &ErrUpdate{})
 	switch {
-	case rerr == nil:
-		return
-
 	case proj == nil:
 		multilog.Error("runtime:rationalizeError called with nil project, error: %s", errs.JoinMessage(*rerr))
 		*rerr = errs.Pack(*rerr, errs.New("project is nil"))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1509" title="DX-1509" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1509</a>  Research a linter that prevents us from committing new changes with unhandled nil pointers
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The `staticcheck` linter is already enabled by default, and so is [`SA5011`](https://staticcheck.dev/docs/checks/#SA5011) (Possible nil pointer dereference), which appears to do what we need:

```
internal\runbits\runtime\rationalize.go:21:30: SA5011: possible nil pointer dereference (staticcheck)
        isUpdateErr := errs.Matches(*rerr, &ErrUpdate{})
```

This PR updates the linter with the termtest refactor and disables warnings about constructing structs with unkeyed fields. It also fixes the nil pointer issue found.