### PR TITLE
Use localcommit in v44

### DIFF
--- a/internal/runners/packages/install.go
+++ b/internal/runners/packages/install.go
@@ -1,8 +1,6 @@
 package packages
 
 import (
-	"time"
-
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
@@ -55,13 +53,13 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 			return errs.Wrap(err, "Unable to get commit ID")
 		}
 
-		_, atTime, err := model.FetchCheckpointForCommit(commitID)
+		atTime, err := model.FetchTimeStampForCommit(commitID)
 		if err != nil {
 			return errs.Wrap(err, "Unable to get commit time")
 		}
 
-		if t := time.Time(atTime); t.After(latest) {
-			ts = &t
+		if atTime.After(latest) {
+			ts = atTime
 		}
 	}
 

--- a/internal/runners/packages/install.go
+++ b/internal/runners/packages/install.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
-	"github.com/ActiveState/cli/internal/runbits/commitmediator"
 	"github.com/ActiveState/cli/internal/runbits/requirements"
+	"github.com/ActiveState/cli/pkg/localcommit"
 	bpModel "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
 	"github.com/ActiveState/cli/pkg/platform/model"
 )
@@ -50,7 +50,7 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 			return errs.Wrap(err, "Unable to fetch latest Platform timestamp")
 		}
 
-		commitID, err := commitmediator.Get(a.prime.Project())
+		commitID, err := localcommit.Get(a.prime.Project().Dir())
 		if err != nil {
 			return errs.Wrap(err, "Unable to get commit ID")
 		}

--- a/internal/runners/packages/install.go
+++ b/internal/runners/packages/install.go
@@ -1,9 +1,13 @@
 package packages
 
 import (
+	"time"
+
 	"github.com/ActiveState/cli/internal/captain"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
+	"github.com/ActiveState/cli/internal/runbits/commitmediator"
 	"github.com/ActiveState/cli/internal/runbits/requirements"
 	bpModel "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
 	"github.com/ActiveState/cli/pkg/platform/model"
@@ -39,6 +43,28 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 		nsTypeV = &nsType
 	}
 
+	ts := params.Timestamp.Time
+	if ts == nil {
+		latest, err := model.FetchLatestTimeStamp()
+		if err != nil {
+			return errs.Wrap(err, "Unable to fetch latest Platform timestamp")
+		}
+
+		commitID, err := commitmediator.Get(a.prime.Project())
+		if err != nil {
+			return errs.Wrap(err, "Unable to get commit ID")
+		}
+
+		_, atTime, err := model.FetchCheckpointForCommit(commitID)
+		if err != nil {
+			return errs.Wrap(err, "Unable to get commit time")
+		}
+
+		if t := time.Time(atTime); t.After(latest) {
+			ts = &t
+		}
+	}
+
 	return requirements.NewRequirementOperation(a.prime).ExecuteRequirementOperation(
 		params.Package.Name,
 		params.Package.Version,
@@ -46,6 +72,6 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 		bpModel.OperationAdded,
 		ns,
 		nsTypeV,
-		params.Timestamp.Time,
+		ts,
 	)
 }

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -504,6 +504,17 @@ func FetchIngredientVersions(ingredientID *strfmt.UUID) ([]*inventory_models.Ing
 	return res.Payload.IngredientVersions, nil
 }
 
+// FetchLatestTimeStamp fetches the latest timestamp from the inventory service.
+func FetchLatestTimeStamp() (time.Time, error) {
+	client := inventory.Get()
+	result, err := client.GetLatestTimestamp(inventory_operations.NewGetLatestTimestampParams())
+	if err != nil {
+		return time.Now(), errs.Wrap(err, "GetLatestTimestamp failed")
+	}
+
+	return time.Time(*result.Payload.Timestamp), nil
+}
+
 func FetchNormalizedName(namespace Namespace, name string) (string, error) {
 	client := inventory.Get()
 	params := inventory_operations.NewNormalizeNamesParams()

--- a/pkg/platform/model/projects.go
+++ b/pkg/platform/model/projects.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 
@@ -92,6 +93,16 @@ func LanguageByCommit(commitID strfmt.UUID) (Language, error) {
 	}
 
 	return languages[0], nil
+}
+
+func FetchTimeStampForCommit(commitID strfmt.UUID) (*time.Time, error) {
+	_, atTime, err := FetchCheckpointForCommit(commitID)
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to fetch checkpoint for commit ID")
+	}
+
+	t := time.Time(atTime)
+	return &t, nil
 }
 
 // DefaultBranchForProjectName retrieves the default branch for the given project owner/name.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2569" title="DX-2569" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2569</a>  `state install --ts` is not preserved 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Merging and propagating #3105 is not compatible with v44 since commitmediator is used in v43, but localcommit is used in v44. That's what this PR is for.