### PR TITLE
Quote `state exec` arguments on Windows.

### DIFF
--- a/internal/osutils/shellescape.go
+++ b/internal/osutils/shellescape.go
@@ -12,7 +12,7 @@ type ShellEscape struct {
 	escapeWith    string
 }
 
-//NewBashEscaper creates a new instance of ShellEscape that's configured for escaping bash style arguments
+// NewBashEscaper creates a new instance of ShellEscape that's configured for escaping bash style arguments
 func NewBashEscaper() *ShellEscape {
 	return &ShellEscape{
 		regexp.MustCompile(`^[\w]+$`),
@@ -33,7 +33,7 @@ func NewBatchEscaper() *ShellEscape {
 // NewCmdEscaper creates a new instance of ShellEscape that's configured for escaping cmd arguments
 func NewCmdEscaper() *ShellEscape {
 	return &ShellEscape{
-		regexp.MustCompile(`^[^ &()\[\]{}^=;!'+,~]+$`), // cmd.exe /? lists these characters as requiring quotes
+		regexp.MustCompile(`^[^ &()\[\]{}^=;!'+,~<>]+$`), // cmd.exe /? lists these characters as requiring quotes
 		regexp.MustCompile(`"`),
 		`""`,
 	}

--- a/internal/subshell/sscommon/sscommon.go
+++ b/internal/subshell/sscommon/sscommon.go
@@ -137,7 +137,12 @@ func runWithCmd(env []string, name string, args ...string) error {
 		return locale.NewInputError("err_sscommon_unsupported_language", "", ext)
 	}
 
-	return runDirect(env, name, args...)
+	esc := osutils.NewCmdEscaper()
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, esc.Quote(arg))
+	}
+	return runDirect(env, name, quoted...)
 }
 
 func binaryPathCmd(env []string, name string) (string, error) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2615" title="DX-2615" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2615</a>  state exec does not always pass arguments correctly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
