### PR TITLE
Added comprehensive test for determining the current project.

### DIFF
--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -758,6 +758,10 @@ func (p *Project) SetBranch(branch string) error {
 }
 
 // GetProjectFilePath returns the path to the project activestate.yaml
+// It considers projects in the following order:
+// 1. Environment variable (e.g. `state shell` sets one)
+// 2. Working directory (i.e. walk up directory tree looking for activestate.yaml)
+// 3. Fall back on default project
 func GetProjectFilePath() (string, error) {
 	defer profile.Measure("GetProjectFilePath", time.Now())
 	lookup := []func() (string, error){

--- a/pkg/projectfile/projectfile_test.go
+++ b/pkg/projectfile/projectfile_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/language"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/osutils"
@@ -207,59 +208,95 @@ func TestSave(t *testing.T) {
 	os.Remove(tmpfile.Name())
 }
 
-// Call getProjectFilePath
 func TestGetProjectFilePath(t *testing.T) {
 	Reset()
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(currentDir)
 
-	root, err := environment.GetRootPath()
-	assert.NoError(t, err, "Should detect root path")
-	cwd, err := osutils.Getwd()
-	assert.NoError(t, err, "Should fetch cwd")
-	defer os.Chdir(cwd) // restore
-	os.Chdir(filepath.Join(root, "pkg", "projectfile", "testdata"))
+	rootDir, err := fileutils.ResolvePath(fileutils.TempDirUnsafe())
+	assert.NoError(t, err)
+	defer os.RemoveAll(rootDir)
 
-	configPath, err := GetProjectFilePath()
-	require.Nil(t, err)
-	expectedPath := filepath.Join(root, "pkg", "projectfile", "testdata", constants.ConfigFileName)
-	assert.Equal(t, expectedPath, configPath, "Project path is properly detected")
-	os.Chdir(cwd) // restore
+	// First, set up a new project with a subproject.
+	projectDir := filepath.Join(rootDir, "project")
+	require.NoError(t, fileutils.Mkdir(projectDir))
+	projectYaml := filepath.Join(projectDir, constants.ConfigFileName)
+	require.NoError(t, fileutils.Touch(projectYaml))
+	subprojectDir := filepath.Join(projectDir, "subproject")
+	require.NoError(t, fileutils.Mkdir(subprojectDir))
+	subprojectYaml := filepath.Join(subprojectDir, constants.ConfigFileName)
+	require.NoError(t, fileutils.Mkdir(subprojectDir))
+	require.NoError(t, fileutils.Touch(subprojectYaml))
 
-	defer os.Unsetenv(constants.ProjectEnvVarName)
-
-	os.Setenv(constants.ProjectEnvVarName, "/some/path")
-	configPath, err = GetProjectFilePath()
-	errt := &ErrorNoProjectFromEnv{}
-	require.ErrorAs(t, err, &errt)
-
-	expectedPath = filepath.Join(root, "pkg", "projectfile", "testdata", constants.ConfigFileName)
-	os.Setenv(constants.ProjectEnvVarName, expectedPath)
-	configPath, err = GetProjectFilePath()
-	require.Nil(t, err)
-	assert.Equal(t, expectedPath, configPath, "Project path is properly detected using the ProjectEnvVarName")
-
-	os.Unsetenv(constants.ProjectEnvVarName)
+	// Then set up a separate, default project.
+	defaultDir := filepath.Join(rootDir, "default")
+	require.NoError(t, fileutils.Mkdir(defaultDir))
+	defaultYaml := filepath.Join(defaultDir, constants.ConfigFileName)
+	require.NoError(t, fileutils.Touch(defaultYaml))
 	cfg, err := config.New()
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cfg.Close()) }()
-	cfg.Set(constants.GlobalDefaultPrefname, "") // ensure it is unset
-	tmpDir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err, "Should create temp dir")
-	defer os.RemoveAll(tmpDir)
-	os.Chdir(tmpDir)
-	_, err = GetProjectFilePath()
-	assert.Error(t, err, "GetProjectFilePath should fail")
-	cfg.Set(constants.GlobalDefaultPrefname, expectedPath)
-	configPath, err = GetProjectFilePath()
-	assert.NoError(t, err, "GetProjectFilePath should succeed")
-	assert.Equal(t, expectedPath, configPath, "Project path is properly detected using default path from config")
+	cfg.Set(constants.GlobalDefaultPrefname, defaultDir)
 
-	// The activestate.yaml for an activated project should be used no matter what.
-	defer os.Unsetenv(constants.ActivatedStateEnvVarName)
-	os.Setenv(constants.ActivatedStateEnvVarName, filepath.Dir(expectedPath))
-	configPath, err = GetProjectFilePath()
-	require.Nil(t, err)
-	assert.Equal(t, expectedPath, configPath, "Project path is properly detected using the ActivatedStateEnvVarName")
-	os.Unsetenv(constants.ActivatedStateEnvVarName)
+	// Now set up an empty directory.
+	emptyDir := filepath.Join(rootDir, "empty")
+	require.NoError(t, fileutils.Mkdir(emptyDir))
+
+	// Now change to the project directory and assert GetProjectFilePath() returns it over the
+	// default project.
+	require.NoError(t, os.Chdir(projectDir))
+	path, err := GetProjectFilePath()
+	assert.NoError(t, err)
+	assert.Equal(t, projectYaml, path)
+
+	// `state shell` sets an environment variable, so run `state shell` in this project and then
+	// change to the subproject directory. Assert GetProjectFilePath() still returns the parent
+	// project.
+	require.NoError(t, os.Setenv(constants.ActivatedStateEnvVarName, projectDir))
+	defer os.Unsetenv(constants.ProfileEnvVarName)
+	require.NoError(t, os.Chdir(subprojectDir))
+	path, err = GetProjectFilePath()
+	assert.NoError(t, err)
+	assert.Equal(t, projectYaml, path)
+
+	// If the project were to not exist, GetProjectFilePath() should return a typed error.
+	require.NoError(t, os.Setenv(constants.ActivatedStateEnvVarName, filepath.Join(rootDir, "does-not-exist")))
+	path, err = GetProjectFilePath()
+	errNoProjectFromEnv := &ErrorNoProjectFromEnv{}
+	assert.ErrorAs(t, err, &errNoProjectFromEnv)
+
+	// After exiting out of the shell, the environment variable is no longer set. Assert
+	// GetProjectFilePath() returns the subproject.
+	require.NoError(t, os.Unsetenv(constants.ActivatedStateEnvVarName))
+	path, err = GetProjectFilePath()
+	assert.NoError(t, err)
+	assert.Equal(t, subprojectYaml, path)
+
+	// If a project's subdirectory does not contain an activestate.yaml file, GetProjectFilePath()
+	// should walk up the tree until it finds one.
+	require.NoError(t, os.Remove(subprojectYaml))
+	path, err = GetProjectFilePath()
+	assert.NoError(t, err)
+	assert.Equal(t, projectYaml, path)
+
+	// Change to an empty directory and assert GetProjectFilePath() returns the default project.
+	require.NoError(t, os.Chdir(emptyDir))
+	path, err = GetProjectFilePath()
+	assert.NoError(t, err)
+	assert.Equal(t, defaultYaml, path)
+
+	// If the default project no longer exists, GetProjectFilePath() should return a typed error.
+	cfg.Set(constants.GlobalDefaultPrefname, filepath.Join(rootDir, "does-not-exist"))
+	path, err = GetProjectFilePath()
+	errNoDefaultProject := &ErrorNoDefaultProject{}
+	assert.ErrorAs(t, err, &errNoDefaultProject)
+
+	// If none of the above, GetProjectFilePath() should return a typed error.
+	cfg.Set(constants.GlobalDefaultPrefname, "")
+	path, err = GetProjectFilePath()
+	errNoProject := &ErrorNoProject{}
+	assert.ErrorAs(t, err, &errNoProject)
 }
 
 // TestGet the config


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1222" title="DX-1222" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1222</a>  We have a critical test that checks our project sourcing priorities
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
There was already a unit test for this that I co-opted and made more clear. Note that documentation-wise, we're half blocked by https://activestatef.atlassian.net/browse/DX-2167, which is supposed to solidify the actual project resolution order, so this test and its underlying code could change after that ticket is resolved.