### PR TITLE
Add notice about how to switch between branches in `state branch` when applicable.

### DIFF
--- a/internal/runners/branch/list.go
+++ b/internal/runners/branch/list.go
@@ -47,5 +47,9 @@ func (l *List) Run() error {
 		project.Branches,
 	))
 
+	if len(project.Branches) > 1 {
+		l.out.Notice(locale.Tl("branch_switch_notice", "To switch to another branch, run '[ACTIONABLE]state branch switch <name>[/RESET]'."))
+	}
+
 	return nil
 }

--- a/test/integration/branch_int_test.go
+++ b/test/integration/branch_int_test.go
@@ -26,6 +26,13 @@ func (suite *BranchIntegrationTestSuite) TestBranch_List() {
 	cp := ts.SpawnWithOpts(e2e.OptArgs("branch"), e2e.OptTermTest(termtest.OptVerboseLogger()))
 	// Sometimes there's a space before the line break, unsure exactly why, but hence the regex
 	cp.ExpectRe(`main \(Current\)\s?\n  ├─ firstbranch\s?\n  │  └─ firstbranchchild\s?\n  │     └─ childoffirstbranchchild\s?\n  ├─ secondbranch\s?\n  └─ thirdbranch`, termtest.OptExpectTimeout(5*time.Second))
+	cp.Expect("To switch to another branch,")
+	cp.ExpectExitCode(0)
+
+	ts.PrepareProject("ActiveState-CLI/small-python", "")
+	cp = ts.Spawn("branch")
+	cp.Expect("main")
+	suite.Assert().NotContains(cp.Snapshot(), "To switch to another branch,") // only shows when multiple branches are listed
 	cp.ExpectExitCode(0)
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-114" title="DX-114" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-114</a>  Add helper copy to "state branch" command so that I know how to switch.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
