### PR TITLE
Do not show EOL platforms as available options in `state platforms search`.

### DIFF
--- a/internal/runners/platforms/platforms.go
+++ b/internal/runners/platforms/platforms.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 
@@ -35,6 +36,10 @@ func makePlatformsFromModelPlatforms(platforms []*model.Platform) []*Platform {
 	var ps []*Platform
 
 	for _, platform := range platforms {
+		if platform.EndOfSupportDate != nil && time.Since(time.Time(*platform.EndOfSupportDate)) > 0 {
+			continue // ignore EOL platforms; the Platform will fail to resolve dependencies on them
+		}
+
 		var p Platform
 		if platform.Kernel != nil && platform.Kernel.Name != nil {
 			p.Name = *platform.Kernel.Name


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-952" title="DX-952" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-952</a>  CLI - PLATFORMS: `state platforms search` provides platforms that are not supported anymore.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
