### PR TITLE
Show version constraints string in `state languages` instead of "Auto".

### DIFF
--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -60,9 +60,10 @@ func FetchLanguagesForCommit(commitID strfmt.UUID, auth *authentication.Auth) ([
 	languages := []Language{}
 	for _, requirement := range checkpoint {
 		if NamespaceMatch(requirement.Namespace, NamespaceLanguageMatch) {
+			version := MonoConstraintsToString(requirement.VersionConstraints)
 			lang := Language{
 				Name:    requirement.Requirement,
-				Version: requirement.VersionConstraint,
+				Version: version,
 			}
 			languages = append(languages, lang)
 		}

--- a/pkg/platform/model/version_constraints.go
+++ b/pkg/platform/model/version_constraints.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ActiveState/cli/internal/multilog"
 	gqlModel "github.com/ActiveState/cli/pkg/platform/api/graphql/model"
 	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_models"
+	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 )
 
 type versionConstraints struct {
@@ -33,6 +34,18 @@ func GqlReqVersionConstraintsString(requirement *gqlModel.Requirement) string {
 
 	constraints := make([]*versionConstraints, len(requirement.VersionConstraints))
 	for i, constraint := range requirement.VersionConstraints {
+		constraints[i] = &versionConstraints{constraint.Comparator, constraint.Version}
+	}
+	return versionConstraintsToString(constraints)
+}
+
+func MonoConstraintsToString(monoConstraints mono_models.Constraints) string {
+	if monoConstraints == nil {
+		return ""
+	}
+
+	constraints := make([]*versionConstraints, len(monoConstraints))
+	for i, constraint := range monoConstraints {
 		constraints[i] = &versionConstraints{constraint.Comparator, constraint.Version}
 	}
 	return versionConstraintsToString(constraints)

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -156,11 +156,7 @@ func (suite *InitIntegrationTestSuite) TestInit_AlreadyExists() {
 }
 
 func (suite *InitIntegrationTestSuite) TestInit_Resolved() {
-	suite.OnlyRunForTags(tagsuite.Init)
-	if runtime.GOOS == "darwin" {
-		suite.T().Skip("Skipping mac for now as the builds are still too unreliable")
-		return
-	}
+	suite.OnlyRunForTags(tagsuite.Init, tagsuite.Languages)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 	ts.LoginAsPersistentUser()
@@ -181,7 +177,7 @@ func (suite *InitIntegrationTestSuite) TestInit_Resolved() {
 	// Run `state languages` to verify a full language version was resolved.
 	cp = ts.Spawn("languages")
 	cp.Expect("python")
-	cp.Expect("Auto → 3.10.") // note: the patch version is variable, so just expect that it exists
+	cp.Expect(">=3.10,<3.11 → 3.10.") // note: the patch version is variable, so just expect that it exists
 	cp.ExpectExitCode(0)
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2662" title="DX-2662" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2662</a>  `state languages` should show larger/smaller than notation for version rather than auto
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
