### PR TITLE
Use time from API rather than local system

### DIFF
--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -258,8 +258,13 @@ Do you want to publish this ingredient?
 		return locale.WrapError(err, "err_uploadingredient_fetch", "Unable to fetch newly published ingredient")
 	}
 	versionID := strfmt.UUID(result.Publish.IngredientVersionID)
-	atTime := strfmt.DateTime(time.Now())
-	publishedVersion, err := model.FetchIngredientVersion(&ingredientID, &versionID, true, &atTime)
+
+	latestTime, err := model.FetchLatestRevisionTimeStamp(r.auth)
+	if err != nil {
+		return locale.WrapError(err, "err_uploadingingredient_fetch_timestamp", "Unable to fetch latest revision timestamp")
+	}
+
+	publishedVersion, err := model.FetchIngredientVersion(&ingredientID, &versionID, true, ptr.To(strfmt.DateTime(latestTime)))
 	if err != nil {
 		return locale.WrapError(err, "err_uploadingingredient_fetch_version", "Unable to fetch newly published ingredient version")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2667" title="DX-2667" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2667</a>  `state publish` fail when user is not superuser with `Unable to fetch newly published ingredient version.`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
