### PR TITLE
Mark `state revert` commit not in history errors as input errors.

### DIFF
--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -102,6 +102,9 @@ func (r *Revert) Run(params *Params) (rerr error) {
 
 	targetCommit, err := model.GetCommitWithinCommitHistory(latestCommit, strfmt.UUID(targetCommitID))
 	if err != nil {
+		if err == model.ErrCommitNotInHistory {
+			return locale.WrapInputError(err, "err_revert_commit_not_found", "The commit [NOTICE]{{.V0}}[/RESET] was not found in the project's commit history.", commitID)
+		}
 		return errs.AddTips(
 			locale.WrapError(err, "err_revert_get_commit", "", commitID),
 			locale.T("tip_private_project_auth"),

--- a/pkg/platform/model/vcs.go
+++ b/pkg/platform/model/vcs.go
@@ -30,6 +30,8 @@ var (
 	ErrMergeFastForward = errs.New("No merge required")
 
 	ErrMergeCommitInHistory = errs.New("Can't merge commit thats already in target commits history")
+
+	ErrCommitNotInHistory = errs.New("Target commit is not in history")
 )
 
 var ErrOrderForbidden = errs.New("no permission to retrieve order")
@@ -940,7 +942,7 @@ func GetCommitWithinCommitHistory(currentCommitID, targetCommitID strfmt.UUID) (
 		return nil, errs.Wrap(err, "API communication failed.")
 	}
 	if !ok {
-		return nil, locale.WrapError(err, "err_get_commit_within_history_not_in", "The target commit is not within the current commit's history.")
+		return nil, ErrCommitNotInHistory
 	}
 
 	return commit, nil

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -108,7 +108,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert_failsOnCommitNotInHistory() 
 	cp.Expect(fmt.Sprintf("Operating on project %s", namespace))
 	cp.SendLine("Y")
 	cp.Expect(commitID)
-	cp.Expect("The target commit is not within the current commit's history")
+	cp.Expect("not found")
 	cp.ExpectNotExitCode(0)
 	ts.IgnoreLogErrors()
 }
@@ -166,7 +166,7 @@ func (suite *RevertIntegrationTestSuite) TestRevertTo_failsOnCommitNotInHistory(
 	cp.Expect(fmt.Sprintf("Operating on project %s", namespace))
 	cp.SendLine("Y")
 	cp.Expect(commitID)
-	cp.Expect("The target commit is not")
+	cp.Expect("not found")
 	cp.ExpectNotExitCode(0)
 	ts.IgnoreLogErrors()
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2577" title="DX-2577" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2577</a>  Rollbar: revert []: Returning error: execute failed:     'Could not fetch commit details for commit with ID:
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This often happens when a user makes a typo or invalid copy-paste.