### PR TITLE
Quote state executable with spaces in name for `state shell`.

### DIFF
--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -348,7 +348,11 @@ func SetupProjectRcFile(prj *project.Project, templateName, ext string, env map[
 	pathList, ok := env["PATH"]
 	inPathList, err := fileutils.PathInList(listSep, pathList, currExecAbsDir)
 	if !ok || !inPathList {
-		rcData["ExecAlias"] = currExec // alias {ExecName}={ExecAlias}
+		safeExec := currExec
+		if strings.Index(currExec, " ") != -1 {
+			safeExec = fmt.Sprintf(`"%s"`, currExec) // quote for alias
+		}
+		rcData["ExecAlias"] = safeExec // alias {ExecName}={ExecAlias}
 	}
 
 	t := template.New("rcfile")

--- a/internal/subshell/sscommon/rcfile.go
+++ b/internal/subshell/sscommon/rcfile.go
@@ -349,7 +349,7 @@ func SetupProjectRcFile(prj *project.Project, templateName, ext string, env map[
 	inPathList, err := fileutils.PathInList(listSep, pathList, currExecAbsDir)
 	if !ok || !inPathList {
 		safeExec := currExec
-		if strings.Index(currExec, " ") != -1 {
+		if strings.ContainsAny(currExec, " ") {
 			safeExec = fmt.Sprintf(`"%s"`, currExec) // quote for alias
 		}
 		rcData["ExecAlias"] = safeExec // alias {ExecName}={ExecAlias}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2487" title="DX-2487" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2487</a>  `state shell` messes with whitespace in PATH
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Without the quotes, the first part before the space would be incorrectly considered a command.