### PR TITLE
Added namespace information to `state history`.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -804,11 +804,11 @@ field_id:
 field_changes:
   other: Changes
 change_added:
-  other: "[SUCCESS]+[/RESET] {{.V0}} {{.V1}}"
+  other: "[SUCCESS]+[/RESET] {{.V0}} {{.V1}}\n     namespace: {{.V2}}"
 change_removed:
-  other: "[ERROR]-[/RESET] {{.V0}}"
+  other: "[ERROR]-[/RESET] {{.V0}}\n     namespace: {{.V1}}"
 change_updated:
-  other: "[ACTIONABLE]•[/RESET] {{.V0}} ({{.V1}} → {{.V2}})"
+  other: "[ACTIONABLE]•[/RESET] {{.V0}} ({{.V1}} → {{.V2}})\n     namespace: {{.V3}}"
 constraint_auto:
   other: Auto
 constraint_resolved:

--- a/internal/runbits/commit/commit.go
+++ b/internal/runbits/commit/commit.go
@@ -31,6 +31,7 @@ type requirementChange struct {
 	Requirement           string `json:"requirement"`
 	VersionConstraintsOld string `json:"version_constraints_old,omitempty"`
 	VersionConstraintsNew string `json:"version_constraints_new,omitempty"`
+	Namespace             string `json:"namespace"`
 }
 
 func (o *commitOutput) MarshalOutput(format output.Format) interface{} {
@@ -122,13 +123,13 @@ func FormatChanges(commit *mono_models.Commit) ([]string, []*requirementChange) 
 		var result, oldConstraints, newConstraints string
 		switch change.Operation {
 		case string(model.OperationAdded):
-			result = locale.Tr("change_added", requirement, versionConstraints)
+			result = locale.Tr("change_added", requirement, versionConstraints, change.Namespace)
 			newConstraints = formatConstraints(change.VersionConstraints)
 		case string(model.OperationRemoved):
-			result = locale.Tr("change_removed", requirement)
+			result = locale.Tr("change_removed", requirement, change.Namespace)
 			oldConstraints = formatConstraints(change.VersionConstraintsOld)
 		case string(model.OperationUpdated):
-			result = locale.Tr("change_updated", requirement, formatConstraints(change.VersionConstraintsOld), versionConstraints)
+			result = locale.Tr("change_updated", requirement, formatConstraints(change.VersionConstraintsOld), versionConstraints, change.Namespace)
 			oldConstraints = formatConstraints(change.VersionConstraintsOld)
 			newConstraints = formatConstraints(change.VersionConstraints)
 		}
@@ -139,6 +140,7 @@ func FormatChanges(commit *mono_models.Commit) ([]string, []*requirementChange) 
 			Requirement:           change.Requirement,
 			VersionConstraintsOld: oldConstraints,
 			VersionConstraintsNew: newConstraints,
+			Namespace:             change.Namespace,
 		})
 	}
 

--- a/test/integration/history_int_test.go
+++ b/test/integration/history_int_test.go
@@ -38,12 +38,15 @@ func (suite *HistoryIntegrationTestSuite) TestHistory_History() {
 	cp.Expect("Revision")
 	cp.Expect("Message")
 	cp.Expect("• requests (2.26.0 → 2.7.0)")
+	cp.Expect("namespace: language/python")
 	cp.Expect("• autopip (1.6.0 → Auto)")
 	cp.Expect("+ autopip 1.6.0")
 	cp.SetLogger(termtest.VerboseLogger)
 	cp.Expect("- convertdate")
+	cp.Expect("namespace: language/python")
 	cp.SetLogger(termtest.VoidLogger)
 	cp.Expect(`+ Platform`)
+	cp.Expect("namespace: platform")
 	suite.Assert().NotContains(cp.Output(), "StructuredChanges")
 	cp.ExpectExitCode(0)
 }
@@ -65,6 +68,7 @@ func (suite *HistoryIntegrationTestSuite) TestJSON() {
 	cp.Expect(`"requirement":`)
 	cp.Expect(`"version_constraints_old":`)
 	cp.Expect(`"version_constraints_new":`)
+	cp.Expect(`"namespace":`)
 	cp.ExpectExitCode(0)
 	// AssertValidJSON(suite.T(), cp) // list is too large to fit in terminal snapshot
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2570" title="DX-2570" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2570</a>  state history should display namespace for packages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Sample:

```
  Commit      c333a724-e425-4ab0-b054-7b0f3dd7bf27                              
  Author      user                                                           
  Date        15 Mar 19 22:24 UTC                                               
  Revision    12 Nov 19 01:41 UTC                                               
  Message     Not provided.                                                     
  Changes      - + pexpect Auto                                                 
                   namespace: language/python                                   
               - + psutil Auto                                                  
                   namespace: language/python
```