### PR TITLE
Fixed premature exit if State Tool could not be downloaded.

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -128,7 +128,7 @@ else
 fi
 
 # Fetch version info.
-$FETCH $INSTALLERTMPDIR/info.json $JSONURL || exit 1
+$FETCH $INSTALLERTMPDIR/info.json $JSONURL
 if [ ! -z "`grep -o Invalid $INSTALLERTMPDIR/info.json`" ]; then
 	error "Could not download a State Tool installer for the given command line arguments"
 	exit 1

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -129,7 +129,7 @@ fi
 
 # Fetch version info.
 $FETCH $INSTALLERTMPDIR/info.json $JSONURL
-if [ ! -z "`grep -o Invalid $INSTALLERTMPDIR/info.json`" ]; then
+if [ $? -ne 0 -o ! -z "`grep -o Invalid $INSTALLERTMPDIR/info.json`" ]; then
 	error "Could not download a State Tool installer for the given command line arguments"
 	exit 1
 fi


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2584" title="DX-2584" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2584</a>  Installer should error out if branch is not valid
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This prevented an informative error message from being printed.

Sample:

```
% ./installers/install.sh -b oops
Could not download a State Tool installer for the given command line arguments
```