### PR TITLE
Mark `state cve` project not found errors as input errors.

### DIFF
--- a/internal/runners/cve/cve.go
+++ b/internal/runners/cve/cve.go
@@ -70,6 +70,9 @@ func (r *Cve) Run(params *Params) error {
 
 	vulnerabilities, err := r.fetchVulnerabilities(*params.Namespace)
 	if err != nil {
+		if errs.Matches(err, &model.ErrProjectNotFound{}) {
+			return locale.WrapInputError(err, "cve_mediator_resp_not_found", "That project was not found")
+		}
 		return locale.WrapError(err, "cve_mediator_resp", "Failed to retrieve vulnerability information")
 	}
 

--- a/internal/runners/cve/cve.go
+++ b/internal/runners/cve/cve.go
@@ -63,7 +63,7 @@ func (r *Cve) Run(params *Params) error {
 
 	if !r.auth.Authenticated() {
 		return errs.AddTips(
-			locale.NewError("cve_needs_authentication"),
+			locale.NewInputError("cve_needs_authentication"),
 			locale.T("auth_tip"),
 		)
 	}

--- a/pkg/platform/model/cve.go
+++ b/pkg/platform/model/cve.go
@@ -22,7 +22,7 @@ func FetchProjectVulnerabilities(auth *authentication.Auth, org, project string)
 	// This should be removed by https://www.pivotaltracker.com/story/show/176508740
 	if !auth.Authenticated() {
 		return nil, errs.AddTips(
-			locale.NewInputError("cve_needs_authentication"),
+			locale.NewError("cve_needs_authentication"),
 			locale.T("auth_tip"),
 		)
 	}
@@ -36,11 +36,10 @@ func FetchProjectVulnerabilities(auth *authentication.Auth, org, project string)
 
 	msg := resp.ProjectVulnerabilities.Message
 	if msg != nil {
-		newError := locale.NewError
 		if resp.ProjectVulnerabilities.TypeName == "NotFound" {
-			newError = locale.NewInputError
+			return nil, &ErrProjectNotFound{org, project}
 		}
-		return nil, newError("project_vulnerability_err", "Request to retrieve vulnerability information failed with error: {{.V0}}", *msg)
+		return nil, locale.NewError("project_vulnerability_err", "Request to retrieve vulnerability information failed with error: {{.V0}}", *msg)
 	}
 
 	return &resp.ProjectVulnerabilities, nil
@@ -51,7 +50,7 @@ func FetchCommitVulnerabilities(auth *authentication.Auth, commitID string) (*mo
 	// This should be removed by https://www.pivotaltracker.com/story/show/176508740
 	if !auth.Authenticated() {
 		return nil, errs.AddTips(
-			locale.NewInputError("cve_needs_authentication"),
+			locale.NewError("cve_needs_authentication"),
 			locale.T("auth_tip"),
 		)
 	}

--- a/pkg/platform/model/cve.go
+++ b/pkg/platform/model/cve.go
@@ -22,7 +22,7 @@ func FetchProjectVulnerabilities(auth *authentication.Auth, org, project string)
 	// This should be removed by https://www.pivotaltracker.com/story/show/176508740
 	if !auth.Authenticated() {
 		return nil, errs.AddTips(
-			locale.NewError("cve_needs_authentication", "You need to be authenticated in order to access vulnerability information about your project."),
+			locale.NewInputError("cve_needs_authentication"),
 			locale.T("auth_tip"),
 		)
 	}
@@ -36,7 +36,11 @@ func FetchProjectVulnerabilities(auth *authentication.Auth, org, project string)
 
 	msg := resp.ProjectVulnerabilities.Message
 	if msg != nil {
-		return nil, locale.NewError("project_vulnerability_err", "Request to retrieve vulnerability information failed with error: {{.V0}}", *msg)
+		newError := locale.NewError
+		if resp.ProjectVulnerabilities.TypeName == "NotFound" {
+			newError = locale.NewInputError
+		}
+		return nil, newError("project_vulnerability_err", "Request to retrieve vulnerability information failed with error: {{.V0}}", *msg)
 	}
 
 	return &resp.ProjectVulnerabilities, nil
@@ -47,7 +51,7 @@ func FetchCommitVulnerabilities(auth *authentication.Auth, commitID string) (*mo
 	// This should be removed by https://www.pivotaltracker.com/story/show/176508740
 	if !auth.Authenticated() {
 		return nil, errs.AddTips(
-			locale.NewError("cve_needs_authentication", "You need to be authenticated in order to access vulnerability information about your project."),
+			locale.NewInputError("cve_needs_authentication"),
 			locale.T("auth_tip"),
 		)
 	}

--- a/test/integration/cve_int_test.go
+++ b/test/integration/cve_int_test.go
@@ -71,7 +71,7 @@ func (suite *CveIntegrationTestSuite) TestCveInvalidProject() {
 	ts.LoginAsPersistentUser()
 
 	cp := ts.Spawn("cve", "invalid/invalid")
-	cp.Expect("Found no project with specified organization and name")
+	cp.Expect("not found")
 
 	cp.ExpectNotExitCode(0)
 	ts.IgnoreLogErrors()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2579" title="DX-2579" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2579</a>  Rollbar: security []: Returning error: execute failed:     Failed to retrieve vulnerability information:         Failed to fetch vulnerability information for project invalid/invalid:
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also mark unauthenticated errors as input errors.