### PR TITLE
Buildscript variable values should be converted to "$var" in build expressions and vice-versa.

### DIFF
--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -76,7 +76,7 @@ func TestRealWorld(t *testing.T) {
 	],
 	camel_flags = [
 	],
-	src = "$sources"
+	src = sources
 )
 sources = solve(
 <<<<<<< local

--- a/internal/runbits/buildscript/testdata/buildscript1.as
+++ b/internal/runbits/buildscript/testdata/buildscript1.as
@@ -3,7 +3,7 @@ runtime = state_tool_artifacts_v1(
 	],
 	camel_flags = [
 	],
-	src = "$sources"
+	src = sources
 )
 sources = solve(
 	at_time = "2023-10-16T22:20:29.000000Z",

--- a/internal/runbits/buildscript/testdata/buildscript2.as
+++ b/internal/runbits/buildscript/testdata/buildscript2.as
@@ -3,7 +3,7 @@ runtime = state_tool_artifacts_v1(
 	],
 	camel_flags = [
 	],
-	src = "$sources"
+	src = sources
 )
 sources = solve(
 	at_time = "2023-08-01T16:20:11.985000Z",

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -40,7 +40,7 @@ type Value struct {
 
 	Assignment *Assignment    `parser:"| @@"`                        // only in FuncCall
 	Object     *[]*Assignment `parser:"| '{' @@ (',' @@)* ','? '}'"` // only in List
-	Ident      *string        `parser:"| @Ident"`                    // only in FuncCall
+	Ident      *string        `parser:"| @Ident"`                    // only in FuncCall or Assignment
 }
 
 type Null struct {
@@ -200,6 +200,9 @@ func valueString(v *buildexpression.Value) string {
 		return buf.String()
 
 	case v.Str != nil:
+		if strings.HasPrefix(*v.Str, "$") { // variable reference
+			return strings.TrimLeft(*v.Str, "$")
+		}
 		return strconv.Quote(*v.Str)
 
 	case v.Float != nil:

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -272,6 +272,7 @@ func TestRoundTrip(t *testing.T) {
 func TestJson(t *testing.T) {
 	script, err := NewScript([]byte(
 		`runtime = solve(
+		at_time = at_time,
 		requirements=[
 			Req(name = "language/python")
 		],
@@ -287,10 +288,11 @@ main = runtime
     "let": {
       "runtime": {
         "solve": {
+          "at_time": "$at_time",
           "requirements": [
             {
               "name": "python",
-			  "namespace": "language"
+              "namespace": "language"
             }
           ],
           "platforms": ["12345", "67890"]

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -28,9 +28,6 @@ func (s *Script) MarshalJSON() ([]byte, error) {
 		value := assignment.Value
 		if key == "main" {
 			key = "in"
-			if value.Ident != nil {
-				value = &Value{Str: ptr.To("$" + *value.Ident)}
-			}
 		}
 		let[key] = value
 	}
@@ -65,7 +62,7 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 		}
 		return json.Marshal(m)
 	case v.Ident != nil:
-		return json.Marshal(v.Ident)
+		return json.Marshal("$" + *v.Ident)
 	}
 	return json.Marshal([]*Value{}) // participle does not create v.List if it's empty
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2586" title="DX-2586" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2586</a>  As a user I can expect variables to be defined consistently
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
