### PR TITLE
`state reset` accepts a branch name.

### DIFF
--- a/cmd/state/internal/cmdtree/reset.go
+++ b/cmd/state/internal/cmdtree/reset.go
@@ -19,9 +19,9 @@ func newResetCommand(prime *primer.Values, globals *globalOptions) *captain.Comm
 		[]*captain.Flag{},
 		[]*captain.Argument{
 			{
-				Name:        locale.Tl("arg_state_reset_commitid", "CommitID"),
-				Description: locale.Tl("arg_state_reset_commitid_description", "The commit ID or branch name to reset to. If not specified, resets local checkout to be equal to the project on the platform"),
-				Value:       &params.CommitID,
+				Name:        locale.Tl("arg_state_reset_target", "target"),
+				Description: locale.Tl("arg_state_reset_target_description", "The commit ID or branch name to reset to. If not specified, resets local checkout to be equal to the project on the platform"),
+				Value:       &params.Target,
 			},
 		},
 		func(ccmd *captain.Command, args []string) error {

--- a/cmd/state/internal/cmdtree/reset.go
+++ b/cmd/state/internal/cmdtree/reset.go
@@ -20,7 +20,7 @@ func newResetCommand(prime *primer.Values, globals *globalOptions) *captain.Comm
 		[]*captain.Argument{
 			{
 				Name:        locale.Tl("arg_state_reset_commitid", "CommitID"),
-				Description: locale.Tl("arg_state_reset_commitid_description", "Reset to the given commit. If not specified, resets local checkout to be equal to the project on the platform"),
+				Description: locale.Tl("arg_state_reset_commitid_description", "The commit ID or branch name to reset to. If not specified, resets local checkout to be equal to the project on the platform"),
 				Value:       &params.CommitID,
 			},
 		},

--- a/internal/runners/reset/reset.go
+++ b/internal/runners/reset/reset.go
@@ -61,7 +61,8 @@ func (r *Reset) Run(params *Params) error {
 	r.out.Notice(locale.Tr("operating_message", r.project.NamespaceString(), r.project.Dir()))
 
 	var commitID strfmt.UUID
-	if params.CommitID == "" {
+	switch {
+	case params.CommitID == "":
 		latestCommit, err := model.BranchCommitID(r.project.Owner(), r.project.Name(), r.project.BranchName())
 		if err != nil {
 			return locale.WrapError(err, "err_reset_latest_commit", "Could not get latest commit ID")
@@ -74,22 +75,29 @@ func (r *Reset) Run(params *Params) error {
 			return locale.NewInputError("err_reset_latest", "You are already on the latest commit")
 		}
 		commitID = *latestCommit
-	} else {
-		if !strfmt.IsUUID(params.CommitID) {
-			return locale.NewInputError("Invalid commit ID")
-		}
-		commitID = strfmt.UUID(params.CommitID)
-		localCommitID, err := localcommit.Get(r.project.Dir())
+
+	case !strfmt.IsUUID(params.CommitID):
+		branch, err := model.BranchForProjectNameByName(r.project.Owner(), r.project.Name(), params.CommitID)
 		if err != nil {
-			return errs.Wrap(err, "Unable to get local commit")
+			return errs.Wrap(err, "Could not get branch")
 		}
-		if commitID == localCommitID {
-			return locale.NewInputError("err_reset_same_commitid", "Your project is already at the given commit ID")
-		}
+		commitID = strfmt.UUID(*branch.CommitID)
+
+	default:
+		commitID = strfmt.UUID(params.CommitID)
+
 		history, err := model.CommitHistoryFromID(commitID, r.auth)
 		if err != nil || len(history) == 0 {
 			return locale.WrapInputError(err, "err_reset_commitid", "The given commit ID does not exist")
 		}
+	}
+
+	localCommitID, err := localcommit.Get(r.project.Dir())
+	if err != nil {
+		return errs.Wrap(err, "Unable to get local commit")
+	}
+	if commitID == localCommitID {
+		return locale.NewInputError("err_reset_same_commitid", "Your project is already at the given commit ID")
 	}
 
 	r.out.Notice(locale.Tl("reset_commit", "Your project will be reset to [ACTIONABLE]{{.V0}}[/RESET]\n", commitID.String()))

--- a/internal/runners/reset/reset.go
+++ b/internal/runners/reset/reset.go
@@ -18,8 +18,8 @@ import (
 )
 
 type Params struct {
-	Force    bool
-	CommitID string
+	Force  bool
+	Target string
 }
 
 type Reset struct {
@@ -62,7 +62,7 @@ func (r *Reset) Run(params *Params) error {
 
 	var commitID strfmt.UUID
 	switch {
-	case params.CommitID == "":
+	case params.Target == "":
 		latestCommit, err := model.BranchCommitID(r.project.Owner(), r.project.Name(), r.project.BranchName())
 		if err != nil {
 			return locale.WrapError(err, "err_reset_latest_commit", "Could not get latest commit ID")
@@ -76,15 +76,15 @@ func (r *Reset) Run(params *Params) error {
 		}
 		commitID = *latestCommit
 
-	case !strfmt.IsUUID(params.CommitID):
-		branch, err := model.BranchForProjectNameByName(r.project.Owner(), r.project.Name(), params.CommitID)
+	case !strfmt.IsUUID(params.Target):
+		branch, err := model.BranchForProjectNameByName(r.project.Owner(), r.project.Name(), params.Target)
 		if err != nil {
 			return errs.Wrap(err, "Could not get branch")
 		}
 		commitID = strfmt.UUID(*branch.CommitID)
 
 	default:
-		commitID = strfmt.UUID(params.CommitID)
+		commitID = strfmt.UUID(params.Target)
 
 		history, err := model.CommitHistoryFromID(commitID, r.auth)
 		if err != nil || len(history) == 0 {

--- a/internal/testhelpers/tagsuite/tagsuite.go
+++ b/internal/testhelpers/tagsuite/tagsuite.go
@@ -67,6 +67,7 @@ const (
 	Python          = "python"
 	Refresh         = "refresh"
 	RemoteInstaller = "remote-installer"
+	Reset           = "reset"
 	Revert          = "revert"
 	Run             = "run"
 	Scripts         = "scripts"

--- a/test/integration/reset_int_test.go
+++ b/test/integration/reset_int_test.go
@@ -1,0 +1,94 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResetIntegrationTestSuite struct {
+	tagsuite.Suite
+}
+
+func (suite *ResetIntegrationTestSuite) TestRevert() {
+	suite.OnlyRunForTags(tagsuite.Reset)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Branches#35af7414-b44b-4fd7-aa93-2ecad337ed2b", ".")
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Checked out")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("install", "requests")
+	cp.Expect("Package added")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("history")
+	cp.Expect("requests")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("reset")
+	cp.Expect("Your project will be reset to 35af7414-b44b-4fd7-aa93-2ecad337ed2b")
+	cp.Expect("Are you sure")
+	cp.Expect("(y/N)")
+	cp.SendLine("y")
+	cp.Expect("Successfully reset to commit: 35af7414-b44b-4fd7-aa93-2ecad337ed2b")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("history")
+	cp.ExpectExitCode(0)
+	suite.Assert().NotContains(cp.Snapshot(), "requests")
+
+	cp = ts.Spawn("reset")
+	cp.Expect("You are already on the latest commit")
+	cp.ExpectNotExitCode(0)
+
+	cp = ts.Spawn("reset", "00000000-0000-0000-0000-000000000000")
+	cp.Expect("The given commit ID does not exist")
+	cp.ExpectNotExitCode(0)
+}
+
+func (suite *ResetIntegrationTestSuite) TestRevertToBranch() {
+	suite.OnlyRunForTags(tagsuite.Reset)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Branches#46c83477-d580-43e2-a0c6-f5d3677517f1", ".")
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Checked out")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("reset", "main", "-n")
+	cp.Expect("Successfully reset to commit: 35af7414-b44b-4fd7-aa93-2ecad337ed2b")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("reset", "main")
+	cp.Expect("Your project is already at the given commit ID")
+	cp.ExpectNotExitCode(0)
+
+	cp = ts.Spawn("reset", "does-not-exist")
+	cp.Expect("This project has no branch with label matching 'does-not-exist'")
+	cp.ExpectNotExitCode(0)
+}
+
+func (suite *ResetIntegrationTestSuite) TestJSON() {
+	suite.OnlyRunForTags(tagsuite.Revert, tagsuite.JSON)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Branches#46c83477-d580-43e2-a0c6-f5d3677517f1", ".")
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Checked out")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("reset", "main", "-o", "json")
+	cp.Expect(`{"commitID":"35af7414-b44b-4fd7-aa93-2ecad337ed2b"}`)
+	cp.ExpectExitCode(0)
+}
+
+func TestResetIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(ResetIntegrationTestSuite))
+}

--- a/test/integration/reset_int_test.go
+++ b/test/integration/reset_int_test.go
@@ -12,7 +12,7 @@ type ResetIntegrationTestSuite struct {
 	tagsuite.Suite
 }
 
-func (suite *ResetIntegrationTestSuite) TestRevert() {
+func (suite *ResetIntegrationTestSuite) TestReset() {
 	suite.OnlyRunForTags(tagsuite.Reset)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
@@ -75,7 +75,7 @@ func (suite *ResetIntegrationTestSuite) TestRevertToBranch() {
 }
 
 func (suite *ResetIntegrationTestSuite) TestJSON() {
-	suite.OnlyRunForTags(tagsuite.Revert, tagsuite.JSON)
+	suite.OnlyRunForTags(tagsuite.Reset, tagsuite.JSON)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2558" title="DX-2558" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2558</a>  Allow passing a branch name to `state reset`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also added new integration tests for `state reset`.