### PR TITLE
Error out if the commit of the namespace to activate doesn't match the checked out project.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1294,6 +1294,8 @@ err_use_default_project_does_not_exist:
   other: "Cannot find your project. Please either check it out again with [ACTIONABLE]state checkout[/RESET] or run [ACTIONABLE]state use reset[/RESET] to stop using it."
 err_shell_commit_id_mismatch:
   other: "Cannot start a shell/prompt for the given commit ID. Please use '[ACTIONABLE]state checkout[/RESET]' to check out a specific commit ID and then try again."
+err_activate_commit_id_mismatch:
+  other: "Cannot activate a project with the given commit ID. Please use '[ACTIONABLE]state checkout[/RESET]' to check out a specific commit ID and then try again."
 err_shell_cannot_load_project:
   other: Cannot load project to start a shell/prompt in.
 err_shell_already_active:

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -142,6 +142,16 @@ func (r *Activate) Run(params *ActivateParams) (rerr error) {
 		return locale.NewInputError("err_conflicting_branch_while_checkedout", "", params.Branch, proj.BranchName())
 	}
 
+	if proj != nil {
+		commitID, err := commitmediator.Get(proj)
+		if err != nil {
+			return errs.Wrap(err, "Unable to get local commit")
+		}
+		if cid := params.Namespace.CommitID; cid != nil && *cid != commitID {
+			return locale.NewInputError("err_activate_commit_id_mismatch")
+		}
+	}
+
 	// Have to call this once the project has been set
 	r.analytics.Event(anaConsts.CatActivationFlow, "start")
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1392" title="DX-1392" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-1392</a>  ACTIVATE: Inexistent commit_id not identified and command executed with no errors.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is similar to `state use` and `state shell` with mismatched commit IDs.