### PR TITLE
No need to have the update checker because we do autoupdate on `state` invocation.

### DIFF
--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -60,7 +60,7 @@ func autoUpdate(svc *model.SvcModel, args []string, cfg *config.Instance, an ana
 	if !isEnabled(cfg) {
 		logging.Debug("Not performing autoupdates because user turned off autoupdates.")
 		an.EventWithLabel(anaConst.CatUpdates, anaConst.ActShouldUpdate, anaConst.UpdateLabelDisabledConfig)
-		out.Notice(output.Title(locale.Tl("update_available_header", "Auto Update")))
+		out.Notice(output.Title(locale.T("update_available_header")))
 		out.Notice(locale.Tr("update_available", constants.Version, avUpdate.Version))
 		return false, nil
 	}

--- a/internal/runbits/checker/checker.go
+++ b/internal/runbits/checker/checker.go
@@ -1,22 +1,14 @@
 package checker
 
 import (
-	"context"
 	"errors"
-	"net"
 	"strconv"
-	"time"
 
-	"github.com/ActiveState/cli/internal/analytics"
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/output"
-	"github.com/ActiveState/cli/internal/profile"
 	"github.com/ActiveState/cli/internal/runbits/commitmediator"
-	"github.com/ActiveState/cli/internal/updater"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
 )
@@ -62,30 +54,4 @@ func CommitsBehind(p *project.Project) (int, error) {
 	}
 
 	return model.CommitsBehind(*latestCommitID, commitID)
-}
-
-func RunUpdateNotifier(an analytics.Dispatcher, svc *model.SvcModel, out output.Outputer) {
-	defer profile.Measure("RunUpdateNotifier", time.Now())
-
-	ctx, cancel := context.WithTimeout(context.Background(), model.SvcTimeoutMinimal)
-	defer cancel()
-
-	upd, err := svc.CheckUpdate(ctx, constants.ChannelName, "")
-	if err != nil {
-		var timeoutErr net.Error
-		if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
-			logging.Debug("CheckUpdate timed out")
-			return
-		}
-		multilog.Error("Could not check for update when running update notifier, error: %v", errs.JoinMessage(err))
-		return
-	}
-
-	update := updater.NewUpdateInstaller(an, updater.NewAvailableUpdateFromGraph(upd))
-	if !update.ShouldInstall() {
-		return
-	}
-
-	out.Notice(output.Title(locale.Tr("update_available_header")))
-	out.Notice(locale.Tr("update_available", constants.Version, update.AvailableUpdate.Version))
 }

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ActiveState/cli/internal/process"
 	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/runbits/activation"
-	"github.com/ActiveState/cli/internal/runbits/checker"
 	"github.com/ActiveState/cli/internal/runbits/checkout"
 	"github.com/ActiveState/cli/internal/runbits/commitmediator"
 	"github.com/ActiveState/cli/internal/runbits/findproject"
@@ -82,8 +81,6 @@ func NewActivate(prime primeable) *Activate {
 
 func (r *Activate) Run(params *ActivateParams) (rerr error) {
 	logging.Debug("Activate %v, %v", params.Namespace, params.PreferredPath)
-
-	checker.RunUpdateNotifier(r.analytics, r.svcModel, r.out)
 
 	r.out.Notice(output.Title(locale.T("info_activating_state")))
 

--- a/internal/runners/checkout/checkout.go
+++ b/internal/runners/checkout/checkout.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
-	"github.com/ActiveState/cli/internal/runbits/checker"
 	"github.com/ActiveState/cli/internal/runbits/checkout"
 	"github.com/ActiveState/cli/internal/runbits/git"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
@@ -73,8 +72,6 @@ func NewCheckout(prime primeable) *Checkout {
 
 func (u *Checkout) Run(params *Params) (rerr error) {
 	logging.Debug("Checkout %v", params.Namespace)
-
-	checker.RunUpdateNotifier(u.analytics, u.svcModel, u.out)
 
 	logging.Debug("Checking out %s to %s", params.Namespace.String(), params.PreferredPath)
 	var err error

--- a/internal/runners/run/run.go
+++ b/internal/runners/run/run.go
@@ -60,8 +60,6 @@ func (r *Run) Run(name string, args []string) error {
 		return locale.NewInputError("err_no_project")
 	}
 
-	checker.RunUpdateNotifier(r.analytics, r.svcModel, r.out)
-
 	r.out.Notice(locale.Tr("operating_message", r.proj.NamespaceString(), r.proj.Dir()))
 
 	if name == "" {

--- a/internal/runners/state/state.go
+++ b/internal/runners/state/state.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/profile"
-	"github.com/ActiveState/cli/internal/runbits/checker"
 	"github.com/ActiveState/cli/pkg/platform/model"
 )
 
@@ -54,7 +53,6 @@ func (s *State) Run(usageFunc func() error) error {
 	defer profile.Measure("runners:state:run", time.Now())
 
 	if s.opts.Version {
-		checker.RunUpdateNotifier(s.an, s.svcMdl, s.out)
 		vd := installation.VersionData{
 			"CLI",
 			constants.LibraryLicense,

--- a/internal/runners/use/use.go
+++ b/internal/runners/use/use.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/prompt"
-	"github.com/ActiveState/cli/internal/runbits/checker"
 	"github.com/ActiveState/cli/internal/runbits/checkout"
 	"github.com/ActiveState/cli/internal/runbits/commitmediator"
 	"github.com/ActiveState/cli/internal/runbits/findproject"
@@ -66,8 +65,6 @@ func NewUse(prime primeable) *Use {
 
 func (u *Use) Run(params *Params) error {
 	logging.Debug("Use %v", params.Namespace)
-
-	checker.RunUpdateNotifier(u.analytics, u.svcModel, u.out)
 
 	proj, err := findproject.FromNamespaceLocal(params.Namespace, u.config, u.prompt)
 	if err != nil {

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -57,6 +57,7 @@ func (suite *UpdateIntegrationTestSuite) env(disableUpdates, forceUpdate bool) [
 	}
 
 	if forceUpdate {
+		env = append(env, constants.TestAutoUpdateEnvVarName+"=true")
 		env = append(env, constants.ForceUpdateEnvVarName+"=true")
 	}
 
@@ -102,6 +103,11 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateAvailable() {
 
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
+
+	cfg, err := config.NewCustom(ts.Dirs.Config, singlethread.New(), true)
+	suite.Require().NoError(err)
+	defer cfg.Close()
+	cfg.Set(constants.AutoUpdateConfigKey, "false")
 
 	search, found := "Update Available", false
 	for i := 0; i < 4; i++ {
@@ -296,7 +302,6 @@ func (suite *UpdateIntegrationTestSuite) testAutoUpdate(ts *e2e.Session, baseDir
 		e2e.OptArgs("--version"),
 		e2e.OptAppendEnv(suite.env(false, true)...),
 		e2e.OptAppendEnv(fmt.Sprintf("HOME=%s", fakeHome)),
-		e2e.OptAppendEnv(constants.TestAutoUpdateEnvVarName + "=true"),
 	}
 	if opts != nil {
 		spawnOpts = append(spawnOpts, opts...)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2391" title="DX-2391" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2391</a>  Same message printed twice when update available
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Autoupdate was removed in https://github.com/ActiveState/cli/pull/1360 (May 2021) in favor of update checking, and then re-added in https://github.com/ActiveState/cli/pull/1527 (Sept 2021), but update checking was left in place.

This allows for update notices twice in certain circumstances (`autoupdate` config option is `false` and you are running one of: `state {activate,checkout,run,use,--version}`).

Since we run autoupdate upon `state` invocation, no matter the command, there's no need for manual update checking anymore, and the user will only ever see one notice at a time per command.