### PR TITLE
Fixed `--ts` flag description in `state search`.

### DIFF
--- a/cmd/state/internal/cmdtree/packages.go
+++ b/cmd/state/internal/cmdtree/packages.go
@@ -159,7 +159,7 @@ func newSearchCommand(prime *primer.Values) *captain.Command {
 			},
 			{
 				Name:        "ts",
-				Description: locale.T("package_search_flag_ts_description"),
+				Description: locale.T("package_flag_ts_description"),
 				Value:       &params.Timestamp,
 			},
 		},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2583" title="DX-2583" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2583</a>  `state search -h` have localization message key instead of description
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Sample:

```
% build/state help search
Search for available packages that can be added to your project

Usage:
    state search [flags] <name>

Arguments:
  <name>            Package name, optionally with namespace, eg. 
'[<namespace>/]<name>'.

Flags:
      --exact-term        Ensures that search results match search term exactly
      --language string   The language used to constrain search results
      --ts timestamp      The timestamp at which you want to query. Can be 
either 'now' or RFC3339 formatted timestamp.
```