### PR TITLE
Add `--full-id` flag to `state builds`

### DIFF
--- a/cmd/state/internal/cmdtree/builds.go
+++ b/cmd/state/internal/cmdtree/builds.go
@@ -22,6 +22,11 @@ func newBuildsCommand(prime *primer.Values) *captain.Command {
 				Description: "List all builds, including individual package artifacts",
 				Value:       &params.All,
 			},
+			{
+				Name:        "full-id",
+				Description: "List builds with their full identifier",
+				Value:       &params.Full,
+			},
 		},
 		[]*captain.Argument{},
 		func(_ *captain.Command, _ []string) error {

--- a/internal/runners/builds/builds.go
+++ b/internal/runners/builds/builds.go
@@ -33,6 +33,7 @@ type primeable interface {
 
 type Params struct {
 	All bool
+	Full bool
 }
 
 type Builds struct {
@@ -165,10 +166,10 @@ func (b *Builds) Run(params *Params) (rerr error) {
 		return nil
 	}
 
-	return b.outputPlain(out)
+	return b.outputPlain(out, params.Full)
 }
 
-func (b *Builds) outputPlain(out *StructuredOutput) error {
+func (b *Builds) outputPlain(out *StructuredOutput, fullID bool) error {
 	for _, platform := range out.Platforms {
 		b.out.Print(fmt.Sprintf("• [NOTICE]%s[/RESET]", platform.Name))
 		for _, artifact := range platform.Builds {
@@ -179,7 +180,11 @@ func (b *Builds) outputPlain(out *StructuredOutput) error {
 			b.out.Print(fmt.Sprintf("  • %s", locale.Tl("builds_packages", "[NOTICE]Packages[/RESET]")))
 		}
 		for _, artifact := range platform.Packages {
-			b.out.Print(fmt.Sprintf("    • %s (ID: [ACTIONABLE]%s[/RESET])", artifact.Name, strings.ToUpper(string(artifact.ID)[0:8])))
+			id := strings.ToUpper(artifact.ID)
+			if !fullID {
+				id = id[0:8]
+			}
+			b.out.Print(fmt.Sprintf("    • %s (ID: [ACTIONABLE]%s[/RESET])", artifact.Name, id))
 		}
 
 		if len(platform.Builds) == 0 && len(platform.Packages) == 0 {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2423" title="DX-2423" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2423</a>  As a user I can inspect which builds were produced for my runtime
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

