### PR TITLE
Buildexpressions now have a default "atTime".

### DIFF
--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -239,15 +239,6 @@ func (r *RequirementOperation) ExecuteRequirementOperation(
 		}
 	}
 
-	if ts == nil {
-		latest, err := model.FetchLatestTimeStamp()
-		if err != nil {
-			return errs.Wrap(err, "Could not fetch latest timestamp")
-		}
-		ts = &latest
-	}
-	timestamp := strfmt.DateTime(*ts)
-
 	name, version, err := model.ResolveRequirementNameAndVersion(requirementName, requirementVersion, requirementBitWidth, *ns)
 	if err != nil {
 		return errs.Wrap(err, "Could not resolve requirement name and version")
@@ -267,7 +258,6 @@ func (r *RequirementOperation) ExecuteRequirementOperation(
 		RequirementVersion:   requirements,
 		RequirementNamespace: *ns,
 		Operation:            operation,
-		TimeStamp:            &timestamp,
 	}
 
 	bp := model.NewBuildPlannerModel(r.Auth)

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -230,11 +230,6 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		return errs.Wrap(err, "Unable to determine Platform ID from %s", model.HostPlatform)
 	}
 
-	timestamp, err := model.FetchLatestTimeStamp()
-	if err != nil {
-		return errs.Wrap(err, "Unable to fetch latest timestamp")
-	}
-
 	bp := model.NewBuildPlannerModel(r.auth)
 	commitID, err := bp.CreateProject(&model.CreateProjectParams{
 		Owner:       namespace.Owner,
@@ -243,7 +238,6 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		Language:    lang.Requirement(),
 		Version:     version,
 		Private:     params.Private,
-		Timestamp:   strfmt.DateTime(timestamp),
 		Description: locale.T("commit_message_add_initial"),
 	})
 	if err != nil {

--- a/pkg/platform/api/buildplanner/request/createproject.go
+++ b/pkg/platform/api/buildplanner/request/createproject.go
@@ -9,6 +9,7 @@ func CreateProject(owner, project string, private bool, expr *buildexpression.Bu
 		"private":      private,
 		"expr":         expr,
 		"description":  description,
+		"atTime":       "", // default to the latest timestamp
 	}}
 }
 

--- a/pkg/platform/api/buildplanner/request/stagecommit.go
+++ b/pkg/platform/api/buildplanner/request/stagecommit.go
@@ -9,6 +9,7 @@ func StageCommit(owner, project, parentCommit, description string, expression *b
 		"parentCommit": parentCommit,
 		"description":  description,
 		"expr":         expression,
+		"atTime":       "", // default to the latest timestamp
 	}}
 }
 

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -225,7 +225,6 @@ type StageCommitParams struct {
 	RequirementVersion   []bpModel.VersionRequirement
 	RequirementNamespace Namespace
 	Operation            bpModel.Operation
-	TimeStamp            *strfmt.DateTime
 	// ... or commits can have an expression (e.g. from pull). When pulling an expression, we do not
 	// compute its changes into a series of above operations. Instead, we just pass the new
 	// expression directly.
@@ -258,11 +257,6 @@ func (bp *BuildPlanner) StageCommit(params StageCommitParams) (strfmt.UUID, erro
 			if err != nil {
 				return "", errs.Wrap(err, "Failed to update build expression with requirement")
 			}
-		}
-
-		err = expression.UpdateTimestamp(*params.TimeStamp)
-		if err != nil {
-			return "", errs.Wrap(err, "Failed to update build expression with timestamp")
 		}
 	}
 
@@ -329,7 +323,6 @@ type CreateProjectParams struct {
 	Language    string
 	Version     string
 	Private     bool
-	Timestamp   strfmt.DateTime
 	Description string
 	Expr        *buildexpression.BuildExpression
 }
@@ -359,9 +352,6 @@ func (bp *BuildPlanner) CreateProject(params *CreateProjectParams) (strfmt.UUID,
 			Namespace:          "language", // TODO: make this a constant DX-1738
 			VersionRequirement: versionRequirements,
 		})
-
-		// Add the timestamp.
-		expr.UpdateTimestamp(params.Timestamp)
 	}
 
 	// Create the project.

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -434,17 +434,6 @@ func FetchIngredientVersions(ingredientID *strfmt.UUID) ([]*inventory_models.Ing
 	return res.Payload.IngredientVersions, nil
 }
 
-// FetchLatestTimeStamp fetches the latest timestamp from the inventory service.
-func FetchLatestTimeStamp() (time.Time, error) {
-	client := inventory.Get()
-	result, err := client.GetLatestTimestamp(inventory_operations.NewGetLatestTimestampParams())
-	if err != nil {
-		return time.Now(), errs.Wrap(err, "GetLatestTimestamp failed")
-	}
-
-	return time.Time(*result.Payload.Timestamp), nil
-}
-
 func FetchNormalizedName(namespace Namespace, name string) (string, error) {
 	client := inventory.Get()
 	params := inventory_operations.NewNormalizeNamesParams()

--- a/pkg/platform/runtime/buildexpression/buildexpression.go
+++ b/pkg/platform/runtime/buildexpression/buildexpression.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
@@ -91,7 +90,7 @@ type In struct {
 //	  "let": {
 //	    "runtime": {
 //	      "solve_legacy": {
-//	        "at_time": "2023-04-27T17:30:05.999000Z",
+//	        "at_time": "$at_time",
 //	        "build_flags": [],
 //	        "camel_flags": [],
 //	        "platforms": [
@@ -180,7 +179,7 @@ func NewEmpty() (*BuildExpression, error) {
 			"let": {
 				"runtime": {
 					"solve_legacy": {
-						"at_time": "",
+						"at_time": "$at_time",
 						"build_flags": [],
 						"camel_flags": [],
 						"platforms": [],
@@ -867,30 +866,6 @@ func (e *BuildExpression) removePlatform(platformID strfmt.UUID) error {
 
 	if !found {
 		return errs.New("Could not find platform")
-	}
-
-	return nil
-}
-
-func (e *BuildExpression) UpdateTimestamp(timestamp strfmt.DateTime) error {
-	formatted, err := time.Parse(time.RFC3339, timestamp.String())
-	if err != nil {
-		return errs.Wrap(err, "Could not parse latest timestamp")
-	}
-
-	solveNode, err := e.getSolveNode()
-	if err != nil {
-		return errs.Wrap(err, "Could not get solve node")
-	}
-
-	for _, arg := range solveNode.Arguments {
-		if arg.Assignment == nil {
-			continue
-		}
-
-		if arg.Assignment.Name == "at_time" {
-			arg.Assignment.Value.Str = ptr.To(formatted.Format(time.RFC3339))
-		}
 	}
 
 	return nil

--- a/pkg/platform/runtime/buildexpression/testdata/buildexpression.json
+++ b/pkg/platform/runtime/buildexpression/testdata/buildexpression.json
@@ -2,7 +2,7 @@
   "let": {
     "runtime": {
       "solve_legacy": {
-        "at_time": "2023-04-27T17:30:05.999000Z",
+        "at_time": "$at_time",
         "build_flags": [],
         "camel_flags": [],
         "platforms": [


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2425" title="DX-2425" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2425</a>  Update timestamp handling when staging commits
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
No need to fetch and set timestamps.