### PR TITLE
Do not attempt to reset executors for a default project that no longer exists.

### DIFF
--- a/internal/runners/prepare/prepare.go
+++ b/internal/runners/prepare/prepare.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/globaldefault"
 	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/installation/storage"
@@ -62,7 +63,7 @@ func New(prime primeable) *Prepare {
 // This ensures that the installation is compatible with an updated State Tool installation
 func (r *Prepare) resetExecutors() error {
 	defaultProjectDir := r.cfg.GetString(constants.GlobalDefaultPrefname)
-	if defaultProjectDir == "" {
+	if defaultProjectDir == "" || !fileutils.TargetExists(defaultProjectDir) {
 		return nil
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2420" title="DX-2420" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2420</a>  Rollbar: _prepare []: prepare error, message: Could not reset global executors, error received: Could not get project from its directory:     ? Could not find project at [NOTICE]C:\Users\ ...
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

