### PR TITLE
Added ability to fetch "now" time from the Platform.

### DIFF
--- a/internal/captain/values.go
+++ b/internal/captain/values.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/model"
 )
 
 // NameVersionValue represents a flag that supports both a name and a version, the following formats are supported:
@@ -242,7 +245,12 @@ func (u *TimeValue) String() string {
 
 func (u *TimeValue) Set(v string) error {
 	if v == "now" {
-		u.Time = ptr.To(time.Now())
+		latest, err := model.FetchLatestRevisionTimeStamp(authentication.LegacyGet())
+		if err != nil {
+			multilog.Error("Unable to determine latest revision time: %v", err)
+			latest = time.Now()
+		}
+		u.Time = ptr.To(latest)
 	} else {
 		u.raw = v
 		tsv, err := time.Parse(time.RFC3339, v)

--- a/internal/captain/values.go
+++ b/internal/captain/values.go
@@ -231,7 +231,7 @@ func (p *PackagesValue) Type() string {
 type TimeValue struct {
 	raw  string
 	Time *time.Time
-	Now  bool
+	now  bool
 }
 
 var _ FlagMarshaler = &TimeValue{}
@@ -249,12 +249,16 @@ func (u *TimeValue) Set(v string) error {
 		}
 		u.Time = &tsv
 	}
-	u.Now = v == "now"
+	u.now = v == "now"
 	return nil
 }
 
 func (u *TimeValue) Type() string {
 	return "timestamp"
+}
+
+func (u *TimeValue) Now() bool {
+	return u.now
 }
 
 type IntValue struct {

--- a/internal/captain/values.go
+++ b/internal/captain/values.go
@@ -8,10 +8,6 @@ import (
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
-	"github.com/ActiveState/cli/internal/multilog"
-	"github.com/ActiveState/cli/internal/rtutils/ptr"
-	"github.com/ActiveState/cli/pkg/platform/authentication"
-	"github.com/ActiveState/cli/pkg/platform/model"
 )
 
 // NameVersionValue represents a flag that supports both a name and a version, the following formats are supported:
@@ -235,6 +231,7 @@ func (p *PackagesValue) Type() string {
 type TimeValue struct {
 	raw  string
 	Time *time.Time
+	Now  bool
 }
 
 var _ FlagMarshaler = &TimeValue{}
@@ -244,21 +241,15 @@ func (u *TimeValue) String() string {
 }
 
 func (u *TimeValue) Set(v string) error {
-	if v == "now" {
-		latest, err := model.FetchLatestRevisionTimeStamp(authentication.LegacyGet())
-		if err != nil {
-			multilog.Error("Unable to determine latest revision time: %v", err)
-			latest = time.Now()
-		}
-		u.Time = ptr.To(latest)
-	} else {
-		u.raw = v
+	u.raw = v
+	if v != "now" {
 		tsv, err := time.Parse(time.RFC3339, v)
 		if err != nil {
 			return locale.WrapInputError(err, "timeflag_format", "Invalid timestamp: Should be RFC3339 formatted.")
 		}
 		u.Time = &tsv
 	}
+	u.Now = v == "now"
 	return nil
 }
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -280,6 +280,9 @@ const BuildPlannerAPIPath = "/sv/buildplanner/graphql"
 // VulnerabilitiesAPIPath is the path used for the vulnerabilities api
 const VulnerabilitiesAPIPath = "/v13s/v1/graphql"
 
+// HasuraInventoryAPIPath is the path used for the hasura inventory api
+const HasuraInventoryAPIPath = "/sv/hasura-inventory/v1/graphql"
+
 // MessagesInfoURL is the URL we check against to see what versions are deprecated
 const MessagesInfoURL = "https://state-tool.s3.amazonaws.com/messages.json"
 

--- a/internal/runners/packages/info.go
+++ b/internal/runners/packages/info.go
@@ -70,7 +70,12 @@ func (i *Info) Run(params InfoRunParams, nstype model.NamespaceType) error {
 		normalized = params.Package.Name
 	}
 
-	packages, err := model.SearchIngredientsStrict(ns.String(), normalized, false, false, params.Timestamp.Time) // ideally case-sensitive would be true (PB-4371)
+	ts, err := getTime(&params.Timestamp, i.auth, i.proj)
+	if err != nil {
+		return errs.Wrap(err, "Unable to get timestamp from params")
+	}
+
+	packages, err := model.SearchIngredientsStrict(ns.String(), normalized, false, false, ts) // ideally case-sensitive would be true (PB-4371)
 	if err != nil {
 		return locale.WrapError(err, "package_err_cannot_obtain_search_results")
 	}

--- a/internal/runners/packages/install.go
+++ b/internal/runners/packages/install.go
@@ -1,6 +1,8 @@
 package packages
 
 import (
+	"time"
+
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
@@ -8,7 +10,9 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/requirements"
 	"github.com/ActiveState/cli/pkg/localcommit"
 	bpModel "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
+	"github.com/ActiveState/cli/pkg/project"
 )
 
 // InstallRunParams tracks the info required for running Install.
@@ -42,26 +46,9 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 		nsTypeV = &nsType
 	}
 
-	ts := params.Timestamp.Time
-	if ts == nil {
-		latest, err := model.FetchLatestTimeStamp()
-		if err != nil {
-			return errs.Wrap(err, "Unable to fetch latest Platform timestamp")
-		}
-
-		commitID, err := localcommit.Get(a.prime.Project().Dir())
-		if err != nil {
-			return errs.Wrap(err, "Unable to get commit ID")
-		}
-
-		atTime, err := model.FetchTimeStampForCommit(commitID)
-		if err != nil {
-			return errs.Wrap(err, "Unable to get commit time")
-		}
-
-		if atTime.After(latest) {
-			ts = atTime
-		}
+	ts, err := getTime(&params.Timestamp, a.prime.Auth(), a.prime.Project())
+	if err != nil {
+		return errs.Wrap(err, "Unable to get timestamp from params")
 	}
 
 	return requirements.NewRequirementOperation(a.prime).ExecuteRequirementOperation(
@@ -74,4 +61,43 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 		nsTypeV,
 		ts,
 	)
+}
+
+// getTime returns a timestamp based on the given "--ts" value.
+// If "now" was given, returns "now" according to the platform.
+// If no timestamp was given but the current project's commit time is after the latest inventory
+// timestamp, returns that commit time.
+// Otherwise, returns the specified timestamp or nil (which falls back on the default Platform
+// timestamp for a given operation)
+func getTime(ts *captain.TimeValue, auth *authentication.Auth, proj *project.Project) (*time.Time, error) {
+	if ts.Now {
+		latest, err := model.FetchLatestRevisionTimeStamp(auth)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to determine latest revision time")
+		}
+		return &latest, nil
+	}
+
+	if ts.Time == nil && proj != nil {
+		latest, err := model.FetchLatestTimeStamp()
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to fetch latest Platform timestamp")
+		}
+
+		commitID, err := localcommit.Get(proj.Dir())
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to get commit ID")
+		}
+
+		atTime, err := model.FetchTimeStampForCommit(commitID)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to get commit time")
+		}
+
+		if atTime.After(latest) {
+			return atTime, nil
+		}
+	}
+
+	return ts.Time, nil
 }

--- a/internal/runners/packages/install.go
+++ b/internal/runners/packages/install.go
@@ -1,18 +1,13 @@
 package packages
 
 import (
-	"time"
-
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/runbits/requirements"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	bpModel "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
-	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
-	"github.com/ActiveState/cli/pkg/project"
 )
 
 // InstallRunParams tracks the info required for running Install.
@@ -61,43 +56,4 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 		nsTypeV,
 		ts,
 	)
-}
-
-// getTime returns a timestamp based on the given "--ts" value.
-// If "now" was given, returns "now" according to the platform.
-// If no timestamp was given but the current project's commit time is after the latest inventory
-// timestamp, returns that commit time.
-// Otherwise, returns the specified timestamp or nil (which falls back on the default Platform
-// timestamp for a given operation)
-func getTime(ts *captain.TimeValue, auth *authentication.Auth, proj *project.Project) (*time.Time, error) {
-	if ts.Now {
-		latest, err := model.FetchLatestRevisionTimeStamp(auth)
-		if err != nil {
-			return nil, errs.Wrap(err, "Unable to determine latest revision time")
-		}
-		return &latest, nil
-	}
-
-	if ts.Time == nil && proj != nil {
-		latest, err := model.FetchLatestTimeStamp()
-		if err != nil {
-			return nil, errs.Wrap(err, "Unable to fetch latest Platform timestamp")
-		}
-
-		commitID, err := localcommit.Get(proj.Dir())
-		if err != nil {
-			return nil, errs.Wrap(err, "Unable to get commit ID")
-		}
-
-		atTime, err := model.FetchTimeStampForCommit(commitID)
-		if err != nil {
-			return nil, errs.Wrap(err, "Unable to get commit time")
-		}
-
-		if atTime.After(latest) {
-			return atTime, nil
-		}
-	}
-
-	return ts.Time, nil
 }

--- a/internal/runners/packages/search.go
+++ b/internal/runners/packages/search.go
@@ -58,12 +58,16 @@ func (s *Search) Run(params SearchRunParams, nstype model.NamespaceType) error {
 		ns = model.NewRawNamespace(params.Ingredient.Namespace)
 	}
 
+	ts, err := getTime(&params.Timestamp, s.auth, s.proj)
+	if err != nil {
+		return errs.Wrap(err, "Unable to get timestamp from params")
+	}
+
 	var packages []*model.IngredientAndVersion
-	var err error
 	if params.ExactTerm {
-		packages, err = model.SearchIngredientsLatestStrict(ns.String(), params.Ingredient.Name, true, true, params.Timestamp.Time)
+		packages, err = model.SearchIngredientsLatestStrict(ns.String(), params.Ingredient.Name, true, true, ts)
 	} else {
-		packages, err = model.SearchIngredientsLatest(ns.String(), params.Ingredient.Name, true, params.Timestamp.Time)
+		packages, err = model.SearchIngredientsLatest(ns.String(), params.Ingredient.Name, true, ts)
 	}
 	if err != nil {
 		return locale.WrapError(err, "package_err_cannot_obtain_search_results")

--- a/internal/runners/packages/time.go
+++ b/internal/runners/packages/time.go
@@ -1,0 +1,51 @@
+package packages
+
+import (
+	"time"
+
+	"github.com/ActiveState/cli/internal/captain"
+	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/pkg/localcommit"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/model"
+	"github.com/ActiveState/cli/pkg/project"
+)
+
+// getTime returns a timestamp based on the given "--ts" value.
+// If "now" was given, returns "now" according to the platform.
+// If no timestamp was given but the current project's commit time is after the latest inventory
+// timestamp, returns that commit time.
+// Otherwise, returns the specified timestamp or nil (which falls back on the default Platform
+// timestamp for a given operation)
+func getTime(ts *captain.TimeValue, auth *authentication.Auth, proj *project.Project) (*time.Time, error) {
+	if ts.Now() {
+		latest, err := model.FetchLatestRevisionTimeStamp(auth)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to determine latest revision time")
+		}
+		return &latest, nil
+	}
+
+	if ts.Time == nil && proj != nil {
+		latest, err := model.FetchLatestTimeStamp()
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to fetch latest Platform timestamp")
+		}
+
+		commitID, err := localcommit.Get(proj.Dir())
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to get commit ID")
+		}
+
+		atTime, err := model.FetchTimeStampForCommit(commitID)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to get commit time")
+		}
+
+		if atTime.After(latest) {
+			return atTime, nil
+		}
+	}
+
+	return ts.Time, nil
+}

--- a/pkg/platform/api/hasura_inventory/inventory.go
+++ b/pkg/platform/api/hasura_inventory/inventory.go
@@ -1,0 +1,17 @@
+package inventory
+
+import (
+	"github.com/ActiveState/cli/internal/gqlclient"
+	"github.com/ActiveState/cli/pkg/platform/api"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+)
+
+func New(auth *authentication.Auth) *gqlclient.Client {
+	client := gqlclient.New(api.GetServiceURL(api.ServiceHasuraInventory).String(), 0)
+
+	if auth != nil && auth.Authenticated() {
+		client.SetTokenProvider(auth)
+	}
+
+	return client
+}

--- a/pkg/platform/api/hasura_inventory/model/inventory.go
+++ b/pkg/platform/api/hasura_inventory/model/inventory.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"github.com/go-openapi/strfmt"
+)
+
+type LastIngredientRevisionTime struct {
+	RevisionTime strfmt.DateTime `json:"revision_time"`
+}
+
+type LatestRevisionResponse struct {
+	RevisionTimes []LastIngredientRevisionTime `json:"last_ingredient_revision_time"`
+}

--- a/pkg/platform/api/hasura_inventory/request/latest_revision.go
+++ b/pkg/platform/api/hasura_inventory/request/latest_revision.go
@@ -1,0 +1,20 @@
+package request
+
+type LatestRevision struct {
+}
+
+func NewLatestRevision() *LatestRevision {
+	return &LatestRevision{}
+}
+
+func (l *LatestRevision) Query() string {
+	return `query last_ingredient_revision_time {
+		last_ingredient_revision_time {
+			revision_time
+		}
+	}`
+}
+
+func (l *LatestRevision) Vars() (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/pkg/platform/api/settings.go
+++ b/pkg/platform/api/settings.go
@@ -46,6 +46,9 @@ const (
 	// ServiceVulnerabilities is Data Acquisition's Hasura service for vulnerability (CVE) information.
 	ServiceVulnerabilities = "vulnerabilities"
 
+	// ServiceHasuraInventory is the Hasura service for inventory information.
+	ServiceHasuraInventory = "hasura-inventory"
+
 	// TestingPlatform is the API host used by tests so-as not to affect production.
 	TestingPlatform = ".testing.tld"
 )
@@ -100,6 +103,11 @@ var urlsByService = map[Service]*url.URL{
 		Scheme: "https",
 		Host:   constants.DefaultAPIHost,
 		Path:   constants.VulnerabilitiesAPIPath,
+	},
+	ServiceHasuraInventory: {
+		Scheme: "https",
+		Host:   constants.DefaultAPIHost,
+		Path:   constants.HasuraInventoryAPIPath,
 	},
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2595" title="DX-2595" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2595</a>  `--ts now` should source time from platform
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This only works on a PR deploy: https://github.com/ActiveState/TheHomeRepot/pull/13250