### PR TITLE
Delete failed checkouts unless `--force` is provided.

### DIFF
--- a/cmd/state/internal/cmdtree/checkout.go
+++ b/cmd/state/internal/cmdtree/checkout.go
@@ -34,6 +34,12 @@ func newCheckoutCommand(prime *primer.Values) *captain.Command {
 				Description: locale.Tl("flag_state_checkout_no_clone_description", "Do not clone the github repository associated with this project (if any)"),
 				Value:       &params.NoClone,
 			},
+			{
+				Name:        "force",
+				Shorthand:   "f",
+				Description: locale.Tl("flag_state_checkout_force", "Leave a failed project checkout on disk; do not delete it"),
+				Value:       &params.Force,
+			},
 		},
 		[]*captain.Argument{
 			{

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -297,6 +297,36 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutBuildtimeClosure() {
 	cp.ExpectExitCode(0)
 }
 
+func (suite *CheckoutIntegrationTestSuite) TestFail() {
+	suite.OnlyRunForTags(tagsuite.Checkout)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("checkout", "ActiveState-CLI/fail"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("Something Went Wrong")
+	cp.ExpectNotExitCode(0)
+	suite.Assert().NoDirExists(filepath.Join(ts.Dirs.Work, "fail"), "state checkout fail did not remove created directory")
+
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("checkout", "ActiveState-CLI/fail", "."),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("Something Went Wrong")
+	cp.ExpectNotExitCode(0)
+	suite.Assert().NoFileExists(filepath.Join(ts.Dirs.Work, constants.ConfigFileName), "state checkout fail did not remove created activestate.yaml")
+
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("checkout", "ActiveState-CLI/fail", "--force"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("Something Went Wrong")
+	cp.ExpectNotExitCode(0)
+	suite.Assert().DirExists(filepath.Join(ts.Dirs.Work, "fail"), "state checkout fail did not leave created directory there despite --force flag override")
+}
+
 func TestCheckoutIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(CheckoutIntegrationTestSuite))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2357" title="DX-2357" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2357</a>  While `checkout` is fail due to build failures the folder is still created
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
