### PR TITLE
Go back to ignoring '-v' for installer.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -186,15 +186,14 @@ func main() {
 				Value:     &params.path,
 			},
 			{
-				Name:      "version",
-				Shorthand: "v",
-				Value:     &params.showVersion,
+				Name:  "version", // note: no shorthand because install.sh uses -v for selecting version
+				Value: &params.showVersion,
 			},
 			// The remaining flags are for backwards compatibility (ie. we don't want to error out when they're provided)
 			{Name: "nnn", Shorthand: "n", Hidden: true, Value: &garbageBool}, // don't prompt; useless cause we don't prompt anyway
 			{Name: "channel", Hidden: true, Value: &garbageString},
 			{Name: "bbb", Shorthand: "b", Hidden: true, Value: &garbageString},
-			{Name: "vvv", Hidden: true, Value: &garbageString},
+			{Name: "vvv", Shorthand: "v", Hidden: true, Value: &garbageString},
 			{Name: "source-path", Hidden: true, Value: &garbageString},
 		},
 		[]*captain.Argument{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2361" title="DX-2361" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2361</a>  Install scripts use '-v' flag, which is simply passed to the installer, but that shows version information instead of doing anything
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
install.sh and install.ps1 will forward that flag, and it should not be interpreted as --version.