### PR TITLE
Removed outdated integration test.

### DIFF
--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -268,18 +268,6 @@ func (suite *PackageIntegrationTestSuite) TestPackage_info() {
 	cp.ExpectExitCode(0)
 }
 
-func (suite *PackageIntegrationTestSuite) TestPackage_infoWrongCase() {
-	suite.OnlyRunForTags(tagsuite.Package)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-	suite.PrepareActiveStateYAML(ts)
-
-	cp := ts.Spawn("info", "Pexpect")
-	cp.Expect("No packages in our catalog are an exact match")
-	cp.ExpectExitCode(1)
-	ts.IgnoreLogErrors()
-}
-
 func (suite *PackageIntegrationTestSuite) TestPackage_detached_operation() {
 	suite.OnlyRunForTags(tagsuite.Package)
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2542" title="DX-2542" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2542</a>  Nightly failure: TestPackageIntegrationTestSuite/TestPackage_infoWrongCase
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This test was not tagged with the Info tagsuite :(