### PR TITLE
When listing requested versions, consider version constraints list.

### DIFF
--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -137,7 +137,10 @@ func (l *List) Run(params ListRunParams, nstype model.NamespaceType) error {
 
 		version := req.VersionConstraint
 		if version == "" {
-			version = locale.T("constraint_auto")
+			version = model.GqlReqVersionConstraintsString(req)
+			if version == "" {
+				version = locale.T("constraint_auto")
+			}
 		}
 
 		resolvedVersion := ""

--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -332,7 +332,7 @@ func prepareEditRequest(ingredient *ParentIngredient, r *request.PublishVariable
 				request.PublishVariableDep{request.Dependency{
 					Name:                ptr.From(dep.Feature, ""),
 					Namespace:           ptr.From(dep.Namespace, ""),
-					VersionRequirements: model.RequirementsToString(dep.Requirements),
+					VersionRequirements: model.InventoryRequirementsToString(dep.Requirements),
 				}, []request.Dependency{}},
 			)
 		}

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
@@ -13,7 +12,6 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/pkg/platform/api/graphql"
 	gqlModel "github.com/ActiveState/cli/pkg/platform/api/graphql/model"
 	"github.com/ActiveState/cli/pkg/platform/api/graphql/request"
@@ -100,35 +98,6 @@ func GqlReqsToMonoCheckpoint(requirements []*gqlModel.Requirement) []*mono_model
 		result = append(result, &req.Checkpoint)
 	}
 	return result
-}
-
-func GqlReqVersionConstraintsString(requirement *gqlModel.Requirement) string {
-	if requirement.VersionConstraints == nil || len(requirement.VersionConstraints) == 0 {
-		return ""
-	}
-
-	parts := []string{}
-	for _, req := range requirement.VersionConstraints {
-		if req.Version == "" || req.Comparator == "" {
-			multilog.Error("Invalid req, has empty values: %v", req)
-			continue
-		}
-		switch req.Comparator {
-		case inventory_models.RequirementComparatorEq:
-			parts = append(parts, req.Version)
-		case inventory_models.RequirementComparatorGt:
-			parts = append(parts, fmt.Sprintf(">%s", req.Version))
-		case inventory_models.RequirementComparatorGte:
-			parts = append(parts, fmt.Sprintf(">=%s", req.Version))
-		case inventory_models.RequirementComparatorLt:
-			parts = append(parts, fmt.Sprintf("<%s", req.Version))
-		case inventory_models.RequirementComparatorLte:
-			parts = append(parts, fmt.Sprintf("<=%s", req.Version))
-		case inventory_models.RequirementComparatorNe:
-			parts = append(parts, fmt.Sprintf("!%s", req.Version))
-		}
-	}
-	return strings.Join(parts, ",")
 }
 
 // FilterCheckpointNamespace filters a Checkpoint removing requirements that do not match the given namespace.

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
@@ -12,6 +13,7 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
+	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/pkg/platform/api/graphql"
 	gqlModel "github.com/ActiveState/cli/pkg/platform/api/graphql/model"
 	"github.com/ActiveState/cli/pkg/platform/api/graphql/request"
@@ -98,6 +100,35 @@ func GqlReqsToMonoCheckpoint(requirements []*gqlModel.Requirement) []*mono_model
 		result = append(result, &req.Checkpoint)
 	}
 	return result
+}
+
+func GqlReqVersionConstraintsString(requirement *gqlModel.Requirement) string {
+	if requirement.VersionConstraints == nil || len(requirement.VersionConstraints) == 0 {
+		return ""
+	}
+
+	parts := []string{}
+	for _, req := range requirement.VersionConstraints {
+		if req.Version == "" || req.Comparator == "" {
+			multilog.Error("Invalid req, has empty values: %v", req)
+			continue
+		}
+		switch req.Comparator {
+		case inventory_models.RequirementComparatorEq:
+			parts = append(parts, req.Version)
+		case inventory_models.RequirementComparatorGt:
+			parts = append(parts, fmt.Sprintf(">%s", req.Version))
+		case inventory_models.RequirementComparatorGte:
+			parts = append(parts, fmt.Sprintf(">=%s", req.Version))
+		case inventory_models.RequirementComparatorLt:
+			parts = append(parts, fmt.Sprintf("<%s", req.Version))
+		case inventory_models.RequirementComparatorLte:
+			parts = append(parts, fmt.Sprintf("<=%s", req.Version))
+		case inventory_models.RequirementComparatorNe:
+			parts = append(parts, fmt.Sprintf("!%s", req.Version))
+		}
+	}
+	return strings.Join(parts, ",")
 }
 
 // FilterCheckpointNamespace filters a Checkpoint removing requirements that do not match the given namespace.

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/go-openapi/strfmt"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -473,33 +472,4 @@ func FetchNormalizedName(namespace Namespace, name string) (string, error) {
 		return "", errs.New("Normalized name for %s not found", name)
 	}
 	return *res.Payload.NormalizedNames[0].Normalized, nil
-}
-
-func RequirementsToString(requirements inventory_models.Requirements) string {
-	if requirements == nil || len(requirements) == 0 {
-		return ""
-	}
-
-	parts := []string{}
-	for _, requirement := range requirements {
-		if requirement.Version == nil || requirement.Comparator == nil {
-			multilog.Error("Invalid requirement, has nil values: %v", requirement)
-			continue
-		}
-		switch *requirement.Comparator {
-		case inventory_models.RequirementComparatorEq:
-			parts = append(parts, *requirement.Version)
-		case inventory_models.RequirementComparatorGt:
-			parts = append(parts, fmt.Sprintf(">%s", *requirement.Version))
-		case inventory_models.RequirementComparatorGte:
-			parts = append(parts, fmt.Sprintf(">=%s", *requirement.Version))
-		case inventory_models.RequirementComparatorLt:
-			parts = append(parts, fmt.Sprintf("<%s", *requirement.Version))
-		case inventory_models.RequirementComparatorLte:
-			parts = append(parts, fmt.Sprintf("<=%s", *requirement.Version))
-		case inventory_models.RequirementComparatorNe:
-			parts = append(parts, fmt.Sprintf("!%s", *requirement.Version))
-		}
-	}
-	return strings.Join(parts, ",")
 }

--- a/pkg/platform/model/version_constraints.go
+++ b/pkg/platform/model/version_constraints.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ActiveState/cli/internal/multilog"
+	gqlModel "github.com/ActiveState/cli/pkg/platform/api/graphql/model"
+	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_models"
+)
+
+type versionConstraints struct {
+	comparator string
+	version    string
+}
+
+func InventoryRequirementsToString(requirements inventory_models.Requirements) string {
+	if requirements == nil {
+		return ""
+	}
+
+	constraints := make([]*versionConstraints, len(requirements))
+	for i, req := range requirements {
+		constraints[i] = &versionConstraints{*req.Comparator, *req.Version}
+	}
+	return versionConstraintsToString(constraints)
+}
+
+func GqlReqVersionConstraintsString(requirement *gqlModel.Requirement) string {
+	if requirement.VersionConstraints == nil {
+		return ""
+	}
+
+	constraints := make([]*versionConstraints, len(requirement.VersionConstraints))
+	for i, constraint := range requirement.VersionConstraints {
+		constraints[i] = &versionConstraints{constraint.Comparator, constraint.Version}
+	}
+	return versionConstraintsToString(constraints)
+}
+
+func versionConstraintsToString(constraints []*versionConstraints) string {
+	if len(constraints) == 0 {
+		return ""
+	}
+
+	parts := []string{}
+	for _, req := range constraints {
+		if req.version == "" || req.comparator == "" {
+			multilog.Error("Invalid req, has empty values: %v", req)
+			continue
+		}
+		switch req.comparator {
+		case inventory_models.RequirementComparatorEq:
+			parts = append(parts, req.version)
+		case inventory_models.RequirementComparatorGt:
+			parts = append(parts, fmt.Sprintf(">%s", req.version))
+		case inventory_models.RequirementComparatorGte:
+			parts = append(parts, fmt.Sprintf(">=%s", req.version))
+		case inventory_models.RequirementComparatorLt:
+			parts = append(parts, fmt.Sprintf("<%s", req.version))
+		case inventory_models.RequirementComparatorLte:
+			parts = append(parts, fmt.Sprintf("<=%s", req.version))
+		case inventory_models.RequirementComparatorNe:
+			parts = append(parts, fmt.Sprintf("!%s", req.version))
+		}
+	}
+	return strings.Join(parts, ",")
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2464" title="DX-2464" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2464</a>  install `django@4.1.x` where expected resolve should be `4.1.13` but under `state pkg` shown `Auto → 4.1.13`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The version constraint string will be empty if it's a complex constraint.

Sample:

```
% ../../cli/build/state packages         
█ Listing Packages

Operating on project ActiveState-CLI/small-python, located at 
/Users/me/tmp/small-python.

  Name      Version              
─────────────────────────────────
  django    >=4.1,<4.2 → 4.1.13
```