### PR TITLE
Consider 'sh' to be a known shell, but unsupported.

### DIFF
--- a/internal/subshell/subshell.go
+++ b/internal/subshell/subshell.go
@@ -225,7 +225,7 @@ func DetectShell(cfg sscommon.Configurable) (string, string) {
 
 	if !isKnownShell {
 		logging.Debug("Unsupported shell: %s, defaulting to OS default.", name)
-		if !strings.EqualFold(name, "powershell") {
+		if !strings.EqualFold(name, "powershell") && name != "sh" {
 			rollbar.Error("Unsupported shell: %s", name) // we just want to know what this person is using
 		}
 		switch runtime.GOOS {


### PR DESCRIPTION
This is so we don't log it to Rollbar.