### PR TITLE
Handle fast-forward merges of buildscripts.

### DIFF
--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -241,7 +241,10 @@ func (p *Pull) mergeBuildScript(remoteCommit, localCommit strfmt.UUID) error {
 	// Compute the merge strategy.
 	strategies, err := model.MergeCommit(remoteCommit, localCommit)
 	if err != nil {
-		if !errors.Is(err, model.ErrMergeCommitInHistory) {
+		switch {
+		case errors.Is(err, model.ErrMergeFastForward):
+			return buildscript.Update(p.project, exprB, p.auth)
+		case !errors.Is(err, model.ErrMergeCommitInHistory):
 			return locale.WrapError(err, "err_mergecommit", "Could not detect if merge is necessary.")
 		}
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2610" title="DX-2610" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2610</a>  state pull results in `Could not detect if merge is necessary.: No merge required`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

