### PR TITLE
Debug integration test failure

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -184,7 +184,6 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "cli-integration-tests/"+projectName, "--path="+ts.Dirs.Work),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-		e2e.OptAppendEnv(constants.DebugServiceRequestsEnvVarName+"=true"),
 	)
 
 	if runtime.GOOS == "linux" {
@@ -193,11 +192,6 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 		cp.ExpectInput(termtest.OptExpectTimeout(40 * time.Second))
 		cp.SendLine("exit")
 		cp.ExpectExitCode(0)
-	} else if runtime.GOOS == "windows" {
-		// We can definitely improve this error, but this particular test is testing that we can still activate on the
-		// platform that DOES match (ie. Linux)
-		cp.Expect("Could not update runtime installation")
-		cp.ExpectNotExitCode(0)
 	} else {
 		cp.Expect("Your current platform")
 		cp.Expect("does not appear to be configured")

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -184,6 +184,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "cli-integration-tests/"+projectName, "--path="+ts.Dirs.Work),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+		e2e.OptAppendEnv(constants.DebugServiceRequestsEnvVarName+"=true"),
 	)
 
 	if runtime.GOOS == "linux" {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2548" title="DX-2548" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2548</a>  TestActivatePythonByHostOnly failing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The integration test was working with a very old project that was in a weird state. It also looks like the project was setup so that Linux would build successfully and windows would fail. Looking at the test it's not clear as to why this is important as we want to test that it activates on the correct host and not on others. I've updated the project and removed Windows as a platform. I believe that should be enough. Here is a link to the project: https://platform.activestate.com/cli-integration-tests/Python-LinuxWorks
