### PR TITLE
Correctly recognize integration test log errors.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -430,7 +430,7 @@ func postInstallEvents(out output.Outputer, cfg *config.Instance, an analytics.D
 		if err := ss.Activate(nil, cfg, out); err != nil {
 			return errs.Wrap(err, "Error activating subshell: %s", errs.JoinMessage(err))
 		}
-		if err = <-ss.Errors(); err != nil {
+		if err = <-ss.Errors(); err != nil && !errs.IsSilent(err) {
 			return errs.Wrap(err, "Error during subshell execution: %s", errs.JoinMessage(err))
 		}
 	}

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -186,6 +186,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 	cp.ExpectExit()
 	suite.Assert().Contains(cp.Output(), "Need More Help?",
 		"error tips should be displayed in shell created by installer")
+	ts.IgnoreLogErrors()
 }
 
 func (suite *InstallerIntegrationTestSuite) TestInstallerOverwriteServiceApp() {

--- a/cmd/state-svc/internal/rtwatcher/entry.go
+++ b/cmd/state-svc/internal/rtwatcher/entry.go
@@ -17,6 +17,11 @@ type entry struct {
 	Dims   *dimensions.Values `json:"dims"`
 }
 
+// processError wraps an OS-level error, not a State Tool error.
+type processError struct {
+	*errs.WrapperError
+}
+
 func (e entry) IsRunning() (bool, error) {
 	logging.Debug("Checking if %s (%d) is still running", e.Exec, e.PID)
 
@@ -31,7 +36,7 @@ func (e entry) IsRunning() (bool, error) {
 
 	exe, err := proc.Exe()
 	if err != nil {
-		return false, errs.Wrap(err, "Could not get executable of process: %d", e.PID)
+		return false, &processError{errs.Wrap(err, "Could not get executable of process: %d", e.PID)}
 	}
 
 	match, err := fileutils.PathsMatch(exe, e.Exec)

--- a/cmd/state-svc/internal/rtwatcher/watcher.go
+++ b/cmd/state-svc/internal/rtwatcher/watcher.go
@@ -80,7 +80,7 @@ func (w *Watcher) check() {
 	for i := range w.watching {
 		e := w.watching[i] // Must use index, because we are deleting indexes further down
 		running, err := e.IsRunning()
-		if err != nil {
+		if err != nil && !errs.Matches(err, &processError{}) {
 			multilog.Error("Could not check if runtime process is running: %s", errs.JoinMessage(err))
 			// Don't return yet, the conditional below still needs to clear this entry
 		}

--- a/internal/osutils/shortcut/shortcut_windows.go
+++ b/internal/osutils/shortcut/shortcut_windows.go
@@ -68,7 +68,7 @@ func (s *Shortcut) Enable() error {
 	if err != nil {
 		oleErr := &ole.OleError{}
 		if errors.As(err, &oleErr) {
-			return errs.Wrap(err, "oleutil CreateShortcut returned error: %s, parent error: %s", oleErr.Description(), oleErr.SubError())
+			return errs.Wrap(err, "oleutil CreateShortcut returned error: %s", oleErr.String())
 		}
 		return errs.Wrap(err, "Could not call CreateShortcut on shell object")
 	}

--- a/internal/output/progress_win.go
+++ b/internal/output/progress_win.go
@@ -43,6 +43,9 @@ func (d *Spinner) moveCaretBackInCommandPrompt(n int) {
 
 	var csbi consoleScreenBufferInfo
 	if r, _, err := procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi))); r != 0 {
+		if csbi.cursorPosition.x < short(n) {
+			return // cannot back up any further
+		}
 		var cursor coord
 		cursor.x = csbi.cursorPosition.x + short(-n)
 		cursor.y = csbi.cursorPosition.y

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -754,10 +754,13 @@ func (s *Session) IgnoreLogErrors() {
 	s.ignoreLogErrors = true
 }
 
-var errorOrPanicRegex = regexp.MustCompile(`(?:\[ERR |Panic:)`)
+var errorOrPanicRegex = regexp.MustCompile(`(?:\[ERR |\[CRT |Panic:)`)
 
 func (s *Session) detectLogErrors() {
 	for _, path := range s.LogFiles() {
+		if !strings.HasPrefix(filepath.Base(path), "state-") {
+			continue
+		}
 		if contents := string(fileutils.ReadFileUnsafe(path)); errorOrPanicRegex.MatchString(contents) {
 			s.T.Errorf("Found error and/or panic in log file %s\nIf this was expected, call session.IgnoreLogErrors() to avoid this check\nLog contents:\n%s", path, contents)
 		}

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -754,7 +754,7 @@ func (s *Session) IgnoreLogErrors() {
 	s.ignoreLogErrors = true
 }
 
-var errorOrPanicRegex = regexp.MustCompile(`(?:\[ERR:|Panic:)`)
+var errorOrPanicRegex = regexp.MustCompile(`(?:\[ERR |Panic:)`)
 
 func (s *Session) detectLogErrors() {
 	for _, path := range s.LogFiles() {

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -83,6 +83,11 @@ func (suite *ActivateIntegrationTestSuite) addForegroundSvc(ts *e2e.Session) fun
 		return nil
 	}, 10*time.Second)
 
+	// This function seems to trigger lots of flisten errors that do not appear to be actual errors
+	// (the integration test expectations all pass). Just ignore log errors for sessions that call
+	// this function.
+	ts.IgnoreLogErrors()
+
 	// Stop function
 	return func() {
 		go func() {

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -309,6 +309,7 @@ func (suite *CheckoutIntegrationTestSuite) TestFail() {
 	cp.Expect("Something Went Wrong")
 	cp.ExpectNotExitCode(0)
 	suite.Assert().NoDirExists(filepath.Join(ts.Dirs.Work, "fail"), "state checkout fail did not remove created directory")
+	ts.IgnoreLogErrors()
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/fail", "."),

--- a/test/integration/edit_int_test.go
+++ b/test/integration/edit_int_test.go
@@ -71,6 +71,7 @@ func (suite *EditIntegrationTestSuite) TestEdit() {
 	cp.Expect("Script changes detected")
 	cp.SendLine("Y")
 	cp.ExpectExitCode(0)
+	ts.IgnoreLogErrors() // ignore EditProject does not exist API errors
 }
 
 func (suite *EditIntegrationTestSuite) TestEdit_NonInteractive() {
@@ -88,6 +89,8 @@ func (suite *EditIntegrationTestSuite) TestEdit_NonInteractive() {
 	cp.Expect("Script changes detected")
 	cp.SendCtrlC()
 	cp.Wait()
+
+	ts.IgnoreLogErrors() // ignore EditProject does not exist API errors
 }
 
 func (suite *EditIntegrationTestSuite) TestEdit_UpdateCorrectPlatform() {
@@ -114,6 +117,8 @@ func (suite *EditIntegrationTestSuite) TestEdit_UpdateCorrectPlatform() {
 	v, err := s.Value()
 	suite.Require().NoError(err)
 	suite.Contains(v, "more info!", "Output of edit command:\n%s", cp.Output())
+
+	ts.IgnoreLogErrors() // ignore EditProject does not exist API errors
 }
 
 func TestEditIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2376" title="DX-2376" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2376</a>  e2e session's detectLogErrors() function does not recognize errors correctly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Also fix various errors this fix uncovered.