### PR TITLE
Show resolved language, package, bundle, etc. versions.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -795,6 +795,10 @@ change_removed:
   other: "[ERROR]-[/RESET] {{.V0}}"
 change_updated:
   other: "[ACTIONABLE]•[/RESET] {{.V0}} ({{.V1}} → {{.V2}})"
+constraint_auto:
+  other: Auto
+constraint_auto_resolved:
+  other: Auto → {{.V0}}
 namespace_label_platform:
   other: "Platform"
 namespace_label_preplatform:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -797,8 +797,8 @@ change_updated:
   other: "[ACTIONABLE]•[/RESET] {{.V0}} ({{.V1}} → {{.V2}})"
 constraint_auto:
   other: Auto
-constraint_auto_resolved:
-  other: Auto → {{.V0}}
+constraint_resolved:
+  other: "{{.V0}} → {{.V1}}"
 namespace_label_platform:
   other: "Platform"
 namespace_label_preplatform:

--- a/internal/runbits/commit/commit.go
+++ b/internal/runbits/commit/commit.go
@@ -147,7 +147,7 @@ func FormatChanges(commit *mono_models.Commit) ([]string, []*requirementChange) 
 
 func formatConstraints(constraints []*mono_models.Constraint) string {
 	if len(constraints) == 0 {
-		return locale.Tl("constraint_auto", "Auto")
+		return locale.T("constraint_auto")
 	}
 
 	var result []string

--- a/internal/runners/languages/install_test.go
+++ b/internal/runners/languages/install_test.go
@@ -1,9 +1,9 @@
 package languages
 
 import (
+	"github.com/ActiveState/cli/pkg/platform/model"
 	"reflect"
 	"testing"
-	"github.com/ActiveState/cli/pkg/platform/model"
 )
 
 func Test_parseLanguage(t *testing.T) {
@@ -19,7 +19,7 @@ func Test_parseLanguage(t *testing.T) {
 		{
 			"Language with version",
 			args{"Python@2"},
-			&model.Language{"Python", "2"},
+			&model.Language{Name: "Python", Version: "2"},
 			false,
 		},
 	}
@@ -51,7 +51,7 @@ func Test_ensureVersionTestable(t *testing.T) {
 		{
 			"Version matches",
 			args{
-				&model.Language{"Python", "3.5"},
+				&model.Language{Name: "Python", Version: "3.5"},
 				func(name string) ([]string, error) { return []string{"2.0", "3.5", "4.0"}, nil },
 			},
 			"3.5",

--- a/internal/runners/languages/languages.go
+++ b/internal/runners/languages/languages.go
@@ -67,12 +67,21 @@ func (l *Languages) Run() error {
 		multilog.Error("Unable to initialize runtime for version resolution: %v", errs.JoinMessage(err))
 	}
 
+	artifacts, err := rt.ResolvedArtifacts()
+	if err != nil {
+		multilog.Error("Unable to retrieve runtime resolved artifact list: %v", errs.JoinMessage(err))
+	}
+	ns := model.NewNamespaceLanguage()
+
 	for i := range langs {
-		if resolvedVersion, err := rt.ResolveArtifactVersion(model.NewNamespaceLanguage(), langs[i].Name); err == nil {
-			langs[i].Version = locale.Tr("constraint_auto_resolved", resolvedVersion)
-		} else {
-			multilog.Error("Unable to resolve language version: %v", errs.JoinMessage(err))
+		if langs[i].Version == "" {
 			langs[i].Version = locale.T("constraint_auto")
+			for _, a := range artifacts {
+				if a.Namespace == ns.String() && a.Name == langs[i].Name {
+					langs[i].Version = locale.Tr("constraint_auto_resolved", *a.Version)
+					break
+				}
+			}
 		}
 		langs[i].Name = strings.Title(langs[i].Name)
 	}

--- a/internal/runners/languages/languages.go
+++ b/internal/runners/languages/languages.go
@@ -6,12 +6,15 @@ import (
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/runbits/commitmediator"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
+	"github.com/ActiveState/cli/pkg/platform/runtime/artifact"
+	"github.com/ActiveState/cli/pkg/platform/runtime/store"
 	"github.com/ActiveState/cli/pkg/platform/runtime/target"
 	"github.com/ActiveState/cli/pkg/project"
 )
@@ -62,14 +65,16 @@ func (l *Languages) Run() error {
 		return locale.WrapError(err, "err_fetching_languages", "Cannot obtain languages")
 	}
 
-	rt, err := runtime.NewFromProject(l.project, target.TriggerLanguage, l.analytics, l.svcModel, l.out, l.auth)
-	if err != nil {
-		multilog.Error("Unable to initialize runtime for version resolution: %v", errs.JoinMessage(err))
-	}
-
-	artifacts, err := rt.ResolvedArtifacts()
-	if err != nil {
-		multilog.Error("Unable to retrieve runtime resolved artifact list: %v", errs.JoinMessage(err))
+	// Fetch resolved artifacts list for showing full version numbers.
+	// Note: any errors here are not fatal, and only some of them should be reported to rollbar.
+	var artifacts []artifact.Artifact
+	if rt, err := runtime.NewFromProject(l.project, target.TriggerLanguage, l.analytics, l.svcModel, l.out, l.auth); err == nil {
+		artifacts, err = rt.ResolvedArtifacts()
+		if err != nil && !errs.Matches(err, store.ErrNoBuildPlanFile) {
+			multilog.Error("Unable to retrieve runtime resolved artifact list: %v", errs.JoinMessage(err))
+		}
+	} else {
+		logging.Error("Unable to initialize runtime for version resolution: %v", errs.JoinMessage(err))
 	}
 	ns := model.NewNamespaceLanguage()
 
@@ -82,20 +87,19 @@ func (l *Languages) Run() error {
 
 		if version == "" {
 			version = locale.T("constraint_auto")
-			if constraints != nil && len(*constraints) > 0 {
-				reqs := model.MonoModelConstraintsToRequirements(constraints)
-				version = model.RequirementsToVersionString(reqs)
-			}
-			for _, a := range artifacts {
-				if a.Namespace != ns.String() || a.Name != name {
-					continue
-				}
-				if version != *a.Version {
-					langs[i].Version = locale.Tr("constraint_resolved", version, *a.Version)
-				}
+		}
+		if constraints != nil && len(*constraints) > 0 {
+			reqs := model.MonoModelConstraintsToRequirements(constraints)
+			version = model.RequirementsToVersionString(reqs)
+		}
+		for _, a := range artifacts {
+			if a.Namespace == ns.String() && a.Name == name && version != *a.Version {
+				// e.g. python@3.10, but resolved artifact version is 3.10.0
+				version = locale.Tr("constraint_resolved", version, *a.Version)
 				break
 			}
 		}
+		langs[i].Version = version
 	}
 
 	l.out.Print(output.Prepare(langs, langs))

--- a/internal/runners/languages/languages.go
+++ b/internal/runners/languages/languages.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/ActiveState/cli/internal/analytics"
+	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -26,6 +27,7 @@ type Languages struct {
 	analytics analytics.Dispatcher
 	svcModel  *model.SvcModel
 	auth      *authentication.Auth
+	cfg       *config.Instance
 }
 
 // NewLanguages prepares a list execution context for use.
@@ -36,6 +38,7 @@ func NewLanguages(prime primeable) *Languages {
 		prime.Analytics(),
 		prime.SvcModel(),
 		prime.Auth(),
+		prime.Config(),
 	}
 }
 
@@ -68,7 +71,7 @@ func (l *Languages) Run() error {
 	// Fetch resolved artifacts list for showing full version numbers.
 	// Note: any errors here are not fatal, and only some of them should be reported to rollbar.
 	var artifacts []artifact.Artifact
-	if rt, err := runtime.NewFromProject(l.project, target.TriggerLanguage, l.analytics, l.svcModel, l.out, l.auth); err == nil {
+	if rt, err := runtime.NewFromProject(l.project, target.TriggerLanguage, l.analytics, l.svcModel, l.out, l.auth, l.cfg); err == nil {
 		artifacts, err = rt.ResolvedArtifacts()
 		if err != nil && !errs.Matches(err, store.ErrNoBuildPlanFile) {
 			multilog.Error("Unable to retrieve runtime resolved artifact list: %v", errs.JoinMessage(err))

--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -58,7 +58,7 @@ func NewList(prime primeable) *List {
 type requirement struct {
 	Name            string `json:"package"`
 	Version         string `json:"version" `
-	ResolvedVersion string `json:"resolved_version,omitempty"`
+	ResolvedVersion string `json:"resolved_version"`
 }
 
 type requirementPlainOutput struct {
@@ -142,14 +142,14 @@ func (l *List) Run(params ListRunParams, nstype model.NamespaceType) error {
 
 		resolvedVersion := ""
 		for _, a := range artifacts {
-			if a.Namespace == ns.String() && a.Name == req.Requirement && version != *a.Version {
+			if a.Namespace == ns.String() && a.Name == req.Requirement {
 				resolvedVersion = *a.Version
 				break
 			}
 		}
 
 		plainVersion := version
-		if resolvedVersion != "" {
+		if resolvedVersion != "" && resolvedVersion != version {
 			plainVersion = locale.Tr("constraint_resolved", version, resolvedVersion)
 		}
 		requirementsPlainOutput = append(requirementsPlainOutput, requirementPlainOutput{

--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -201,7 +201,7 @@ func newFilteredRequirementsTable(requirements []*gqlModel.Requirement, filter s
 	if rt != nil && ns != nil {
 		var err error
 		artifacts, err = rt.ResolvedArtifacts()
-		if !errs.Matches(err, store.ErrNoBuildPlanFile) {
+		if err != nil && !errs.Matches(err, store.ErrNoBuildPlanFile) {
 			multilog.Error("Unable to retrieve runtime resolved artifact list: %v", errs.JoinMessage(err))
 		}
 	}

--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -201,11 +201,16 @@ func newFilteredRequirementsTable(requirements []*gqlModel.Requirement, filter s
 		versionConstraint := req.VersionConstraint
 		if versionConstraint == "" {
 			versionConstraint = locale.T("constraint_auto")
+			if len(req.VersionConstraints) > 0 {
+				reqs := model.MonoModelConstraintsToRequirements(&req.VersionConstraints)
+				versionConstraint = model.RequirementsToVersionString(reqs)
+			}
+
 			if rt != nil && ns != nil {
 				if artifacts, err := rt.ResolvedArtifacts(); err == nil {
 					for _, a := range artifacts {
 						if a.Namespace == ns.String() && a.Name == req.Requirement {
-							versionConstraint = locale.Tr("constraint_auto_resolved", *a.Version)
+							versionConstraint = locale.Tr("constraint_resolved", versionConstraint, *a.Version)
 							break
 						}
 					}

--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/strfmt"
 
 	"github.com/ActiveState/cli/internal/analytics"
+	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
@@ -41,6 +42,7 @@ type List struct {
 	analytics analytics.Dispatcher
 	svcModel  *model.SvcModel
 	auth      *authentication.Auth
+	cfg       *config.Instance
 }
 
 // NewList prepares a list execution context for use.
@@ -51,6 +53,7 @@ func NewList(prime primeable) *List {
 		analytics: prime.Analytics(),
 		svcModel:  prime.SvcModel(),
 		auth:      prime.Auth(),
+		cfg:       prime.Config(),
 	}
 }
 
@@ -92,7 +95,7 @@ func (l *List) Run(params ListRunParams, nstype model.NamespaceType) error {
 	// Note: any errors here are not fatal, and should not be reported to rollbar.
 	var rt *runtime.Runtime
 	if l.project != nil && params.Project == "" {
-		rt, err = runbitsRuntime.NewFromProject(l.project, target.TriggerPackage, l.analytics, l.svcModel, l.out, l.auth)
+		rt, err = runbitsRuntime.NewFromProject(l.project, target.TriggerPackage, l.analytics, l.svcModel, l.out, l.auth, l.cfg)
 		if err != nil {
 			logging.Error("Unable to initialize runtime for version resolution: %v", errs.JoinMessage(err))
 		}

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -553,10 +553,10 @@ func VersionStringToRequirements(version string) ([]bpModel.VersionRequirement, 
 	return requirements, nil
 }
 
-func MonoModelConstraintsToRequirements(constraints *mono_models.Constraints) []bpModel.VersionRequirement {
-	requirements := []bpModel.VersionRequirement{}
+func MonoModelConstraintsToRequirements(constraints *mono_models.Constraints) []*bpModel.VersionRequirement {
+	requirements := []*bpModel.VersionRequirement{}
 	for _, constraint := range *constraints {
-		requirements = append(requirements, bpModel.VersionRequirement{
+		requirements = append(requirements, &bpModel.VersionRequirement{
 			bpModel.VersionRequirementComparatorKey: constraint.Comparator,
 			bpModel.VersionRequirementVersionKey:    constraint.Version,
 		})
@@ -564,15 +564,15 @@ func MonoModelConstraintsToRequirements(constraints *mono_models.Constraints) []
 	return requirements
 }
 
-func RequirementsToVersionString(requirements []bpModel.VersionRequirement) string {
+func RequirementsToVersionString(requirements []*bpModel.VersionRequirement) string {
 	if requirements == nil || len(requirements) == 0 {
 		return ""
 	}
 
 	parts := make([]string, len(requirements))
 	for i, requirement := range requirements {
-		version := requirement[bpModel.VersionRequirementVersionKey]
-		switch requirement[bpModel.VersionRequirementComparatorKey] {
+		version := (*requirement)[bpModel.VersionRequirementVersionKey]
+		switch (*requirement)[bpModel.VersionRequirementComparatorKey] {
 		case bpModel.ComparatorEQ:
 			parts[i] = version
 		case bpModel.ComparatorGT:

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -19,7 +18,6 @@ import (
 	bpModel "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/request"
 	"github.com/ActiveState/cli/pkg/platform/api/headchef/headchef_models"
-	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	"github.com/ActiveState/cli/pkg/platform/api/reqsimport"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/runtime/artifact"
@@ -551,41 +549,4 @@ func VersionStringToRequirements(version string) ([]bpModel.VersionRequirement, 
 		})
 	}
 	return requirements, nil
-}
-
-func MonoModelConstraintsToRequirements(constraints *mono_models.Constraints) []*bpModel.VersionRequirement {
-	requirements := []*bpModel.VersionRequirement{}
-	for _, constraint := range *constraints {
-		requirements = append(requirements, &bpModel.VersionRequirement{
-			bpModel.VersionRequirementComparatorKey: constraint.Comparator,
-			bpModel.VersionRequirementVersionKey:    constraint.Version,
-		})
-	}
-	return requirements
-}
-
-func RequirementsToVersionString(requirements []*bpModel.VersionRequirement) string {
-	if requirements == nil || len(requirements) == 0 {
-		return ""
-	}
-
-	parts := make([]string, len(requirements))
-	for i, requirement := range requirements {
-		version := (*requirement)[bpModel.VersionRequirementVersionKey]
-		switch (*requirement)[bpModel.VersionRequirementComparatorKey] {
-		case bpModel.ComparatorEQ:
-			parts[i] = version
-		case bpModel.ComparatorGT:
-			parts[i] = fmt.Sprintf(">%s", version)
-		case bpModel.ComparatorGTE:
-			parts[i] = fmt.Sprintf(">=%s", version)
-		case bpModel.ComparatorLT:
-			parts[i] = fmt.Sprintf("<%s", version)
-		case bpModel.ComparatorLTE:
-			parts[i] = fmt.Sprintf("<=%s", version)
-		case bpModel.ComparatorNE:
-			parts[i] = fmt.Sprintf("!%s", version)
-		}
-	}
-	return strings.Join(parts, ",")
 }

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -27,8 +27,9 @@ type Checkpoint []*mono_models.Checkpoint
 
 // Language represents a language requirement
 type Language struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name               string `json:"name"`
+	Version            string `json:"version"`
+	versionConstraints mono_models.Constraints
 }
 
 // GetRequirement searches a commit for a requirement by name.
@@ -60,8 +61,9 @@ func FetchLanguagesForCommit(commitID strfmt.UUID) ([]Language, error) {
 	for _, requirement := range checkpoint {
 		if NamespaceMatch(requirement.Namespace, NamespaceLanguageMatch) {
 			lang := Language{
-				Name:    requirement.Requirement,
-				Version: requirement.VersionConstraint,
+				Name:               requirement.Requirement,
+				Version:            requirement.VersionConstraint,
+				versionConstraints: requirement.VersionConstraints,
 			}
 			languages = append(languages, lang)
 		}
@@ -274,4 +276,11 @@ func fallbackArch(platform, arch string) string {
 		return "amd64"
 	}
 	return arch
+}
+
+func (l *Language) VersionConstraints() *mono_models.Constraints {
+	if l.versionConstraints == nil {
+		return nil
+	}
+	return &l.versionConstraints
 }

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -49,24 +49,6 @@ func GetRequirement(commitID strfmt.UUID, namespace Namespace, requirement strin
 	return nil, nil
 }
 
-// getVersionFromConstraints attempts to determine a language version from a set of requirement
-// constraints.
-// For example, `state init --language python` creates a commit with the constraints
-// "python >=3.x.y,<3.x.y+1". In these cases, return 3.x.y.
-// For other cases, return an error.
-func getVersionFromConstraints(constraints mono_models.Constraints) (string, error) {
-	if len(constraints) == 0 {
-		return "", nil // could be auto, or the Platform did not specify one
-	}
-	if len(constraints) != 2 {
-		return "", errs.New("Unrecognized constraint")
-	}
-	if constraints[0].Comparator != "gte" || constraints[1].Comparator != "lt" {
-		return "", errs.New("Unrecognized constraint")
-	}
-	return constraints[0].Version, nil
-}
-
 // FetchLanguagesForCommit fetches a list of language names for the given commit
 func FetchLanguagesForCommit(commitID strfmt.UUID) ([]Language, error) {
 	checkpoint, _, err := FetchCheckpointForCommit(commitID)
@@ -80,13 +62,6 @@ func FetchLanguagesForCommit(commitID strfmt.UUID) ([]Language, error) {
 			lang := Language{
 				Name:    requirement.Requirement,
 				Version: requirement.VersionConstraint,
-			}
-			if lang.Version == "" {
-				version, err := getVersionFromConstraints(requirement.VersionConstraints)
-				if err != nil {
-					return nil, errs.Wrap(err, "Unable to determine commit's language version based on constraints")
-				}
-				lang.Version = version
 			}
 			languages = append(languages, lang)
 		}
@@ -215,15 +190,7 @@ func CheckpointToLanguage(requirements []*gqlModel.Requirement) (*Language, erro
 		if !NamespaceMatch(req.Namespace, NamespaceLanguageMatch) {
 			continue
 		}
-		version := req.VersionConstraint
-		if version == "" {
-			var err error
-			version, err = getVersionFromConstraints(req.VersionConstraints)
-			if err != nil {
-				return nil, locale.WrapError(err, "err_detect_language")
-			}
-		}
-		lang, err := FetchLanguageByDetails(req.Requirement, version)
+		lang, err := FetchLanguageByDetails(req.Requirement, req.VersionConstraint)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -27,9 +27,9 @@ type Checkpoint []*mono_models.Checkpoint
 
 // Language represents a language requirement
 type Language struct {
-	Name               string `json:"name"`
-	Version            string `json:"version"`
-	versionConstraints mono_models.Constraints
+	Name            string `json:"name"`
+	Version         string `json:"version"`
+	ResolvedVersion string `json:"resolved_version,omitempty"`
 }
 
 // GetRequirement searches a commit for a requirement by name.
@@ -61,9 +61,8 @@ func FetchLanguagesForCommit(commitID strfmt.UUID) ([]Language, error) {
 	for _, requirement := range checkpoint {
 		if NamespaceMatch(requirement.Namespace, NamespaceLanguageMatch) {
 			lang := Language{
-				Name:               requirement.Requirement,
-				Version:            requirement.VersionConstraint,
-				versionConstraints: requirement.VersionConstraints,
+				Name:    requirement.Requirement,
+				Version: requirement.VersionConstraint,
 			}
 			languages = append(languages, lang)
 		}
@@ -276,11 +275,4 @@ func fallbackArch(platform, arch string) string {
 		return "amd64"
 	}
 	return arch
-}
-
-func (l *Language) VersionConstraints() *mono_models.Constraints {
-	if l.versionConstraints == nil {
-		return nil
-	}
-	return &l.versionConstraints
 }

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -27,9 +27,8 @@ type Checkpoint []*mono_models.Checkpoint
 
 // Language represents a language requirement
 type Language struct {
-	Name            string `json:"name"`
-	Version         string `json:"version"`
-	ResolvedVersion string `json:"resolved_version,omitempty"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 // GetRequirement searches a commit for a requirement by name.

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -45,7 +45,7 @@ type Runtime struct {
 	auth              *authentication.Auth
 	completed         bool
 	cfg               model.Configurable
-	resolvedArtifacts []artifact.Artifact
+	resolvedArtifacts []*artifact.Artifact
 }
 
 // NeedsUpdateError is an error returned when the runtime is not completely installed yet.
@@ -361,7 +361,7 @@ func IsRuntimeDir(dir string) bool {
 	return store.New(dir).HasMarker()
 }
 
-func (r *Runtime) ResolvedArtifacts() ([]artifact.Artifact, error) {
+func (r *Runtime) ResolvedArtifacts() ([]*artifact.Artifact, error) {
 	if r.resolvedArtifacts == nil {
 		runtimeStore := r.store
 		if runtimeStore == nil {
@@ -373,9 +373,9 @@ func (r *Runtime) ResolvedArtifacts() ([]artifact.Artifact, error) {
 			return nil, errs.Wrap(err, "Unable to fetch build plan")
 		}
 
-		r.resolvedArtifacts = make([]artifact.Artifact, len(plan.Sources))
+		r.resolvedArtifacts = make([]*artifact.Artifact, len(plan.Sources))
 		for i, source := range plan.Sources {
-			r.resolvedArtifacts[i] = artifact.Artifact{
+			r.resolvedArtifacts[i] = &artifact.Artifact{
 				ArtifactID: source.NodeID,
 				Name:       source.Name,
 				Namespace:  source.Namespace,

--- a/pkg/platform/runtime/store/store.go
+++ b/pkg/platform/runtime/store/store.go
@@ -255,7 +255,12 @@ func (s *Store) InstallPath() string {
 	return s.installPath
 }
 
+var ErrNoBuildPlanFile = errs.New("no build plan file")
+
 func (s *Store) BuildPlanRaw() ([]byte, error) {
+	if !fileutils.FileExists(s.buildPlanFile()) {
+		return nil, ErrNoBuildPlanFile
+	}
 	data, err := fileutils.ReadFile(s.buildPlanFile())
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not read build plan file.")

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -174,7 +174,7 @@ func (suite *InitIntegrationTestSuite) TestInit_Resolved() {
 	// Run `state languages` to verify a full language version was resolved.
 	cp = ts.Spawn("languages")
 	cp.Expect("Python")
-	cp.Expect("3.10.") // trailing '.' means the full version resolved (e.g. 3.10.12)
+	cp.Expect("3.10 → 3.10.0")
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -152,6 +152,32 @@ func (suite *InitIntegrationTestSuite) TestInit_AlreadyExists() {
 	cp.ExpectExitCode(1)
 }
 
+func (suite *InitIntegrationTestSuite) TestInit_Resolved() {
+	suite.OnlyRunForTags(tagsuite.Init)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+	ts.LoginAsPersistentUser()
+
+	// Generate a new namespace for the project to be created.
+	pname := strutils.UUID()
+	namespace := fmt.Sprintf("%s/%s", e2e.PersistentUsername, pname)
+
+	// Run `state init`, creating the project.
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("init", namespace, "--language", "python@3.10"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect(fmt.Sprintf("Project '%s' has been successfully initialized", namespace), e2e.RuntimeSourcingTimeoutOpt)
+	cp.ExpectExitCode(0)
+	ts.NotifyProjectCreated(e2e.PersistentUsername, pname.String())
+
+	// Run `state languages` to verify a full language version was resolved.
+	cp = ts.Spawn("languages")
+	cp.Expect("Python")
+	cp.Expect("3.10.") // trailing '.' means the full version resolved (e.g. 3.10.12)
+	cp.ExpectExitCode(0)
+}
+
 func (suite *InitIntegrationTestSuite) TestInit_NoOrg() {
 	suite.OnlyRunForTags(tagsuite.Init)
 	ts := e2e.New(suite.T(), false)

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -173,7 +173,7 @@ func (suite *InitIntegrationTestSuite) TestInit_Resolved() {
 
 	// Run `state languages` to verify a full language version was resolved.
 	cp = ts.Spawn("languages")
-	cp.Expect("Python")
+	cp.Expect("python")
 	cp.Expect("3.10 → 3.10.0")
 	cp.ExpectExitCode(0)
 }

--- a/test/integration/languages_int_test.go
+++ b/test/integration/languages_int_test.go
@@ -94,12 +94,12 @@ func (suite *LanguagesIntegrationTestSuite) TestJSON() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("languages", "-o", "json")
-	cp.Expect(`[{"name":"Python","version":`)
+	cp.Expect(`[{"name":"Python","version":"Auto →"`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
 	cp = ts.Spawn("languages", "search", "--output", "json")
-	cp.Expect(`[{"name":"perl","version":`)
+	cp.Expect(`[{"name":"perl","version":"Auto →"`)
 	cp.ExpectExitCode(0)
 	//AssertValidJSON(suite.T(), cp) // currently too big to fit in the terminal window for validation
 }

--- a/test/integration/languages_int_test.go
+++ b/test/integration/languages_int_test.go
@@ -26,7 +26,7 @@ func (suite *LanguagesIntegrationTestSuite) TestLanguages_list() {
 
 	cp := ts.Spawn("languages")
 	cp.Expect("Name")
-	cp.Expect("Python")
+	cp.Expect("python")
 	cp.Expect("3.9.15")
 	cp.ExpectExitCode(0)
 }
@@ -54,7 +54,7 @@ func (suite *LanguagesIntegrationTestSuite) TestLanguages_install() {
 
 	cp := ts.Spawn("languages")
 	cp.Expect("Name")
-	cp.Expect("Python")
+	cp.Expect("python")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("languages", "install", "python")
@@ -69,7 +69,7 @@ func (suite *LanguagesIntegrationTestSuite) TestLanguages_install() {
 
 	cp = ts.Spawn("languages")
 	cp.Expect("Name")
-	cp.Expect("Python")
+	cp.Expect("python")
 	versionRe := regexp.MustCompile(`(\d+)\.(\d+).(\d+)`)
 	cp.ExpectRe(versionRe.String())
 	cp.ExpectExitCode(0)
@@ -94,7 +94,7 @@ func (suite *LanguagesIntegrationTestSuite) TestJSON() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("languages", "-o", "json")
-	cp.Expect(`[{"name":"Python","version":`)
+	cp.Expect(`[{"name":"python","version":`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 

--- a/test/integration/languages_int_test.go
+++ b/test/integration/languages_int_test.go
@@ -94,12 +94,12 @@ func (suite *LanguagesIntegrationTestSuite) TestJSON() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("languages", "-o", "json")
-	cp.Expect(`[{"name":"Python","version":"Auto →"`)
+	cp.Expect(`[{"name":"Python","version":`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
 	cp = ts.Spawn("languages", "search", "--output", "json")
-	cp.Expect(`[{"name":"perl","version":"Auto →"`)
+	cp.Expect(`[{"name":"perl","version":`)
 	cp.ExpectExitCode(0)
 	//AssertValidJSON(suite.T(), cp) // currently too big to fit in the terminal window for validation
 }

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -446,7 +446,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 	AssertValidJSON(suite.T(), cp)
 
 	cp = ts.Spawn("packages", "-o", "json")
-	cp.Expect(`[{"package":"Text-CSV","version":"Auto →`)
+	cp.Expect(`[{"package":"Text-CSV","version":"Auto","resolved_version":"`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
@@ -640,6 +640,27 @@ func (suite *PackageIntegrationTestSuite) TestProjectWithOfflineInstallerAndDock
 		e2e.OptArgs("uninstall", "requests"),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
+	cp.ExpectExitCode(0)
+}
+
+func (suite *PackageIntegrationTestSuite) TestResolved() {
+	suite.OnlyRunForTags(tagsuite.Package)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Checked out project")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("install", "requests"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("packages")
+	cp.Expect("Auto →")
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -446,7 +446,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 	AssertValidJSON(suite.T(), cp)
 
 	cp = ts.Spawn("packages", "-o", "json")
-	cp.Expect(`[{"package":"Text-CSV","version":"Auto"}]`)
+	cp.Expect(`[{"package":"Text-CSV","version":"Auto →`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1965" title="DX-1965" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-1965</a>  As a user I can see both the requested and the resulting version of requirements
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Before:

```
>state packages
█ Listing Packages

Operating on project ActiveState/cli, located at C:\Users\me\cli.

  Name        Version
───────────────────────
  libsass     Auto
  pexpect     4.4.0
  psutil      Auto
  requests    2.25.0
```

After:

```
>build\state.exe packages
█ Listing Packages

Operating on project ActiveState/cli, located at C:\Users\me\cli.

Skipping runtime setup because it was disabled by an environment variable
  Name        Version
─────────────────────────────
  libsass     Auto → 0.21.0
  pexpect     4.4.0
  psutil      Auto → 5.9.0
  requests    2.25.0
```

Also:

```
>state init org/project --language python@3.10

[...]

>state languages
█ Listing Languages (Beta)

Beta Feature: This feature is still in beta and may be unstable.

  Name      Version
───────────────────────────
  Python    3.10 → 3.10.0
```

Note: `state platforms` already displays resolved versions. Also, platforms are not artifacts, so we cannot obtain version numbers from the build plan.