### PR TITLE
Verify existing environment variables are inherited by activated states.

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -259,6 +259,14 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 	cp.ExpectInput(termtest.OptExpectTimeout(40 * time.Second))
 	pythonShim := pythonExe + osutils.ExeExtension
 
+	// test that existing environment variables are inherited by the activated shell
+	if runtime.GOOS == "windows" {
+		cp.SendLine(fmt.Sprintf("echo %%%s%%", constants.DisableRuntime))
+	} else {
+		cp.SendLine("echo $" + constants.DisableRuntime)
+	}
+	cp.Expect("false")
+
 	// test that other executables that use python work as well
 	pipExe := "pip" + version
 	cp.SendLine(fmt.Sprintf("%s --version", pipExe))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-556" title="DX-556" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-556</a>  `state activate` should inherit the current env
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Environment inheritance has always been working as far as I know, but adding an integration test for it doesn't hurt.