### PR TITLE
Fix failing integration tests

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -192,6 +192,9 @@ const SvcAuthPollingRateEnvVarName = "ACTIVESTATE_SVC_AUTH_POLLING_RATE"
 // log rotation timer interval (1 minute).
 const SvcLogRotateIntervalEnvVarName = "ACTIVESTATE_CLI_LOG_ROTATE_INTERVAL_MS"
 
+// DisableActivateEventsEnvVarName is the environment variable used to disable events when activating or checking out a project
+const DisableActivateEventsEnvVarName = "ACTIVESTATE_CLI_DISABLE_ACTIVATE_EVENTS"
+
 // APIUpdateInfoURL is the URL for our update info server
 const APIUpdateInfoURL = "https://platform.activestate.com/sv/state-update/api/v1"
 

--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -37,6 +37,7 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 		constants.ServiceSockDir + "=" + dirs.SockRoot,
 		constants.HomeEnvVarName + "=" + dirs.HomeDir,
 		systemHomeEnvVarName + "=" + dirs.HomeDir,
+		constants.DisableActivateEventsEnvVarName + "=true",
 		"NO_COLOR=true",
 		"CI=true",
 	}...)

--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -20,7 +20,6 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 		basePath = os.Getenv("PATH")
 		env = append(env, os.Environ()...)
 	}
-
 	if value := os.Getenv(constants.ActiveStateCIEnvVarName); value != "" {
 		env = append(env, fmt.Sprintf("%s=%s", constants.ActiveStateCIEnvVarName, value))
 	}

--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -20,6 +20,7 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 		basePath = os.Getenv("PATH")
 		env = append(env, os.Environ()...)
 	}
+
 	if value := os.Getenv(constants.ActiveStateCIEnvVarName); value != "" {
 		env = append(env, fmt.Sprintf("%s=%s", constants.ActiveStateCIEnvVarName, value))
 	}

--- a/pkg/project/events.go
+++ b/pkg/project/events.go
@@ -1,5 +1,12 @@
 package project
 
+import (
+	"os"
+	"strings"
+
+	"github.com/ActiveState/cli/internal/constants"
+)
+
 type EventType string
 
 const (
@@ -14,6 +21,10 @@ func (e EventType) String() string {
 }
 
 func ActivateEvents() []EventType {
+	if strings.EqualFold(os.Getenv(constants.DisableActivateEventsEnvVarName), "true") {
+		return []EventType{}
+	}
+
 	return []EventType{
 		Activate,
 		FirstActivate,

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -644,9 +644,9 @@ func (suite *ActivateIntegrationTestSuite) TestActivateBranch() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace, "--branch", "firstbranch"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 }

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -644,9 +644,9 @@ func (suite *ActivateIntegrationTestSuite) TestActivateBranch() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace, "--branch", "firstbranch"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Activated")
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 }

--- a/test/integration/install_scripts_int_test.go
+++ b/test/integration/install_scripts_int_test.go
@@ -99,6 +99,7 @@ func (suite *InstallScriptsIntegrationTestSuite) TestInstall() {
 				e2e.OptAppendEnv(constants.DisableRuntime + "=false"),
 				e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.AppInstallDirOverrideEnvVarName, appInstallDir)),
 				e2e.OptAppendEnv(fmt.Sprintf("%s=FOO", constants.OverrideSessionTokenEnvVarName)),
+				e2e.OptAppendEnv(fmt.Sprintf("%s=false", constants.DisableActivateEventsEnvVarName)),
 			}
 			if runtime.GOOS == "windows" {
 				cmd = "powershell.exe"

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -232,9 +232,11 @@ func (suite *RunIntegrationTestSuite) TestRun_Unauthenticated() {
 
 	suite.createProjectFile(ts, 2)
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("activate"))
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Activated")
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("activate"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
 
 	cp.SendLine(fmt.Sprintf("%s run testMultipleLanguages", cp.Executable()))

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -236,7 +236,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Unauthenticated() {
 		e2e.OptArgs("activate"),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
 
 	cp.SendLine(fmt.Sprintf("%s run testMultipleLanguages", cp.Executable()))

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -232,11 +232,9 @@ func (suite *RunIntegrationTestSuite) TestRun_Unauthenticated() {
 
 	suite.createProjectFile(ts, 2)
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp := ts.SpawnWithOpts(e2e.OptArgs("activate"))
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Activated")
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
 
 	cp.SendLine(fmt.Sprintf("%s run testMultipleLanguages", cp.Executable()))

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -232,8 +232,10 @@ func (suite *RunIntegrationTestSuite) TestRun_Unauthenticated() {
 
 	suite.createProjectFile(ts, 2)
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("activate"))
-	cp.Expect("Skipping runtime setup")
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("activate"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
 	cp.Expect("Activated")
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
 

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -32,16 +32,18 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Checked out project")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	args := []string{"small-python", "ActiveState-CLI/small-python"}
 	for _, arg := range args {
 		cp := ts.SpawnWithOpts(
 			e2e.OptArgs("shell", arg),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
-		cp.Expect("Activated")
+		cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectInput()
 
 		cp.SendLine("python3 --version")

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -32,18 +32,16 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
 	args := []string{"small-python", "ActiveState-CLI/small-python"}
 	for _, arg := range args {
 		cp := ts.SpawnWithOpts(
 			e2e.OptArgs("shell", arg),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
-		cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+		cp.Expect("Activated")
 		cp.ExpectInput()
 
 		cp.SendLine("python3 --version")
@@ -84,11 +82,9 @@ func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
 	defer ts.Close()
 
 	// Checkout.
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
+	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/small-python"))
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
 	// Use.
@@ -101,9 +97,8 @@ func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -117,19 +112,17 @@ func (suite *ShellIntegrationTestSuite) TestCwdShell() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptWD(filepath.Join(ts.Dirs.Work, "small-python")),
 	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -143,9 +136,8 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -156,10 +148,9 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptWD(subdir),
 	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 	cp.ExpectInput()
 	if runtime.GOOS != "windows" {
 		cp.SendLine("pwd")
@@ -171,10 +162,9 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell", "ActiveState-CLI/small-python", "--cd"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptWD(subdir),
 	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 	cp.ExpectInput()
 	if runtime.GOOS != "windows" {
 		cp.SendLine("ls")

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -32,16 +32,18 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Checked out project")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	args := []string{"small-python", "ActiveState-CLI/small-python"}
 	for _, arg := range args {
 		cp := ts.SpawnWithOpts(
 			e2e.OptArgs("shell", arg),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
-		cp.Expect("Activated")
+		cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectInput()
 
 		cp.SendLine("python3 --version")
@@ -82,9 +84,11 @@ func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
 	defer ts.Close()
 
 	// Checkout.
-	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/small-python"))
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	// Use.
@@ -97,8 +101,9 @@ func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -112,17 +117,19 @@ func (suite *ShellIntegrationTestSuite) TestCwdShell() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/small-python"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptWD(filepath.Join(ts.Dirs.Work, "small-python")),
 	)
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -136,8 +143,9 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/small-python"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -148,9 +156,10 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell", "ActiveState-CLI/small-python"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptWD(subdir),
 	)
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	if runtime.GOOS != "windows" {
 		cp.SendLine("pwd")
@@ -162,9 +171,10 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell", "ActiveState-CLI/small-python", "--cd"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptWD(subdir),
 	)
-	cp.Expect("Activated")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	if runtime.GOOS != "windows" {
 		cp.SendLine("ls")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2432" title="DX-2432" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2432</a>  Nightly failure: TestShellIntegrationTestSuite
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This also fixes DX-2429 and DX-2431

Since the sandboxed test environment doesn't have a default python on `PATH` we have to enable the runtime setup. It's likely that these tests weren't erroring out before because of the CI runner environment.
