### PR TITLE
Added catch-all for permission errors.

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ActiveState/cli/internal/logging"
 	configMediator "github.com/ActiveState/cli/internal/mediators/config"
 	"github.com/ActiveState/cli/internal/multilog"
+	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/profile"
@@ -250,6 +251,13 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 		}
 		if !out.Type().IsStructured() {
 			err = errs.AddTips(err, locale.Tl("err_tip_run_help", "Run → '[ACTIONABLE]state {{.V0}}--help[/RESET]' for general help", cmdName))
+		}
+		if osutils.IsAccessDeniedError(err) && !errs.IsUserFacing(err) && !locale.IsInputError(err) {
+			err = locale.WrapInputError(err,
+				"err_permission_catchall",
+				"You do not have permission to perform that operation. "+
+					"Please view the log file at '[ACTIONABLE]{{.V0}}[/RESET]' for more details.",
+				logging.FilePath())
 		}
 		errors.ReportError(err, cmds.Command(), an)
 	}

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -337,10 +337,6 @@ func WriteFile(filePath string, data []byte) error {
 
 	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, FileMode)
 	if err != nil {
-		if !fileExists {
-			target := filepath.Dir(filePath)
-			err = fmt.Errorf("access to target %q is denied", target)
-		}
 		return errs.Wrap(err, "os.OpenFile %s failed", filePath)
 	}
 	defer f.Close()

--- a/internal/runners/clean/run.go
+++ b/internal/runners/clean/run.go
@@ -15,9 +15,6 @@ import (
 func removeCache(cachePath string) error {
 	err := os.RemoveAll(cachePath)
 	if err != nil {
-		if osutils.IsAccessDeniedError(err) {
-			return locale.WrapInputError(err, "err_remove_cache")
-		}
 		return locale.WrapError(err, "err_remove_cache")
 	}
 	return nil

--- a/internal/subshell/fish/fish.go
+++ b/internal/subshell/fish/fish.go
@@ -91,7 +91,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	fpath := filepath.Join(homeDir, ".config/fish/completions", constants.CommandName+".fish")
 	err = fileutils.WriteFile(fpath, []byte(completionScript))
 	if err != nil {
-		return errs.Wrap(err, "Could not write completions script")
+		logging.Debug("Could not write completions script '%s', likely due to non-admin privileges", fpath)
 	}
 
 	return nil

--- a/internal/subshell/zsh/zsh.go
+++ b/internal/subshell/zsh/zsh.go
@@ -99,7 +99,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	logging.Debug("Writing to %s: %s", fpath, completionScript)
 	err := fileutils.WriteFile(fpath, []byte(completionScript))
 	if err != nil {
-		return errs.Wrap(err, "Could not write completions script")
+		logging.Debug("Could not write completions script '%s', likely due to non-admin privileges", fpath)
 	}
 
 	homeDir, err := user.HomeDir()

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -1384,7 +1384,7 @@ func StoreProjectMapping(cfg ConfigGetter, namespace, projectPath string) {
 		},
 	)
 	if err != nil {
-		multilog.Error("Could not set project mapping in config, error: %v", err)
+		multilog.Error("Could not set project mapping in config, error: %s", errs.JoinMessage(err))
 	}
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2646" title="DX-2646" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2646</a>  We don't report access denied errors to rollbar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

We don't want to report these to rollbar.

Note: I chose not to centralize reporting inside the `fileutils` package because there are dozens of functions in there that would have to be changed, and there are also other files that use os-level functions that may return these types of errors (such as `os.OpenFile()` used by the `projectfile` package). I figured the best way to approach this was to have a catch-all at the bottom of the error funnel rather than having callers explicitly check for permission issues (similar to top-level  `rationalize.ErrNoProject` handling) and crafting appropriate error messages.

Further note: based on the generality of this solution, it's impossible to provide a truly helpful message (such as which file/folder had a permission issue) without implementing full-blown user-facing errors and types/structs. I figured that was out of scope for this small-ish task at hand.