### PR TITLE
Added revision information to commit history.

### DIFF
--- a/internal/runbits/commit/commit.go
+++ b/internal/runbits/commit/commit.go
@@ -20,6 +20,7 @@ type commitOutput struct {
 	Hash              string               `locale:"hash,[HEADING]Commit[/RESET]" json:"hash"`
 	Author            string               `locale:"author,[HEADING]Author[/RESET]" json:"author"`
 	Date              string               `locale:"date,[HEADING]Date[/RESET]" json:"date"`
+	Revision          string               `locale:"revision,[HEADING]Revision[/RESET]" json:"revision"`
 	Message           string               `locale:"message,[HEADING]Message[/RESET]" json:"message"`
 	PlainChanges      []string             `locale:"changes,[HEADING]Changes[/RESET]" json:"-"`
 	StructuredChanges []*requirementChange `opts:"hidePlain" json:"changes"`
@@ -79,6 +80,12 @@ func newCommitOutput(commit *mono_models.Commit, orgs []gmodel.Organization, isL
 		multilog.Error("Could not parse commit time: %v", err)
 	}
 	commitOutput.Date = dt.Format(time.RFC822)
+
+	dt, err = time.Parse(time.RFC3339, commit.AtTime.String())
+	if err != nil {
+		multilog.Error("Could not parse revision time: %v", err)
+	}
+	commitOutput.Revision = dt.Format(time.RFC822)
 
 	commitOutput.Message = locale.Tl("print_commit_no_message", "[DISABLED]Not provided.[/RESET]")
 	if commit.Message != "" {

--- a/test/integration/history_int_test.go
+++ b/test/integration/history_int_test.go
@@ -35,6 +35,7 @@ func (suite *HistoryIntegrationTestSuite) TestHistory_History() {
 	cp.Expect("Commit")
 	cp.Expect("Author")
 	cp.Expect("Date")
+	cp.Expect("Revision")
 	cp.Expect("Message")
 	cp.Expect("• requests (2.26.0 → 2.7.0)")
 	cp.Expect("• autopip (1.6.0 → Auto)")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2398" title="DX-2398" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2398</a>  Provide catalog revision information on `state history`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is analogous to the Dashboard's "Catalog Revision ID".