### PR TITLE
Deprioritize showing `activate` over `use` and `shell` in help listing.

### DIFF
--- a/cmd/state/internal/cmdtree/activate.go
+++ b/cmd/state/internal/cmdtree/activate.go
@@ -87,5 +87,6 @@ func newActivateCommand(prime *primer.Values) *captain.Command {
 		},
 	)
 	cmd.SetGroup(EnvironmentUsageGroup)
+	cmd.DeprioritizeInHelpListing()
 	return cmd
 }

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -89,6 +89,8 @@ type Command struct {
 
 	group CommandGroup
 
+	deprioritizeInHelpListing bool
+
 	flags     []*Flag
 	arguments []*Argument
 
@@ -439,6 +441,10 @@ func (c *Command) Group() CommandGroup {
 	return c.group
 }
 
+func (c *Command) DeprioritizeInHelpListing() {
+	c.deprioritizeInHelpListing = true
+}
+
 // SetHasVariableArguments allows a captain Command to accept a variable number of command line
 // arguments.
 // By default, captain has Cobra restrict the command line arguments accepted to those given in the
@@ -458,10 +464,14 @@ func (c *Command) SkipChecks() bool {
 }
 
 func (c *Command) SortBefore(c2 *Command) bool {
-	if c.group != c2.group {
+	switch {
+	case c.group != c2.group:
 		return c.group.SortBefore(c2.group)
+	case c.deprioritizeInHelpListing == c2.deprioritizeInHelpListing:
+		return c.Name() < c2.Name()
+	default:
+		return !c.deprioritizeInHelpListing
 	}
-	return c.Name() < c2.Name()
 }
 
 func (c *Command) AddChildren(children ...*Command) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2460" title="DX-2460" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2460</a>  Update help output to promote use and shell over activate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
```
  Environment Usage:
    exec                        Intercept and run a script via a project runtime environment
    refresh                     Updates the given project runtime based on its current configuration
    shell                       Starts a shell/prompt in a virtual environment for the given project runtime
    use                         Use the given project as your default
    activate                    Activate a project
```