### PR TITLE
Show `state publish` API errors.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1511,6 +1511,11 @@ alternative_unknown_pkg_name:
   other: unknown
 err_uploadingredient_edit_description_not_supported:
   other: Editing an ingredient description is not yet supported.
+err_uploadingredient_publish:
+  other: |
+    Could not publish ingredient.
+
+    Error received: {{.V0}}
 uploadingredient_editor_opening:
   other: |
     Opening editor to edit ingredient meta information. Alternatively you may manually edit the following file: [ACTIONABLE]{{.V0}}[/RESET].

--- a/internal/runbits/errors/errors.go
+++ b/internal/runbits/errors/errors.go
@@ -129,7 +129,7 @@ func (o *OutputError) MarshalStructured(f output.Format) interface{} {
 
 // normalizeError ensures the given erorr message ends with a period.
 func normalizeError(msg string) string {
-	msg = strings.TrimRight(msg, " ")
+	msg = strings.TrimRight(msg, " \r\n")
 	if !strings.HasSuffix(msg, ".") {
 		msg = msg + "."
 	}

--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -247,7 +247,7 @@ func (r *Runner) Run(params *Params) error {
 	result := graphModel.PublishResult{}
 
 	if err := r.client.Run(pr, &result); err != nil {
-		return locale.WrapError(err, "err_uploadingredient_publish", "Could not publish ingredient")
+		return locale.WrapInputError(err, "err_uploadingredient_publish", "", err.Error())
 	}
 
 	if result.Publish.Error != "" {

--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -247,7 +247,7 @@ func (r *Runner) Run(params *Params) error {
 	result := graphModel.PublishResult{}
 
 	if err := r.client.Run(pr, &result); err != nil {
-		return locale.WrapInputError(err, "err_uploadingredient_publish", "", err.Error())
+		return locale.WrapError(err, "err_uploadingredient_publish", "", err.Error())
 	}
 
 	if result.Publish.Error != "" {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2563" title="DX-2563" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2563</a>  state publish not showing helpful error messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This gives more context around "Could not publish ingredient".

Sample:

```
% build/state publish ~/tmp/hello-world5-1.0.1.zip --namespace <namespace> -n
█ Publish Ingredient (Beta)

Beta Feature: This feature is still in beta and may be unstable.

Publishing ingredient...
 x Could not publish ingredient.
  
  Error received: inventory.add_namespace: namespace needs to have 'org/' 
prefix.

█ Need More Help?
 • Run → 'state publish --help' for general help.
 • Ask For Help → https://community.activestate.com/c/state-tool/.
```