### PR TITLE
Only do word wrapping in interactive mode.

### DIFF
--- a/internal/output/plain.go
+++ b/internal/output/plain.go
@@ -101,13 +101,16 @@ func (f *Plain) write(writer io.Writer, value interface{}) {
 
 // writeNow is a little helper that just writes the given value to the requested writer (no marshalling)
 func (f *Plain) writeNow(writer io.Writer, value string) {
-	_, err := colorize.Colorize(WordWrap(value), writer, !f.cfg.Colored)
+	if f.Config().Interactive {
+		value = wordWrap(value)
+	}
+	_, err := colorize.Colorize(value, writer, !f.cfg.Colored)
 	if err != nil {
 		logging.ErrorNoStacktrace("Writing colored output failed: %v", err)
 	}
 }
 
-func WordWrap(text string) string {
+func wordWrap(text string) string {
 	return wordWrapWithWidth(text, termutils.GetWidth())
 }
 

--- a/internal/runbits/dependencies/changesummary_test.go
+++ b/internal/runbits/dependencies/changesummary_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/testhelpers/outputhelper"
 	"github.com/ActiveState/cli/pkg/platform/runtime/artifact"
@@ -132,7 +131,7 @@ func TestChangeSummary(t *testing.T) {
 			out := outputhelper.NewCatcher()
 			OutputChangeSummary(out, tt.changed, artifacts, tt.existing)
 
-			assert.Equal(t, output.WordWrap(tt.expected), strings.TrimSpace(out.CombinedOutput()))
+			assert.Equal(t, tt.expected, strings.TrimSpace(out.CombinedOutput()))
 		})
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2622" title="DX-2622" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2622</a>  We should not wrap in non-interactive mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Note you'll have to use `cat "$(state export log -n)"` because `state` sees a normal stdin (not closed, in a terminal, etc.) and cannot discern that a user typing into the terminal does not send those characters to the `state` process.

We could do a test if data was being piped to stdin (https://www.socketloop.com/tutorials/golang-check-if-os-stdin-input-data-is-piped-or-from-terminal), but that's not the case here.