### PR TITLE
Fix regex matching activestate.*.yaml.

### DIFF
--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -414,7 +414,7 @@ func Parse(configFilepath string) (_ *Project, rerr error) {
 		return nil, err
 	}
 
-	re, _ := regexp.Compile(`activestate.(\w+).yaml`)
+	re, _ := regexp.Compile(`activestate\.(\w+)\.yaml`)
 	for _, file := range files {
 		match := re.FindStringSubmatch(file.Name())
 		if len(match) == 0 {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-607" title="DX-607" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-607</a>  Clarify alternate projectfile naming formats
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

It was a bit too broad.

No need to consider other weird formats or update documentation. It's `activestate.yaml` for the main config file and `activestate.*.yaml` for extra inclusions like our `activestate.generators.yaml` and `activestate.windows.yaml`.