### PR TITLE
Ensure commits only ever write the buildscript to a commit

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1546,3 +1546,5 @@ uploadingredient_success:
     You can install this package by running `[ACTIONABLE]state install {{.V1}}/{{.V0}} --ts now`[/RESET].
 err_runtime_cache_invalid:
   other: Your runtime needs to be updated, please run '[ACTIONABLE]state refresh[/RESET]'.
+err_buildscript_notexist:
+  other: Your project does not have a buildscript.as file. Please refer to the documentation on how to create one.

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1546,5 +1546,5 @@ uploadingredient_success:
     You can install this package by running `[ACTIONABLE]state install {{.V1}}/{{.V0}} --ts now`[/RESET].
 err_runtime_cache_invalid:
   other: Your runtime needs to be updated, please run '[ACTIONABLE]state refresh[/RESET]'.
-err_buildscript_notexist:
+err_buildscript_not_exist:
   other: Your project does not have a buildscript.as file. Please refer to the documentation on how to create one.

--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -39,7 +39,7 @@ func getBuildExpression(proj *project.Project, customCommit *strfmt.UUID, auth *
 // commit with them in order to update the remote one.
 func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, auth *authentication.Auth) (synced bool, err error) {
 	logging.Debug("Synchronizing local build script using commit %s", commitID)
-	script, err := buildscript.NewScriptFromProject(proj, auth)
+	script, err := buildscript.ScriptFromProjectWithFallback(proj, auth)
 	if err != nil {
 		return false, errs.Wrap(err, "Could not get local build script")
 	}

--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -3,13 +3,15 @@ package commit
 import (
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
-	"github.com/ActiveState/cli/internal/runbits/buildscript"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
+	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
+	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
 	"github.com/ActiveState/cli/pkg/platform/runtime/setup"
 	"github.com/ActiveState/cli/pkg/platform/runtime/target"
 	"github.com/ActiveState/cli/pkg/project"
@@ -44,17 +46,78 @@ func New(p primeable) *Commit {
 	}
 }
 
-func (c *Commit) Run() error {
+func rationalizeError(err *error) {
+	switch {
+	case err == nil:
+		return
+	case errs.Matches(*err, buildscript.ErrBuildscriptNotExist):
+		*err = errs.WrapUserFacing(*err, locale.T("err_buildscript_notexist"))
+	}
+}
+
+func (c *Commit) Run() (rerr error) {
+	defer rationalizeError(&rerr)
+
 	if c.proj == nil {
 		return locale.NewInputError("err_no_project")
 	}
 
-	changesCommitted, err := buildscript.Sync(c.proj, nil, c.out, c.auth)
+	// Get buildscript.as representation
+	script, err := buildscript.ScriptFromProject(c.proj)
 	if err != nil {
-		return locale.WrapError(
-			err, "err_commit_sync_buildscript",
-			"Could not synchronize the buildscript.",
-		)
+		return errs.Wrap(err, "Could not get local build script")
+	}
+
+	// Get build expression for current state of the project
+	localCommitID, err := localcommit.Get(c.proj.Dir())
+	if err != nil {
+		return errs.Wrap(err, "Unable to get local commit ID")
+	}
+	bp := model.NewBuildPlannerModel(c.auth)
+	exprProject, err := bp.GetBuildExpression(localCommitID.String())
+	if err != nil {
+		return errs.Wrap(err, "Could not get remote build expr for provided commit")
+	}
+
+	// Check if there is anything to commit
+	if script.EqualsBuildExpression(exprProject) {
+		c.out.Print(output.Prepare(
+			locale.Tl(
+				"commit_notice_no_change",
+				"No change to the buildscript was found.",
+			),
+			struct{}{},
+		))
+
+		return nil
+	}
+
+	exprBuildscript, err := script.BuildExpression()
+	if err != nil {
+		return errs.Wrap(err, "Unable to get build expression from build script")
+	}
+
+	stagedCommitID, err := bp.StageCommit(model.StageCommitParams{
+		Owner:        c.proj.Owner(),
+		Project:      c.proj.Name(),
+		ParentCommit: localCommitID.String(),
+		Expression:   exprBuildscript,
+	})
+	if err != nil {
+		return errs.Wrap(err, "Could not update project to reflect build script changes.")
+	}
+
+	if err := localcommit.Set(c.proj.Dir(), stagedCommitID.String()); err != nil {
+		return errs.Wrap(err, "Could not set local commit ID")
+	}
+
+	// Update our local build expression to match the committed one. This allows our API a way to ensure forward compatibility.
+	newBuildExpr, err := bp.GetBuildExpression(stagedCommitID.String())
+	if err != nil {
+		return errs.Wrap(err, "Unable to get the remote build expression")
+	}
+	if err := buildscript.Update(c.proj, newBuildExpr, c.auth); err != nil {
+		return errs.Wrap(err, "Could not update local build script.")
 	}
 
 	trigger := target.TriggerCommit
@@ -67,18 +130,6 @@ func (c *Commit) Run() error {
 	}
 
 	execDir := setup.ExecDir(rti.Target().Dir())
-
-	if !changesCommitted {
-		c.out.Print(output.Prepare(
-			locale.Tl(
-				"commit_notice_no_change",
-				"No change to the buildscript was found.",
-			),
-			struct{}{},
-		))
-
-		return nil
-	}
 
 	c.out.Print(output.Prepare(
 		locale.Tl(

--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -51,7 +51,7 @@ func rationalizeError(err *error) {
 	case err == nil:
 		return
 	case errs.Matches(*err, buildscript.ErrBuildscriptNotExist):
-		*err = errs.WrapUserFacing(*err, locale.T("err_buildscript_notexist"))
+		*err = errs.WrapUserFacing(*err, locale.T("err_buildscript_not_exist"))
 	}
 }
 

--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -222,7 +222,7 @@ func (p *Pull) performMerge(remoteCommit, localCommit strfmt.UUID, namespace *pr
 // mergeBuildScript merges the local build script with the remote buildexpression (not script).
 func (p *Pull) mergeBuildScript(remoteCommit, localCommit strfmt.UUID) error {
 	// Get the build script to merge.
-	script, err := buildscript.NewScriptFromProject(p.project, p.auth)
+	script, err := buildscript.ScriptFromProjectWithFallback(p.project, p.auth)
 	if err != nil {
 		return errs.Wrap(err, "Could not get local build script")
 	}

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -303,7 +303,7 @@ func TestRoundTrip(t *testing.T) {
 	tmpfile.Write([]byte(script.String()))
 	tmpfile.Close()
 
-	roundTripScript, err := newScriptFromFile(tmpfile.Name(), "", "", nil)
+	roundTripScript, err := ScriptFromFile(tmpfile.Name(), "", "", nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, script, roundTripScript)

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -303,7 +303,7 @@ func TestRoundTrip(t *testing.T) {
 	tmpfile.Write([]byte(script.String()))
 	tmpfile.Close()
 
-	roundTripScript, err := ScriptFromFile(tmpfile.Name(), "", "", nil)
+	roundTripScript, err := ScriptFromFile(tmpfile.Name())
 	require.NoError(t, err)
 
 	assert.Equal(t, script, roundTripScript)

--- a/pkg/platform/runtime/buildscript/file.go
+++ b/pkg/platform/runtime/buildscript/file.go
@@ -22,40 +22,59 @@ type projecter interface {
 	Name() string
 }
 
-func NewScriptFromProject(proj projecter, auth *authentication.Auth) (*Script, error) {
-	return newScriptFromFile(filepath.Join(proj.ProjectDir(), constants.BuildScriptFileName), proj.Owner(), proj.Name(), auth)
+var ErrBuildscriptNotExist = errors.New("Build script does not exist")
+
+// ScriptFromProjectWithFallback will source the buildscript from the project, and create it if it does not exist.
+func ScriptFromProjectWithFallback(proj projecter, auth *authentication.Auth) (*Script, error) {
+	path := filepath.Join(proj.ProjectDir(), constants.BuildScriptFileName)
+
+	buildscript, err := ScriptFromFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, errs.Wrap(err, "Could not read build script from file")
+		}
+
+		logging.Debug("Build script does not exist. Creating one.")
+		commitId, err := localcommit.Get(filepath.Dir(path))
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to get the local commit ID")
+		}
+		buildplanner := model.NewBuildPlannerModel(auth)
+		expr, err := buildplanner.GetBuildExpression(commitId.String())
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to get the remote build expression")
+		}
+		buildscript, err = NewScriptFromBuildExpression(expr)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to convert build expression to build script")
+		}
+		err = fileutils.WriteFile(path, []byte(buildscript.String()))
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to write build script")
+		}
+	}
+
+	return buildscript, nil
 }
 
-func newScriptFromFile(path, org, project string, auth *authentication.Auth) (*Script, error) {
-	if data, err := fileutils.ReadFile(path); err == nil {
-		return NewScript(data)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return nil, errs.Wrap(err, "Could not read build script")
-	}
+func ScriptFromProject(proj projecter) (*Script, error) {
+	path := filepath.Join(proj.ProjectDir(), constants.BuildScriptFileName)
+	return ScriptFromFile(path)
+}
 
-	logging.Debug("Build script does not exist. Creating one.")
-	commitId, err := localcommit.Get(filepath.Dir(path))
+func ScriptFromFile(path string) (*Script, error) {
+	data, err := fileutils.ReadFile(path)
 	if err != nil {
-		return nil, errs.Wrap(err, "Unable to get the local commit ID")
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, errs.Pack(err, ErrBuildscriptNotExist)
+		}
+		return nil, errs.Wrap(err, "Could not read build script from file")
 	}
-	buildplanner := model.NewBuildPlannerModel(auth)
-	expr, err := buildplanner.GetBuildExpression(commitId.String())
-	if err != nil {
-		return nil, errs.Wrap(err, "Unable to get the remote build expression")
-	}
-	script, err := NewScriptFromBuildExpression(expr)
-	if err != nil {
-		return nil, errs.Wrap(err, "Unable to convert build expression to build script")
-	}
-	err = fileutils.WriteFile(path, []byte(script.String()))
-	if err != nil {
-		return nil, errs.Wrap(err, "Unable to write build script")
-	}
-	return script, nil
+	return NewScript(data)
 }
 
 func Update(proj projecter, newExpr *buildexpression.BuildExpression, auth *authentication.Auth) error {
-	if script, err := NewScriptFromProject(proj, auth); err == nil && (script == nil || !script.EqualsBuildExpression(newExpr)) {
+	if script, err := ScriptFromProjectWithFallback(proj, auth); err == nil && (script == nil || !script.EqualsBuildExpression(newExpr)) {
 		update(proj.ProjectDir(), newExpr, auth)
 	} else if err != nil {
 		return errs.Wrap(err, "Could not read build script")

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -148,7 +148,7 @@ func (r *Runtime) validateCache() error {
 
 	// Check if local build script has changes that should be committed.
 	if r.cfg.GetBool(constants.OptinBuildscriptsConfig) {
-		script, err := buildscript.NewScriptFromProject(r.target, r.auth)
+		script, err := buildscript.ScriptFromProject(r.target)
 		if err != nil {
 			return errs.Wrap(err, "Unable to get local build script")
 		}

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
-	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -43,14 +43,14 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	proj, err := project.FromPath(ts.Dirs.Work)
 	suite.NoError(err, "Error loading project")
 
-	_, err = buildscript.NewScriptFromProject(proj, nil)
-	suite.Require().NoError(err, errs.JoinMessage(err)) // verify validity
+	_, err = buildscript.ScriptFromProject(proj)
+	suite.Require().NoError(err) // verify validity
 
 	cp = ts.Spawn("commit")
 	cp.Expect("No change")
 	cp.ExpectExitCode(0)
 
-	_, err = buildscript.NewScriptFromProject(proj, nil)
+	_, err = buildscript.ScriptFromProject(proj)
 	suite.Require().NoError(err) // verify validity
 
 	scriptPath := filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName)

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -98,7 +98,7 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	proj, err := project.FromPath(ts.Dirs.Work)
 	suite.NoError(err, "Error loading project")
 
-	_, err = buildscript.NewScriptFromProject(proj, nil)
+	_, err = buildscript.ScriptFromProjectWithFallback(proj, nil)
 	suite.Require().NoError(err) // just verify it's a valid build script
 
 	cp = ts.Spawn("pull")
@@ -106,7 +106,7 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	cp.ExpectNotExitCode(0)
 	ts.IgnoreLogErrors()
 
-	_, err = buildscript.NewScriptFromProject(proj, nil)
+	_, err = buildscript.ScriptFromProjectWithFallback(proj, nil)
 	suite.Assert().Error(err)
 	bytes := fileutils.ReadFileUnsafe(filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName))
 	suite.Assert().Contains(string(bytes), "<<<<<<<", "No merge conflict markers are in build script")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2620" title="DX-2620" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2620</a>  `buildscript.as` changed to previous content every time `state commit` executed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Effectively this was running into the implicitness of Sync, which is tracked here:

https://activestatef.atlassian.net/browse/DX-2619

Sync is doing too much at the moment. Rather than try and fix that and all the other issues that might arise from doing so, I opted to instead implement the commit logic in the commit runner, which is frankly where it should live anyway.