### PR TITLE
Added ability to set default timestamp in buildexpression if it matches a commit time.

### DIFF
--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -110,6 +110,12 @@ func NewFromCommit(atTime *strfmt.DateTime, expr *buildexpression.BuildExpressio
 		return nil, errs.Wrap(err, "Could not copy build expression")
 	}
 
+	// Update old expressions that bake in at_time as a timestamp instead of as a variable.
+	err = expr.MaybeSetDefaultTimestamp(atTime)
+	if err != nil {
+		return nil, errs.Wrap(err, "Could not set default timestamp")
+	}
+
 	return &Script{AtTime: atTime, Expr: expr}, nil
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2611" title="DX-2611" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2611</a>  Buildscript conflicts should diff `at_time` properly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is helpful for merging buildscripts involving older buildexpressions with non-variable at_time values.