### PR TITLE
Ensure error messages always end in a period.

### DIFF
--- a/internal/runbits/errors/errors.go
+++ b/internal/runbits/errors/errors.go
@@ -57,7 +57,7 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 			rerrs = []error{o.error}
 		}
 		for _, errv := range rerrs {
-			message := trimError(locale.ErrorMessage(errv))
+			message := normalizeError(locale.ErrorMessage(errv))
 			if f == output.PlainFormatName {
 				outLines = append(outLines, formatMessage(message)...)
 			} else {
@@ -76,7 +76,7 @@ func (o *OutputError) MarshalOutput(f output.Format) interface{} {
 		outLines = append(outLines, "") // separate error from "Need More Help?" header
 		outLines = append(outLines, strings.TrimSpace(output.Title(locale.Tl("err_more_help", "Need More Help?")).String()))
 		for _, tip := range errorTips {
-			outLines = append(outLines, fmt.Sprintf(" [DISABLED]•[/RESET] %s", trimError(tip)))
+			outLines = append(outLines, fmt.Sprintf(" [DISABLED]•[/RESET] %s", normalizeError(tip)))
 		}
 	}
 	return strings.Join(outLines, "\n")
@@ -127,11 +127,13 @@ func (o *OutputError) MarshalStructured(f output.Format) interface{} {
 	return output.StructuredError{message, getErrorTips(o.error)}
 }
 
-func trimError(msg string) string {
-	if strings.Count(msg, ".") > 1 || strings.Count(msg, ",") > 0 {
-		return msg // Don't trim dots if we have multiple sentences.
+// normalizeError ensures the given erorr message ends with a period.
+func normalizeError(msg string) string {
+	msg = strings.TrimRight(msg, " ")
+	if !strings.HasSuffix(msg, ".") {
+		msg = msg + "."
 	}
-	return strings.TrimRight(msg, " .")
+	return msg
 }
 
 // ParseUserFacing returns the exit code and a user facing error message.

--- a/test/integration/errors_int_test.go
+++ b/test/integration/errors_int_test.go
@@ -32,7 +32,7 @@ func (suite *ErrorsIntegrationTestSuite) TestMultiError() {
 	defer ts.Close()
 
 	cp := ts.Spawn("__test", "multierror")
-	cp.ExpectRe(`\s+x error1\s+\s+x error2\s+x error3\s+x error4\s+█\s+Need More Help`)
+	cp.ExpectRe(`\s+x error1.\s+\s+x error2.\s+x error3.\s+x error4.\s+█\s+Need More Help`)
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2453" title="DX-2453" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2453</a>  Change standardization of error formatting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
