### PR TITLE
Only export to an activated shell activestate.yaml constants marked for export.

### DIFF
--- a/internal/virtualenvironment/virtualenvironment.go
+++ b/internal/virtualenvironment/virtualenvironment.go
@@ -53,6 +53,9 @@ func (v *VirtualEnvironment) GetEnv(inherit bool, useExecutors bool, projectDir,
 			return envMap, locale.WrapError(err, "err_parse_project", "", configFile)
 		}
 		for _, constant := range pj.Constants() {
+			if !constant.Export() {
+				continue
+			}
 			v, err := constant.Value()
 			envMap[constant.Name()] = strings.Replace(v, "\n", `\n`, -1)
 			if err != nil {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -369,6 +369,9 @@ func (c *Constant) Value() (string, error) {
 	return ExpandFromProject(c.constant.Value, c.project)
 }
 
+// Export returns whether or not the constant should be exported to an activated shell environment.
+func (c *Constant) Export() bool { return c.constant.ConstantFields.Export }
+
 // SecretScope defines the scope of a secret
 type SecretScope string
 

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -113,6 +113,7 @@ type Build map[string]string
 // ConstantFields are the common fields for the Constant type. This is required
 // for type composition related to its yaml.Unmarshaler implementation.
 type ConstantFields struct {
+	Export      bool        `yaml:"export"`
 	Conditional Conditional `yaml:"if"`
 }
 

--- a/pkg/projectfile/projectfile_test.go
+++ b/pkg/projectfile/projectfile_test.go
@@ -110,13 +110,15 @@ func TestConstantStruct(t *testing.T) {
 	constant := Constant{}
 	dat := strings.TrimSpace(`
 name: valueForName
-value: valueForConstant`)
+value: valueForConstant
+export: true`)
 
 	err := yaml.Unmarshal([]byte(dat), &constant)
 	assert.Nil(t, err, "Should not throw an error")
 
 	assert.Equal(t, "valueForName", constant.Name, "Name should be set")
 	assert.Equal(t, "valueForConstant", constant.Value, "Constant should be set")
+	assert.Equal(t, true, constant.Export, "Constant export should be set")
 }
 
 func TestSecretStruct(t *testing.T) {
@@ -150,6 +152,7 @@ func TestParse(t *testing.T) {
 
 	assert.NotEmpty(t, project.Constants[0].Name, "Constant name should be set")
 	assert.NotEmpty(t, project.Constants[0].Value, "Constant value should be set")
+	assert.False(t, project.Constants[0].Export, "Constant export value should not be set")
 
 	assert.NotEmpty(t, project.Secrets.User[0].Name, "Variable name should be set")
 	assert.NotEmpty(t, project.Secrets.Project[0].Name, "Variable name should be set")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-525" title="DX-525" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-525</a>  Constants are only exported as env vars when marked as such
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I'm not 100% sure this is desirable, but I had some time waiting for other CI jobs to finish to knock out this one.