### PR TITLE
Drop version requirement for `state publish --edit`.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1491,10 +1491,6 @@ err_searchingredient_toomany:
   other: Too many ingredients match the query '[ACTIONABLE]{{.V0}}[/RESET]', please try to be more specific.
 alternative_unknown_pkg_name:
   other: unknown
-err_uploadingredient_edit_version_required:
-  other: When editing you must always provide a new version number.
-err_uploadingredient_edit_version_different:
-  other: You did not provide a unique version number. Make sure the version number you provided has not been used before.
 err_uploadingredient_edit_description_not_supported:
   other: Editing an ingredient description is not yet supported.
 uploadingredient_editor_opening:

--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -158,18 +158,6 @@ func (r *Runner) Run(params *Params) error {
 
 	// Validate user input
 	if params.Edit {
-		// Validate that the version input is valid
-		// https://activestatef.atlassian.net/browse/DX-1885
-		if reqVars.Version == "" {
-			return locale.NewInputError("err_uploadingredient_edit_version_required")
-		} else {
-			for _, v := range ingredient.Versions {
-				if reqVars.Version == v.Version {
-					return locale.NewInputError("err_uploadingredient_edit_version_different")
-				}
-			}
-		}
-
 		// Description is not currently supported for edit
 		// https://activestatef.atlassian.net/browse/DX-1886
 		if reqVars.Description != ptr.From(ingredient.Ingredient.Description, "") {

--- a/test/integration/publish_int_test.go
+++ b/test/integration/publish_int_test.go
@@ -292,26 +292,6 @@ authors:
 						0,
 					},
 				},
-				{ // Must supply version
-					input{
-						[]string{
-							"--edit",
-							"--name", "editable",
-							"--description", "foo",
-						},
-						nil,
-						nil,
-						false,
-					},
-					expect{
-						[]string{
-							`You did not provide a unique version number`,
-						},
-						"",
-						true,
-						1,
-					},
-				},
 				{ // description editing not supported
 					input{
 						[]string{
@@ -325,7 +305,7 @@ authors:
 					},
 					expect{
 						[]string{
-							`You did not provide a unique version number`,
+							`Editing an ingredient description is not yet supported`,
 						},
 						"",
 						true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2403" title="DX-2403" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2403</a>  Drop the --version requirement for making edits with `state publish`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
