### PR TITLE
`state commit` should set the `at_time` specified in the buildscript.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -387,6 +387,9 @@ const RuntimeBuildPlanStore = "build_plan"
 // BuildExpressionStore holds the cached build expression for the current commit ID.
 const BuildExpressionStore = "build_expression"
 
+// BuildScriptStore holds the cached buildscript for the current project.
+const BuildScriptStore = "build_script"
+
 // StateToolMarketingPage links to the marketing page for the state tool
 const StateToolMarketingPage = "https://www.activestate.com/products/platform/state-tool/"
 

--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -21,6 +21,10 @@ import (
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
+// getEquivalentBuildScript constructs and returns a buildscript that represents the
+// buildexpression and at_time of a fetched project commit.
+// This is used either to compare the local build script with a remote equivalent, or to update
+// the local build script with a remote equivalent.
 func getEquivalentBuildScript(proj *project.Project, customCommit *strfmt.UUID, auth *authentication.Auth) (*buildscript.Script, error) {
 	bp := model.NewBuildPlannerModel(auth)
 	commitID, err := localcommit.Get(proj.Dir())

--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -14,14 +15,13 @@ import (
 	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
-	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/go-openapi/strfmt"
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
-func getBuildExpression(proj *project.Project, customCommit *strfmt.UUID, auth *authentication.Auth) (*buildexpression.BuildExpression, error) {
+func getEquivalentBuildScript(proj *project.Project, customCommit *strfmt.UUID, auth *authentication.Auth) (*buildscript.Script, error) {
 	bp := model.NewBuildPlannerModel(auth)
 	commitID, err := localcommit.Get(proj.Dir())
 	if err != nil {
@@ -30,7 +30,11 @@ func getBuildExpression(proj *project.Project, customCommit *strfmt.UUID, auth *
 	if customCommit != nil {
 		commitID = *customCommit
 	}
-	return bp.GetBuildExpression(commitID.String())
+	expr, atTime, err := bp.GetBuildExpressionAndTime(commitID.String())
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to get remote build expression and time")
+	}
+	return buildscript.NewFromCommit(atTime, expr)
 }
 
 // Sync synchronizes the local build script with the remote one.
@@ -44,16 +48,16 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		return false, errs.Wrap(err, "Could not get local build script")
 	}
 
-	expr, err := getBuildExpression(proj, commitID, auth)
+	remoteScript, err := getEquivalentBuildScript(proj, commitID, auth)
 	if err != nil {
-		return false, errs.Wrap(err, "Could not get remote build expr for provided commit")
+		return false, errs.Wrap(err, "Could not get remote build script-equivalent")
 	}
 
 	// If commitID is given, a mutation happened, so prefer the remote build expression.
 	// Otherwise, prefer local changes.
 	if script != nil && commitID == nil {
 		logging.Debug("Checking for changes")
-		if script.EqualsBuildExpression(expr) {
+		if script.Equals(remoteScript) {
 			return false, nil // nothing to do
 		}
 		logging.Debug("Merging changes")
@@ -64,9 +68,10 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 			return false, errs.Wrap(err, "Unable to get local commit ID")
 		}
 
-		expr, err := script.BuildExpression()
-		if err != nil {
-			return false, errs.Wrap(err, "Unable to get build expression from build script")
+		var atTime *time.Time
+		if script.AtTime != nil {
+			scriptAtTime := time.Time(*script.AtTime)
+			atTime = &scriptAtTime
 		}
 
 		bp := model.NewBuildPlannerModel(auth)
@@ -74,7 +79,8 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 			Owner:        proj.Owner(),
 			Project:      proj.Name(),
 			ParentCommit: localCommitID.String(),
-			Expression:   expr,
+			Expression:   script.Expr,
+			TimeStamp:    atTime,
 		})
 		if err != nil {
 			return false, errs.Wrap(err, "Could not update project to reflect build script changes.")
@@ -83,7 +89,7 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 
 		localcommit.Set(proj.Dir(), commitID.String())
 
-		expr, err = getBuildExpression(proj, commitID, auth) // timestamps might be different
+		script, err = getEquivalentBuildScript(proj, commitID, auth) // timestamps might be different
 		if err != nil {
 			return false, errs.Wrap(err, "Could not get remote build expr for staged commit")
 		}
@@ -91,26 +97,21 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		synced = true
 	}
 
-	if err := buildscript.Update(proj, expr, auth); err != nil {
+	if err := buildscript.Update(proj, script.AtTime, script.Expr, auth); err != nil {
 		return false, errs.Wrap(err, "Could not update local build script.")
 	}
 
 	return synced, nil
 }
 
-func generateDiff(script *buildscript.Script, expr *buildexpression.BuildExpression) (string, error) {
-	newScript, err := buildscript.NewScriptFromBuildExpression(expr)
-	if err != nil {
-		return "", errs.Wrap(err, "Unable to transform build expression to build script")
-	}
-
+func generateDiff(script *buildscript.Script, otherScript *buildscript.Script) (string, error) {
 	local := locale.Tl("diff_local", "local")
 	remote := locale.Tl("diff_remote", "remote")
 
 	var result bytes.Buffer
 
 	diff := diffmatchpatch.New()
-	scriptLines, newScriptLines, lines := diff.DiffLinesToChars(script.String(), newScript.String())
+	scriptLines, newScriptLines, lines := diff.DiffLinesToChars(script.String(), otherScript.String())
 	hunks := diff.DiffMain(scriptLines, newScriptLines, false)
 	hunks = diff.DiffCharsToLines(hunks, lines)
 	hunks = diff.DiffCleanupSemantic(hunks)
@@ -138,8 +139,8 @@ func generateDiff(script *buildscript.Script, expr *buildexpression.BuildExpress
 	return result.String(), nil
 }
 
-func GenerateAndWriteDiff(proj *project.Project, script *buildscript.Script, expr *buildexpression.BuildExpression) error {
-	result, err := generateDiff(script, expr)
+func GenerateAndWriteDiff(proj *project.Project, script *buildscript.Script, otherScript *buildscript.Script) error {
+	result, err := generateDiff(script, otherScript)
 	if err != nil {
 		return errs.Wrap(err, "Could not generate diff between local and remote build scripts")
 	}

--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -99,6 +99,8 @@ func Sync(proj *project.Project, commitID *strfmt.UUID, out output.Outputer, aut
 		}
 
 		synced = true
+	} else {
+		script = remoteScript
 	}
 
 	if err := buildscript.Update(proj, script.AtTime, script.Expr, auth); err != nil {

--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDiff(t *testing.T) {
-	script, err := buildscript.NewScript([]byte(
+	script, err := buildscript.New([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
 	at_time = at_time,
@@ -28,15 +28,12 @@ runtime = solve(
 main = runtime`))
 	require.NoError(t, err)
 
-	expr, err := script.BuildExpression()
-	require.NoError(t, err)
-
 	// Modify the build script.
-	script, err = buildscript.NewScript([]byte(strings.Replace(script.String(), "12345", "77777", 1)))
+	modifiedScript, err := buildscript.New([]byte(strings.Replace(script.String(), "12345", "77777", 1)))
 	require.NoError(t, err)
 
 	// Generate the difference between the modified script and the original expression.
-	result, err := generateDiff(script, expr)
+	result, err := generateDiff(modifiedScript, script)
 	require.NoError(t, err)
 	assert.Equal(t, `at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
@@ -65,13 +62,11 @@ main = runtime`, result)
 //   - The local project pulls from the Platform project, resulting in conflicting times and version
 //     requirements for requests.
 func TestRealWorld(t *testing.T) {
-	script1, err := buildscript.NewScript(fileutils.ReadFileUnsafe(filepath.Join("testdata", "buildscript1.as")))
+	script1, err := buildscript.New(fileutils.ReadFileUnsafe(filepath.Join("testdata", "buildscript1.as")))
 	require.NoError(t, err)
-	script2, err := buildscript.NewScript(fileutils.ReadFileUnsafe(filepath.Join("testdata", "buildscript2.as")))
+	script2, err := buildscript.New(fileutils.ReadFileUnsafe(filepath.Join("testdata", "buildscript2.as")))
 	require.NoError(t, err)
-	expr2, err := script2.BuildExpression()
-	require.NoError(t, err)
-	result, err := generateDiff(script1, expr2)
+	result, err := generateDiff(script1, script2)
 	require.NoError(t, err)
 	assert.Equal(t, `<<<<<<< local
 at_time = "2023-10-16T22:20:29.000Z"

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -417,12 +417,12 @@ func (r *RequirementOperation) updateCommitID(commitID strfmt.UUID) error {
 
 	if r.Config.GetBool(constants.OptinBuildscriptsConfig) {
 		bp := model.NewBuildPlannerModel(r.Auth)
-		expr, err := bp.GetBuildExpression(commitID.String())
+		expr, atTime, err := bp.GetBuildExpressionAndTime(commitID.String())
 		if err != nil {
-			return errs.Wrap(err, "Could not get remote build expr")
+			return errs.Wrap(err, "Could not get remote build expr and time")
 		}
 
-		err = buildscript.Update(r.Project, expr, r.Auth)
+		err = buildscript.Update(r.Project, atTime, expr, r.Auth)
 		if err != nil {
 			return locale.WrapError(err, "err_update_build_script")
 		}

--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"errors"
+	"time"
 
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
@@ -114,11 +115,18 @@ func (c *Commit) Run() (rerr error) {
 		return errs.Wrap(err, "Unable to get build expression from build script")
 	}
 
+	var exprAtTime *time.Time
+	if atTime := script.AtTime; atTime != nil {
+		atTimeTime := time.Time(*atTime)
+		exprAtTime = &atTimeTime
+	}
+
 	stagedCommitID, err := bp.StageCommit(model.StageCommitParams{
 		Owner:        c.proj.Owner(),
 		Project:      c.proj.Name(),
 		ParentCommit: localCommitID.String(),
 		Expression:   exprBuildscript,
+		TimeStamp:    exprAtTime,
 	})
 	if err != nil {
 		return errs.Wrap(err, "Could not update project to reflect build script changes.")

--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -94,25 +94,24 @@ func (c *Commit) Run() (rerr error) {
 		return errs.Wrap(err, "Could not get local build script")
 	}
 
-	// Get build expression for current state of the project
+	// Get equivalent build script for current state of the project
 	localCommitID, err := localcommit.Get(c.proj.Dir())
 	if err != nil {
 		return errs.Wrap(err, "Unable to get local commit ID")
 	}
 	bp := model.NewBuildPlannerModel(c.auth)
-	exprProject, err := bp.GetBuildExpression(localCommitID.String())
+	exprProject, atTime, err := bp.GetBuildExpressionAndTime(localCommitID.String())
 	if err != nil {
-		return errs.Wrap(err, "Could not get remote build expr for provided commit")
+		return errs.Wrap(err, "Could not get remote build expr and time for provided commit")
+	}
+	remoteScript, err := buildscript.NewFromCommit(atTime, exprProject)
+	if err != nil {
+		return errs.Wrap(err, "Could not convert build expression to build script")
 	}
 
 	// Check if there is anything to commit
-	if script.EqualsBuildExpression(exprProject) {
+	if script.Equals(remoteScript) {
 		return ErrNoChanges
-	}
-
-	exprBuildscript, err := script.BuildExpression()
-	if err != nil {
-		return errs.Wrap(err, "Unable to get build expression from build script")
 	}
 
 	var exprAtTime *time.Time
@@ -125,7 +124,7 @@ func (c *Commit) Run() (rerr error) {
 		Owner:        c.proj.Owner(),
 		Project:      c.proj.Name(),
 		ParentCommit: localCommitID.String(),
-		Expression:   exprBuildscript,
+		Expression:   script.Expr,
 		TimeStamp:    exprAtTime,
 	})
 	if err != nil {
@@ -138,12 +137,12 @@ func (c *Commit) Run() (rerr error) {
 	}
 
 	// Update our local build expression to match the committed one. This allows our API a way to ensure forward compatibility.
-	newBuildExpr, err := bp.GetBuildExpression(stagedCommitID.String())
+	newBuildExpr, newAtTime, err := bp.GetBuildExpressionAndTime(stagedCommitID.String())
 	if err != nil {
-		return errs.Wrap(err, "Unable to get the remote build expression")
+		return errs.Wrap(err, "Unable to get the remote build expression and time")
 	}
-	if err := buildscript.Update(c.proj, newBuildExpr, c.auth); err != nil {
-		return errs.Wrap(err, "Could not update local build script.")
+	if err := buildscript.Update(c.proj, newAtTime, newBuildExpr, c.auth); err != nil {
+		return errs.Wrap(err, "Could not update local build script")
 	}
 
 	pg.Stop(locale.T("progress_success") + "\n")

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -135,7 +135,7 @@ func (i *Import) Run(params *ImportRunParams) error {
 		return locale.WrapError(err, "err_cannot_apply_changeset", "Could not apply changeset")
 	}
 
-	if _, err := be.SetDefaultTimestamp(); err != nil {
+	if err := be.SetDefaultTimestamp(); err != nil {
 		return locale.WrapError(err, "err_cannot_set_timestamp", "Could not set timestamp")
 	}
 

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -92,6 +92,7 @@ type BuildResult struct {
 	BuildStatus         string
 	BuildReady          bool
 	BuildExpression     *buildexpression.BuildExpression
+	AtTime              *strfmt.DateTime
 }
 
 func (b *BuildResult) OrderedArtifacts() []artifact.ArtifactID {
@@ -165,9 +166,9 @@ func (bp *BuildPlanner) FetchBuildResult(commitID strfmt.UUID, owner, project st
 		return nil, errs.Wrap(err, "Response does not contain commitID")
 	}
 
-	expr, err := bp.GetBuildExpression(commitID.String())
+	expr, atTime, err := bp.GetBuildExpressionAndTime(commitID.String())
 	if err != nil {
-		return nil, errs.Wrap(err, "Failed to get build expression")
+		return nil, errs.Wrap(err, "Failed to get build expression and time")
 	}
 
 	res := BuildResult{
@@ -176,6 +177,7 @@ func (bp *BuildPlanner) FetchBuildResult(commitID strfmt.UUID, owner, project st
 		BuildReady:      build.Status == bpModel.Completed,
 		CommitID:        id,
 		BuildExpression: expr,
+		AtTime:          atTime,
 		BuildStatus:     build.Status,
 	}
 
@@ -300,7 +302,7 @@ func (bp *BuildPlanner) StageCommit(params StageCommitParams) (strfmt.UUID, erro
 				return "", errs.Wrap(err, "Failed to update build expression with requirement")
 			}
 
-			if _, err := expression.SetDefaultTimestamp(); err != nil {
+			if err := expression.SetDefaultTimestamp(); err != nil {
 				return "", errs.Wrap(err, "Failed to set default timestamp")
 			}
 		}
@@ -354,12 +356,35 @@ func (bp *BuildPlanner) GetBuildExpression(commitID string) (*buildexpression.Bu
 		return nil, errs.Wrap(err, "failed to parse build expression")
 	}
 
-	err = expression.MaybeUpdateTimestamp(resp.Commit.AtTime)
+	return expression, nil
+}
+
+func (bp *BuildPlanner) GetBuildExpressionAndTime(commitID string) (*buildexpression.BuildExpression, *strfmt.DateTime, error) {
+	logging.Debug("GetBuildExpressionAndTime, commitID: %s", commitID)
+	resp := &bpModel.BuildExpression{}
+	err := bp.client.Run(request.BuildExpression(commitID), resp)
 	if err != nil {
-		return nil, errs.Wrap(err, "failed to possibly update %s in build expression", buildexpression.AtTimeKey)
+		return nil, nil, processBuildPlannerError(err, "failed to fetch build expression")
 	}
 
-	return expression, nil
+	if resp.Commit == nil {
+		return nil, nil, errs.New("Commit is nil")
+	}
+
+	if bpModel.IsErrorResponse(resp.Commit.Type) {
+		return nil, nil, bpModel.ProcessCommitError(resp.Commit, "Could not get build expression from commit")
+	}
+
+	if resp.Commit.Expression == nil {
+		return nil, nil, errs.New("Commit does not contain expression")
+	}
+
+	expression, err := buildexpression.New(resp.Commit.Expression)
+	if err != nil {
+		return nil, nil, errs.Wrap(err, "failed to parse build expression")
+	}
+
+	return expression, &resp.Commit.AtTime, nil
 }
 
 // CreateProjectParams contains information for the project to create.

--- a/pkg/platform/runtime/buildexpression/merge/merge_test.go
+++ b/pkg/platform/runtime/buildexpression/merge/merge_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMergeAdd(t *testing.T) {
-	scriptA, err := buildscript.NewScript([]byte(
+	scriptA, err := buildscript.New([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
 	at_time = at_time,
@@ -26,10 +26,9 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
-	exprA, err := scriptA.BuildExpression()
-	require.NoError(t, err)
+	exprA := scriptA.Expr
 
-	scriptB, err := buildscript.NewScript([]byte(
+	scriptB, err := buildscript.New([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
 	at_time = at_time,
@@ -45,8 +44,7 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
-	exprB, err := scriptB.BuildExpression()
-	require.NoError(t, err)
+	exprB := scriptB.Expr
 
 	strategies := &mono_models.MergeStrategies{
 		OverwriteChanges: []*mono_models.CommitChangeEditable{
@@ -59,7 +57,7 @@ main = runtime`))
 	mergedExpr, err := Merge(exprA, exprB, strategies)
 	require.NoError(t, err)
 
-	mergedScript, err := buildscript.NewScriptFromBuildExpression(mergedExpr)
+	mergedScript, err := buildscript.NewFromCommit(scriptA.AtTime, mergedExpr)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -81,7 +79,7 @@ main = runtime`, mergedScript.String())
 }
 
 func TestMergeRemove(t *testing.T) {
-	scriptA, err := buildscript.NewScript([]byte(
+	scriptA, err := buildscript.New([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
 	at_time = at_time,
@@ -98,10 +96,9 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
-	exprA, err := scriptA.BuildExpression()
-	require.NoError(t, err)
+	exprA := scriptA.Expr
 
-	scriptB, err := buildscript.NewScript([]byte(
+	scriptB, err := buildscript.New([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
 	at_time = at_time,
@@ -117,8 +114,7 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
-	exprB, err := scriptB.BuildExpression()
-	require.NoError(t, err)
+	exprB := scriptB.Expr
 
 	strategies := &mono_models.MergeStrategies{
 		OverwriteChanges: []*mono_models.CommitChangeEditable{
@@ -131,7 +127,7 @@ main = runtime`))
 	mergedExpr, err := Merge(exprA, exprB, strategies)
 	require.NoError(t, err)
 
-	mergedScript, err := buildscript.NewScriptFromBuildExpression(mergedExpr)
+	mergedScript, err := buildscript.NewFromCommit(scriptA.AtTime, mergedExpr)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -152,7 +148,7 @@ main = runtime`, mergedScript.String())
 }
 
 func TestMergeConflict(t *testing.T) {
-	scriptA, err := buildscript.NewScript([]byte(
+	scriptA, err := buildscript.New([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
 	at_time = at_time,
@@ -167,10 +163,9 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
-	exprA, err := scriptA.BuildExpression()
-	require.NoError(t, err)
+	exprA := scriptA.Expr
 
-	scriptB, err := buildscript.NewScript([]byte(
+	scriptB, err := buildscript.New([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
 	at_time = at_time,
@@ -185,8 +180,7 @@ runtime = solve(
 
 main = runtime`))
 	require.NoError(t, err)
-	exprB, err := scriptB.BuildExpression()
-	require.NoError(t, err)
+	exprB := scriptB.Expr
 
 	assert.False(t, isAutoMergePossible(exprA, exprB)) // platforms do not match
 

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -28,7 +28,7 @@ import (
 type Script struct {
 	Assignments []*Assignment `parser:"@@+"`
 	expr        *buildexpression.BuildExpression
-	atTime      *strfmt.DateTime
+	AtTime      *strfmt.DateTime
 }
 
 type Assignment struct {
@@ -115,7 +115,7 @@ func NewScriptFromBuildExpression(expr *buildexpression.BuildExpression) (*Scrip
 		return nil, errs.Wrap(err, "Could not set default timestamp in build expression")
 	}
 
-	return &Script{expr: expr, atTime: atTime}, nil
+	return &Script{expr: expr, AtTime: atTime}, nil
 }
 
 func indent(s string) string {
@@ -125,10 +125,10 @@ func indent(s string) string {
 func (s *Script) String() string {
 	buf := strings.Builder{}
 
-	if s.atTime != nil {
+	if s.AtTime != nil {
 		buf.WriteString(assignmentString(&buildexpression.Var{
 			Name:  buildexpression.AtTimeKey,
-			Value: &buildexpression.Value{Str: ptr.To(s.atTime.String())},
+			Value: &buildexpression.Value{Str: ptr.To(s.AtTime.String())},
 		}))
 		buf.WriteString("\n")
 	}
@@ -160,13 +160,13 @@ func (s *Script) String() string {
 func (s *Script) BuildExpression() (*buildexpression.BuildExpression, error) {
 	expr := s.expr
 
-	if s.atTime != nil {
+	if s.AtTime != nil {
 		var err error
 		expr, err = expr.Copy()
 		if err != nil {
 			return nil, errs.Wrap(err, "Failed to copy buildexpression")
 		}
-		err = expr.MaybeUpdateTimestamp(*s.atTime)
+		err = expr.MaybeUpdateTimestamp(*s.AtTime)
 		if err != nil {
 			return nil, errs.Wrap(err, "Failed to possibly update %s", buildexpression.AtTimeKey)
 		}

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -27,8 +27,8 @@ import (
 // modify or manually populate the Participle-produced fields and re-generate a build expression.
 type Script struct {
 	Assignments []*Assignment `parser:"@@+"`
-	expr        *buildexpression.BuildExpression
 	AtTime      *strfmt.DateTime
+	Expr        *buildexpression.BuildExpression
 }
 
 type Assignment struct {
@@ -73,7 +73,7 @@ var (
 	andFuncName = "And"
 )
 
-func NewScript(data []byte) (*Script, error) {
+func New(data []byte) (*Script, error) {
 	parser, err := participle.Build[Script]()
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not create parser for build script")
@@ -97,12 +97,12 @@ func NewScript(data []byte) (*Script, error) {
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not construct build expression")
 	}
-	script.expr = expr
+	script.Expr = expr
 
 	return script, nil
 }
 
-func NewScriptFromBuildExpression(expr *buildexpression.BuildExpression) (*Script, error) {
+func NewFromCommit(atTime *strfmt.DateTime, expr *buildexpression.BuildExpression) (*Script, error) {
 	// Copy incoming build expression to keep any modifications local.
 	var err error
 	expr, err = expr.Copy()
@@ -110,12 +110,7 @@ func NewScriptFromBuildExpression(expr *buildexpression.BuildExpression) (*Scrip
 		return nil, errs.Wrap(err, "Could not copy build expression")
 	}
 
-	atTime, err := expr.SetDefaultTimestamp()
-	if err != nil {
-		return nil, errs.Wrap(err, "Could not set default timestamp in build expression")
-	}
-
-	return &Script{expr: expr, AtTime: atTime}, nil
+	return &Script{AtTime: atTime, Expr: expr}, nil
 }
 
 func indent(s string) string {
@@ -133,7 +128,7 @@ func (s *Script) String() string {
 		buf.WriteString("\n")
 	}
 
-	for _, assignment := range s.expr.Let.Assignments {
+	for _, assignment := range s.Expr.Let.Assignments {
 		if assignment.Name == buildexpression.RequirementsKey {
 			assignment = transformRequirements(assignment)
 		}
@@ -144,35 +139,13 @@ func (s *Script) String() string {
 	buf.WriteString("\n")
 	buf.WriteString("main = ")
 	switch {
-	case s.expr.Let.In.FuncCall != nil:
-		buf.WriteString(apString(s.expr.Let.In.FuncCall))
-	case s.expr.Let.In.Name != nil:
-		buf.WriteString(*s.expr.Let.In.Name)
+	case s.Expr.Let.In.FuncCall != nil:
+		buf.WriteString(apString(s.Expr.Let.In.FuncCall))
+	case s.Expr.Let.In.Name != nil:
+		buf.WriteString(*s.Expr.Let.In.Name)
 	}
 
 	return buf.String()
-}
-
-// BuildExpression returns a copy of this script's underlying buildexpression for use in a
-// buildplanner context.
-// For example, the solve node's "at_time" will not contain a variable reference if this script
-// has a top-level assignment for it.
-func (s *Script) BuildExpression() (*buildexpression.BuildExpression, error) {
-	expr := s.expr
-
-	if s.AtTime != nil {
-		var err error
-		expr, err = expr.Copy()
-		if err != nil {
-			return nil, errs.Wrap(err, "Failed to copy buildexpression")
-		}
-		err = expr.MaybeUpdateTimestamp(*s.AtTime)
-		if err != nil {
-			return nil, errs.Wrap(err, "Failed to possibly update %s", buildexpression.AtTimeKey)
-		}
-	}
-
-	return expr, nil
 }
 
 // transformRequirements transforms a buildexpression list of requirements in object form into a
@@ -398,27 +371,22 @@ func apString(f *buildexpression.Ap) string {
 	return buf.String()
 }
 
-func (s *Script) EqualsBuildExpressionBytes(exprBytes []byte) bool {
-	expr, err := buildexpression.New(exprBytes)
-	if err != nil {
-		multilog.Error("Unable to create buildexpression from incoming JSON: %v", err)
+func (s *Script) Equals(other *Script) bool {
+	// Compare top-level at_time.
+	switch {
+	case s.AtTime != nil && other.AtTime != nil && s.AtTime.String() != other.AtTime.String():
+		return false
+	case (s.AtTime == nil) != (other.AtTime == nil):
 		return false
 	}
-	return s.EqualsBuildExpression(expr)
-}
 
-func (s *Script) EqualsBuildExpression(expr *buildexpression.BuildExpression) bool {
-	thisExpr, err := s.BuildExpression()
-	if err != nil {
-		multilog.Error("Unable to compute buildexpression from this buildscript: %v", err)
-		return false
-	}
-	myJson, err := json.Marshal(thisExpr)
+	// Compare buildexpression JSON.
+	myJson, err := json.Marshal(s.Expr)
 	if err != nil {
 		multilog.Error("Unable to marshal this buildscript to JSON: %v", err)
 		return false
 	}
-	otherJson, err := json.Marshal(expr)
+	otherJson, err := json.Marshal(other.Expr)
 	if err != nil {
 		multilog.Error("Unable to marshal other buildscript to JSON: %v", err)
 		return false

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -16,7 +16,7 @@ import (
 
 // toBuildExpression converts given script constructed by Participle into a buildexpression.
 // This function should not be used to convert an arbitrary script to buildexpression.
-// NewScript*() populates the expr field with the equivalent build expression.
+// New*() populates the Expr field with the equivalent build expression.
 // This function exists solely for testing that functionality.
 func toBuildExpression(script *Script) (*buildexpression.BuildExpression, error) {
 	bytes, err := json.Marshal(script)
@@ -27,8 +27,10 @@ func toBuildExpression(script *Script) (*buildexpression.BuildExpression, error)
 }
 
 func TestBasic(t *testing.T) {
-	script, err := NewScript([]byte(
-		`runtime = solve(
+	script, err := New([]byte(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = ["linux", "windows"],
 	requirements = [
 		Req(name = "language/python"),
@@ -40,13 +42,18 @@ main = runtime
 `))
 	require.NoError(t, err)
 
+	atTime, err := strfmt.ParseDateTime("2000-01-01T00:00:00.000Z")
+	require.NoError(t, err)
+
 	expr, err := toBuildExpression(script)
 	require.NoError(t, err)
 
 	assert.Equal(t, &Script{
 		[]*Assignment{
+			{"at_time", &Value{Str: ptr.To(`"2000-01-01T00:00:00.000Z"`)}},
 			{"runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
+					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
 					{Assignment: &Assignment{
 						"platforms", &Value{List: &[]*Value{
 							{Str: ptr.To(`"linux"`)},
@@ -84,14 +91,16 @@ main = runtime
 			}},
 			{"main", &Value{Ident: ptr.To("runtime")}},
 		},
+		&atTime,
 		expr,
-		nil,
 	}, script)
 }
 
 func TestComplex(t *testing.T) {
-	script, err := NewScript([]byte(
-		`linux_runtime = solve(
+	script, err := New([]byte(
+		`at_time = "2000-01-01T00:00:00.000Z"
+linux_runtime = solve(
+		at_time = at_time,
 		requirements=[
 			Req(name = "language/python")
 		],
@@ -99,6 +108,7 @@ func TestComplex(t *testing.T) {
 )
 
 win_runtime = solve(
+		at_time = at_time,
 		requirements=[
 			Req(name = "language/perl")
 		],
@@ -112,13 +122,18 @@ main = merge(
 `))
 	require.NoError(t, err)
 
+	atTime, err := strfmt.ParseDateTime("2000-01-01T00:00:00.000Z")
+	require.NoError(t, err)
+
 	expr, err := toBuildExpression(script)
 	require.NoError(t, err)
 
 	assert.Equal(t, &Script{
 		[]*Assignment{
+			{"at_time", &Value{Str: ptr.To(`"2000-01-01T00:00:00.000Z"`)}},
 			{"linux_runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
+					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
 					{Assignment: &Assignment{
 						"requirements", &Value{List: &[]*Value{
 							{FuncCall: &FuncCall{
@@ -140,6 +155,7 @@ main = merge(
 			}},
 			{"win_runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
+					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
 					{Assignment: &Assignment{
 						"requirements", &Value{List: &[]*Value{
 							{FuncCall: &FuncCall{
@@ -165,8 +181,8 @@ main = merge(
 					{FuncCall: &FuncCall{"tar_installer", []*Value{{Ident: ptr.To("linux_runtime")}}}},
 				}}}},
 		},
+		&atTime,
 		expr,
-		nil,
 	}, script)
 }
 
@@ -185,13 +201,13 @@ runtime = solve(
 main = runtime`
 
 func TestExample(t *testing.T) {
-	script, err := NewScript([]byte(example))
-	require.NoError(t, err)
-
-	expr, err := toBuildExpression(script)
+	script, err := New([]byte(example))
 	require.NoError(t, err)
 
 	atTime, err := strfmt.ParseDateTime("2023-04-27T17:30:05.999Z")
+	require.NoError(t, err)
+
+	expr, err := toBuildExpression(script)
 	require.NoError(t, err)
 
 	assert.Equal(t, &Script{
@@ -270,14 +286,16 @@ func TestExample(t *testing.T) {
 			}},
 			{"main", &Value{Ident: ptr.To("runtime")}},
 		},
-		expr,
 		&atTime,
+		expr,
 	}, script)
 }
 
 func TestString(t *testing.T) {
-	script, err := NewScript([]byte(
-		`runtime = solve(
+	script, err := New([]byte(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+		at_time = at_time,
 		platforms=["12345", "67890"],
 		requirements=[Req(name = "language/python", version = Eq(value = "3.10.10"))]
 )
@@ -287,7 +305,9 @@ main = runtime
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		`runtime = solve(
+		`at_time = "2000-01-01T00:00:00.000Z"
+runtime = solve(
+	at_time = at_time,
 	platforms = [
 		"12345",
 		"67890"
@@ -305,7 +325,7 @@ func TestRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
-	script, err := NewScript([]byte(example))
+	script, err := New([]byte(example))
 	require.NoError(t, err)
 
 	tmpfile.Write([]byte(script.String()))
@@ -318,7 +338,7 @@ func TestRoundTrip(t *testing.T) {
 }
 
 func TestJson(t *testing.T) {
-	script, err := NewScript([]byte(
+	script, err := New([]byte(
 		`at_time = "2000-01-01T00:00:00.000Z"
 runtime = solve(
 		at_time = at_time,
@@ -337,7 +357,7 @@ main = runtime
     "let": {
       "runtime": {
         "solve": {
-          "at_time": "2000-01-01T00:00:00.000Z",
+          "at_time": "$at_time",
           "requirements": [
             {
               "name": "python",
@@ -357,9 +377,7 @@ main = runtime
 	require.NoError(t, err)
 	expectedJson, err := json.Marshal(marshaledInput)
 
-	actualExpr, err := script.BuildExpression()
-	require.NoError(t, err)
-	actualJson, err := json.Marshal(actualExpr)
+	actualJson, err := json.Marshal(script.Expr)
 	require.NoError(t, err)
 	assert.Equal(t, string(expectedJson), string(actualJson))
 }
@@ -412,20 +430,20 @@ func TestBuildExpression(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify conversions between buildscripts and buildexpressions is accurate.
-	script, err := NewScriptFromBuildExpression(expr)
+	script, err := NewFromCommit(nil, expr)
 	require.NoError(t, err)
 	require.NotNil(t, script)
-	newExpr, err := script.BuildExpression()
-	require.NoError(t, err)
+	newExpr := script.Expr
 	exprBytes, err := json.Marshal(expr)
 	require.NoError(t, err)
 	newExprBytes, err := json.Marshal(newExpr)
 	require.NoError(t, err)
 	assert.Equal(t, string(exprBytes), string(newExprBytes))
 
-	// Verify comparisons between buildscripts and buildexpressions is accurate.
-	assert.True(t, script.EqualsBuildExpression(expr))
-	assert.True(t, script.EqualsBuildExpressionBytes(exprBytes))
+	// Verify comparisons between buildscripts is accurate.
+	newScript, err := NewFromCommit(nil, newExpr)
+	require.NoError(t, err)
+	assert.True(t, script.Equals(newScript))
 
 	// Verify null JSON value is handled correctly.
 	var null *string

--- a/pkg/platform/runtime/buildscript/file.go
+++ b/pkg/platform/runtime/buildscript/file.go
@@ -91,7 +91,7 @@ func Update(proj projecter, atTime *strfmt.DateTime, newExpr *buildexpression.Bu
 	}
 
 	logging.Debug("Writing build script")
-	if err := fileutils.WriteFile(filepath.Join(proj.ProjectDir(), constants.BuildScriptFileName), []byte(script.String())); err != nil {
+	if err := fileutils.WriteFile(filepath.Join(proj.ProjectDir(), constants.BuildScriptFileName), []byte(newScript.String())); err != nil {
 		return errs.Wrap(err, "Could not write build script to file")
 	}
 	return nil

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -29,7 +29,7 @@ func (s *Script) MarshalJSON() ([]byte, error) {
 			if err != nil {
 				return nil, errs.Wrap(err, "Invalid timestamp: %s", *value.Str)
 			}
-			s.atTime = &atTime
+			s.AtTime = &atTime
 			continue // do not include this custom assignment in the let block
 		case "main":
 			key = "in"

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -152,21 +152,7 @@ func (r *Runtime) validateCache() error {
 				return &NeedsCommitError{errs.New("Runtime changes should be committed")}
 			}
 
-		case err == store.ErrNoBuildScriptFile:
-			bp := model.NewBuildPlannerModel(r.auth)
-			expr, atTime, err := bp.GetBuildExpressionAndTime(commitID)
-			if err != nil {
-				return errs.Wrap(err, "Unable to get remote build expression and time")
-			}
-			script, err := buildscript.NewFromCommit(atTime, expr)
-			if err != nil {
-				return errs.Wrap(err, "Unable to get local build script")
-			}
-			if err := r.store.StoreBuildScript(script); err != nil {
-				return errs.Wrap(err, "Unable to store build script")
-			}
-
-		default:
+		case !errors.Is(err, store.ErrNoBuildScriptFile):
 			return errs.Wrap(err, "Unable to read cached build script")
 		}
 	}

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -626,8 +626,15 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 	}
 
 	if s.target.ProjectDir() != "" && s.cfg.GetBool(constants.OptinBuildscriptsConfig) {
-		if err := buildscript.Update(s.target, buildResult.AtTime, buildResult.BuildExpression, s.auth); err != nil {
-			return nil, nil, errs.Wrap(err, "Could not save build script.")
+		script, err := buildscript.NewFromCommit(buildResult.AtTime, buildResult.BuildExpression)
+		if err != nil {
+			return nil, nil, errs.Wrap(err, "Could not construct build script")
+		}
+		if err := s.store.StoreBuildScript(script); err != nil {
+			return nil, nil, errs.Wrap(err, "Could not save build script")
+		}
+		if err := buildscript.Update(s.target, script.AtTime, script.Expr, s.auth); err != nil {
+			return nil, nil, errs.Wrap(err, "Could not update build script.")
 		}
 	}
 

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -626,7 +626,7 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 	}
 
 	if s.target.ProjectDir() != "" && s.cfg.GetBool(constants.OptinBuildscriptsConfig) {
-		if err := buildscript.Update(s.target, buildResult.BuildExpression, s.auth); err != nil {
+		if err := buildscript.Update(s.target, buildResult.AtTime, buildResult.BuildExpression, s.auth); err != nil {
 			return nil, nil, errs.Wrap(err, "Could not save build script.")
 		}
 	}

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -626,14 +626,7 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(installFunc artifactInstal
 	}
 
 	if s.target.ProjectDir() != "" && s.cfg.GetBool(constants.OptinBuildscriptsConfig) {
-		script, err := buildscript.NewFromCommit(buildResult.AtTime, buildResult.BuildExpression)
-		if err != nil {
-			return nil, nil, errs.Wrap(err, "Could not construct build script")
-		}
-		if err := s.store.StoreBuildScript(script); err != nil {
-			return nil, nil, errs.Wrap(err, "Could not save build script")
-		}
-		if err := buildscript.Update(s.target, script.AtTime, script.Expr, s.auth); err != nil {
+		if err := buildscript.Update(s.target, buildResult.AtTime, buildResult.BuildExpression, s.auth); err != nil {
 			return nil, nil, errs.Wrap(err, "Could not update build script.")
 		}
 	}

--- a/pkg/platform/runtime/store/store.go
+++ b/pkg/platform/runtime/store/store.go
@@ -7,17 +7,17 @@ import (
 	"path/filepath"
 	"strings"
 
-	bpModel "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
-
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
+	bpModel "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
 	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_models"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/platform/runtime/artifact"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
+	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
 	"github.com/ActiveState/cli/pkg/platform/runtime/envdef"
 )
 
@@ -66,6 +66,10 @@ func (s *Store) buildPlanFile() string {
 
 func (s *Store) buildExpressionFile() string {
 	return filepath.Join(s.storagePath, constants.BuildExpressionStore)
+}
+
+func (s *Store) buildScriptFile() string {
+	return filepath.Join(s.storagePath, constants.BuildScriptStore)
 }
 
 // BuildEngine returns the runtime build engine value stored in the runtime directory
@@ -330,4 +334,21 @@ func (s *Store) StoreBuildExpression(expr *buildexpression.BuildExpression, comm
 		return errs.Wrap(err, "Could not marshal buildexpression")
 	}
 	return fileutils.WriteFile(s.buildExpressionFile(), data)
+}
+
+var ErrNoBuildScriptFile = errs.New("no buildscript file")
+
+func (s *Store) BuildScript() (*buildscript.Script, error) {
+	if !fileutils.FileExists(s.buildScriptFile()) {
+		return nil, ErrNoBuildScriptFile
+	}
+	bytes, err := fileutils.ReadFile(s.buildScriptFile())
+	if err != nil {
+		return nil, errs.Wrap(err, "Could not read buildscript file")
+	}
+	return buildscript.New(bytes)
+}
+
+func (s *Store) StoreBuildScript(script *buildscript.Script) error {
+	return fileutils.WriteFile(s.buildScriptFile(), []byte(script.String()))
 }

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
@@ -22,8 +23,6 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	suite.OnlyRunForTags(tagsuite.Commit)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-
-	ts.LoginAsPersistentUser()
 
 	cp := ts.Spawn("config", "set", constants.OptinBuildscriptsConfig, "true")
 	cp.ExpectExitCode(0)
@@ -61,6 +60,47 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 		e2e.OptArgs("commit"),
 	)
 	cp.Expect("successfully created")
+	cp.ExpectExitCode(0)
+}
+
+func (suite *CommitIntegrationTestSuite) TestCommitAtTimeChange() {
+	suite.OnlyRunForTags(tagsuite.Commit)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("config", "set", constants.OptinBuildscriptsConfig, "true")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("checkout", "ActiveState-CLI/Commit-Test-A#7a1b416e-c17f-4d4a-9e27-cbad9e8f5655", "."),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
+	cp.ExpectExitCode(0)
+
+	proj, err := project.FromPath(ts.Dirs.Work)
+	suite.NoError(err, "Error loading project")
+
+	_, err = buildscript.ScriptFromProject(proj)
+	suite.Require().NoError(err) // verify validity
+
+	// Update top-level at_time variable.
+	dateTime := "2023-03-01T12:34:56.789Z"
+	buildScriptFile := filepath.Join(proj.Dir(), constants.BuildScriptFileName)
+	contents, err := fileutils.ReadFile(buildScriptFile)
+	suite.Require().NoError(err)
+	suite.Require().NoError(fileutils.WriteFile(buildScriptFile, bytes.Replace(contents, []byte("2023-06-22T21:56:10.504Z"), []byte(dateTime), 1)))
+	suite.Require().Contains(string(fileutils.ReadFileUnsafe(filepath.Join(proj.Dir(), constants.BuildScriptFileName))), dateTime)
+
+	cp = ts.Spawn("commit")
+	cp.Expect("successfully created")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("history")
+	cp.Expect("Revision")
+	revisionTime, err := time.Parse(time.RFC3339, dateTime)
+	suite.Require().NoError(err)
+	cp.Expect(revisionTime.Format(time.RFC822))
 	cp.ExpectExitCode(0)
 }
 

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -86,8 +86,6 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	cp.Expect("Checked out")
 	cp.ExpectExitCode(0)
 
-	ts.LoginAsPersistentUser()
-
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("install", "requests"),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2642" title="DX-2642" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2642</a>  Buildscript to build expression at_time definition doesn't get turned into "$at_time"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Keep "$at_time" variables in buildexpressions.

Do not replace buildexpression "$at_time" with commit time. Instead, just set the commit time when staging commits, etc. This allows for using a buildscripts `Expr` field directly again.

This reverts most of the changes in [#3149](https://github.com/ActiveState/cli/issues/3149).
