### PR TITLE
Drop description validation, let the API handle it

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1525,8 +1525,6 @@ err_searchingredient_toomany:
   other: Too many ingredients match the query '[ACTIONABLE]{{.V0}}[/RESET]', please try to be more specific.
 alternative_unknown_pkg_name:
   other: unknown
-err_uploadingredient_edit_description_not_supported:
-  other: Editing an ingredient description is not yet supported.
 err_uploadingredient_publish:
   other: |
     Could not publish ingredient.

--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -205,15 +205,6 @@ func (r *Runner) Run(params *Params) error {
 		}
 	}
 
-	// Validate user input
-	if params.Edit {
-		// Description is not currently supported for edit
-		// https://activestatef.atlassian.net/browse/DX-1886
-		if reqVars.Description != "" {
-			return locale.NewInputError("err_uploadingredient_edit_description_not_supported")
-		}
-	}
-
 	if reqVars.Namespace == "" {
 		return locale.NewInputError("err_uploadingredient_namespace_required", "You have to supply the namespace when working outside of a project context")
 	}

--- a/test/integration/publish_int_test.go
+++ b/test/integration/publish_int_test.go
@@ -292,26 +292,6 @@ authors:
 						0,
 					},
 				},
-				{ // description editing not supported
-					input{
-						[]string{
-							"--edit",
-							"--name", "editable",
-							"--description", "foo",
-						},
-						nil,
-						nil,
-						false,
-					},
-					expect{
-						[]string{
-							`Editing an ingredient description is not yet supported`,
-						},
-						"",
-						true,
-						1,
-					},
-				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2649" title="DX-2649" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2649</a>  Misleading error message on publish when editing an existing version
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
