### PR TITLE
The CI environment sandbox needs to pass through `ACTIVESTATE_CI`.

### DIFF
--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -20,6 +20,9 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 		basePath = os.Getenv("PATH")
 		env = append(env, os.Environ()...)
 	}
+	if value := os.Getenv(constants.ActiveStateCIEnvVarName); value != "" {
+		env = append(env, fmt.Sprintf("%s=%s", constants.ActiveStateCIEnvVarName, value))
+	}
 
 	env = append(env, []string{
 		constants.ConfigEnvVarName + "=" + dirs.Config,


### PR DESCRIPTION
Otherwise analytics will be skewed.