### PR TITLE
The CI environment sandbox needs to pass through `ACTIVESTATE_CI`.

### DIFF
--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -20,6 +20,9 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 		basePath = os.Getenv("PATH")
 		env = append(env, os.Environ()...)
 	}
+	if value := os.Getenv(constants.ActiveStateCIEnvVarName); value != "" {
+		env = append(env, fmt.Sprintf("%s=%s", constants.ActiveStateCIEnvVarName, value))
+	}
 
 	env = append(env, []string{
 		constants.ConfigEnvVarName + "=" + dirs.Config,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2426" title="DX-2426" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2426</a>  Nightly failure: TestAnalyticsIntegrationTestSuite/TestCIAndInteractiveDimensions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Otherwise analytics will be skewed.