### PR TITLE
Fixed `state history` help description.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -802,7 +802,7 @@ namespace_label_preplatform:
 namespace_label_packager:
   other: "Docker/Installer packagers"
 history_cmd_description:
-  other: View history of the active or given project
+  other: View history of the active project
 clean_description:
   other: Clean caches, configuration files, or completely remove the state tool
 uninstall_description:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2379" title="DX-2379" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2379</a>  `state history` help incorrectly hints at showing other project histories
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
