### PR TITLE
Proof-of-concept using git hooks to auto-compute commit ID files after resolving a merge conflict

### DIFF
--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -76,6 +76,8 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		}
 		commitID = &stagedCommitID
 
+		localcommit.Set(proj.Dir(), commitID.String())
+
 		expr, err = getBuildExpression(proj, commitID, auth) // timestamps might be different
 		if err != nil {
 			return false, errs.Wrap(err, "Could not get remote build expr for staged commit")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2536" title="DX-2536" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2536</a>  Investigate using git hooks to auto resolve commit ID conflicts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
1. Checkout a new Perl 5.36.3 project

```
C:\Users\me\tmp>..\cli\build\state.exe checkout mitchell-as/perl hooks-demo
Setting Up Runtime
Resolving Dependencies ✔ Done
Downloading                                  1/1
Installing                                   1/1
✔ All dependencies have been installed and verified

Checked out project mitchell-as/perl, located at C:\Users\me\tmp\hooks-demo.
For editors and other tooling use the executables at: C:\Users\me\AppData\Local\activestate\cache\b87cdc00\exec.
```

2. Initialize a git repo and make an initial commit.

```
C:\Users\me\tmp\hooks-demo>git init
Initialized empty Git repository in C:/Users/me/tmp/hooks-demo/.git/

C:\Users\me\tmp\hooks-demo>git add .activestate activestate.yaml buildscript.as
warning: in the working copy of 'buildscript.as', LF will be replaced by CRLF the next time Git touches it

C:\Users\me\tmp\hooks-demo>git commit
running pre-commit git hook
fatal: bad revision 'HEAD@{1}'
hint: Waiting for your editor to close the file... unix2dos: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to DOS format...
dos2unix: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to Unix format...
[master (root-commit) de7ea01] initial commit
 3 files changed, 84 insertions(+)
 create mode 100644 .activestate/commit
 create mode 100644 activestate.yaml
 create mode 100644 buildscript.as
```

3. Create a new branch and install JSON@4.09 and Try-Tiny@auto to it.

```
C:\Users\me\tmp\hooks-demo>git branch json-4.09

C:\Users\me\tmp\hooks-demo>..\..\cli\build\state.exe install JSON@4.09
█ Installing Package

Operating on project mitchell-as/perl, located at C:\Users\me\tmp\hooks-demo.

 • Searching for JSON in the ActiveState Catalog ✔ Found
 • Creating commit ✔ Done
█ Updating Runtime

Changes to your runtime may require some dependencies to be rebuilt.

Setting Up Runtime
Resolving Dependencies ✔ Done
Build Log
C:\Users\me\AppData\Roaming\activestate\cli-mitchell\dx-2415\logs\build-0d4382ac-8341-4047-a578-987d61736f4e-20240206182809.log
Building                                     3/3
✔ All dependencies have been installed and verified

Package added: JSON@4.09
Your local project has been updated.
Run state push to save changes to the platform.


C:\Users\me\tmp\hooks-demo>git add .activestate\commit buildscript.as
warning: in the working copy of 'buildscript.as', LF will be replaced by CRLF the next time Git touches it

C:\Users\me\tmp\hooks-demo>git commit
running pre-commit git hook
hint: Waiting for your editor to close the file... unix2dos: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to DOS format...
dos2unix: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to Unix format...
[json-4.09 b8be5cc] add json-4.09
 2 files changed, 12 insertions(+), 2 deletions(-)

C:\Users\me\tmp\hooks-demo>..\..\cli\build\state.exe install Try-Tiny
█ Installing Package

Operating on project mitchell-as/perl, located at C:\Users\me\tmp\hooks-demo.

 • Searching for Try-Tiny in the ActiveState Catalog ✔ Found
 • Creating commit |✔ Done
█ Updating Runtime

Changes to your runtime may require some dependencies to be rebuilt.

Setting Up Runtime
Resolving Dependencies ✔ Done
Build Log
C:\Users\me\AppData\Roaming\activestate\cli-mitchell\dx-2415\logs\build-30e0ea7d-5655-4253-ad79-fd6b7ea00a77-20240206182837.log
Building                                     4/4
Downloading                                  1/1
Installing                                   1/1
✔ All dependencies have been installed and verified

Package added: Try-Tiny
Your local project has been updated.
Run state push to save changes to the platform.


C:\Users\me\tmp\hooks-demo>git add .activestate\commit buildscript.as
warning: in the working copy of 'buildscript.as', LF will be replaced by CRLF the next time Git touches it

C:\Users\me\tmp\hooks-demo>git commit
running pre-commit git hook
buildscript.as changed, running 'state commit'
█ Commit Changes (Beta)

Beta Feature: This feature is still in beta and may be unstable.

No change to the buildscript was found.
hint: Waiting for your editor to close the file... unix2dos: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to DOS format...
dos2unix: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to Unix format...
[json-4.09 fd8ef71] added try-tiny
 2 files changed, 5 insertions(+), 1 deletion(-)
```

4. Switch back to master and install JSON@auto to it.

```
C:\Users\me\tmp\hooks-demo>git checkout master
Switched to branch 'master'

C:\Users\me\tmp\hooks-demo>..\..\cli\build\state.exe install JSON
█ Installing Package

Operating on project mitchell-as/perl, located at C:\Users\me\tmp\hooks-demo.

 • Searching for JSON in the ActiveState Catalog ✔ Found
 • Creating commit ✔ Done
█ Updating Runtime

Changes to your runtime may require some dependencies to be rebuilt.

Setting Up Runtime
Resolving Dependencies ✔ Done
Build Log
C:\Users\me\AppData\Roaming\activestate\cli-mitchell\dx-2415\logs\build-2741ddd8-c513-4347-84fb-97693c4f6f74-20240206182924.log
Building                                     3/3
Downloading                                  1/1
Installing                                   1/1
✔ All dependencies have been installed and verified

Package added: JSON
Your local project has been updated.
Run state push to save changes to the platform.


C:\Users\me\tmp\hooks-demo>git add .activestate\commit buildscript.as
warning: in the working copy of 'buildscript.as', LF will be replaced by CRLF the next time Git touches it

C:\Users\me\tmp\hooks-demo>git commit
running pre-commit git hook
buildscript.as changed, running 'state commit'
█ Commit Changes (Beta)

Beta Feature: This feature is still in beta and may be unstable.

No change to the buildscript was found.
hint: Waiting for your editor to close the file... unix2dos: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to DOS format...
dos2unix: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to Unix format...
[master 4e08fd3] added JSON
 2 files changed, 6 insertions(+), 2 deletions(-)
```

5. Now attempt to merge the json-4.09 branch into master. There will be a merge conflict in the buildscript and commit ID file.

```
C:\Users\me\tmp\hooks-demo>git merge json-4.09
Auto-merging .activestate/commit
CONFLICT (content): Merge conflict in .activestate/commit
Auto-merging buildscript.as
CONFLICT (content): Merge conflict in buildscript.as
Automatic merge failed; fix conflicts and then commit the result.
```

6. Resolve the conflict by picking JSON@auto and Try-Tiny@auto, and pick whichever commit ID you want (it doesn't matter, as it will be recomputed and overwritten). Then continue the merge.

```
C:\Users\me\tmp\hooks-demo>git add .activestate\commit buildscript.as

C:\Users\me\tmp\hooks-demo>git merge --continue
running pre-commit git hook
buildscript.as changed, running 'state commit'
█ Commit Changes (Beta)

Beta Feature: This feature is still in beta and may be unstable.

Updating project to reflect build script changes...
Setting Up Runtime ....... ✔ All dependencies have been installed and verified
Runtime updated for project mitchell-as/perl, located at C:\Users\me\tmp\hooks-demo.
For editors and other tooling use the executables at:
C:\Users\me\AppData\Local\activestate\cache\b87cdc00\exec.

adding new commit id
hint: Waiting for your editor to close the file... unix2dos: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to DOS format...
dos2unix: converting file C:/Users/me/tmp/hooks-demo/.git/COMMIT_EDITMSG to Unix format...
[master 2703984] Merge branch 'json-4.09'
```

7. Verify the updated buildscript and commit ID are valid and up to date.

```
C:\Users\me\tmp\hooks-demo>..\..\cli\build\state.exe commit
█ Commit Changes (Beta)

Beta Feature: This feature is still in beta and may be unstable.

No change to the buildscript was found.
```