### PR TITLE
Use generic "value" placeholder for flag values.

### DIFF
--- a/internal/assets/contents/usage.tpl
+++ b/internal/assets/contents/usage.tpl
@@ -32,12 +32,12 @@ Arguments:
 {{- if .Cobra.HasAvailableFlags}}
 
 Flags:
-{{.Cobra.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+{{.Cmd.LocalFlagUsages | trimTrailingWhitespaces}}
 {{- end}}
 {{- if .Cobra.HasAvailableInheritedFlags}}
 
 Global Flags:
-{{.Cobra.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+{{.Cmd.InheritedFlagUsages | trimTrailingWhitespaces}}
 {{- end}}
 
 {{- if .Cobra.HasHelpSubCommands}}

--- a/internal/captain/flag.go
+++ b/internal/captain/flag.go
@@ -1,6 +1,7 @@
 package captain
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -180,4 +181,163 @@ func (b *NullBool) AsPtrTo() *bool {
 	}
 	v := b.b
 	return &v
+}
+
+// LocalFlagUsages is a substitute for c.cobra.LocalFlags().FlagUsages() to replace Cobra's
+// intuited flag value placeholders with "<value>".
+func (c *Command) LocalFlagUsages() string {
+	return flagUsagesWrapped(c.cobra.LocalFlags(), 0)
+}
+
+// InheritedFlagUsages is a substitute for c.cobra.InheritedFlags().FlagUsages() to replace Cobra's
+// intuited flag value placeholders with "<value>".
+func (c *Command) InheritedFlagUsages() string {
+	return flagUsagesWrapped(c.cobra.InheritedFlags(), 0)
+}
+
+// flagUsagesWrapped is a copy of pflag.FlagSet.FlagUsagesWrapped(), but ignores Cobra's intuited
+// flag value placeholders and uses "<value>" instead.
+func flagUsagesWrapped(f *pflag.FlagSet, cols int) string {
+	buf := new(bytes.Buffer)
+
+	lines := make([]string, 0)
+
+	maxlen := 0
+	f.VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+
+		line := ""
+		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
+			line = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
+		} else {
+			line = fmt.Sprintf("      --%s", flag.Name)
+		}
+
+		// varname, usage := UnquoteUsage(flag)
+		varname := ""
+		if flag.Value.Type() != "bool" {
+			varname = "<value>"
+		}
+		usage := flag.Usage
+		if varname != "" {
+			line += " " + varname
+		}
+		if flag.NoOptDefVal != "" {
+			switch flag.Value.Type() {
+			case "string":
+				line += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
+			case "bool":
+				if flag.NoOptDefVal != "true" {
+					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+				}
+			case "count":
+				if flag.NoOptDefVal != "+1" {
+					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+				}
+			default:
+				line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+			}
+		}
+
+		// This special character will be replaced with spacing once the
+		// correct alignment is calculated
+		line += "\x00"
+		if len(line) > maxlen {
+			maxlen = len(line)
+		}
+
+		line += usage
+		//if !flag.defaultIsZeroValue() {
+		//	if flag.Value.Type() == "string" {
+		//		line += fmt.Sprintf(" (default %q)", flag.DefValue)
+		//	} else {
+		//		line += fmt.Sprintf(" (default %s)", flag.DefValue)
+		//	}
+		//}
+		if len(flag.Deprecated) != 0 {
+			line += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
+		}
+
+		lines = append(lines, line)
+	})
+
+	for _, line := range lines {
+		sidx := strings.Index(line, "\x00")
+		spacing := strings.Repeat(" ", maxlen-sidx)
+		// maxlen + 2 comes from + 1 for the \x00 and + 1 for the (deliberate) off-by-one in maxlen-sidx
+		fmt.Fprintln(buf, line[:sidx], spacing, wrap(maxlen+2, cols, line[sidx+1:]))
+	}
+
+	return buf.String()
+}
+
+// Splits the string `s` on whitespace into an initial substring up to
+// `i` runes in length and the remainder. Will go `slop` over `i` if
+// that encompasses the entire string (which allows the caller to
+// avoid short orphan words on the final line).
+func wrapN(i, slop int, s string) (string, string) {
+	if i+slop > len(s) {
+		return s, ""
+	}
+
+	w := strings.LastIndexAny(s[:i], " \t\n")
+	if w <= 0 {
+		return s, ""
+	}
+	nlPos := strings.LastIndex(s[:i], "\n")
+	if nlPos > 0 && nlPos < w {
+		return s[:nlPos], s[nlPos+1:]
+	}
+	return s[:w], s[w+1:]
+}
+
+// Wraps the string `s` to a maximum width `w` with leading indent
+// `i`. The first line is not indented (this is assumed to be done by
+// caller). Pass `w` == 0 to do no wrapping
+func wrap(i, w int, s string) string {
+	if w == 0 {
+		return strings.Replace(s, "\n", "\n"+strings.Repeat(" ", i), -1)
+	}
+
+	// space between indent i and end of line width w into which
+	// we should wrap the text.
+	wrap := w - i
+
+	var r, l string
+
+	// Not enough space for sensible wrapping. Wrap as a block on
+	// the next line instead.
+	if wrap < 24 {
+		i = 16
+		wrap = w - i
+		r += "\n" + strings.Repeat(" ", i)
+	}
+	// If still not enough space then don't even try to wrap.
+	if wrap < 24 {
+		return strings.Replace(s, "\n", r, -1)
+	}
+
+	// Try to avoid short orphan words on the final line, by
+	// allowing wrapN to go a bit over if that would fit in the
+	// remainder of the line.
+	slop := 5
+	wrap = wrap - slop
+
+	// Handle first line, which is indented by the caller (or the
+	// special case above)
+	l, s = wrapN(wrap, slop, s)
+	r = r + strings.Replace(l, "\n", "\n"+strings.Repeat(" ", i), -1)
+
+	// Now wrap the rest
+	for s != "" {
+		var t string
+
+		t, s = wrapN(wrap, slop, s)
+		r = r + "\n" + strings.Repeat(" ", i) + strings.Replace(t, "\n", "\n"+strings.Repeat(" ", i), -1)
+	}
+
+	return r
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2547" title="DX-2547" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2547</a>  Revisit flag rendering for `state --help`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Sample:

```
% build/state help publish
Publish an Ingredient for private consumption.

Usage:
    state publish [flags] <filepath>

Arguments:
  <filepath>            A tar.gz or zip archive containing the source files of the ingredient.

Flags:
      --author <value>        Ingredient author, in the format of "[<name>] <email>". Can be set multiple times.
      --depend <value>        Ingredient that this ingredient depends on, format as <namespace>/<name>[@<version>]. Can be set multiple times.
      --description <value>   A short description summarizing what this ingredient is for.
      --edit                  Create a revision for an existing ingredient, matched by their name and namespace.
      --editor                Edit the ingredient information in your editor before uploading.
      --feature <value>       Feature that this ingredient provides, format as <namespace>/<name>[@<version>]. Can be set multiple times.
      --meta <value>          A yaml file expressing the ingredient meta information. Use --editor to review the file format.
      --name <value>          The name of the ingredient. Defaults to basename of filepath.
      --namespace <value>     The namespace of the ingredient. Defaults to org/<orgname>. Must start with 'org/<orgname>'.
      --version <value>       Version of the ingredient (preferably semver).

Global Flags:
  -h, --help              Help for this command
  -l, --locale <value>    Set the localisation
      --mono              Force monochrome text output
  -n, --non-interactive   Run the State Tool without any prompts
  -o, --output <value>    Set the output method, possible values: plain, simple, json, editor
  -v, --verbose           Verbose output
```