### PR TITLE
Mark invalid `state init` languages as input errors.

### DIFF
--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -33,7 +33,7 @@ func UnrecognizedLanguageError(name string, options []string) *locale.LocalizedE
 	if len(options) > 0 {
 		opts = strings.Join(options, ", ")
 	}
-	return locale.NewError("err_invalid_language", "", name, opts)
+	return locale.NewInputError("err_invalid_language", "", name, opts)
 }
 
 const (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2449" title="DX-2449" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2449</a>  INIT: `CRT` error in log for expected behavior
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
