### PR TITLE
Fix edit integration test

### DIFF
--- a/internal/testhelpers/e2e/dirs.go
+++ b/internal/testhelpers/e2e/dirs.go
@@ -46,7 +46,7 @@ func NewDirs(base string) (*Dirs, error) {
 	homeDir := filepath.Join(base, "home")
 	tempDir := filepath.Join(base, "temp")
 
-	subdirs := []string{config, cache, bin, work, defaultBin}
+	subdirs := []string{config, cache, bin, work, defaultBin, sockRoot, homeDir, tempDir}
 	for _, subdir := range subdirs {
 		if err := os.MkdirAll(subdir, 0700); err != nil {
 			return nil, err

--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -3,8 +3,10 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -23,6 +25,10 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 	if value := os.Getenv(constants.ActiveStateCIEnvVarName); value != "" {
 		env = append(env, fmt.Sprintf("%s=%s", constants.ActiveStateCIEnvVarName, value))
 	}
+
+	// add go binary to PATH
+	goBinary := goBinaryPath()
+	basePath = fmt.Sprintf("%s%s%s", basePath, string(os.PathListSeparator), filepath.Dir(goBinary))
 
 	env = append(env, []string{
 		constants.ConfigEnvVarName + "=" + dirs.Config,
@@ -92,5 +98,19 @@ func prepareHomeDir(dir string) error {
 	}
 
 	return nil
+}
 
+func goBinaryPath() string {
+	locator := "which"
+	if runtime.GOOS == "windows" {
+		locator = "where"
+	}
+	cmd := exec.Command(locator, "go")
+	output, err := cmd.Output()
+	if err != nil {
+		panic(fmt.Sprintf("go binary not found in path: %s", string(output)))
+	}
+	goBinary := string(output)
+	goBinary = strings.TrimSpace(string(goBinary))
+	return goBinary
 }

--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -27,7 +27,7 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 	}
 
 	// add go binary to PATH
-	goBinary := goBinaryPath()
+	goBinary := goBinaryPath(t)
 	basePath = fmt.Sprintf("%s%s%s", basePath, string(os.PathListSeparator), filepath.Dir(goBinary))
 
 	env = append(env, []string{
@@ -100,7 +100,7 @@ func prepareHomeDir(dir string) error {
 	return nil
 }
 
-func goBinaryPath() string {
+func goBinaryPath(t *testing.T) string {
 	locator := "which"
 	if runtime.GOOS == "windows" {
 		locator = "where"
@@ -108,7 +108,8 @@ func goBinaryPath() string {
 	cmd := exec.Command(locator, "go")
 	output, err := cmd.Output()
 	if err != nil {
-		panic(fmt.Sprintf("go binary not found in path: %s", string(output)))
+		t.Log("Could not find go binary")
+		return ""
 	}
 	goBinary := string(output)
 	goBinary = strings.TrimSpace(string(goBinary))

--- a/internal/testhelpers/e2e/env_windows.go
+++ b/internal/testhelpers/e2e/env_windows.go
@@ -35,6 +35,7 @@ func platformSpecificEnv(dirs *Dirs) []string {
 		// Other environment variables are commonly set by CI systems, but this one is not.
 		// This is requried for some tests in order to get the correct powershell output.
 		fmt.Sprintf("PSModulePath=%s", os.Getenv("PSModulePath")),
+		fmt.Sprintf("LOCALAPPDATA=%s", dirs.TempDir),
 	}
 }
 

--- a/test/integration/edit_int_test.go
+++ b/test/integration/edit_int_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -44,28 +43,14 @@ scripts:
 
 	editorScriptDir := filepath.Join(ts.Dirs.Work, "editor")
 
-	locator := "which"
-	env := []string{}
 	var extension string
 	if runtime.GOOS == "windows" {
 		extension = ".exe"
-		locator = "where"
-		// The LOCALAPPDATA env var is used by the go binary to locate the cache dir
-		env = append(env, "LOCALAPPDATA="+ts.Dirs.TempDir)
 	}
-
-	// Locate the go binary as it will not be on PATH in the sandboxed environment
-	cmd := exec.Command(locator, "go")
-	output, err := cmd.Output()
-	suite.Require().NoError(err, "go binary not found in path: %s", string(output))
-	goBinary := string(output)
-	goBinary = strings.TrimSpace(string(goBinary))
-
 	cp := ts.SpawnCmdWithOpts(
-		goBinary,
+		"go",
 		e2e.OptArgs("build", "-o", "editor"+extension, target),
 		e2e.OptWD(editorScriptDir),
-		e2e.OptAppendEnv(env...),
 	)
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2430" title="DX-2430" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2430</a>  Nightly failure: TestEditIntegrationTestSuite/Test{Edit,Edit_UpdateCorrectPlatform}
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

It turns out that this test uses the `go` binary so we have to do some inspection of the environment CI is running on and use that in the test.