### PR TITLE
Fix merge conflict from v43 to v44.

### DIFF
--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -414,7 +414,7 @@ func Parse(configFilepath string) (_ *Project, rerr error) {
 		return nil, err
 	}
 
-	re, _ := regexp.Compile(`activestate\.(\w+)\.yaml`)
+	re, _ := regexp.Compile(`activestate[._-](\w+)\.yaml`)
 	for _, file := range files {
 		match := re.FindStringSubmatch(file.Name())
 		if len(match) == 0 {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2598" title="DX-2598" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2598</a>  State scripts defined outside of activestate.yaml no longer work
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
