### PR TITLE
Re-enable Ruby tests on Windows.

### DIFF
--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -594,10 +594,8 @@ func (suite *PackageIntegrationTestSuite) TestUpdate() {
 }
 
 func (suite *PackageIntegrationTestSuite) TestRuby() {
-	// TODO: Re-enable this test when Ruby is supported on the Platform
-	// https://activestatef.atlassian.net/browse/DX-2384
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		return // Ruby support is not yet enabled on the Platform
+	if runtime.GOOS == "darwin" {
+		return // Ruby support for macOS is not yet enabled on the Platform
 	}
 	suite.OnlyRunForTags(tagsuite.Package)
 	ts := e2e.New(suite.T(), false)

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -265,10 +265,8 @@ func (suite *ShellIntegrationTestSuite) SetupRCFile(ts *e2e.Session) {
 }
 
 func (suite *ShellIntegrationTestSuite) TestRuby() {
-	// TODO: Re-enable this test when Ruby is supported on the Platform
-	// https://activestatef.atlassian.net/browse/DX-2384
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		return // Ruby support is not yet enabled on the Platform
+	if runtime.GOOS == "darwin" {
+		return // Ruby support for macOS is not yet enabled on the Platform
 	}
 	suite.OnlyRunForTags(tagsuite.Shell)
 	ts := e2e.New(suite.T(), false)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2384" title="DX-2384" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2384</a>  Re-enable Ruby integration tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Ruby is still not supported on macOS yet.