### PR TITLE
Use a more informative name for downloaded artifacts if necessary.

### DIFF
--- a/test/integration/builds_int_test.go
+++ b/test/integration/builds_int_test.go
@@ -153,7 +153,7 @@ func (suite *BuildsIntegrationTestSuite) TestBuilds_Download() {
 	)
 	cp.Expect("Downloaded bzip2", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
-	require.FileExists(suite.T(), filepath.Join(ts.Dirs.Work, "artifact.tar.gz"))
+	require.FileExists(suite.T(), filepath.Join(ts.Dirs.Work, "bzip2-1.0.8.tar.gz"))
 }
 
 func (suite *BuildsIntegrationTestSuite) TestBuilds_Download_Remote() {
@@ -164,7 +164,7 @@ func (suite *BuildsIntegrationTestSuite) TestBuilds_Download_Remote() {
 	cp := ts.Spawn("builds", "dl", "a46a74e9", ".", "--namespace", "ActiveState-CLI/Python-With-Custom-Builds")
 	cp.Expect("Downloaded bzip2", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
-	require.FileExists(suite.T(), filepath.Join(ts.Dirs.Work, "artifact.tar.gz"))
+	require.FileExists(suite.T(), filepath.Join(ts.Dirs.Work, "bzip2-1.0.8.tar.gz"))
 }
 
 func TestBuildsIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2561" title="DX-2561" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2561</a>  `state builds dl <pkg artifact ID` rewriting the downloaded `artifact.tar.gz`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Sample:

```
% build/state builds dl 0EC791E7 
█ Download build artifacts (Beta)

Beta Feature: This feature is still in beta and may be unstable.

Setting Up Runtime
Resolving Dependencies ✔ Done
✔ All dependencies have been installed and verified

zlib               570.0KB/570.0KB       
Downloaded zlib to /Users/me/cli/zlib-1.2.12.tar.gz
```