### PR TITLE
Added version wildcard syntax to help for `state install`.

### DIFF
--- a/cmd/state/internal/cmdtree/packages.go
+++ b/cmd/state/internal/cmdtree/packages.go
@@ -74,7 +74,7 @@ func newInstallCommand(prime *primer.Values) *captain.Command {
 		[]*captain.Argument{
 			{
 				Name:        locale.T("package_arg_nameversion"),
-				Description: locale.T("package_arg_nameversion_description"),
+				Description: locale.T("package_arg_nameversion_wildcard_description"),
 				Value:       &params.Package,
 				Required:    true,
 			},

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -596,8 +596,10 @@ bundle_arg_name_description:
   other: Bundle name
 package_arg_nameversion:
   other: name[@version]
+package_arg_nameversion_wildcard_description:
+  other: "Package name and optionally the desired version. The version may contain wildcards, for example: '1.0.x'."
 package_arg_nameversion_description:
-  other: Package name and optionally the desired version, optionally with namespace, eg. '[<namespace>/]<name>'.
+  other: Package name and optionally the desired version
 bundle_arg_nameversion:
   other: name[@version]
 bundle_arg_nameversion_description:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2559" title="DX-2559" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2559</a>  Demonstrate version notation on `state install --help`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
