### PR TITLE
Support top-level "at_time" variable in buildscripts.

### DIFF
--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -30,7 +30,7 @@ func getBuildExpression(proj *project.Project, customCommit *strfmt.UUID, auth *
 	if customCommit != nil {
 		commitID = *customCommit
 	}
-	return bp.GetBuildExpression(proj.Owner(), proj.Name(), commitID.String())
+	return bp.GetBuildExpression(commitID.String())
 }
 
 // Sync synchronizes the local build script with the remote one.

--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -64,12 +64,17 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 			return false, errs.Wrap(err, "Unable to get local commit ID")
 		}
 
+		expr, err := script.BuildExpression()
+		if err != nil {
+			return false, errs.Wrap(err, "Unable to get build expression from build script")
+		}
+
 		bp := model.NewBuildPlannerModel(auth)
 		stagedCommitID, err := bp.StageCommit(model.StageCommitParams{
 			Owner:        proj.Owner(),
 			Project:      proj.Name(),
 			ParentCommit: localCommitID.String(),
-			Expression:   script.Expr,
+			Expression:   expr,
 		})
 		if err != nil {
 			return false, errs.Wrap(err, "Could not update project to reflect build script changes.")

--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -15,7 +15,9 @@ import (
 
 func TestDiff(t *testing.T) {
 	script, err := buildscript.NewScript([]byte(
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -35,12 +37,14 @@ main = runtime`))
 	require.NoError(t, err)
 
 	// Modify the build script.
-	(*script.Expr.Let.Assignments[0].Value.Ap.Arguments[0].Assignment.Value.List)[0].Str = ptr.To(`77777`)
+	(*script.Expr.Let.Assignments[0].Value.Ap.Arguments[1].Assignment.Value.List)[0].Str = ptr.To(`77777`)
 
 	// Generate the difference between the modified script and the original expression.
 	result, err := generateDiff(script, expr)
 	require.NoError(t, err)
-	assert.Equal(t, `runtime = solve(
+	assert.Equal(t, `at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 <<<<<<< local
 		"77777",
@@ -71,7 +75,12 @@ func TestRealWorld(t *testing.T) {
 	require.NoError(t, err)
 	result, err := generateDiff(script1, script2.Expr)
 	require.NoError(t, err)
-	assert.Equal(t, `runtime = state_tool_artifacts_v1(
+	assert.Equal(t, `<<<<<<< local
+at_time = "2023-10-16T22:20:29.000Z"
+=======
+at_time = "2023-08-01T16:20:11.985Z"
+>>>>>>> remote
+runtime = state_tool_artifacts_v1(
 	build_flags = [
 	],
 	camel_flags = [
@@ -79,11 +88,7 @@ func TestRealWorld(t *testing.T) {
 	src = sources
 )
 sources = solve(
-<<<<<<< local
-	at_time = "2023-10-16T22:20:29.000000Z",
-=======
-	at_time = "2023-08-01T16:20:11.985000Z",
->>>>>>> remote
+	at_time = at_time,
 	platforms = [
 		"78977bc8-0f32-519d-80f3-9043f059398c",
 		"7c998ec2-7491-4e75-be4d-8885800ef5f2",

--- a/internal/runbits/buildscript/testdata/buildscript1.as
+++ b/internal/runbits/buildscript/testdata/buildscript1.as
@@ -1,3 +1,4 @@
+at_time = "2023-10-16T22:20:29.000000Z"
 runtime = state_tool_artifacts_v1(
 	build_flags = [
 	],
@@ -6,7 +7,7 @@ runtime = state_tool_artifacts_v1(
 	src = sources
 )
 sources = solve(
-	at_time = "2023-10-16T22:20:29.000000Z",
+	at_time = at_time,
 	platforms = [
 		"78977bc8-0f32-519d-80f3-9043f059398c",
 		"7c998ec2-7491-4e75-be4d-8885800ef5f2",

--- a/internal/runbits/buildscript/testdata/buildscript2.as
+++ b/internal/runbits/buildscript/testdata/buildscript2.as
@@ -1,3 +1,4 @@
+at_time = "2023-08-01T16:20:11.985000Z"
 runtime = state_tool_artifacts_v1(
 	build_flags = [
 	],
@@ -6,7 +7,7 @@ runtime = state_tool_artifacts_v1(
 	src = sources
 )
 sources = solve(
-	at_time = "2023-08-01T16:20:11.985000Z",
+	at_time = at_time,
 	platforms = [
 		"78977bc8-0f32-519d-80f3-9043f059398c",
 		"7c998ec2-7491-4e75-be4d-8885800ef5f2",

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -332,7 +332,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(
 		RequirementName:      name,
 		RequirementVersion:   requirements,
 		RequirementNamespace: *ns,
-		RequirementRevision: requirementRevision,
+		RequirementRevision:  requirementRevision,
 		Operation:            operation,
 		TimeStamp:            ts,
 	}
@@ -416,7 +416,7 @@ func (r *RequirementOperation) updateCommitID(commitID strfmt.UUID) error {
 	}
 
 	bp := model.NewBuildPlannerModel(r.Auth)
-	expr, err := bp.GetBuildExpression(r.Project.Owner(), r.Project.Name(), commitID.String())
+	expr, err := bp.GetBuildExpression(commitID.String())
 	if err != nil {
 		return errs.Wrap(err, "Could not get remote build expr")
 	}

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -135,7 +135,7 @@ func (i *Import) Run(params *ImportRunParams) error {
 		return locale.WrapError(err, "err_cannot_apply_changeset", "Could not apply changeset")
 	}
 
-	if err := be.SetDefaultTimestamp(); err != nil {
+	if _, err := be.SetDefaultTimestamp(); err != nil {
 		return locale.WrapError(err, "err_cannot_set_timestamp", "Could not set timestamp")
 	}
 

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -126,7 +126,7 @@ func (i *Import) Run(params *ImportRunParams) error {
 	}
 
 	bp := model.NewBuildPlannerModel(i.auth)
-	be, err := bp.GetBuildExpression(i.proj.Owner(), i.proj.Name(), latestCommit.String())
+	be, err := bp.GetBuildExpression(latestCommit.String())
 	if err != nil {
 		return locale.WrapError(err, "err_cannot_get_build_expression", "Could not get build expression")
 	}

--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -228,7 +228,7 @@ func (p *Pull) mergeBuildScript(remoteCommit, localCommit strfmt.UUID) error {
 	// Get the local and remote build expressions to merge.
 	exprA := script.Expr
 	bp := model.NewBuildPlannerModel(p.auth)
-	exprB, err := bp.GetBuildExpression(p.project.Owner(), p.project.Name(), remoteCommit.String())
+	exprB, err := bp.GetBuildExpression(remoteCommit.String())
 	if err != nil {
 		return errs.Wrap(err, "Unable to get buildexpression for remote commit")
 	}

--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -226,7 +226,10 @@ func (p *Pull) mergeBuildScript(remoteCommit, localCommit strfmt.UUID) error {
 	}
 
 	// Get the local and remote build expressions to merge.
-	exprA := script.Expr
+	exprA, err := script.BuildExpression()
+	if err != nil {
+		return errs.Wrap(err, "Could not get buildexpression from local build script")
+	}
 	bp := model.NewBuildPlannerModel(p.auth)
 	exprB, err := bp.GetBuildExpression(remoteCommit.String())
 	if err != nil {

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -174,7 +174,7 @@ func (r *Push) Run(params PushParams) (rerr error) {
 		r.out.Notice(locale.Tl("push_creating_project", "Creating project [NOTICE]{{.V1}}[/RESET] under [NOTICE]{{.V0}}[/RESET] on the ActiveState Platform", targetNamespace.Owner, targetNamespace.Project))
 
 		// Create a new project with the current project's buildexpression.
-		expr, err := bp.GetBuildExpression(r.project.Owner(), r.project.Name(), commitID.String())
+		expr, err := bp.GetBuildExpression(commitID.String())
 		if err != nil {
 			return errs.Wrap(err, "Could not get buildexpression")
 		}

--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -183,7 +183,7 @@ func (r *Revert) revertCommit(params revertParams, bp *model.BuildPlanner) (strf
 }
 
 func (r *Revert) revertToCommit(params revertParams, bp *model.BuildPlanner) (strfmt.UUID, error) {
-	buildExpression, err := bp.GetBuildExpression(params.organization, params.project, params.revertCommitID)
+	buildExpression, err := bp.GetBuildExpression(params.revertCommitID)
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get build expression")
 	}

--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -531,6 +531,7 @@ type Project struct {
 // Commit contains the build and any errors.
 type Commit struct {
 	Type       string          `json:"__typename"`
+	AtTime     strfmt.DateTime `json:"atTime"`
 	Expression json.RawMessage `json:"expr"`
 	CommitID   strfmt.UUID     `json:"commitId"`
 	Build      *Build          `json:"build"`

--- a/pkg/platform/api/buildplanner/request/buildexpression.go
+++ b/pkg/platform/api/buildplanner/request/buildexpression.go
@@ -16,6 +16,7 @@ query ($commitID: ID!) {
   commit(commitId: $commitID) {
     ... on Commit {
       __typename
+      atTime
       expr
     }
     ... on Error{

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -355,7 +355,7 @@ func (bp *BuildPlanner) GetBuildExpression(commitID string) (*buildexpression.Bu
 
 	err = expression.MaybeUpdateTimestamp(resp.Commit.AtTime)
 	if err != nil {
-		return nil, errs.Wrap(err, "failed to possibly update at_time in build expression")
+		return nil, errs.Wrap(err, "failed to possibly update %s in build expression", buildexpression.AtTimeKey)
 	}
 
 	return expression, nil

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -299,7 +299,7 @@ func (bp *BuildPlanner) StageCommit(params StageCommitParams) (strfmt.UUID, erro
 				return "", errs.Wrap(err, "Failed to update build expression with requirement")
 			}
 
-			if err := expression.SetDefaultTimestamp(); err != nil {
+			if _, err := expression.SetDefaultTimestamp(); err != nil {
 				return "", errs.Wrap(err, "Failed to set default timestamp")
 			}
 		}

--- a/pkg/platform/runtime/buildexpression/buildexpression.go
+++ b/pkg/platform/runtime/buildexpression/buildexpression.go
@@ -930,9 +930,9 @@ func (e *BuildExpression) MaybeUpdateTimestamp(ts strfmt.DateTime) error {
 
 	// Normalize existing timestamp.
 	// Platform timestamps may differ from the strfmt.DateTime format. For example, Platform
-	// timestamps will have 6-digit millisecond precision, while strfmt.DateTime will only have
-	// three-digit precision. This will affect comparisons between buildexpressions (which is
-	// normally done byte-by-byte).
+	// timestamps will have microsecond precision, while strfmt.DateTime will only have millisecond
+	// precision. This will affect comparisons between buildexpressions (which is normally done
+	// byte-by-byte).
 	case !strings.HasPrefix(*atTimeNode.Str, "$"):
 		atTime, err := strfmt.ParseDateTime(*atTimeNode.Str)
 		if err != nil {
@@ -942,6 +942,14 @@ func (e *BuildExpression) MaybeUpdateTimestamp(ts strfmt.DateTime) error {
 	}
 
 	return nil
+}
+
+func (e *BuildExpression) Copy() (*BuildExpression, error) {
+	bytes, err := json.Marshal(e)
+	if err != nil {
+		return nil, errs.Wrap(err, "Failed to marshal build expression during copy")
+	}
+	return New(bytes)
 }
 
 func (e *BuildExpression) MarshalJSON() ([]byte, error) {

--- a/pkg/platform/runtime/buildexpression/buildexpression.go
+++ b/pkg/platform/runtime/buildexpression/buildexpression.go
@@ -898,7 +898,7 @@ func (e *BuildExpression) removePlatform(platformID strfmt.UUID) error {
 func (e *BuildExpression) SetDefaultTimestamp() (*strfmt.DateTime, error) {
 	atTimeNode, err := e.getSolveAtTimeValue()
 	if err != nil {
-		return nil, errs.Wrap(err, "Could not get at time node")
+		return nil, errs.Wrap(err, "Could not get %s node", AtTimeKey)
 	}
 	var atTimePtr *strfmt.DateTime
 	if atTimeNode.Str != nil && !strings.HasPrefix(*atTimeNode.Str, "$") {

--- a/pkg/platform/runtime/buildexpression/merge/merge_test.go
+++ b/pkg/platform/runtime/buildexpression/merge/merge_test.go
@@ -1,11 +1,9 @@
 package merge
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
-	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +11,9 @@ import (
 
 func TestMergeAdd(t *testing.T) {
 	scriptA, err := buildscript.NewScript([]byte(
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -26,13 +26,11 @@ func TestMergeAdd(t *testing.T) {
 
 main = runtime`))
 	require.NoError(t, err)
-	bytes, err := json.Marshal(scriptA)
-	require.NoError(t, err)
-	exprA, err := buildexpression.New(bytes)
-	require.NoError(t, err)
 
 	scriptB, err := buildscript.NewScript([]byte(
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -45,10 +43,6 @@ main = runtime`))
 
 main = runtime`))
 	require.NoError(t, err)
-	bytes, err = json.Marshal(scriptB)
-	require.NoError(t, err)
-	exprB, err := buildexpression.New(bytes)
-	require.NoError(t, err)
 
 	strategies := &mono_models.MergeStrategies{
 		OverwriteChanges: []*mono_models.CommitChangeEditable{
@@ -56,16 +50,18 @@ main = runtime`))
 		},
 	}
 
-	require.True(t, isAutoMergePossible(exprA, exprB))
+	require.True(t, isAutoMergePossible(scriptA.Expr, scriptB.Expr))
 
-	mergedExpr, err := Merge(exprA, exprB, strategies)
+	mergedExpr, err := Merge(scriptA.Expr, scriptB.Expr, strategies)
 	require.NoError(t, err)
 
 	mergedScript, err := buildscript.NewScriptFromBuildExpression(mergedExpr)
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -82,7 +78,9 @@ main = runtime`, mergedScript.String())
 
 func TestMergeRemove(t *testing.T) {
 	scriptA, err := buildscript.NewScript([]byte(
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -96,13 +94,11 @@ func TestMergeRemove(t *testing.T) {
 
 main = runtime`))
 	require.NoError(t, err)
-	bytes, err := json.Marshal(scriptA)
-	require.NoError(t, err)
-	exprA, err := buildexpression.New(bytes)
-	require.NoError(t, err)
 
 	scriptB, err := buildscript.NewScript([]byte(
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -115,10 +111,6 @@ main = runtime`))
 
 main = runtime`))
 	require.NoError(t, err)
-	bytes, err = json.Marshal(scriptB)
-	require.NoError(t, err)
-	exprB, err := buildexpression.New(bytes)
-	require.NoError(t, err)
 
 	strategies := &mono_models.MergeStrategies{
 		OverwriteChanges: []*mono_models.CommitChangeEditable{
@@ -126,16 +118,18 @@ main = runtime`))
 		},
 	}
 
-	require.True(t, isAutoMergePossible(exprA, exprB))
+	require.True(t, isAutoMergePossible(scriptA.Expr, scriptB.Expr))
 
-	mergedExpr, err := Merge(exprA, exprB, strategies)
+	mergedExpr, err := Merge(scriptA.Expr, scriptB.Expr, strategies)
 	require.NoError(t, err)
 
 	mergedScript, err := buildscript.NewScriptFromBuildExpression(mergedExpr)
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -151,7 +145,9 @@ main = runtime`, mergedScript.String())
 
 func TestMergeConflict(t *testing.T) {
 	scriptA, err := buildscript.NewScript([]byte(
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -163,13 +159,11 @@ func TestMergeConflict(t *testing.T) {
 
 main = runtime`))
 	require.NoError(t, err)
-	bytes, err := json.Marshal(scriptA)
-	require.NoError(t, err)
-	exprA, err := buildexpression.New(bytes)
-	require.NoError(t, err)
 
 	scriptB, err := buildscript.NewScript([]byte(
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345"
 	],
@@ -181,14 +175,10 @@ main = runtime`))
 
 main = runtime`))
 	require.NoError(t, err)
-	bytes, err = json.Marshal(scriptB)
-	require.NoError(t, err)
-	exprB, err := buildexpression.New(bytes)
-	require.NoError(t, err)
 
-	assert.False(t, isAutoMergePossible(exprA, exprB)) // platforms do not match
+	assert.False(t, isAutoMergePossible(scriptA.Expr, scriptB.Expr)) // platforms do not match
 
-	_, err = Merge(exprA, exprB, nil)
+	_, err = Merge(scriptA.Expr, scriptB.Expr, nil)
 	require.Error(t, err)
 }
 

--- a/pkg/platform/runtime/buildexpression/merge/merge_test.go
+++ b/pkg/platform/runtime/buildexpression/merge/merge_test.go
@@ -26,6 +26,8 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
+	exprA, err := scriptA.BuildExpression()
+	require.NoError(t, err)
 
 	scriptB, err := buildscript.NewScript([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
@@ -43,6 +45,8 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
+	exprB, err := scriptB.BuildExpression()
+	require.NoError(t, err)
 
 	strategies := &mono_models.MergeStrategies{
 		OverwriteChanges: []*mono_models.CommitChangeEditable{
@@ -50,9 +54,9 @@ main = runtime`))
 		},
 	}
 
-	require.True(t, isAutoMergePossible(scriptA.Expr, scriptB.Expr))
+	require.True(t, isAutoMergePossible(exprA, exprB))
 
-	mergedExpr, err := Merge(scriptA.Expr, scriptB.Expr, strategies)
+	mergedExpr, err := Merge(exprA, exprB, strategies)
 	require.NoError(t, err)
 
 	mergedScript, err := buildscript.NewScriptFromBuildExpression(mergedExpr)
@@ -94,6 +98,8 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
+	exprA, err := scriptA.BuildExpression()
+	require.NoError(t, err)
 
 	scriptB, err := buildscript.NewScript([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
@@ -111,6 +117,8 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
+	exprB, err := scriptB.BuildExpression()
+	require.NoError(t, err)
 
 	strategies := &mono_models.MergeStrategies{
 		OverwriteChanges: []*mono_models.CommitChangeEditable{
@@ -118,9 +126,9 @@ main = runtime`))
 		},
 	}
 
-	require.True(t, isAutoMergePossible(scriptA.Expr, scriptB.Expr))
+	require.True(t, isAutoMergePossible(exprA, exprB))
 
-	mergedExpr, err := Merge(scriptA.Expr, scriptB.Expr, strategies)
+	mergedExpr, err := Merge(exprA, exprB, strategies)
 	require.NoError(t, err)
 
 	mergedScript, err := buildscript.NewScriptFromBuildExpression(mergedExpr)
@@ -159,6 +167,8 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
+	exprA, err := scriptA.BuildExpression()
+	require.NoError(t, err)
 
 	scriptB, err := buildscript.NewScript([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
@@ -175,10 +185,12 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
+	exprB, err := scriptB.BuildExpression()
+	require.NoError(t, err)
 
-	assert.False(t, isAutoMergePossible(scriptA.Expr, scriptB.Expr)) // platforms do not match
+	assert.False(t, isAutoMergePossible(exprA, exprB)) // platforms do not match
 
-	_, err = Merge(scriptA.Expr, scriptB.Expr, nil)
+	_, err = Merge(exprA, exprB, nil)
 	require.Error(t, err)
 }
 

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -322,7 +322,7 @@ func TestRoundTrip(t *testing.T) {
 func TestJson(t *testing.T) {
 	script, err := NewScript([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
-		runtime = solve(
+runtime = solve(
 		at_time = at_time,
 		requirements=[
 			Req(name = "language/python")

--- a/pkg/platform/runtime/buildscript/file.go
+++ b/pkg/platform/runtime/buildscript/file.go
@@ -39,7 +39,7 @@ func newScriptFromFile(path, org, project string, auth *authentication.Auth) (*S
 		return nil, errs.Wrap(err, "Unable to get the local commit ID")
 	}
 	buildplanner := model.NewBuildPlannerModel(auth)
-	expr, err := buildplanner.GetBuildExpression(org, project, commitId.String())
+	expr, err := buildplanner.GetBuildExpression(commitId.String())
 	if err != nil {
 		return nil, errs.Wrap(err, "Unable to get the remote build expression")
 	}

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -22,15 +22,14 @@ func (s *Script) MarshalJSON() ([]byte, error) {
 		value := assignment.Value
 		switch key {
 		case buildexpression.AtTimeKey:
-			if value.Str != nil {
-				atTime, err := strfmt.ParseDateTime(strings.Trim(*value.Str, `"`))
-				if err != nil {
-					return nil, errs.Wrap(err, "Invalid timestamp: %s", *value.Str)
-				}
-				s.atTime = &atTime
-			} else {
+			if value.Str == nil {
 				return nil, errs.New("String timestamp expected for '%s'", key)
 			}
+			atTime, err := strfmt.ParseDateTime(strings.Trim(*value.Str, `"`))
+			if err != nil {
+				return nil, errs.Wrap(err, "Invalid timestamp: %s", *value.Str)
+			}
+			s.atTime = &atTime
 			continue // do not include this custom assignment in the let block
 		case "main":
 			key = "in"

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -133,7 +133,7 @@ func (r *Runtime) validateCache() error {
 	expr, err := r.store.GetAndValidateBuildExpression(commitID)
 	if err != nil {
 		bp := model.NewBuildPlannerModel(r.auth)
-		bpExpr, err := bp.GetBuildExpression(r.target.Owner(), r.target.Name(), commitID)
+		bpExpr, err := bp.GetBuildExpression(commitID)
 		if err != nil {
 			return errs.Wrap(err, "Unable to get remote build expression")
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2539" title="DX-2539" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2539</a>  at_time is embedded in buildscript through var
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The idea behind this PR is:

1. Change `buildplanner.GetBuildExpression()` to substitute "$at_time" with the commit's `atTime`. This applies to all build expressions, not just those used for buildscripts.
2. The buildscript will preprocess a buildexpression, extract the timestamp from step 1, replace it with an `at_time` variable, and define this variable at the top of the buildscript.
3. When translating the buildscript back to a buildexpression, the `at_time` variable will be replaced with the timestamp in the top-level assignment. (If there is no top-level assignment, the `at_time` variable will fall back to `"$at_time"`, which the Platform interprets as its default timestamp.)