### PR TITLE
Include original webclient ID in auth and signup URLs.

### DIFF
--- a/internal/runbits/auth/signup.go
+++ b/internal/runbits/auth/signup.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
@@ -9,10 +10,10 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 )
 
-func SignupWithBrowser(out output.Outputer, auth *authentication.Auth, prompt prompt.Prompter) error {
+func SignupWithBrowser(out output.Outputer, auth *authentication.Auth, prompt prompt.Prompter, cfg keypairs.Configurable) error {
 	logging.Debug("Signing up with browser")
 
-	err := authenticateWithBrowser(out, auth, prompt, true)
+	err := authenticateWithBrowser(out, auth, prompt, cfg, true)
 	if err != nil {
 		return errs.Wrap(err, "Error signing up with browser")
 	}

--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -95,7 +95,7 @@ func (a *Auth) authenticate(params *AuthParams) error {
 		return locale.NewInputError("err_auth_needinput")
 	}
 
-	return auth.AuthenticateWithBrowser(a.Outputer, a.Auth, a.Prompter)
+	return auth.AuthenticateWithBrowser(a.Outputer, a.Auth, a.Prompter, a.Cfg)
 }
 
 func (a *Auth) verifyAuthentication() error {

--- a/internal/runners/auth/signup.go
+++ b/internal/runners/auth/signup.go
@@ -29,5 +29,5 @@ func (s *Signup) Run(params *SignupParams) error {
 		return locale.NewInputError("err_auth_authenticated", "You are already authenticated as: {{.V0}}. You can log out by running '[ACTIONABLE]state auth logout[/RESET]'.", s.Auth.WhoAmI())
 	}
 
-	return auth.SignupWithBrowser(s.Outputer, s.Auth, s.Prompter)
+	return auth.SignupWithBrowser(s.Outputer, s.Auth, s.Prompter, s.Configurable)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2529" title="DX-2529" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2529</a>  Pass webclient_id to signup and sign-in pages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
