### PR TITLE
Quote missing branch label.

### DIFF
--- a/pkg/platform/model/projects.go
+++ b/pkg/platform/model/projects.go
@@ -165,7 +165,7 @@ func BranchForProjectByName(pj *mono_models.Project, name string) (*mono_models.
 
 	return nil, locale.NewInputError(
 		"err_no_matching_branch_label",
-		"This project has no branch with label matching [NOTICE]{{.V0}}[/RESET].",
+		"This project has no branch with label matching '[NOTICE]{{.V0}}[/RESET]'.",
 		name,
 	)
 }

--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -163,7 +163,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutWithFlags() {
 	// Test --branch mismatch in non-checked-out project.
 	branchPath := filepath.Join(ts.Dirs.Base, "branch")
 	cp = ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/Python-3.9", branchPath, "--branch", "doesNotExist"))
-	cp.Expect("This project has no branch with label matching doesNotExist")
+	cp.Expect("This project has no branch with label matching 'doesNotExist'")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2381" title="DX-2381" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2381</a>  SWITCH: Error messages during `state switch` to non-existent branch/commit not consistent with emphasized by a quote of the parameter's names.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

🤦 