### PR TITLE
Produce buildscript parsing errors

### DIFF
--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
@@ -79,12 +80,20 @@ func NewScript(data []byte) (*Script, error) {
 
 	script, err := parser.ParseBytes(constants.BuildScriptFileName, data)
 	if err != nil {
+		parseErrors := errs.Unpack(err)
+		if len(parseErrors) > 0 {
+			return nil, locale.NewInputError("err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}", parseErrors[len(parseErrors)-1].Error())
+		}
 		return nil, errs.Wrap(err, "Could not parse build script")
 	}
 
 	// Construct the equivalent buildexpression.
 	bytes, err := json.Marshal(script)
 	if err != nil {
+		parseErrors := errs.Unpack(err)
+		if len(parseErrors) > 0 {
+			return nil, locale.NewInputError("err_marshall_buildscript", "Could not marshall build script: {{.V0}}", parseErrors[len(parseErrors)-1].Error())
+		}
 		return nil, errs.Wrap(err, "Could not marshal build script to build expression")
 	}
 	expr, err := buildexpression.New(bytes)

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -85,7 +85,7 @@ func NewScript(data []byte) (*Script, error) {
 		if errors.As(err, &parseError) {
 			return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}: {{.V1}}", parseError.Position().String(), parseError.Message())
 		}
-		return nil, locale.WrapError(err, "err_parse_buildscript_bytes", "Could not parse build script")
+		return nil, locale.WrapError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}", err.Error())
 	}
 
 	// Construct the equivalent buildexpression.

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -82,7 +82,7 @@ func NewScript(data []byte) (*Script, error) {
 	if err != nil {
 		parseErrors := errs.Unpack(err)
 		if len(parseErrors) > 0 {
-			return nil, locale.NewInputError("err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}", parseErrors[len(parseErrors)-1].Error())
+			return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}", parseErrors[len(parseErrors)-1].Error())
 		}
 		return nil, errs.Wrap(err, "Could not parse build script")
 	}

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -3,6 +3,7 @@ package buildscript
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -80,7 +81,11 @@ func NewScript(data []byte) (*Script, error) {
 
 	script, err := parser.ParseBytes(constants.BuildScriptFileName, data)
 	if err != nil {
-		return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}", errs.JoinMessage(err))
+		var parseError participle.Error
+		if errors.As(err, &parseError) {
+			return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}: {{.V1}}", parseError.Position().String(), parseError.Message())
+		}
+		return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script")
 	}
 
 	// Construct the equivalent buildexpression.

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -80,11 +80,7 @@ func NewScript(data []byte) (*Script, error) {
 
 	script, err := parser.ParseBytes(constants.BuildScriptFileName, data)
 	if err != nil {
-		parseErrors := errs.Unpack(err)
-		if len(parseErrors) > 0 {
-			return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}", parseErrors[len(parseErrors)-1].Error())
-		}
-		return nil, errs.Wrap(err, "Could not parse build script")
+		return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}", errs.JoinMessage(err))
 	}
 
 	// Construct the equivalent buildexpression.

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -85,7 +85,7 @@ func NewScript(data []byte) (*Script, error) {
 		if errors.As(err, &parseError) {
 			return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}: {{.V1}}", parseError.Position().String(), parseError.Message())
 		}
-		return nil, locale.WrapInputError(err, "err_parse_buildscript_bytes", "Could not parse build script")
+		return nil, locale.WrapError(err, "err_parse_buildscript_bytes", "Could not parse build script")
 	}
 
 	// Construct the equivalent buildexpression.

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -90,10 +90,6 @@ func NewScript(data []byte) (*Script, error) {
 	// Construct the equivalent buildexpression.
 	bytes, err := json.Marshal(script)
 	if err != nil {
-		parseErrors := errs.Unpack(err)
-		if len(parseErrors) > 0 {
-			return nil, locale.NewInputError("err_marshall_buildscript", "Could not marshall build script: {{.V0}}", parseErrors[len(parseErrors)-1].Error())
-		}
 		return nil, errs.Wrap(err, "Could not marshal build script to build expression")
 	}
 	expr, err := buildexpression.New(bytes)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2639" title="DX-2639" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2639</a>  We produce buildscript parsing errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Unfortunately, parsing errors don't cover all of the cases we may have initially though. For example, if you provide a requirement like `Req(name = "language/python", version = "3.10.13")` This will not be a parsing error but an error when we try to construct the equivalent build expression. This produces a not so helpful error: `Invalid or unknown argument: &{version 0x1400093e400}`.

For the actual parsing error we get something nicer like:

```
❯ ~/work/cli/build/state commit
█ Commit Changes

 • Creating commit x Failed

 x Could not parse build script: buildscript.as:15:57: literal not terminated.

█ Need More Help?
 • Run → 'state commit --help' for general help.
 • Ask For Help → https://community.activestate.com/c/state-tool/.
```

For now, this PR is only hoisting up the parsing errors.