### PR TITLE
Fixed artifact caching despite previously cached artifacts not existing.

### DIFF
--- a/pkg/platform/runtime/artifactcache/artifactcache.go
+++ b/pkg/platform/runtime/artifactcache/artifactcache.go
@@ -112,9 +112,11 @@ func (cache *ArtifactCache) Store(a artifact.ArtifactID, archivePath string) err
 	if existingArtifact, found := cache.artifacts[a]; found {
 		path := existingArtifact.ArchivePath
 		logging.Debug("Replacing cached artifact '%s'", path)
-		err := os.Remove(path)
-		if err != nil {
-			return errs.Wrap(err, "Unable to overwrite existing artifact '%s'", path)
+		if fileutils.TargetExists(path) {
+			err := os.Remove(path)
+			if err != nil {
+				return errs.Wrap(err, "Unable to overwrite existing artifact '%s'", path)
+			}
 		}
 		delete(cache.artifacts, existingArtifact.Id)
 		cache.currentSize -= existingArtifact.Size
@@ -147,9 +149,11 @@ func (cache *ArtifactCache) Store(a artifact.ArtifactID, archivePath string) err
 		}
 
 		logging.Debug("Removing cached artifact '%s' last accessed on %s", lastAccessed.ArchivePath, time.Unix(lastAccessed.LastAccessTime, 0).Format(time.UnixDate))
-		err := os.Remove(lastAccessed.ArchivePath)
-		if err != nil {
-			return errs.Wrap(err, "Unable to remove cached artifact '%s'", lastAccessed.ArchivePath)
+		if fileutils.TargetExists(lastAccessed.ArchivePath) {
+			err := os.Remove(lastAccessed.ArchivePath)
+			if err != nil {
+				return errs.Wrap(err, "Unable to remove cached artifact '%s'", lastAccessed.ArchivePath)
+			}
 		}
 		delete(cache.artifacts, lastAccessed.Id)
 		cache.currentSize -= lastAccessed.Size


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2545" title="DX-2545" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2545</a>  state tool should install from cache locally whenever possible, especially for init
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
