### PR TITLE
Fix failing integration test

### DIFF
--- a/test/integration/update_lock_int_test.go
+++ b/test/integration/update_lock_int_test.go
@@ -204,6 +204,7 @@ func (suite *UpdateIntegrationTestSuite) TestLockUnlock() {
 	data, err = ioutil.ReadFile(pjfile.Path())
 	suite.Require().NoError(err)
 	suite.Assert().False(lockRegex.Match(data), "lock info was not removed from "+pjfile.Path())
+	ts.IgnoreLogErrors()
 }
 
 func (suite *UpdateIntegrationTestSuite) TestJSON() {

--- a/test/integration/update_lock_int_test.go
+++ b/test/integration/update_lock_int_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -189,7 +189,7 @@ func (suite *UpdateIntegrationTestSuite) TestLockUnlock() {
 	)
 	cp.Expect("locked at")
 
-	data, err := ioutil.ReadFile(pjfile.Path())
+	data, err := os.ReadFile(pjfile.Path())
 	suite.Require().NoError(err)
 
 	lockRegex := regexp.MustCompile(`(?m)^lock:.*`)
@@ -201,9 +201,12 @@ func (suite *UpdateIntegrationTestSuite) TestLockUnlock() {
 	)
 	cp.Expect("unlocked")
 
-	data, err = ioutil.ReadFile(pjfile.Path())
+	data, err = os.ReadFile(pjfile.Path())
 	suite.Require().NoError(err)
 	suite.Assert().False(lockRegex.Match(data), "lock info was not removed from "+pjfile.Path())
+	// Ignore log errors here as the project we are using in this test does not
+	// actually exist. So there will be some errors related to fetching the
+	// project into.
 	ts.IgnoreLogErrors()
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2446" title="DX-2446" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2446</a>  Nightly failure: TestUpdateIntegrationTestSuite/TestLockUnlock
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I spent some time trying to determine why this started failing a few days ago. I'm still not sure but regardless the error in the log is expected and should be ignored.