### PR TITLE
Allow a "reconfigure" installation.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -284,6 +284,7 @@ func execute(out output.Outputer, cfg *config.Instance, an analytics.Dispatcher,
 	}
 	// Older state tools did not bake in meta information, in this case we allow overwriting regardless of branch
 	targetingSameBranch := installedBranch == "" || installedBranch == constants.BranchName
+	stateToolInstalledAndFunctional := stateToolInstalled && installationIsOnPATH(params.path) && targetingSameBranch
 
 	// If this is a fresh installation we ensure that the target directory is empty
 	if !stateToolInstalled && fileutils.DirExists(params.path) && !params.force {
@@ -305,9 +306,9 @@ func execute(out output.Outputer, cfg *config.Instance, an analytics.Dispatcher,
 	}
 	an.Event(anaConst.CatInstallerFunnel, route)
 
-	// Check if state tool already installed
-	if !params.isUpdate && !params.force && stateToolInstalled && !targetingSameBranch {
-		logging.Debug("Cancelling out because State Tool is already installed")
+	// Check if state tool already installed and functional
+	if stateToolInstalledAndFunctional && !params.isUpdate && !params.force {
+		logging.Debug("Cancelling out because State Tool is already installed and functional")
 		out.Print(fmt.Sprintf("State Tool Package Manager is already installed at [NOTICE]%s[/RESET]. To reinstall use the [ACTIONABLE]--force[/RESET] flag.", installPath))
 		an.Event(anaConst.CatInstallerFunnel, "already-installed")
 		params.isUpdate = true

--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -240,3 +240,19 @@ func installedOnPath(installRoot, branch string) (bool, string, error) {
 
 	return false, installRoot, nil
 }
+
+// installationIsOnPATH returns whether the installed State Tool root is on $PATH or %PATH%.
+func installationIsOnPATH(installRoot string) bool {
+	// This is not using appinfo on purpose because we want to deal with legacy installation formats, which appinfo does not
+	stateCmd := constants.StateCmd + osutils.ExeExtension
+
+	exeOnPATH := osutils.FindExeOnPATH(stateCmd)
+	if exeOnPATH == "" {
+		return false
+	}
+	onPATH, err := fileutils.PathContainsParent(exeOnPATH, installRoot)
+	if err != nil {
+		multilog.Error("Unable to determine if state tool on PATH is in path to install to: %v", err)
+	}
+	return onPATH
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1189" title="DX-1189" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1189</a>  Installer should reinstall if current install is not configured
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
State Tool might be installed, but not on PATH. If that's the case, allow installation to proceed so PATH is reconfigured.

Only error out if State Tool is installed and properly configured on PATH.