### PR TITLE
Ensure dependencies are reset if there is user input

### DIFF
--- a/internal/runners/publish/publish.go
+++ b/internal/runners/publish/publish.go
@@ -195,15 +195,6 @@ func (r *Runner) Run(params *Params) error {
 		}
 	}
 
-	// Validate user input
-	if params.Edit {
-		// Description is not currently supported for edit
-		// https://activestatef.atlassian.net/browse/DX-1886
-		if params.Description != "" {
-			return locale.NewInputError("err_uploadingredient_edit_description_not_supported")
-		}
-	}
-
 	if err := prepareRequestFromParams(&reqVars, params, isRevision); err != nil {
 		return errs.Wrap(err, "Could not prepare request from params")
 	}
@@ -332,6 +323,11 @@ func prepareRequestFromParams(r *request.PublishVariables, params *Params, isRev
 				Email: author.Email,
 			})
 		}
+	}
+
+	// User input trumps inheritance from previous ingredient
+	if len(params.Depends) != 0 || len(params.DependsRuntime) != 0 || len(params.DependsBuild) != 0 || len(params.DependsTest) != 0 {
+		r.Dependencies = []request.PublishVariableDep{}
 	}
 
 	if len(params.Depends) != 0 {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2655" title="DX-2655" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2655</a>  `state publish` failing on version constraint on master
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


For whatever reason this line existed on v0.43, but not on v0.44:

https://github.com/ActiveState/cli/blob/e85cd5d8b64191f27207396d4cc4c96c60488b5e/internal/runners/publish/publish.go#L326-L326

Likely a bad merge. This brings it back into v0.44, as well as considers the other ways dependencies can be specified.
