### PR TITLE
Show timestamp with `state publish` output.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1542,6 +1542,7 @@ uploadingredient_success:
     Namespace: [ACTIONABLE]{{.V1}}[/RESET]
     Version: [ACTIONABLE]{{.V2}}[/RESET]
     Revision: [ACTIONABLE]{{.V3}}[/RESET]
+    Timestamp: [ACTIONABLE]{{.V4}}[/RESET]
 
     You can install this package by running `[ACTIONABLE]state install {{.V1}}/{{.V0}} --ts now`[/RESET].
 err_runtime_cache_invalid:

--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -278,6 +278,7 @@ func (r *Runner) Run(params *Params) error {
 			*publishedIngredient.PrimaryNamespace,
 			*publishedVersion.Version,
 			strconv.Itoa(int(*publishedVersion.Revision)),
+			publishedVersion.RevisionTimestamp.String(),
 		),
 		result.Publish,
 	))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2628" title="DX-2628" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2628</a>  `state publish` prints a timestamp that can be used in the buildscript
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Sample output:

```
% build/state publish <name>-<version>.zip --namespace <namespace>
█ Publish Ingredient

Publishing ingredient...
Successfully published as:
Name: <name>
Namespace: <namespace>
Version: <version>
Revision: 1
Timestamp: 2024-03-12T18:44:34.092Z

You can install this package by running `state install <namespace>/<name> --ts now`.
```