### PR TITLE
Use `state revert REMOTE` instead of `state revert HEAD`.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1140,7 +1140,7 @@ err_user_libc_solution:
   other: If you specified a glibc version, please check it is configured → [ACTIONABLE]{{.V0}}[/RESET].
 warn_revert_head:
   other: |
-    [NOTICE]DEPRECATION WARNING[/RESET]: 'state revert HEAD' has been deprecated in favor of '[ACTIONABLE]state revert REMOTE[/RESET]'. Please use '[ACTIONABLE]state revert REMOTE[/RESET]' instead.
+    [NOTICE]DEPRECATION WARNING[/RESET]: '[ACTIONABLE]state revert HEAD[/RESET]' has been deprecated in favor of '[ACTIONABLE]state revert REMOTE[/RESET]'. Please use '[ACTIONABLE]state revert REMOTE[/RESET]' instead.
 err_revert_get_commit:
   other: "Could not fetch commit details for commit with ID: {{.V0}}"
 err_revert_commit:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1140,7 +1140,7 @@ err_user_libc_solution:
   other: If you specified a glibc version, please check it is configured → [ACTIONABLE]{{.V0}}[/RESET].
 warn_revert_head:
   other: |
-    [NOTICE]DEPRECATION WARNING[/RESET]: `state revert HEAD` has been deprecated in favor of `[ACTIONABLE]state revert REMOTE[/RESET]`. Please use `[ACTIONABLE]state revert REMOTE[/RESET]` instead.
+    [NOTICE]DEPRECATION WARNING[/RESET]: 'state revert HEAD' has been deprecated in favor of '[ACTIONABLE]state revert REMOTE[/RESET]'. Please use '[ACTIONABLE]state revert REMOTE[/RESET]' instead.
 err_revert_get_commit:
   other: "Could not fetch commit details for commit with ID: {{.V0}}"
 err_revert_commit:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1138,6 +1138,9 @@ err_user_network_solution:
     If your issue persists consider reporting it on our forums at {{.V0}}.
 err_user_libc_solution:
   other: If you specified a glibc version, please check it is configured → [ACTIONABLE]{{.V0}}[/RESET].
+warn_revert_head:
+  other: |
+    [NOTICE]DEPRECATION WARNING[/RESET]: `state revert HEAD` has been deprecated in favor of `[ACTIONABLE]state revert REMOTE[/RESET]`. Please use `[ACTIONABLE]state revert REMOTE[/RESET]` instead.
 err_revert_get_commit:
   other: "Could not fetch commit details for commit with ID: {{.V0}}"
 err_revert_commit:

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1140,7 +1140,7 @@ err_user_libc_solution:
   other: If you specified a glibc version, please check it is configured → [ACTIONABLE]{{.V0}}[/RESET].
 warn_revert_head:
   other: |
-    [NOTICE]DEPRECATION WARNING[/RESET]: '[ACTIONABLE]state revert HEAD[/RESET]' has been deprecated in favor of '[ACTIONABLE]state revert REMOTE[/RESET]'. Please use '[ACTIONABLE]state revert REMOTE[/RESET]' instead.
+    [NOTICE]DEPRECATION WARNING[/RESET]: 'state revert HEAD' has been deprecated in favor of '[ACTIONABLE]state revert REMOTE[/RESET]'. Please use '[ACTIONABLE]state revert REMOTE[/RESET]' instead.
 err_revert_get_commit:
   other: "Could not fetch commit details for commit with ID: {{.V0}}"
 err_revert_commit:

--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -59,6 +59,7 @@ func New(prime primeable) *Revert {
 	}
 }
 
+const remoteCommitID = "REMOTE"
 const headCommitID = "HEAD"
 
 func (r *Revert) Run(params *Params) (rerr error) {
@@ -69,14 +70,18 @@ func (r *Revert) Run(params *Params) (rerr error) {
 	}
 
 	commitID := params.CommitID
-	if !strfmt.IsUUID(commitID) && !strings.EqualFold(commitID, headCommitID) {
+	if strings.EqualFold(commitID, headCommitID) {
+		r.out.Notice(locale.T("warn_revert_head"))
+		commitID = remoteCommitID
+	}
+	if !strfmt.IsUUID(commitID) && !strings.EqualFold(commitID, remoteCommitID) {
 		return locale.NewInputError("err_invalid_commit_id", "Invalid commit ID")
 	}
 	latestCommit, err := localcommit.Get(r.project.Dir())
 	if err != nil {
 		return errs.Wrap(err, "Unable to get local commit")
 	}
-	if strings.EqualFold(commitID, headCommitID) {
+	if strings.EqualFold(commitID, remoteCommitID) {
 		commitID = latestCommit.String()
 	}
 

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -66,7 +66,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	cp.ExpectExitCode(0)
 }
 
-func (suite *RevertIntegrationTestSuite) TestRevertHead() {
+func (suite *RevertIntegrationTestSuite) TestRevertRemote() {
 	suite.OnlyRunForTags(tagsuite.Revert)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
@@ -80,7 +80,7 @@ func (suite *RevertIntegrationTestSuite) TestRevertHead() {
 	cp.Expect("Package added")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("revert", "HEAD", "--non-interactive")
+	cp = ts.Spawn("revert", "REMOTE", "--non-interactive")
 	cp.Expect("Successfully reverted")
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2674" title="DX-2674" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2674</a>  As a user I can use intuitive terms to reference the local / remote project
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Convert from HEAD to REMOTE, but show a deprecation message.