### PR TITLE
Remove duplicate errors from `state eval`

### DIFF
--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -663,7 +663,7 @@ func (bp *BuildPlanner) BuildTarget(owner, project, commitID, target string) err
 }
 
 type ErrFailedArtifacts struct {
-	Artifacts []*bpModel.Artifact
+	Artifacts map[strfmt.UUID]*bpModel.Artifact
 }
 
 func (e ErrFailedArtifacts) Error() string {
@@ -671,7 +671,7 @@ func (e ErrFailedArtifacts) Error() string {
 }
 
 func (bp *BuildPlanner) PollBuildStatus(commitID, owner, project, target string) error {
-	var failedArtifacts []*model.Artifact
+	failedArtifacts := map[strfmt.UUID]*model.Artifact{}
 	resp := model.NewBuildPlanResponse(owner, project)
 	ticker := time.NewTicker(pollInterval)
 	for {
@@ -712,7 +712,7 @@ func (bp *BuildPlanner) PollBuildStatus(commitID, owner, project, target string)
 
 				if artifact.Status == bpModel.ArtifactFailedPermanently ||
 					artifact.Status == bpModel.ArtifactFailedTransiently {
-					failedArtifacts = append(failedArtifacts, artifact)
+					failedArtifacts[artifact.NodeID] = artifact
 				}
 			}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2651" title="DX-2651" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2651</a>  `state eval` reports redundant errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

