### PR TITLE
Mark "no deployed runtime" errors as input errors.

### DIFF
--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -77,7 +77,7 @@ func (u *Uninstall) Run(params *Params) error {
 	store := store.New(path)
 	if !store.HasMarker() {
 		return errs.AddTips(
-			locale.NewError("err_deploy_uninstall_not_deployed", "There is no deployed runtime at '{{.V0}}' to uninstall.", path),
+			locale.NewInputError("err_deploy_uninstall_not_deployed", "There is no deployed runtime at '{{.V0}}' to uninstall.", path),
 			locale.Tl("err_deploy_uninstall_not_deployed_tip", "Either change the current directory to a deployment or supply '--path <path>' arguments."))
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2575" title="DX-2575" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2575</a>  Rollbar: deploy uninstall [--path]: Returning error: execute failed: There is no deployed runtime at ...
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
