### PR TITLE
Prompt the user if they wish to continue running the installer as administrator.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -51,7 +51,11 @@ type Params struct {
 }
 
 func newParams() *Params {
-	return &Params{activate: &project.Namespaced{}, activateDefault: &project.Namespaced{}}
+	return &Params{
+		activate:        &project.Namespaced{},
+		activateDefault: &project.Namespaced{},
+		nonInteractive:  !term.IsTerminal(int(os.Stdin.Fd())),
+	}
 }
 
 func main() {

--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -47,6 +47,7 @@ type Params struct {
 	activate        *project.Namespaced
 	activateDefault *project.Namespaced
 	showVersion     bool
+	nonInteractive  bool
 }
 
 func newParams() *Params {
@@ -109,7 +110,6 @@ func main() {
 		return
 	}
 
-	var garbageBool bool
 	var garbageString string
 
 	// We have old install one liners around that use `-activate` instead of `--activate`
@@ -189,8 +189,8 @@ func main() {
 				Name:  "version", // note: no shorthand because install.sh uses -v for selecting version
 				Value: &params.showVersion,
 			},
+			{Name: "non-interactive", Shorthand: "n", Hidden: true, Value: &params.nonInteractive}, // don't prompt
 			// The remaining flags are for backwards compatibility (ie. we don't want to error out when they're provided)
-			{Name: "nnn", Shorthand: "n", Hidden: true, Value: &garbageBool}, // don't prompt; useless cause we don't prompt anyway
 			{Name: "channel", Hidden: true, Value: &garbageString},
 			{Name: "bbb", Shorthand: "b", Hidden: true, Value: &garbageString},
 			{Name: "vvv", Shorthand: "v", Hidden: true, Value: &garbageString},
@@ -341,7 +341,7 @@ func installOrUpdateFromLocalSource(out output.Outputer, cfg *config.Instance, a
 		return err
 	}
 
-	installer, err := NewInstaller(cfg, out, payloadPath, params)
+	installer, err := NewInstaller(cfg, out, an, payloadPath, params)
 	if err != nil {
 		out.Print(fmt.Sprintf("[ERROR]Could not create installer: %s[/RESET]", errs.JoinMessage(err)))
 		return err

--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ActiveState/cli/internal/osutils/autostart"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/prompt"
+	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
 	"github.com/ActiveState/cli/internal/updater"
@@ -52,10 +53,9 @@ func (i *Installer) Install() (rerr error) {
 	if err != nil {
 		return errs.Wrap(err, "Could not determine if running as Windows administrator")
 	}
-	if isAdmin {
-		prompter := prompt.New(!i.Params.nonInteractive, i.an)
-		defaultChoice := !prompter.IsInteractive() // default to no for interactive, yes for non-interactive
-		confirm, err := prompter.Confirm("", locale.T("installer_prompt_is_admin"), &defaultChoice)
+	if isAdmin && !i.Params.nonInteractive {
+		prompter := prompt.New(true, i.an)
+		confirm, err := prompter.Confirm("", locale.T("installer_prompt_is_admin"), ptr.To(false))
 		if err != nil {
 			return errs.Wrap(err, "Unable to confirm")
 		}

--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -60,7 +60,7 @@ func (i *Installer) Install() (rerr error) {
 			return errs.Wrap(err, "Unable to confirm")
 		}
 		if !confirm {
-			return // halt installation
+			return locale.NewInputError("installer_aborted", "Installation aborted by the user")
 		}
 	}
 

--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -42,7 +42,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallFromLocalSource() {
 	// Run installer with source-path flag (ie. install from this local path)
 	cp := ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts)),
+		e2e.OptArgs(installationDir(ts), "-n"),
 		e2e.OptAppendEnv(constants.DisableUpdates+"=false"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
 	)
@@ -59,7 +59,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallFromLocalSource() {
 	// Ensure installing overtop doesn't result in errors
 	cp = ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts)),
+		e2e.OptArgs(installationDir(ts), "-n"),
 		e2e.OptAppendEnv(constants.DisableUpdates+"=false"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
 	)
@@ -73,7 +73,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallFromLocalSource() {
 	suite.Require().NoError(fileutils.WriteFile(filepath.Join(installationDir(ts), installation.InstallDirMarker), []byte{}))
 	cp = ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts)),
+		e2e.OptArgs(installationDir(ts), "-n"),
 		e2e.OptAppendEnv(constants.DisableUpdates+"=false"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
 	)
@@ -137,7 +137,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallIncompatible() {
 	// Run installer with source-path flag (ie. install from this local path)
 	cp := ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts)),
+		e2e.OptArgs(installationDir(ts), "-n"),
 		e2e.OptAppendEnv(constants.DisableUpdates+"=false", sysinfo.VersionOverrideEnvVar+"=10.0.0"),
 	)
 
@@ -157,7 +157,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallNoErrorTips() {
 
 	cp := ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts), "--activate", "ActiveState/DoesNotExist"),
+		e2e.OptArgs(installationDir(ts), "--activate", "ActiveState/DoesNotExist", "-n"),
 		e2e.OptAppendEnv(constants.DisableUpdates+"=true"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
 	)
@@ -177,7 +177,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallErrorTips() {
 
 	cp := ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts), "--activate", "ActiveState-CLI/Python3"),
+		e2e.OptArgs(installationDir(ts), "--activate", "ActiveState-CLI/Python3", "-n"),
 		e2e.OptAppendEnv(constants.DisableUpdates+"=true"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
 	)
@@ -207,7 +207,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallerOverwriteServiceApp() {
 
 	cp := ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts)),
+		e2e.OptArgs(installationDir(ts), "-n"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.AppInstallDirOverrideEnvVarName, appInstallDir)),
 	)
 	cp.Expect("Done")
@@ -217,7 +217,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallerOverwriteServiceApp() {
 	// State Service.app should be overwritten cleanly without error.
 	cp = ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts)+"2"),
+		e2e.OptArgs(installationDir(ts)+"2", "-n"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.AppInstallDirOverrideEnvVarName, appInstallDir)),
 	)
 	cp.Expect("Done")
@@ -239,7 +239,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallWhileInUse() {
 
 	cp := ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts)),
+		e2e.OptArgs(installationDir(ts), "-n"),
 		e2e.OptAppendEnv(constants.DisableUpdates+"=true"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
 	)
@@ -255,7 +255,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallWhileInUse() {
 	// executables. Verify that this works without error.
 	cp2 := ts.SpawnCmdWithOpts(
 		suite.installerExe,
-		e2e.OptArgs(installationDir(ts), "-f"),
+		e2e.OptArgs(installationDir(ts), "-f", "-n"),
 		e2e.OptAppendEnv(constants.DisableUpdates+"=true"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.OverwriteDefaultSystemPathEnvVarName, dir)),
 	)

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1326,6 +1326,9 @@ secrets_unstable_warning:
     The secrets feature is currently unstable and not ready for production use. If you want to opt-in to unstable features, run the following command:
 
     [ACTIONABLE]state config set optin.unstable true[/RESET]
+installer_prompt_is_admin:
+  other: |
+    You are installing the State Tool as an administrator. The State Tool was designed to be installed without administrator privileges, and you may run into issues if you continue. Are you sure you want to do this?
 err_update_corrupt_install:
   other: |
     Unfortunately your current installation appears to have been corrupted. Please reinstall the State Tool by first


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2647" title="DX-2647" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2647</a>  We provide a warning to users when installing the state tool as administrator.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is not recommended.

Note: this only works for Windows. Detecting whether or not the user is an admin or has admin privileges on macOS and Linux is not straightforward at all, if even possible: 

- https://stackoverflow.com/questions/27366298/check-if-application-is-running-as-administrator-in-golang
- https://serverfault.com/questions/568627/can-a-program-tell-it-is-being-run-under-sudo
- https://stackoverflow.com/questions/29733575/how-to-find-the-user-that-executed-a-program-as-root-using-golang