### PR TITLE
Show the full name of the artifact being downloaded.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1534,3 +1534,5 @@ err_runtime_cache_invalid:
   other: Your runtime needs to be updated, please run '[ACTIONABLE]state refresh[/RESET]'.
 err_buildscript_not_exist:
   other: Your project does not have a buildscript.as file. Please refer to the documentation on how to create one.
+builds_dl_downloading:
+  other: Downloading {{.V0}}

--- a/internal/runners/builds/progress.go
+++ b/internal/runners/builds/progress.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
-	"github.com/ActiveState/cli/internal/runbits/runtime/progress"
 	"github.com/vbauerster/mpb/v7"
 	"github.com/vbauerster/mpb/v7/decor"
 )
@@ -25,6 +24,7 @@ type interactiveProgress struct {
 	bar          *mpb.Bar
 	artifactName string
 	artifactSize int
+	out          output.Outputer
 }
 
 func newDownloadProgress(ctx context.Context, out output.Outputer, artifactName, downloadPath string) downloadProgress {
@@ -47,19 +47,17 @@ func newDownloadProgress(ctx context.Context, out output.Outputer, artifactName,
 		mpb.WithRefreshRate(constants.TerminalAnimationInterval),
 	)
 
-	if len(artifactName) > progress.MaxNameWidth() {
-		artifactName = artifactName[0:progress.MaxNameWidth()]
-	}
-
 	return &interactiveProgress{
 		pg:           pg,
 		artifactName: artifactName,
+		out:          out,
 	}
 }
 
 func (p *interactiveProgress) Start(size int64) {
+	p.out.Notice(locale.Tr("builds_dl_downloading", p.artifactName))
 	prependDecorators := []decor.Decorator{
-		decor.Name(p.artifactName, decor.WC{W: progress.MaxNameWidth(), C: decor.DidentRight}),
+		decor.Name(locale.T("downloading")),
 		decor.OnComplete(
 			decor.Spinner(output.SpinnerFrames, decor.WCSyncSpace), "",
 		),
@@ -103,7 +101,7 @@ type nonInteractiveProgress struct {
 }
 
 func (p *nonInteractiveProgress) Start(_ int64) {
-	p.spinner = output.StartSpinner(p.out, locale.Tl("builds_dl_downloading", "Downloading {{.V0}}", p.artifactName), constants.TerminalAnimationInterval)
+	p.spinner = output.StartSpinner(p.out, locale.Tr("builds_dl_downloading", p.artifactName), constants.TerminalAnimationInterval)
 }
 
 func (p *nonInteractiveProgress) Inc(_ int) {}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2591" title="DX-2591" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2591</a>  BUILDS: The name of the build cut-off
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It often gets truncated when put next to the progressbar.