### PR TITLE
Enable wildcards for `state languages install`.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -656,6 +656,10 @@ bundle_added:
   other: "[SUCCESS]✔ {{.V0}} Bundle successfully installed![/RESET]"
 bundle_version_added:
   other: "[SUCCESS]✔ {{.V0}} Bundle @ version {{.V1}} successfully installed![/RESET]"
+language_updated:
+  other: "Language updated: [NOTICE]{{.V0}}[/RESET]"
+language_version_updated:
+  other: "Language updated: [NOTICE]{{.V0}}@{{.V1}}[/RESET]"
 err_package_updated:
   other: Failed to update package
 err_bundle_updated:
@@ -864,10 +868,6 @@ arg_languages_install_description:
   other: The language to update in the form of <language>@<version>
 err_language_format:
   other: The language and version provided is not formatting correctly, must be in the form of <language>@<version>
-err_update_not_found:
-  other: "Could not find the requested language: [NOTICE]{{.V0}}[/RESET]. Please ensure the language name is correct and supported by the ActiveState platform"
-err_language_version_not_found:
-  other: The requested version [NOTICE]{{.V0}}[/RESET] for the language [NOTICE]{{.V1}}[/RESET] is not available
 err_language_mismatch:
   other: Cannot change languages, only changes to the current project's language is allowed
 err_no_recipes:

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -155,7 +155,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(
 		}
 	}
 
-	var validatePkg = operation == bpModel.OperationAdded && ns != nil && (ns.Type() == model.NamespacePackage || ns.Type() == model.NamespaceBundle)
+	var validatePkg = operation == bpModel.OperationAdded && ns != nil && (ns.Type() == model.NamespacePackage || ns.Type() == model.NamespaceBundle || ns.Type() == model.NamespaceLanguage)
 	if (ns == nil || !ns.IsValid()) && nsType != nil && (*nsType == model.NamespacePackage || *nsType == model.NamespaceBundle) {
 		pg = output.StartSpinner(out, locale.Tr("progress_pkg_nolang", requirementName), constants.TerminalAnimationInterval)
 

--- a/internal/runners/languages/install.go
+++ b/internal/runners/languages/install.go
@@ -53,21 +53,8 @@ func (u *Update) Run(params *UpdateParams) error {
 		return err
 	}
 
-	err = ensureLanguagePlatform(lang, u.prime.Auth())
-	if err != nil {
-		return err
-	}
-
-	err = ensureVersion(lang, u.prime.Auth())
-	if err != nil {
-		if lang.Version == "" {
-			return locale.WrapInputError(err, "err_language_project", "Language: {{.V0}} is already installed, you can update it by running {{.V0}}@<version>", lang.Name)
-		}
-		return err
-	}
-
 	op := requirements.NewRequirementOperation(u.prime)
-	err = op.ExecuteRequirementOperation(
+	return op.ExecuteRequirementOperation(
 		lang.Name,
 		lang.Version,
 		nil,
@@ -76,16 +63,6 @@ func (u *Update) Run(params *UpdateParams) error {
 		nil,
 		&model.NamespaceLanguage,
 		nil)
-	if err != nil {
-		return locale.WrapError(err, "err_language_update", "Could not update language: {{.V0}}", lang.Name)
-	}
-
-	langName := lang.Name
-	if lang.Version != "" {
-		langName = langName + "@" + lang.Version
-	}
-	u.prime.Output().Notice(locale.Tl("language_added", "Language added: {{.V0}}", langName))
-	return nil
 }
 
 func parseLanguage(langName string) (*model.Language, error) {
@@ -109,21 +86,6 @@ func parseLanguage(langName string) (*model.Language, error) {
 	}, nil
 }
 
-func ensureLanguagePlatform(language *model.Language, auth *authentication.Auth) error {
-	platformLanguages, err := model.FetchLanguages(auth)
-	if err != nil {
-		return err
-	}
-
-	for _, pl := range platformLanguages {
-		if strings.EqualFold(pl.Name, language.Name) {
-			return nil
-		}
-	}
-
-	return locale.NewError("err_update_not_found", language.Name)
-}
-
 func ensureLanguageProject(language *model.Language, project *project.Project, auth *authentication.Auth) error {
 	targetCommitID, err := model.BranchCommitID(project.Owner(), project.Name(), project.BranchName())
 	if err != nil {
@@ -139,29 +101,4 @@ func ensureLanguageProject(language *model.Language, project *project.Project, a
 		return locale.NewInputError("err_language_mismatch")
 	}
 	return nil
-}
-
-type fetchVersionsFunc func(name string, auth *authentication.Auth) ([]string, error)
-
-func ensureVersion(language *model.Language, auth *authentication.Auth) error {
-	return ensureVersionTestable(language, model.FetchLanguageVersions, auth)
-}
-
-func ensureVersionTestable(language *model.Language, fetchVersions fetchVersionsFunc, auth *authentication.Auth) error {
-	if language.Version == "" {
-		return locale.NewInputError("err_language_no_version", "No language version provided")
-	}
-
-	versions, err := fetchVersions(language.Name, auth)
-	if err != nil {
-		return err
-	}
-
-	for _, ver := range versions {
-		if language.Version == ver {
-			return nil
-		}
-	}
-
-	return locale.NewInputError("err_language_version_not_found", "", language.Version, language.Name)
 }

--- a/internal/runners/languages/install_test.go
+++ b/internal/runners/languages/install_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 )
 
@@ -34,48 +33,6 @@ func Test_parseLanguage(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseLanguage() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_ensureVersionTestable(t *testing.T) {
-	type args struct {
-		language      *model.Language
-		fetchVersions fetchVersionsFunc
-	}
-	tests := []struct {
-		name        string
-		args        args
-		wantVersion string
-		wantErr     bool
-	}{
-		{
-			"Version matches",
-			args{
-				&model.Language{Name: "Python", Version: "3.5"},
-				func(name string, auth *authentication.Auth) ([]string, error) {
-					return []string{"2.0", "3.5", "4.0"}, nil
-				},
-			},
-			"3.5",
-			false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ensureVersionTestable(tt.args.language, tt.args.fetchVersions, nil)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ensureVersionTestable() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if err != nil {
-				return
-			}
-
-			if tt.args.language.Version != tt.wantVersion {
-				t.Errorf("ensureVersionTestable() version = %v, wantVersion %v", tt.args.language.Version, tt.wantVersion)
 			}
 		})
 	}

--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -358,6 +358,11 @@ func ProcessCommitError(commit *Commit, fallbackMessage string) error {
 			commit.Type, commit.Error.Message,
 			locale.NewInputError("err_buildplanner_no_change_since_last_commit", "No new changes to commit."),
 		}, commit.Error.Message)
+	case ValidationErrorType:
+		return &CommitError{
+			commit.Type, commit.Error.Message,
+			locale.NewInputError("err_buildplanner_validation_error", "Invalid request: {{.V0}}", commit.Message),
+		}
 	default:
 		return errs.New(fallbackMessage)
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2626" title="DX-2626" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2626</a>  As a user I can use wildcard versions when running `state languages install`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This PR changes `state languages install` to piggy-back more off of the existing `requirements` package's capabilities for installing/updating packages by treating the language to be installed as just a package. It will inherit all the usual behaviors of `state install`, including `.x` wildcard support and silently appending wildcards for partial version numbers.