### PR TITLE
Make identifier distinct in error message.

### DIFF
--- a/internal/runners/swtch/switch.go
+++ b/internal/runners/swtch/switch.go
@@ -92,7 +92,7 @@ func (s *Switch) Run(params SwitchParams) error {
 
 	identifier, err := resolveIdentifier(project, params.Identifier)
 	if err != nil {
-		return locale.WrapError(err, "err_resolve_identifier", "Could not resolve identifier: {{.V0}}", params.Identifier)
+		return locale.WrapError(err, "err_resolve_identifier", "Could not resolve identifier '{{.V0}}'", params.Identifier)
 	}
 
 	if id, ok := identifier.(branchIdentifier); ok {

--- a/internal/runners/swtch/switch.go
+++ b/internal/runners/swtch/switch.go
@@ -92,7 +92,7 @@ func (s *Switch) Run(params SwitchParams) error {
 
 	identifier, err := resolveIdentifier(project, params.Identifier)
 	if err != nil {
-		return locale.WrapError(err, "err_resolve_identifier", "Could not resolve identifier {{.V0}}", params.Identifier)
+		return locale.WrapError(err, "err_resolve_identifier", "Could not resolve identifier: {{.V0}}", params.Identifier)
 	}
 
 	if id, ok := identifier.(branchIdentifier); ok {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2381" title="DX-2381" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2381</a>  SWITCH: Error messages during `state switch` to non-existent branch/commit not consistent with emphasized by a quote of the parameter's names.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I chose a `:` over quotes because our error messages tend to prefer this over strings that end in quotes in Go (e.g. an apostrophe and then a double-quote).