### PR TITLE
Initial ability to list package versions installed instead of just "Auto".

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -795,6 +795,10 @@ change_removed:
   other: "[ERROR]-[/RESET] {{.V0}}"
 change_updated:
   other: "[ACTIONABLE]•[/RESET] {{.V0}} ({{.V1}} → {{.V2}})"
+constraint_auto:
+  other: Auto
+constraint_auto_resolved:
+  other: Auto → {{.V0}}
 namespace_label_platform:
   other: "Platform"
 namespace_label_preplatform:

--- a/internal/runbits/commit/commit.go
+++ b/internal/runbits/commit/commit.go
@@ -147,7 +147,7 @@ func FormatChanges(commit *mono_models.Commit) ([]string, []*requirementChange) 
 
 func formatConstraints(constraints []*mono_models.Constraint) string {
 	if len(constraints) == 0 {
-		return locale.Tl("constraint_auto", "Auto")
+		return locale.T("constraint_auto")
 	}
 
 	var result []string

--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -210,7 +210,7 @@ func newFilteredRequirementsTable(requirements []*gqlModel.Requirement, filter s
 						}
 					}
 				} else {
-					multilog.Error("Unable to retrieve ", req.Requirement, req.Namespace)
+					multilog.Error("Unable to retrieve runtime resolved artifact list: %v", errs.JoinMessage(err))
 				}
 			}
 		}

--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -200,14 +200,17 @@ func newFilteredRequirementsTable(requirements []*gqlModel.Requirement, filter s
 
 		versionConstraint := req.VersionConstraint
 		if versionConstraint == "" {
-			if rt == nil || ns == nil {
-				versionConstraint = locale.T("constraint_auto")
-			} else {
-				if resolvedVersion, err := rt.ResolveArtifactVersion(*ns, req.Requirement); err == nil {
-					versionConstraint = locale.Tr("constraint_auto_resolved", resolvedVersion)
+			versionConstraint = locale.T("constraint_auto")
+			if rt != nil && ns != nil {
+				if artifacts, err := rt.ResolvedArtifacts(); err == nil {
+					for _, a := range artifacts {
+						if a.Namespace == ns.String() && a.Name == req.Requirement {
+							versionConstraint = locale.Tr("constraint_auto_resolved", *a.Version)
+							break
+						}
+					}
 				} else {
-					multilog.Error("Unable to resolve version for '%s' in namespace '%s'", req.Requirement, req.Namespace)
-					versionConstraint = locale.T("constraint_auto")
+					multilog.Error("Unable to retrieve ", req.Requirement, req.Namespace)
 				}
 			}
 		}

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -446,7 +446,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 	AssertValidJSON(suite.T(), cp)
 
 	cp = ts.Spawn("packages", "-o", "json")
-	cp.Expect(`[{"package":"Text-CSV","version":"Auto"}]`)
+	cp.Expect(`[{"package":"Text-CSV","version":"Auto →`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-942" title="DX-942" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-942</a>  `state packages` should show what's installed, not what's ordered
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Before:

```
>state packages
█ Listing Packages

Operating on project ActiveState/cli, located at C:\Users\me\cli.

  Name        Version
───────────────────────
  libsass     Auto
  pexpect     4.4.0
  psutil      Auto
  requests    2.25.0
```

After:

```
>build\state.exe packages
█ Listing Packages

Operating on project ActiveState/cli, located at C:\Users\me\cli.

Skipping runtime setup because it was disabled by an environment variable
  Name        Version
─────────────────────────────
  libsass     Auto → 0.21.0
  pexpect     4.4.0
  psutil      Auto → 5.9.0
  requests    2.25.0
```