### PR TITLE
Validate UUID for namespace arguments.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -437,6 +437,8 @@ err_signs3_invalid_url:
   other: API Responded with an invalid S3 URL, please contact support
 err_invalid_namespace:
   other: "Invalid namespace: [NOTICE]{{.V0}}[/RESET]. Should be in the format of [NOTICE]org/project[/RESET], and can optionally contain a [NOTICE]#COMMIT_ID[/RESET] suffix. Names should be alphanumeric and may contain dashes and periods."
+err_invalid_commit_id:
+  other: "Invalid commit ID: [NOTICE]{{.V0}}[/RESET]. It should be a valid UUID."
 err_invalid_project_name:
   other: "Invalid project name: [NOTICE]{{.V0}}[/RESET]. Names should be alphanumeric, may contain dashes and periods, and can optionally contain a [NOTICE]#COMMIT_ID[/RESET] suffix."
 err_could_not_get_commit_behind_count:

--- a/pkg/project/namespace.go
+++ b/pkg/project/namespace.go
@@ -109,7 +109,11 @@ func ParseNamespace(raw string) (*Namespaced, error) {
 	}
 
 	if len(groups) > 3 && len(groups[3]) > 0 {
-		uuid := strfmt.UUID(groups[3])
+		uuidString := groups[3]
+		if !strfmt.IsUUID(uuidString) {
+			return nil, locale.NewInputError("err_invalid_commit_id", "", uuidString)
+		}
+		uuid := strfmt.UUID(uuidString)
 		names.CommitID = &uuid
 	}
 
@@ -129,7 +133,11 @@ func ParseProjectNoOwner(raw string) (*Namespaced, error) {
 	}
 
 	if len(groups) > 2 && len(groups[2]) > 0 {
-		uuid := strfmt.UUID(groups[2])
+		uuidString := groups[2]
+		if !strfmt.IsUUID(uuidString) {
+			return nil, locale.NewInputError("err_invalid_commit_id", "", uuidString)
+		}
+		uuid := strfmt.UUID(uuidString)
 		names.CommitID = &uuid
 	}
 

--- a/pkg/project/namespace_test.go
+++ b/pkg/project/namespace_test.go
@@ -19,8 +19,11 @@ func TestParseNamespace(t *testing.T) {
 	_, err := ParseNamespace("valid/namespace")
 	assert.NoError(t, err, "should parse a valid namespace")
 
-	_, err = ParseNamespace("valid/namespace#a10-b11c12-d13e14-f15")
+	_, err = ParseNamespace("valid/namespace#00000000-0000-0000-0000-000000000000")
 	assert.NoError(t, err, "should parse a valid namespace with 'uuid'")
+
+	_, err = ParseNamespace("valid/namespace#a10-b11c12-d13e14-f15")
+	assert.Error(t, err, "should fail to parse an invalid 'uuid'")
 
 	_, err = ParseNamespace("valid/namespace#")
 	assert.NoError(t, err, "should parse a valid namespace with empty uuid")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2475" title="DX-2475" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2475</a>  ACTIVATE: `CRT` error in log for expected behavior
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Invalid UUIDs should trigger user input errors ASAP.