### PR TITLE
Added `--namespace` and `--commit` flags for `state builds` and subcommands.

### DIFF
--- a/cmd/state/internal/cmdtree/builds.go
+++ b/cmd/state/internal/cmdtree/builds.go
@@ -5,11 +5,12 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/runners/builds"
+	"github.com/ActiveState/cli/pkg/project"
 )
 
 func newBuildsCommand(prime *primer.Values) *captain.Command {
 	runner := builds.New(prime)
-	params := &builds.Params{}
+	params := &builds.Params{Namespace: &project.Namespaced{}}
 
 	cmd := captain.NewCommand(
 		"builds",
@@ -19,8 +20,18 @@ func newBuildsCommand(prime *primer.Values) *captain.Command {
 		[]*captain.Flag{
 			{
 				Name:        "all",
-				Description: "List all builds, including individual package artifacts",
+				Description: locale.Tl("builds_flags_all_description", "List all builds, including individual package artifacts"),
 				Value:       &params.All,
+			},
+			{
+				Name:        "namespace",
+				Description: locale.Tl("builds_flags_namespace_description", "The namespace of the project to inspect builds for"),
+				Value:       params.Namespace,
+			},
+			{
+				Name:        "commit",
+				Description: locale.Tl("builds_flags_commit_description", "The commit ID to inspect builds for"),
+				Value:       &params.CommitID,
 			},
 		},
 		[]*captain.Argument{},
@@ -37,14 +48,25 @@ func newBuildsCommand(prime *primer.Values) *captain.Command {
 
 func newBuildsDownloadCommand(prime *primer.Values) *captain.Command {
 	runner := builds.NewDownload(prime)
-	params := &builds.DownloadParams{}
+	params := &builds.DownloadParams{Namespace: &project.Namespaced{}}
 
 	cmd := captain.NewCommand(
 		"dl",
 		locale.Tl("builds_download_title", "Download build artifacts"),
 		locale.Tl("builds_download_description", "Download build artifacts for a given build"),
 		prime,
-		[]*captain.Flag{},
+		[]*captain.Flag{
+			{
+				Name:        "namespace",
+				Description: locale.Tl("builds_download_flags_namespace_description", "The namespace of the project to download artifacts from"),
+				Value:       params.Namespace,
+			},
+			{
+				Name:        "commit",
+				Description: locale.Tl("builds_download_flags_commit_description", "The commit ID to download artifacts from"),
+				Value:       &params.CommitID,
+			},
+		},
 		[]*captain.Argument{
 			{
 				Name:        "ID",

--- a/internal/runners/builds/builds.go
+++ b/internal/runners/builds/builds.go
@@ -233,7 +233,7 @@ func getTerminalArtifactMap(
 		// Return the artifact map for the latest commitID of the given project.
 		pj, err := model.FetchProjectByName(namespace.Owner, namespace.Project)
 		if err != nil {
-			return nil, locale.WrapError(err, "err_fetch_project", "", namespace.String())
+			return nil, locale.WrapInputError(err, "err_fetch_project", "", namespace.String())
 		}
 
 		branch, err := model.DefaultBranchForProject(pj)

--- a/internal/runners/builds/builds.go
+++ b/internal/runners/builds/builds.go
@@ -35,7 +35,7 @@ type Params struct {
 	All       bool
 	Namespace *project.Namespaced
 	CommitID  string
-	Full bool
+	Full      bool
 }
 
 type Builds struct {

--- a/internal/runners/builds/rationalize.go
+++ b/internal/runners/builds/rationalize.go
@@ -9,10 +9,17 @@ import (
 )
 
 func rationalizeCommonError(err *error) {
+	var invalidCommitIdErr *errInvalidCommitId
+
 	switch {
 	case errors.Is(*err, rationalize.ErrNoProject):
 		*err = errs.WrapUserFacing(*err,
 			locale.Tr("err_no_project"),
+			errs.SetInput())
+
+	case errors.As(*err, &invalidCommitIdErr):
+		*err = errs.WrapUserFacing(
+			*err, locale.Tr("err_commit_id_invalid", invalidCommitIdErr.id),
 			errs.SetInput())
 	}
 }

--- a/test/integration/builds_int_test.go
+++ b/test/integration/builds_int_test.go
@@ -101,6 +101,40 @@ func (suite *BuildsIntegrationTestSuite) TestBuilds() {
 	})
 }
 
+func (suite *BuildsIntegrationTestSuite) TestBuilds_Remote() {
+	suite.OnlyRunForTags(tagsuite.Builds)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	suite.Run("Namespace only", func() {
+		cp := ts.Spawn("builds", "--namespace", "ActiveState-CLI/Python-With-Custom-Builds")
+		cp.Expect("CentOS")
+		cp.Expect("Docker Image")
+		cp.Expect("Installer")
+		cp.Expect("macOS")
+		cp.Expect("No builds")
+		cp.Expect("Windows")
+		cp.Expect("Signed Installer")
+		cp.Expect(".exe")
+		cp.Expect("To download builds run")
+		cp.ExpectExitCode(0)
+	})
+
+	suite.Run("Namespace and commit ID", func() {
+		cp := ts.Spawn("builds", "--namespace", "ActiveState-CLI/Python-With-Custom-Builds", "--commit", "993454c7-6613-4b1a-8981-1cee43cc249e")
+		cp.Expect("CentOS")
+		cp.Expect("Docker Image")
+		cp.Expect("Installer")
+		cp.Expect("macOS")
+		cp.Expect("No builds")
+		cp.Expect("Windows")
+		cp.Expect("Signed Installer")
+		cp.Expect(".exe")
+		cp.Expect("To download builds run")
+		cp.ExpectExitCode(0)
+	})
+}
+
 func (suite *BuildsIntegrationTestSuite) TestBuilds_Download() {
 	suite.OnlyRunForTags(tagsuite.Builds)
 	ts := e2e.New(suite.T(), false)
@@ -117,6 +151,17 @@ func (suite *BuildsIntegrationTestSuite) TestBuilds_Download() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("builds", "dl", "a46a74e9", "."),
 	)
+	cp.Expect("Downloaded bzip2", e2e.RuntimeSourcingTimeoutOpt)
+	cp.ExpectExitCode(0)
+	require.FileExists(suite.T(), filepath.Join(ts.Dirs.Work, "artifact.tar.gz"))
+}
+
+func (suite *BuildsIntegrationTestSuite) TestBuilds_Download_Remote() {
+	suite.OnlyRunForTags(tagsuite.Builds)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("builds", "dl", "a46a74e9", ".", "--namespace", "ActiveState-CLI/Python-With-Custom-Builds")
 	cp.Expect("Downloaded bzip2", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 	require.FileExists(suite.T(), filepath.Join(ts.Dirs.Work, "artifact.tar.gz"))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2513" title="DX-2513" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2513</a>  `state builds` and subcommands work with remote projects
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

