### PR TITLE
Uninstalling in an activated state is an input error.

### DIFF
--- a/internal/runners/clean/uninstall.go
+++ b/internal/runners/clean/uninstall.go
@@ -60,7 +60,7 @@ func newUninstall(out output.Outputer, prompt promptable, cfg *config.Instance, 
 
 func (u *Uninstall) Run(params *UninstallParams) error {
 	if os.Getenv(constants.ActivatedStateEnvVarName) != "" {
-		return locale.NewError("err_uninstall_activated")
+		return locale.NewInputError("err_uninstall_activated")
 	}
 
 	err := verifyInstallation()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2421" title="DX-2421" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2421</a>  Rollbar: clean uninstall []: Returning error: execute failed: Cannot uninstall the State Tool while in an activated state. Please deactivate by entering [ACTIONABLE]exit[/RESET] or pressing [ACTIONABLE]Ctrl+D[/RESET] and then try again.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Do not log it to Rollbar.