### PR TITLE
Fix buildscript should only be created if opted in

### DIFF
--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -192,6 +193,10 @@ func (e *BuildPlannerError) Error() string {
 	}
 
 	return err.Error()
+}
+
+func (e *BuildPlannerError) Unwrap() error {
+	return errors.Unwrap(e.Err)
 }
 
 // BuildPlan is the top level object returned by the build planner. It contains

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -40,7 +41,7 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	suite.NoError(err, "Error loading project")
 
 	_, err = buildscript.NewScriptFromProject(proj, nil)
-	suite.Require().NoError(err) // verify validity
+	suite.Require().NoError(err, errs.JoinMessage(err)) // verify validity
 
 	cp = ts.Spawn("commit")
 	cp.Expect("No change")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2614" title="DX-2614" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2614</a>  Disable buildscripts for anything but `state commit` and `state eval`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

