### PR TITLE
Replace uses of `os.Exit()` outside main with `panic()`.

### DIFF
--- a/internal/runners/projects/remote.go
+++ b/internal/runners/projects/remote.go
@@ -18,6 +18,10 @@ import (
 func (r *Projects) RunRemote(params *Params) error {
 	projectfile.CleanProjectMapping(r.config)
 
+	if !r.auth.Authenticated() {
+		return locale.NewInputError("err_api_not_authenticated")
+	}
+
 	remoteProjects, err := r.newRemoteProjectsOutput(params.Local)
 	if err != nil {
 		return locale.WrapError(err, "project_err")

--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -62,8 +62,7 @@ func LegacyGet() *Auth {
 		cfg, err := config.New()
 		if err != nil {
 			// TODO: We need to get rid of this Get() function altogether...
-			multilog.Error("Could not get configuration required by auth: %v", err)
-			os.Exit(1)
+			panic(fmt.Sprintf("Could not get configuration required by auth: %v", err))
 		}
 
 		persist = New(cfg)
@@ -353,7 +352,7 @@ func (s *Auth) Client() *mono_client.Mono {
 	if err != nil {
 		logging.Debug("Trying to get the Client while not authenticated")
 		fmt.Fprintln(os.Stderr, colorize.StripColorCodes(locale.T("err_api_not_authenticated")))
-		exit(1)
+		panic("Trying to get the Client while not authenticated")
 	}
 
 	return client

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -282,8 +282,9 @@ func Get() *Project {
 	pj := projectfile.Get()
 	project, err := New(pj, output.Get())
 	if err != nil {
-		fmt.Fprint(os.Stderr, locale.Tr("err_project_unavailable", err.Error()))
-		os.Exit(1)
+		message := locale.Tr("err_project_unavailable", err.Error())
+		fmt.Fprint(os.Stderr, message)
+		panic(message)
 	}
 	return project
 }

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -822,9 +822,8 @@ func getProjectFilePathFromDefault() (_ string, rerr error) {
 func Get() *Project {
 	project, err := GetSafe()
 	if err != nil {
-		multilog.Error("projectfile.Get() failed with: %s", err.Error())
 		fmt.Fprint(os.Stderr, locale.T("err_project_file_unavailable"))
-		os.Exit(1)
+		panic(fmt.Sprintf("projectfile.Get() failed with: %s", err.Error()))
 	}
 
 	return project
@@ -1190,9 +1189,8 @@ func Reset() {
 // Only one project can persist at a time.
 func (p *Project) Persist() {
 	if p.Project == "" {
-		multilog.Error("projectfile.Persist() failed because no project is defined")
 		fmt.Fprint(os.Stderr, locale.T("err_invalid_project"))
-		os.Exit(1)
+		panic("projectfile.Persist() failed because no project is defined")
 	}
 	persistentProject = p
 	os.Setenv(constants.ProjectEnvVarName, p.Path())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2468" title="DX-2468" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2468</a>  Running `state projects remote` when not auth, exit state prematurely causing printed command not echo in the prompt
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

main recovers from panics and reports them to Rollbar.

Also require authentication prior to running `state projects remote`, which triggered this PR.

Any calls to `os.Exit()` will ignore the deferred method in main that turns back on terminal echoing. (It is supposed to be turned off during State Tool execution.) Linux was susceptible to having terminal echo left off after a premature exit.