### PR TITLE
Ensure timestamp we use is covering most recent ingredient revision

### DIFF
--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -271,6 +271,14 @@ func (r *Runner) Run(params *Params) error {
 		return locale.WrapError(err, "err_uploadingingredient_fetch_version", "Unable to fetch newly published ingredient version")
 	}
 
+	ingTime, err := time.Parse(time.RFC3339, publishedVersion.RevisionTimestamp.String())
+	if err != nil {
+		return errs.Wrap(err, "Ingredient timestamp invalid")
+	}
+
+	// Increment time by 1 second to work around API precision issue where same second comparisons can fall on either side
+	ingTime = ingTime.Add(time.Second)
+
 	r.out.Print(output.Prepare(
 		locale.Tl(
 			"uploadingredient_success", "",
@@ -278,7 +286,7 @@ func (r *Runner) Run(params *Params) error {
 			*publishedIngredient.PrimaryNamespace,
 			*publishedVersion.Version,
 			strconv.Itoa(int(*publishedVersion.Revision)),
-			publishedVersion.RevisionTimestamp.String(),
+			ingTime.Format(time.RFC3339),
 		),
 		result.Publish,
 	))

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -570,7 +570,12 @@ func FetchLatestRevisionTimeStamp(auth *authentication.Auth) (time.Time, error) 
 	if err != nil {
 		return time.Now(), errs.Wrap(err, "Failed to get latest change time")
 	}
-	return time.Time(response.RevisionTimes[0].RevisionTime), nil
+
+	// Increment time by 1 second to work around API precision issue where same second comparisons can fall on either side
+	t := time.Time(response.RevisionTimes[0].RevisionTime)
+	t = t.Add(time.Second)
+
+	return t, nil
 }
 
 func FetchNormalizedName(namespace Namespace, name string) (string, error) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2633" title="DX-2633" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2633</a>  We increment the timestamp returned by `state publish` by 1 second
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

