### PR TITLE
Auto-resolve version.txt conflicts by choosing the target branch's version.

### DIFF
--- a/scripts/ci/propagate-pr/main.go
+++ b/scripts/ci/propagate-pr/main.go
@@ -131,16 +131,27 @@ func run() error {
 			return errs.Wrap(err, "failed to checkout %s, stdout:\n%s\nstderr:\n%s", v.TargetBranch, stdout, stderr)
 		}
 
-		stdout, stderr, err = osutils.ExecSimpleFromDir(root, "git", []string{
-			"merge", v.SourceBranch,
-			"--no-edit", "-m",
-			fmt.Sprintf("Merge branch %s to adopt changes from PR #%d", v.SourceBranch, prNumber),
-		}, nil)
+		commitMessage := fmt.Sprintf("Merge branch %s to adopt changes from PR #%d", v.SourceBranch, prNumber)
+		stdout, stderr, err = merge(root, v.SourceBranch, commitMessage)
 		if err != nil {
-			return errs.Wrap(err,
-				"failed to merge %s into %s. please manually merge the following branches: %s"+
-					"\nstdout:\n%s\nstderr:\n%s",
-				v.SourceBranch, v.TargetBranch, intend[i:].String(), stdout, stderr)
+			conflictOnlyInVersionTxt := strings.Count(stdout, "CONFLICT (content): Merge conflict in") == 1 &&
+				strings.Index(stdout, "Merge conflict in version.txt") != -1
+
+			if conflictOnlyInVersionTxt {
+				// Abort the conflicted merge and then redo it, preferring the target branch's version.txt.
+				stdout, stderr, err = osutils.ExecSimpleFromDir(root, "git", []string{"merge", "--abort"}, nil)
+				if err != nil {
+					return errs.Wrap(err, "failed to abort conflicted merge\nstdout: %s\nstderr: %s\n", stdout, stderr)
+				}
+				stdout, stderr, err = merge(root, v.SourceBranch, commitMessage, "-s", "ort", "-X", "ours")
+			}
+
+			if err != nil {
+				return errs.Wrap(err,
+					"failed to merge %s into %s. please manually merge the following branches: %s"+
+						"\nstdout:\n%s\nstderr:\n%s",
+					v.SourceBranch, v.TargetBranch, intend[i:].String(), stdout, stderr)
+			}
 		}
 
 		stdout, stderr, err = osutils.ExecSimpleFromDir(root, "git", []string{"push"}, nil)
@@ -217,4 +228,13 @@ func fetchMeta(ghClient *github.Client, jiraClient *jira.Client, prNumber int) (
 	}
 
 	return result, nil
+}
+
+func merge(rootDir, sourceBranch, commitMessage string, extraGitArgs ...string) (string, string, error) {
+	args := append([]string{
+		"merge", sourceBranch,
+		"-m", commitMessage,
+		"--no-edit",
+	}, extraGitArgs...)
+	return osutils.ExecSimpleFromDir(rootDir, "git", args, nil)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-1393" title="DX-1393" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-1393</a>  As a DevX engineer I can count on version.txt always being correct when changes are propagated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
