### PR TITLE
Delete failed checkouts due to libc errors.

### DIFF
--- a/internal/runners/checkout/checkout.go
+++ b/internal/runners/checkout/checkout.go
@@ -88,11 +88,6 @@ func (u *Checkout) Run(params *Params) (rerr error) {
 		return locale.WrapError(err, "err_project_frompath")
 	}
 
-	err = setLibcVersion(params.LibcVersion)
-	if err != nil {
-		return locale.WrapError(err, "Failed to set libc version")
-	}
-
 	// If an error occurs, remove the created activestate.yaml file and/or directory.
 	if !params.Force {
 		defer func() {
@@ -113,6 +108,11 @@ func (u *Checkout) Run(params *Params) (rerr error) {
 				}
 			}
 		}()
+	}
+
+	err = setLibcVersion(params.LibcVersion)
+	if err != nil {
+		return locale.WrapError(err, "Failed to set libc version")
 	}
 
 	rti, err := runtime.NewFromProject(proj, target.TriggerCheckout, u.analytics, u.svcModel, u.out, u.auth)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2386" title="DX-2386" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2386</a>  CHECKOUT: In case `--runtime-env-libc-version` flag used and fail it still create a folder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
