### PR TITLE
Use "channel" instead of "branch" when referring to State Tool versions.

### DIFF
--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -216,7 +216,7 @@ func isStateExecutable(name string) bool {
 	return false
 }
 
-func installedOnPath(installRoot, branch string) (bool, string, error) {
+func installedOnPath(installRoot, channel string) (bool, string, error) {
 	if !fileutils.DirExists(installRoot) {
 		return false, "", nil
 	}
@@ -224,11 +224,11 @@ func installedOnPath(installRoot, branch string) (bool, string, error) {
 	// This is not using appinfo on purpose because we want to deal with legacy installation formats, which appinfo does not
 	stateCmd := constants.StateCmd + osutils.ExeExtension
 
-	// Check for state.exe in branch, root and bin dir
+	// Check for state.exe in channel, root and bin dir
 	// This is to handle older state tool versions that gave incompatible input paths
 	candidates := []string{
-		filepath.Join(installRoot, branch, installation.BinDirName, stateCmd),
-		filepath.Join(installRoot, branch, stateCmd),
+		filepath.Join(installRoot, channel, installation.BinDirName, stateCmd),
+		filepath.Join(installRoot, channel, stateCmd),
 		filepath.Join(installRoot, installation.BinDirName, stateCmd),
 		filepath.Join(installRoot, stateCmd),
 	}

--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Params struct {
-	branch  string
+	channel string
 	force   bool
 	version string
 }
@@ -116,12 +116,12 @@ func main() {
 			{
 				Name:        "channel",
 				Description: "Defaults to 'release'.  Specify an alternative channel to install from (eg. beta)",
-				Value:       &params.branch,
+				Value:       &params.channel,
 			},
 			{
 				Shorthand: "b", // backwards compatibility
 				Hidden:    true,
-				Value:     &params.branch,
+				Value:     &params.channel,
 			},
 			{
 				Name:        "version",
@@ -171,22 +171,22 @@ func execute(out output.Outputer, prompt prompt.Prompter, cfg *config.Instance, 
 		return locale.NewInputError("install_cancel", "Installation cancelled")
 	}
 
-	branch := params.branch
-	if branch == "" {
-		branch = constants.ReleaseBranch
+	channel := params.channel
+	if channel == "" {
+		channel = constants.ReleaseChannel
 	}
 
 	// Fetch payload
 	checker := updater.NewDefaultChecker(cfg, an)
 	checker.InvocationSource = updater.InvocationSourceInstall // Installing from a remote source is only ever encountered via the install flow
-	availableUpdate, err := checker.CheckFor(branch, params.version)
+	availableUpdate, err := checker.CheckFor(channel, params.version)
 	if err != nil {
 		return errs.Wrap(err, "Could not retrieve install package information")
 	}
 
 	version := availableUpdate.Version
-	if params.branch != "" {
-		version = fmt.Sprintf("%s (%s)", version, branch)
+	if params.channel != "" {
+		version = fmt.Sprintf("%s (%s)", version, channel)
 	}
 
 	update := updater.NewUpdateInstaller(an, availableUpdate)

--- a/cmd/state-svc/internal/messages/messages.go
+++ b/cmd/state-svc/internal/messages/messages.go
@@ -51,7 +51,7 @@ func New(cfg *config.Instance, auth *auth.Auth) (*Messages, error) {
 		baseParams: &ConditionParams{
 			OS:           sysinfo.OS().String(),
 			OSVersion:    NewVersionFromSysinfo(osVersion),
-			StateChannel: constants.BranchName,
+			StateChannel: constants.ChannelName,
 			StateVersion: NewVersionFromSemver(stateVersion),
 		},
 		cfg:  cfg,

--- a/cmd/state-svc/internal/resolver/resolver.go
+++ b/cmd/state-svc/internal/resolver/resolver.go
@@ -52,7 +52,7 @@ func New(cfg *config.Instance, an *sync.Client, auth *authentication.Auth) (*Res
 	upchecker := updater.NewDefaultChecker(cfg, an)
 	pollUpdate := poller.New(1*time.Hour, func() (interface{}, error) {
 		logging.Debug("Poller checking for update info")
-		return upchecker.CheckFor(constants.BranchName, "")
+		return upchecker.CheckFor(constants.ChannelName, "")
 	})
 
 	pollRate := time.Minute.Milliseconds()
@@ -107,7 +107,7 @@ func (r *Resolver) Version(ctx context.Context) (*graph.Version, error) {
 		State: &graph.StateVersion{
 			License:  constants.LibraryLicense,
 			Version:  constants.Version,
-			Branch:   constants.BranchName,
+			Channel:  constants.ChannelName,
 			Revision: constants.RevisionHash,
 			Date:     constants.Date,
 		},
@@ -118,7 +118,7 @@ func (r *Resolver) AvailableUpdate(ctx context.Context, desiredChannel, desiredV
 	defer func() { handlePanics(recover(), debug.Stack()) }()
 
 	if desiredChannel == "" {
-		desiredChannel = constants.BranchName
+		desiredChannel = constants.ChannelName
 	}
 
 	r.an.EventWithLabel(anaConsts.CatStateSvc, "endpoint", "AvailableUpdate")
@@ -132,7 +132,7 @@ func (r *Resolver) AvailableUpdate(ctx context.Context, desiredChannel, desiredV
 	)
 
 	switch {
-	case desiredChannel == constants.BranchName && desiredVersion == "":
+	case desiredChannel == constants.ChannelName && desiredVersion == "":
 		avUpdate, ok = r.updatePoller.ValueFromCache().(*updater.AvailableUpdate)
 		if !ok || avUpdate == nil {
 			logging.Debug("No update info in poller cache")
@@ -142,7 +142,7 @@ func (r *Resolver) AvailableUpdate(ctx context.Context, desiredChannel, desiredV
 		logging.Debug("Update info pulled from poller cache")
 
 	default:
-		logging.Debug("Update info requested for specific branch/version")
+		logging.Debug("Update info requested for specific channel/version")
 
 		upchecker := updater.NewDefaultChecker(r.cfg, r.an)
 		avUpdate, err = upchecker.CheckFor(desiredChannel, desiredVersion)

--- a/cmd/state-svc/internal/server/generated/generated.go
+++ b/cmd/state-svc/internal/server/generated/generated.go
@@ -88,7 +88,7 @@ type ComplexityRoot struct {
 	}
 
 	StateVersion struct {
-		Branch   func(childComplexity int) int
+		Channel  func(childComplexity int) int
 		Date     func(childComplexity int) int
 		License  func(childComplexity int) int
 		Revision func(childComplexity int) int
@@ -319,12 +319,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ReportRuntimeUsageResponse.Received(childComplexity), true
 
-	case "StateVersion.branch":
-		if e.complexity.StateVersion.Branch == nil {
+	case "StateVersion.channel":
+		if e.complexity.StateVersion.Channel == nil {
 			break
 		}
 
-		return e.complexity.StateVersion.Branch(childComplexity), true
+		return e.complexity.StateVersion.Channel(childComplexity), true
 
 	case "StateVersion.date":
 		if e.complexity.StateVersion.Date == nil {
@@ -420,7 +420,7 @@ var sources = []*ast.Source{
 type StateVersion {
     license: String!
     version: String!
-    branch: String!
+    channel: String!
     revision: String!
     date: String!
 }
@@ -2071,7 +2071,7 @@ func (ec *executionContext) _StateVersion_branch(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Branch, nil
+		return obj.Channel, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -2232,7 +2232,7 @@ func (ec *executionContext) fieldContext_Version_state(ctx context.Context, fiel
 				return ec.fieldContext_StateVersion_license(ctx, field)
 			case "version":
 				return ec.fieldContext_StateVersion_version(ctx, field)
-			case "branch":
+			case "channel":
 				return ec.fieldContext_StateVersion_branch(ctx, field)
 			case "revision":
 				return ec.fieldContext_StateVersion_revision(ctx, field)
@@ -4486,7 +4486,7 @@ func (ec *executionContext) _StateVersion(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "branch":
+		case "channel":
 
 			out.Values[i] = ec._StateVersion_branch(ctx, field, obj)
 

--- a/cmd/state-svc/main.go
+++ b/cmd/state-svc/main.go
@@ -135,7 +135,7 @@ func run(cfg *config.Instance) error {
 					"CLI Service",
 					constants.LibraryLicense,
 					constants.Version,
-					constants.BranchName,
+					constants.ChannelName,
 					constants.RevisionHash,
 					constants.Date,
 					constants.OnCI == "true",

--- a/cmd/state-svc/schema/schema.graphqls
+++ b/cmd/state-svc/schema/schema.graphqls
@@ -5,7 +5,7 @@ type Version {
 type StateVersion {
     license: String!
     version: String!
-    branch: String!
+    channel: String!
     revision: String!
     date: String!
 }

--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -45,7 +45,7 @@ func autoUpdate(svc *model.SvcModel, args []string, cfg *config.Instance, an ana
 	}
 
 	// Check for available update
-	upd, err := svc.CheckUpdate(context.Background(), constants.BranchName, "")
+	upd, err := svc.CheckUpdate(context.Background(), constants.ChannelName, "")
 	if err != nil {
 		return false, errs.Wrap(err, "Failed to check for update")
 	}

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -242,7 +242,7 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 
 		if childCmd.Name() != "update" && pj != nil && pj.IsLocked() {
 			if (pj.Version() != "" && pj.Version() != constants.Version) ||
-				(pj.VersionBranch() != "" && pj.VersionBranch() != constants.ChannelName) {
+				(pj.Channel() != "" && pj.Channel() != constants.ChannelName) {
 				return errs.AddTips(
 					locale.NewInputError("lock_version_mismatch", "", pj.Source().Lock, constants.ChannelName, constants.Version),
 					locale.Tr("lock_update_legacy_version", constants.DocumentationURLLocking),

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -242,9 +242,9 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 
 		if childCmd.Name() != "update" && pj != nil && pj.IsLocked() {
 			if (pj.Version() != "" && pj.Version() != constants.Version) ||
-				(pj.VersionBranch() != "" && pj.VersionBranch() != constants.BranchName) {
+				(pj.VersionBranch() != "" && pj.VersionBranch() != constants.ChannelName) {
 				return errs.AddTips(
-					locale.NewInputError("lock_version_mismatch", "", pj.Source().Lock, constants.BranchName, constants.Version),
+					locale.NewInputError("lock_version_mismatch", "", pj.Source().Lock, constants.ChannelName, constants.Version),
 					locale.Tr("lock_update_legacy_version", constants.DocumentationURLLocking),
 					locale.T("lock_update_lock"),
 				)

--- a/internal/analytics/client/sync/client.go
+++ b/internal/analytics/client/sync/client.go
@@ -103,7 +103,7 @@ func New(source string, cfg *config.Instance, auth *authentication.Auth, out out
 
 	customDimensions := &dimensions.Values{
 		Version:       ptr.To(constants.Version),
-		BranchName:    ptr.To(constants.BranchName),
+		ChannelName:   ptr.To(constants.ChannelName),
 		OSName:        ptr.To(osName),
 		OSVersion:     ptr.To(osVersion),
 		InstallSource: ptr.To(installSource),

--- a/internal/analytics/client/sync/reporters/ga-state.go
+++ b/internal/analytics/client/sync/reporters/ga-state.go
@@ -76,7 +76,7 @@ func legacyDimensionMap(d *dimensions.Values) map[string]string {
 		// Commented out idx 1 so it's clear why we start with 2. We used to log the hostname while dogfooding internally.
 		// "1": "hostname (deprecated)"
 		"2": ptr.From(d.Version, ""),
-		"3": ptr.From(d.BranchName, ""),
+		"3": ptr.From(d.ChannelName, ""),
 		"4": ptr.From(d.UserID, ""),
 		"5": ptr.From(d.OutputType, ""),
 		"6": ptr.From(d.OSName, ""),

--- a/internal/analytics/dimensions/dimensions.go
+++ b/internal/analytics/dimensions/dimensions.go
@@ -22,7 +22,7 @@ import (
 
 type Values struct {
 	Version          *string
-	BranchName       *string
+	ChannelName      *string
 	UserID           *string
 	OSName           *string
 	OSVersion        *string
@@ -76,7 +76,7 @@ func NewDefaultDimensions(pjNamespace, sessionToken, updateTag string) *Values {
 
 	return &Values{
 		ptr.To(constants.Version),
-		ptr.To(constants.BranchName),
+		ptr.To(constants.ChannelName),
 		ptr.To(userIDString),
 		ptr.To(osName),
 		ptr.To(osVersion),
@@ -107,7 +107,7 @@ func NewDefaultDimensions(pjNamespace, sessionToken, updateTag string) *Values {
 func (v *Values) Clone() *Values {
 	return &Values{
 		Version:          ptr.Clone(v.Version),
-		BranchName:       ptr.Clone(v.BranchName),
+		ChannelName:      ptr.Clone(v.ChannelName),
 		UserID:           ptr.Clone(v.UserID),
 		OSName:           ptr.Clone(v.OSName),
 		OSVersion:        ptr.Clone(v.OSVersion),
@@ -142,8 +142,8 @@ func (m *Values) Merge(mergeWith ...*Values) {
 		if dim.Version != nil {
 			m.Version = dim.Version
 		}
-		if dim.BranchName != nil {
-			m.BranchName = dim.BranchName
+		if dim.ChannelName != nil {
+			m.ChannelName = dim.ChannelName
 		}
 		if dim.UserID != nil {
 			m.UserID = dim.UserID

--- a/internal/analytics/dimensions/dimensions_test.go
+++ b/internal/analytics/dimensions/dimensions_test.go
@@ -19,8 +19,8 @@ func TestMap_Merge(t *testing.T) {
 		{
 			"Simple",
 			&Values{Version: ptr.To("inputVersion")},
-			&Values{BranchName: ptr.To("mergeBranchName")},
-			&Values{Version: ptr.To("inputVersion"), BranchName: ptr.To("mergeBranchName")},
+			&Values{ChannelName: ptr.To("mergeChannelName")},
+			&Values{Version: ptr.To("inputVersion"), ChannelName: ptr.To("mergeChannelName")},
 		},
 		{
 			"Override",

--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -30,7 +30,7 @@ func OnCI() bool {
 }
 
 func IsLTS() bool {
-	return strings.HasPrefix(constants.BranchName, "LTS")
+	return strings.HasPrefix(constants.ChannelName, "LTS")
 }
 
 func BuiltViaCI() bool {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -66,8 +66,8 @@ const DisableLanguageTemplates = "ACTIVESTATE_CLI_DISABLE_LANGUAGE_TEMPLATES"
 // This is set by default for integration tests for backward-compatibility with old integration tests.
 const DisableProjectMigrationPrompt = "ACTIVESTATE_CLI_DISABLE_PROJECT_MIGRATION_PROMPT"
 
-// UpdateBranchEnvVarName is the env var that is used to override which branch to pull the update from
-const UpdateBranchEnvVarName = "ACTIVESTATE_CLI_UPDATE_BRANCH"
+// UpdateChannelEnvVarName is the env var that is used to override which channel to pull the update from
+const UpdateChannelEnvVarName = "ACTIVESTATE_CLI_UPDATE_CHANNEL"
 
 // InstallBuildDependencies is the env var that is used to override whether to install build dependencies
 const InstallBuildDependencies = "ACTIVESTATE_CLI_INSTALL_BUILD_DEPENDENCIES"
@@ -237,14 +237,14 @@ const DefaultRSABitLength int = 4096
 // ExpanderMaxDepth defines the maximum depth to fully expand a given value.
 const ExpanderMaxDepth = int(10)
 
-// ReleaseBranch is the branch used for release builds
-const ReleaseBranch = "release"
+// ReleaseChannel is the channel used for release builds
+const ReleaseChannel = "release"
 
-// BetaBranch is the branch used for beta builds
-const BetaBranch = "beta"
+// BetaChannel is the channel used for beta builds
+const BetaChannel = "beta"
 
-// ExperimentalBranch is the branch used for experimental builds
-const ExperimentalBranch = "master"
+// ExperimentalChannel is the channel used for experimental builds
+const ExperimentalChannel = "master"
 
 // MonoAPIPath is the api path used for the platform api
 const MonoAPIPath = "/api/v1"

--- a/internal/constants/preprocess/preprocess.go
+++ b/internal/constants/preprocess/preprocess.go
@@ -19,7 +19,7 @@ import (
 var Constants = map[string]func() interface{}{}
 
 func init() {
-	branchName, commitRef := branchName()
+	channelName, commitRef := channelName()
 	buildNumber := buildNumber()
 
 	if sha, exists := os.LookupEnv("GITHUB_SHA"); exists {
@@ -36,7 +36,7 @@ func init() {
 		log.Fatalf("Could not parse new remote installer version: %s", err)
 	}
 
-	Constants["BranchName"] = func() interface{} { return branchName }
+	Constants["ChannelName"] = func() interface{} { return channelName }
 	Constants["BuildNumber"] = func() interface{} { return buildNumber }
 	Constants["RevisionHash"] = func() interface{} { return getCmdOutput("git rev-parse --verify " + commitRef) }
 	Constants["RevisionHashShort"] = func() interface{} { return getCmdOutput("git rev-parse --short " + commitRef) }
@@ -47,9 +47,9 @@ func init() {
 	Constants["RemoteInstallerVersion"] = func() interface{} { return remoteInstallerVersion.String() }
 	Constants["Date"] = func() interface{} { return time.Now().Format(constants.DateTimeFormatRecord) }
 	Constants["UserAgent"] = func() interface{} {
-		return fmt.Sprintf("%s/%s; %s", constants.CommandName, Constants["Version"](), branchName)
+		return fmt.Sprintf("%s/%s; %s", constants.CommandName, Constants["Version"](), channelName)
 	}
-	Constants["APITokenName"] = func() interface{} { return fmt.Sprintf("%s-%s", constants.APITokenNamePrefix, branchName) }
+	Constants["APITokenName"] = func() interface{} { return fmt.Sprintf("%s-%s", constants.APITokenNamePrefix, channelName) }
 	Constants["OnCI"] = func() interface{} { return os.Getenv("CI") }
 }
 
@@ -66,10 +66,9 @@ func gitBranchName() string {
 	return branch
 }
 
-// branchName returns the release name and the branch name it is generated from
-// Usually the release name is identical to the branch name, unless environment variable
-// `BRANCH_OVERRIDE` is set
-func branchName() (string, string) {
+// channelName returns the release name and the branch name it is generated from
+// Usually the release name is identical to the branch name.
+func channelName() (string, string) {
 	branch := gitBranchName()
 	releaseName := strings.TrimPrefix(branch, "origin/")
 

--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -45,7 +45,7 @@ type ReportRuntimeUsageResponse struct {
 type StateVersion struct {
 	License  string `json:"license"`
 	Version  string `json:"version"`
-	Branch   string `json:"branch"`
+	Channel  string `json:"channel"`
 	Revision string `json:"revision"`
 	Date     string `json:"date"`
 }

--- a/internal/installation/paths.go
+++ b/internal/installation/paths.go
@@ -22,7 +22,7 @@ const (
 )
 
 type InstallMarkerMeta struct {
-	Branch  string `json:"branch"`
+	Channel  string `json:"channel"`
 	Version string `json:"version"`
 }
 
@@ -33,18 +33,18 @@ func IsStateExeDoesNotExistError(err error) bool {
 }
 
 func DefaultInstallPath() (string, error) {
-	return InstallPathForBranch(constants.BranchName)
+	return InstallPathForChannel(constants.ChannelName)
 }
 
-// InstallPathForBranch gets the installation path for the given branch.
-func InstallPathForBranch(branch string) (string, error) {
+// InstallPathForBranch gets the installation path for the given channel.
+func InstallPathForChannel(channel string) (string, error) {
 	if v := os.Getenv(constants.InstallPathOverrideEnvVarName); v != "" {
 		return filepath.Clean(v), nil
 	}
 
-	installPath, err := installPathForBranch(branch)
+	installPath, err := installPathForChannel(channel)
 	if err != nil {
-		return "", errs.Wrap(err, "Unable to determine install path for branch")
+		return "", errs.Wrap(err, "Unable to determine install path for channel")
 	}
 
 	return installPath, nil

--- a/internal/installation/paths_darwin.go
+++ b/internal/installation/paths_darwin.go
@@ -7,12 +7,12 @@ import (
 	"github.com/ActiveState/cli/internal/osutils/user"
 )
 
-func installPathForBranch(branch string) (string, error) {
+func installPathForChannel(channel string) (string, error) {
 	home, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}
-	return filepath.Join(home, ".local", "ActiveState", "StateTool", branch), nil
+	return filepath.Join(home, ".local", "ActiveState", "StateTool", channel), nil
 }
 
 func defaultSystemInstallPath() (string, error) {

--- a/internal/installation/paths_linux.go
+++ b/internal/installation/paths_linux.go
@@ -7,12 +7,12 @@ import (
 	"github.com/ActiveState/cli/internal/osutils/user"
 )
 
-func installPathForBranch(branch string) (string, error) {
+func installPathForChannel(channel string) (string, error) {
 	home, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get home directory")
 	}
-	return filepath.Join(home, ".local", "ActiveState", "StateTool", branch), nil
+	return filepath.Join(home, ".local", "ActiveState", "StateTool", channel), nil
 }
 
 func defaultSystemInstallPath() (string, error) {

--- a/internal/installation/paths_windows.go
+++ b/internal/installation/paths_windows.go
@@ -7,12 +7,12 @@ import (
 	"github.com/ActiveState/cli/internal/osutils/user"
 )
 
-func installPathForBranch(branch string) (string, error) {
+func installPathForChannel(channel string) (string, error) {
 	home, err := user.HomeDir()
 	if err != nil {
 		return "", errs.Wrap(err, "Could not determine home directory")
 	}
-	return filepath.Join(home, "AppData", "Local", "ActiveState", "StateTool", branch), nil
+	return filepath.Join(home, "AppData", "Local", "ActiveState", "StateTool", channel), nil
 }
 
 func defaultSystemInstallPath() (string, error) {

--- a/internal/installation/storage/storage.go
+++ b/internal/installation/storage/storage.go
@@ -16,7 +16,7 @@ import (
 )
 
 func AppDataPath() (string, error) {
-	configDirs := configdir.New(constants.InternalConfigNamespace, fmt.Sprintf("%s-%s", constants.LibraryName, constants.BranchName))
+	configDirs := configdir.New(constants.InternalConfigNamespace, fmt.Sprintf("%s-%s", constants.LibraryName, constants.ChannelName))
 
 	localPath, envSet := os.LookupEnv(constants.ConfigEnvVarName)
 	if envSet {
@@ -80,7 +80,7 @@ func appDataPathInTest() (string, error) {
 }
 
 func AppDataPathWithParent(parentDir string) (string, error) {
-	configDirs := configdir.New(constants.InternalConfigNamespace, fmt.Sprintf("%s-%s", constants.LibraryName, constants.BranchName))
+	configDirs := configdir.New(constants.InternalConfigNamespace, fmt.Sprintf("%s-%s", constants.LibraryName, constants.ChannelName))
 	configDirs.LocalPath = parentDir
 	dir := configDirs.QueryFolders(configdir.Local)[0].Path
 

--- a/internal/installation/versiondata.go
+++ b/internal/installation/versiondata.go
@@ -4,7 +4,7 @@ type VersionData struct {
 	Name       string `json:"name"`
 	License    string `json:"license"`
 	Version    string `json:"version"`
-	Branch     string `json:"branch"`
+	Channel    string `json:"channel"`
 	Revision   string `json:"revision"`
 	Date       string `json:"date"`
 	BuiltViaCI bool   `json:"builtViaCI"`

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -39,7 +39,7 @@ version_info:
     License [NOTICE]{{.License}}[/RESET]
     Version [NOTICE]{{.Version}}[/RESET]
     Revision [NOTICE]{{.Revision}}[/RESET]
-    Branch [NOTICE]{{.Branch}}[/RESET]
+    Channel [NOTICE]{{.Channel}}[/RESET]
     Built [NOTICE]{{.Date}}[/RESET]{{if not .BuiltViaCI}} (dev){{end}}
 err_project_file_unavailable:
   other: Could not load the project file

--- a/internal/rollbar/rollbar.go
+++ b/internal/rollbar/rollbar.go
@@ -77,7 +77,7 @@ func SetupRollbar(token string) {
 	}
 	rollbar.SetRetryAttempts(0)
 	rollbar.SetToken(token)
-	rollbar.SetEnvironment(constants.BranchName)
+	rollbar.SetEnvironment(constants.ChannelName)
 
 	rollbar.SetCodeVersion(constants.Version)
 	rollbar.SetServerRoot("github.com/ActiveState/cli")
@@ -141,8 +141,8 @@ func AddLogDataAmender(f func(string) string) {
 }
 
 func logToRollbar(critical bool, message string, args ...interface{}) {
-	// only log to rollbar when on release, beta or unstable branch and when built via CI (ie., non-local build)
-	isPublicChannel := constants.BranchName == constants.ReleaseBranch || constants.BranchName == constants.BetaBranch || constants.BranchName == constants.ExperimentalBranch
+	// only log to rollbar when on release, beta or unstable channel and when built via CI (ie., non-local build)
+	isPublicChannel := constants.ChannelName == constants.ReleaseChannel || constants.ChannelName == constants.BetaChannel || constants.ChannelName == constants.ExperimentalChannel
 	if !isPublicChannel || !condition.BuiltViaCI() || reportingDisabled {
 		return
 	}

--- a/internal/runbits/checker/checker.go
+++ b/internal/runbits/checker/checker.go
@@ -70,7 +70,7 @@ func RunUpdateNotifier(an analytics.Dispatcher, svc *model.SvcModel, out output.
 	ctx, cancel := context.WithTimeout(context.Background(), model.SvcTimeoutMinimal)
 	defer cancel()
 
-	upd, err := svc.CheckUpdate(ctx, constants.BranchName, "")
+	upd, err := svc.CheckUpdate(ctx, constants.ChannelName, "")
 	if err != nil {
 		var timeoutErr net.Error
 		if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {

--- a/internal/runners/state/state.go
+++ b/internal/runners/state/state.go
@@ -59,7 +59,7 @@ func (s *State) Run(usageFunc func() error) error {
 			"CLI",
 			constants.LibraryLicense,
 			constants.Version,
-			constants.BranchName,
+			constants.ChannelName,
 			constants.RevisionHash,
 			constants.Date,
 			constants.OnCI == "true",

--- a/internal/runners/update/lock.go
+++ b/internal/runners/update/lock.go
@@ -84,13 +84,13 @@ func (l *Lock) Run(params *LockParams) error {
 	defaultChannel, lockVersion := params.Channel.Name(), params.Channel.Version()
 	prefer := true
 	if defaultChannel == "" {
-		defaultChannel = l.project.VersionBranch()
+		defaultChannel = l.project.Channel()
 		prefer = false // may be overwritten by env var
 	}
 	channel := fetchChannel(defaultChannel, prefer)
 
 	var version string
-	if l.project.IsLocked() && channel == l.project.VersionBranch() {
+	if l.project.IsLocked() && channel == l.project.Channel() {
 		version = l.project.Version()
 	}
 

--- a/internal/runners/update/update.go
+++ b/internal/runners/update/update.go
@@ -80,10 +80,10 @@ func (u *Update) Run(params *Params) error {
 
 	// Handle switching channels
 	var installPath string
-	if channel != constants.BranchName {
-		installPath, err = installation.InstallPathForBranch(channel)
+	if channel != constants.ChannelName {
+		installPath, err = installation.InstallPathForChannel(channel)
 		if err != nil {
-			return locale.WrapError(err, "err_update_install_path", "Could not get installation path for branch {{.V0}}", channel)
+			return locale.WrapError(err, "err_update_install_path", "Could not get installation path for Channel {{.V0}}", channel)
 		}
 	}
 
@@ -101,7 +101,7 @@ func (u *Update) Run(params *Params) error {
 	}
 
 	message := ""
-	if channel != constants.BranchName {
+	if channel != constants.ChannelName {
 		message = locale.Tl("update_switch_channel", "[NOTICE]Please start a new shell for the update to take effect.[/RESET]")
 	}
 	u.out.Print(output.Prepare(
@@ -114,12 +114,12 @@ func (u *Update) Run(params *Params) error {
 
 func fetchChannel(defaultChannel string, preferDefault bool) string {
 	if defaultChannel == "" || !preferDefault {
-		if overrideBranch := os.Getenv(constants.UpdateBranchEnvVarName); overrideBranch != "" {
-			return overrideBranch
+		if overrideChannel := os.Getenv(constants.UpdateChannelEnvVarName); overrideChannel != "" {
+			return overrideChannel
 		}
 	}
 	if defaultChannel != "" {
 		return defaultChannel
 	}
-	return constants.BranchName
+	return constants.ChannelName
 }

--- a/internal/svcctl/svcctl.go
+++ b/internal/svcctl/svcctl.go
@@ -53,7 +53,7 @@ func NewIPCSockPathFromGlobals() *ipc.SockPath {
 	return &ipc.SockPath{
 		RootDir:    rootDir,
 		AppName:    constants.CommandName,
-		AppChannel: constants.BranchName,
+		AppChannel: constants.ChannelName,
 	}
 }
 

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -194,7 +194,7 @@ func new(t *testing.T, retainDirs, updatePath bool, extraEnv ...string) *Session
 		// This is a workaround as our test sessions are not compeltely
 		// sandboxed. This should be addressed in: https://activestatef.atlassian.net/browse/DX-2285
 		oldPath, _ := os.LookupEnv("PATH")
-		installPath, err := installation.InstallPathForBranch("release")
+		installPath, err := installation.InstallPathForChannel("release")
 		require.NoError(t, err)
 
 		binPath := filepath.Join(installPath, "bin")
@@ -626,7 +626,7 @@ func (s *Session) Close() error {
 	// does not appear on the PATH when a new subshell is started. This is a
 	// workaround to be addressed in: https://activestatef.atlassian.net/browse/DX-2285
 	if runtime.GOOS != "windows" {
-		installPath, err := installation.InstallPathForBranch("release")
+		installPath, err := installation.InstallPathForChannel("release")
 		if err != nil {
 			s.T.Errorf("Could not get install path: %v", errs.JoinMessage(err))
 		}

--- a/internal/testhelpers/installation/fakeversioncmd/main.go
+++ b/internal/testhelpers/installation/fakeversioncmd/main.go
@@ -15,7 +15,7 @@ var channel string // can be set through linker flag -ldflags "-X main.channel=t
 
 func main() {
 	if channel == "" {
-		channel = constants.BranchName
+		channel = constants.ChannelName
 	}
-	fmt.Printf(`{"version": "%s", "branch": "%s"}`, version, channel)
+	fmt.Printf(`{"version": "%s", "channel": "%s"}`, version, channel)
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -44,7 +44,7 @@ type Origin struct {
 
 func NewOriginDefault() *Origin {
 	return &Origin{
-		Channel: constants.BranchName,
+		Channel: constants.ChannelName,
 		Version: constants.Version,
 	}
 }

--- a/pkg/platform/api/svc/request/version.go
+++ b/pkg/platform/api/svc/request/version.go
@@ -13,7 +13,7 @@ func (v *VersionRequest) Query() string {
             state {
                 license,
                 version,
-                branch,
+                channel,
                 revision,
                 date,
             }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -238,8 +238,8 @@ func (p *Project) NormalizedName() string {
 // Version returns the locked state tool version
 func (p *Project) Version() string { return p.projectfile.Version() }
 
-// VersionBranch returns branch that we're pinned to (useless unless version is also set)
-func (p *Project) VersionBranch() string { return p.projectfile.VersionBranch() }
+// Channel returns channel that we're pinned to (useless unless version is also set)
+func (p *Project) Channel() string { return p.projectfile.Channel() }
 
 // IsLocked returns whether the current project is locked
 func (p *Project) IsLocked() bool { return p.Lock() != "" }

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -75,10 +75,10 @@ var projectMapMutex = &sync.Mutex{}
 
 const LocalProjectsConfigKey = "projects"
 
-// VersionInfo is used in cases where we only care about parsing the version field. In all other cases the version is parsed via
-// the Project struct
+// VersionInfo is used in cases where we only care about parsing the version and channel fields.
+// In all other cases the version is parsed via the Project struct
 type VersionInfo struct {
-	Branch  string
+	Channel string `yaml:"branch"` // branch for backward compatibility
 	Version string
 	Lock    string `yaml:"lock"`
 }
@@ -102,7 +102,7 @@ type Project struct {
 	Cache         string        `yaml:"cache,omitempty"`
 	path          string        // "private"
 	parsedURL     projectURL    // parsed url data
-	parsedBranch  string
+	parsedChannel string
 	parsedVersion string
 }
 
@@ -478,7 +478,7 @@ func (p *Project) Init() error {
 			return errs.Wrap(err, "ParseLock %s failed", p.Lock)
 		}
 
-		p.parsedBranch = parsedLock.Branch
+		p.parsedChannel = parsedLock.Channel
 		p.parsedVersion = parsedLock.Version
 	}
 
@@ -592,12 +592,12 @@ func (p *Project) SetPath(path string) {
 	p.path = path
 }
 
-// VersionBranch returns the branch as it was interpreted from the lock
-func (p *Project) VersionBranch() string {
-	return p.parsedBranch
+// Channel returns the channel as it was interpreted from the lock
+func (p *Project) Channel() string {
+	return p.parsedChannel
 }
 
-// Version returns the branch as it was interpreted from the lock
+// Version returns the version as it was interpreted from the lock
 func (p *Project) Version() string {
 	return p.parsedVersion
 }
@@ -1133,7 +1133,7 @@ func ParseLock(lock string) (*VersionInfo, error) {
 	}
 
 	return &VersionInfo{
-		Branch:  split[0],
+		Channel: split[0],
 		Version: split[1],
 		Lock:    lock,
 	}, nil

--- a/scripts/ci/deploy-generator/remote-installer/main.go
+++ b/scripts/ci/deploy-generator/remote-installer/main.go
@@ -30,8 +30,8 @@ func run() error {
 	}
 	platform := goos + "-" + goarch
 
-	relPath := filepath.Join("remote-installer", constants.BranchName, platform)
-	relVersionedPath := filepath.Join("remote-installer", constants.BranchName, version, platform)
+	relPath := filepath.Join("remote-installer", constants.ChannelName, platform)
+	relVersionedPath := filepath.Join("remote-installer", constants.ChannelName, version, platform)
 
 	buildPath := filepath.Join(environment.GetRootPathUnsafe(), "build")
 

--- a/scripts/ci/payload-generator/main.go
+++ b/scripts/ci/payload-generator/main.go
@@ -43,18 +43,18 @@ func run() error {
 		inDir   = defaultInputDir
 		outDir  = defaultOutputDir
 		binDir  = defaultOutputBinDir
-		branch  = constants.BranchName
+		channel = constants.ChannelName
 		version = constants.Version
 	)
 
-	flag.StringVar(&branch, "b", branch, "Override target branch. (Branch to receive update.)")
+	flag.StringVar(&channel, "b", channel, "Override target channel. (Channel to receive update.)")
 	flag.StringVar(&version, "v", version, "Override version number for this update.")
 	flag.Parse()
 
-	return generatePayload(inDir, outDir, binDir, branch, version)
+	return generatePayload(inDir, outDir, binDir, channel, version)
 }
 
-func generatePayload(inDir, outDir, binDir, branch, version string) error {
+func generatePayload(inDir, outDir, binDir, channel, version string) error {
 	emsg := "generate payload: %w"
 
 	if err := fileutils.MkdirUnlessExists(binDir); err != nil {
@@ -62,7 +62,7 @@ func generatePayload(inDir, outDir, binDir, branch, version string) error {
 	}
 
 	log("Creating install dir marker in %s", outDir)
-	if err := createInstallMarker(outDir, branch, version); err != nil {
+	if err := createInstallMarker(outDir, channel, version); err != nil {
 		return fmt.Errorf(emsg, err)
 	}
 
@@ -79,11 +79,11 @@ func generatePayload(inDir, outDir, binDir, branch, version string) error {
 	return nil
 }
 
-func createInstallMarker(dir, branch, version string) error {
+func createInstallMarker(dir, channel, version string) error {
 	emsg := "create install marker: %w"
 
 	markerContents := installation.InstallMarkerMeta{
-		Branch:  branch,
+		Channel: channel,
 		Version: version,
 	}
 	b, err := json.Marshal(markerContents)

--- a/scripts/ci/update-generator/main.go
+++ b/scripts/ci/update-generator/main.go
@@ -133,7 +133,7 @@ func run() error {
 		inDir         = defaultInputDir
 		outDir        = defaultOutputDir
 		platform      = fetchPlatform()
-		branch        = constants.BranchName
+		channel       = constants.ChannelName
 		version       = constants.Version
 		versionNumber = constants.VersionNumber
 	)
@@ -143,7 +143,7 @@ func run() error {
 		&platform, "platform", platform,
 		"Target platform in the form OS-ARCH. Defaults to running os/arch or the combination of the environment variables GOOS and GOARCH if both are set.",
 	)
-	flag.StringVar(&branch, "b", branch, "Override target branch. (Branch to receive update.)")
+	flag.StringVar(&channel, "b", channel, "Override target channel. (Channel to receive update.)")
 	flag.StringVar(&version, "v", version, "Override version number for this update.")
 	flag.Parse()
 
@@ -151,11 +151,11 @@ func run() error {
 		return err
 	}
 
-	if err := createUpdate(outDir, branch, version, versionNumber, platform, inDir); err != nil {
+	if err := createUpdate(outDir, channel, version, versionNumber, platform, inDir); err != nil {
 		return err
 	}
 
-	if err := createInstaller(binDir, outDir, branch, platform); err != nil {
+	if err := createInstaller(binDir, outDir, channel, platform); err != nil {
 		return err
 	}
 

--- a/scripts/ci/update-version-list/main.go
+++ b/scripts/ci/update-version-list/main.go
@@ -23,7 +23,7 @@ const S3Bucket = "update/state/"
 const VersionsJson = "versions.json"
 
 // Valid channels to update the master version file with.
-var ValidChannels = []string{constants.BetaBranch, constants.ReleaseBranch}
+var ValidChannels = []string{constants.BetaChannel, constants.ReleaseChannel}
 
 func init() {
 	if !condition.OnCI() {

--- a/scripts/internal/workflow-helpers/github.go
+++ b/scripts/internal/workflow-helpers/github.go
@@ -338,7 +338,7 @@ func GetCommitsBehind(client *github.Client, base, head string) ([]*github.Repos
 		}
 		suffix := strings.TrimPrefix(msgWords[len(msgWords)-1], "ActiveState/")
 		if (strings.HasPrefix(msg, "Merge pull request") && IsVersionBranch(suffix)) ||
-			(strings.HasPrefix(msg, "Merge branch '"+constants.BetaBranch+"'") && IsVersionBranch(suffix)) {
+			(strings.HasPrefix(msg, "Merge branch '"+constants.BetaChannel+"'") && IsVersionBranch(suffix)) {
 			// Git's compare commits is not smart enough to consider merge commits from other version branches equal
 			// This matches the following types of messages:
 			// Merge pull request #2531 from ActiveState/version/0-38-1-RC1

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -434,7 +434,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_Subdir() {
 project: "https://platform.activestate.com/ActiveState-CLI/Python3"
 branch: %s
 version: %s
-`, constants.BranchName, constants.Version))
+`, constants.ChannelName, constants.Version))
 
 	ts.PrepareActiveStateYAML(content)
 	ts.PrepareCommitIdFile("59404293-e5a9-4fd0-8843-77cd4761b5b5")

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -39,9 +39,9 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 	}{
 		// {"install-release-latest", "", "release", "", ""},
 		{"install-prbranch", "", "", "", ""},
-		{"install-prbranch-with-version", constants.Version, constants.BranchName, "", ""},
-		{"install-prbranch-and-activate", "", constants.BranchName, "ActiveState-CLI/small-python", ""},
-		{"install-prbranch-and-activate-by-command", "", constants.BranchName, "", "ActiveState-CLI/small-python"},
+		{"install-prbranch-with-version", constants.Version, constants.ChannelName, "", ""},
+		{"install-prbranch-and-activate", "", constants.ChannelName, "ActiveState-CLI/small-python", ""},
+		{"install-prbranch-and-activate-by-command", "", constants.ChannelName, "", "ActiveState-CLI/small-python"},
 	}
 
 	for _, tt := range tests {
@@ -57,7 +57,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 			} else {
 				scriptBaseName += "ps1"
 			}
-			scriptUrl := baseUrl + constants.BranchName + "/" + scriptBaseName
+			scriptUrl := baseUrl + constants.ChannelName + "/" + scriptBaseName
 
 			// Fetch it.
 			b, err := httputil.GetDirect(scriptUrl)
@@ -119,7 +119,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 			// We get the default install path and use that to directly invoke
 			// the state tool. This is to avoid inadvertently using the state
 			// tool that is already on the PATH.
-			installPath, err := installation.InstallPathForBranch(constants.BranchName)
+			installPath, err := installation.InstallPathForChannel(constants.ChannelName)
 			suite.NoError(err)
 
 			binPath := filepath.Join(installPath, "bin")
@@ -132,7 +132,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 			cp.Expect(installPath)
 			cp.SendLine("state --version")
 			cp.Expect("Version " + constants.Version)
-			cp.Expect("Branch " + constants.BranchName)
+			cp.Expect("Channel " + constants.ChannelName)
 			cp.Expect("Built")
 			cp.SendLine("exit")
 
@@ -170,7 +170,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall_NonEmptyTarget() {
 
 	script := scriptPath(suite.T(), ts.Dirs.Work)
 	argsPlain := []string{script, "-t", ts.Dirs.Work}
-	argsPlain = append(argsPlain, "-b", constants.BranchName)
+	argsPlain = append(argsPlain, "-b", constants.ChannelName)
 	var cp *e2e.SpawnedCmd
 	if runtime.GOOS != "windows" {
 		cp = ts.SpawnCmdWithOpts("bash", e2e.OptArgs(argsPlain...))
@@ -247,10 +247,10 @@ func listFilesOnly(dir string) []string {
 	return funk.Map(files, filepath.Base).([]string)
 }
 
-func (suite *InstallScriptsIntegrationTestSuite) assertCorrectVersion(ts *e2e.Session, installDir, expectedVersion, expectedBranch string) {
+func (suite *InstallScriptsIntegrationTestSuite) assertCorrectVersion(ts *e2e.Session, installDir, expectedVersion, expectedChannel string) {
 	type versionData struct {
 		Version string `json:"version"`
-		Branch  string `json:"branch"`
+		Channel string `json:"channel"`
 	}
 
 	stateExec, err := installation.StateExecFromDir(installDir)
@@ -265,8 +265,8 @@ func (suite *InstallScriptsIntegrationTestSuite) assertCorrectVersion(ts *e2e.Se
 	if expectedVersion != "" {
 		suite.Equal(expectedVersion, actual.Version)
 	}
-	if expectedBranch != "" {
-		suite.Equal(expectedBranch, actual.Branch)
+	if expectedChannel != "" {
+		suite.Equal(expectedChannel, actual.Channel)
 	}
 }
 

--- a/test/integration/performance_svc_int_test.go
+++ b/test/integration/performance_svc_int_test.go
@@ -89,7 +89,7 @@ func (suite *PerformanceIntegrationTestSuite) TestSvcPerformance() {
 
 	suite.Run("Query Update", func() {
 		t := time.Now()
-		_, err := svcmodel.CheckUpdate(context.Background(), constants.BranchName, "")
+		_, err := svcmodel.CheckUpdate(context.Background(), constants.ChannelName, "")
 		suite.Require().NoError(err, ts.DebugMessage(fmt.Sprintf("Error: %s\nLog Tail:\n%s", errs.JoinMessage(err), logging.ReadTail())))
 		duration := time.Since(t)
 

--- a/test/integration/remote_installer_int_test.go
+++ b/test/integration/remote_installer_int_test.go
@@ -31,10 +31,10 @@ func (suite *RemoteInstallIntegrationTestSuite) TestInstall() {
 		Channel string
 	}{
 		// Disabled until the target installers support the installpath override env var: DX-1350
-		// {"install-release-latest", "", constants.ReleaseBranch},
+		// {"install-release-latest", "", constants.ReleaseChannel},
 		// {"install-prbranch", "", ""},
-		// {"install-prbranch-with-version", constants.Version, constants.BranchName},
-		{"install-prbranch-and-branch", "", constants.BranchName},
+		// {"install-prbranch-with-version", constants.Version, constants.ChannelName},
+		{"install-prbranch-and-channel", "", constants.ChannelName},
 	}
 
 	for _, tt := range tests {
@@ -84,7 +84,7 @@ func (suite *RemoteInstallIntegrationTestSuite) TestInstall() {
 				cp.Expect("Version " + tt.Version)
 			}
 			if tt.Channel != "" {
-				cp.Expect("Branch " + tt.Channel)
+				cp.Expect("Channel " + tt.Channel)
 			}
 			cp.Expect("Built")
 			cp.ExpectExitCode(0)

--- a/test/integration/uninstall_int_test.go
+++ b/test/integration/uninstall_int_test.go
@@ -35,7 +35,7 @@ func (suite *UninstallIntegrationTestSuite) install(ts *e2e.Session) string {
 	} else {
 		scriptBaseName += "ps1"
 	}
-	scriptUrl := baseUrl + constants.BranchName + "/" + scriptBaseName
+	scriptUrl := baseUrl + constants.ChannelName + "/" + scriptBaseName
 
 	// Fetch it.
 	b, err := httputil.GetDirect(scriptUrl)

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -32,15 +32,15 @@ type UpdateIntegrationTestSuite struct {
 type matcherFunc func(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool
 
 // Todo https://www.pivotaltracker.com/story/show/177863116
-// Update to release branch when possible
+// Update to release channel when possible
 var (
-	targetBranch     = "beta"
+	targetChannel    = "beta"
 	oldUpdateVersion = "beta@0.32.2-SHA3e1d435"
 )
 
 func init() {
-	if constants.BranchName == targetBranch {
-		targetBranch = "master"
+	if constants.ChannelName == targetChannel {
+		targetChannel = "master"
 	}
 }
 
@@ -82,19 +82,19 @@ func (suite *UpdateIntegrationTestSuite) versionCompare(ts *e2e.Session, expecte
 	matcher(expected, version.Version, fmt.Sprintf("Version could not be matched, output:\n\n%s", out))
 }
 
-func (suite *UpdateIntegrationTestSuite) branchCompare(ts *e2e.Session, expected string, matcher matcherFunc) {
-	type branchData struct {
-		Branch string `json:"branch"`
+func (suite *UpdateIntegrationTestSuite) channelCompare(ts *e2e.Session, expected string, matcher matcherFunc) {
+	type channelData struct {
+		Channel string `json:"channel"`
 	}
 
 	cp := ts.SpawnWithOpts(e2e.OptArgs("--version", "--output=json"), e2e.OptAppendEnv(suite.env(true, false)...))
 	cp.ExpectExitCode(0, termtest.OptExpectTimeout(30*time.Second))
 
-	branch := branchData{}
+	channel := channelData{}
 	out := cp.StrippedSnapshot()
-	json.Unmarshal([]byte(out), &branch)
+	json.Unmarshal([]byte(out), &channel)
 
-	matcher(expected, branch.Branch, fmt.Sprintf("Branch could not be matched, output:\n\n%s", out))
+	matcher(expected, channel.Channel, fmt.Sprintf("Channel could not be matched, output:\n\n%s", out))
 }
 
 func (suite *UpdateIntegrationTestSuite) TestUpdateAvailable() {
@@ -220,12 +220,12 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateChannel() {
 		Channel string
 	}{
 		{"release-channel", "release"},
-		{"specific-update", targetBranch},
+		{"specific-update", targetChannel},
 	}
 
 	for _, tt := range tests {
 		suite.Run(tt.Name, func() {
-			// TODO: Update targetBranch and specificVersion after a v0.34.0 release
+			// TODO: Update targetChannel and specificVersion after a v0.34.0 release
 			suite.T().Skip("Skipping these tests for now as the update changes need to be available in an older version of the state tool.")
 			ts := e2e.New(suite.T(), false)
 			defer ts.Close()
@@ -240,7 +240,7 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateChannel() {
 			cp.Expect("Updating")
 			cp.ExpectExitCode(0, termtest.OptExpectTimeout(1*time.Minute))
 
-			suite.branchCompare(ts, tt.Channel, suite.Equal)
+			suite.channelCompare(ts, tt.Channel, suite.Equal)
 		})
 	}
 }
@@ -361,7 +361,7 @@ func (suite *UpdateIntegrationTestSuite) TestAutoUpdateToCurrent() {
 
 	suite.installLatestReleaseVersion(ts, installDir)
 
-	suite.testAutoUpdate(ts, installDir, e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.UpdateBranchEnvVarName, constants.BranchName)))
+	suite.testAutoUpdate(ts, installDir, e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.UpdateChannelEnvVarName, constants.ChannelName)))
 }
 
 func (suite *UpdateIntegrationTestSuite) TestUpdateToCurrent() {
@@ -379,5 +379,5 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateToCurrent() {
 
 	suite.installLatestReleaseVersion(ts, installDir)
 
-	suite.testUpdate(ts, installDir, e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.UpdateBranchEnvVarName, constants.BranchName)))
+	suite.testUpdate(ts, installDir, e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.UpdateChannelEnvVarName, constants.ChannelName)))
 }

--- a/test/integration/update_lock_int_test.go
+++ b/test/integration/update_lock_int_test.go
@@ -45,7 +45,7 @@ func (suite *UpdateIntegrationTestSuite) TestLocked() {
 func (suite *UpdateIntegrationTestSuite) TestLockedChannel() {
 	suite.OnlyRunForTags(tagsuite.Update)
 	targetBranch := "release"
-	if constants.BranchName == "release" {
+	if constants.ChannelName == "release" {
 		targetBranch = "master"
 	}
 	tests := []struct {
@@ -132,7 +132,7 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateLockedConfirmation() {
 			suite.OnlyRunForTags(tagsuite.Update)
 			pjfile := projectfile.Project{
 				Project: lockedProjectURL(),
-				Lock:    fmt.Sprintf("%s@%s", constants.BranchName, constants.Version),
+				Lock:    fmt.Sprintf("%s@%s", constants.ChannelName, constants.Version),
 			}
 
 			ts := e2e.New(suite.T(), false)

--- a/test/integration/upgen_int_test.go
+++ b/test/integration/upgen_int_test.go
@@ -35,7 +35,7 @@ func (suite *UpdateGenIntegrationTestSuite) TestUpdateBits() {
 	}
 	platform := runtime.GOOS + "-" + hostArch
 
-	archivePath := filepath.Join(root, "build/update", constants.BranchName, constants.VersionNumber, platform, fmt.Sprintf("state-%s-%s%s", platform, constants.Version, ext))
+	archivePath := filepath.Join(root, "build/update", constants.ChannelName, constants.VersionNumber, platform, fmt.Sprintf("state-%s-%s%s", platform, constants.Version, ext))
 	suite.Require().FileExists(archivePath, "Make sure you ran 'state run generate-update'")
 	suite.T().Logf("file %s exists\n", archivePath)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-207" title="DX-207" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-207</a>  State tool consistent terminology (Branch VS Channel)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This tends to cause confusion because Platform projects have branches.