### PR TITLE
Always check for empty namespace

### DIFF
--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -205,10 +205,10 @@ func (r *Runner) Run(params *Params) error {
 		if reqVars.Description != "" {
 			return locale.NewInputError("err_uploadingredient_edit_description_not_supported")
 		}
+	}
 
-		if reqVars.Namespace == "" {
-			return locale.NewInputError("err_uploadingredient_namespace_required", "You have to supply the namespace when working outside of a project context")
-		}
+	if reqVars.Namespace == "" {
+		return locale.NewInputError("err_uploadingredient_namespace_required", "You have to supply the namespace when working outside of a project context")
 	}
 
 	b, err := reqVars.MarshalYaml(false)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2495" title="DX-2495" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2495</a>  state publish gives actionable errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

I'm not entirely sure about this fix. The ticket is written almost like a story but it is a bug. I was able to repro and this fixes the bug. For `state publish` to provide actionable errors we should add user facing errors to the runner, but that feels out of scope for this bug. If that's what we want to do, or we want to do more of an audit on the potential errors let me know and I'll take another stab at it.