### PR TITLE
Drop Windows runtime sourcing timeout back to 3 minutes.

### DIFF
--- a/internal/testhelpers/e2e/session_windows.go
+++ b/internal/testhelpers/e2e/session_windows.go
@@ -10,5 +10,5 @@ import (
 )
 
 var (
-	RuntimeSourcingTimeoutOpt = termtest.OptExpectTimeout(5 * time.Minute)
+	RuntimeSourcingTimeoutOpt = termtest.OptExpectTimeout(3 * time.Minute)
 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2476" title="DX-2476" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2476</a>  Identify why Windows runtime sourcing needs more time
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

