### PR TITLE
More fixes for integration tests invoking the installer non-interactively.

### DIFF
--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -53,7 +53,7 @@ func (i *Installer) Install() (rerr error) {
 	if err != nil {
 		return errs.Wrap(err, "Could not determine if running as Windows administrator")
 	}
-	if isAdmin && !i.Params.nonInteractive {
+	if isAdmin && !i.Params.force && !i.Params.isUpdate && !i.Params.nonInteractive {
 		prompter := prompt.New(true, i.an)
 		confirm, err := prompter.Confirm("", locale.T("installer_prompt_is_admin"), ptr.To(false))
 		if err != nil {

--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -32,9 +32,10 @@ import (
 )
 
 type Params struct {
-	channel string
-	force   bool
-	version string
+	channel        string
+	force          bool
+	version        string
+	nonInteractive bool
 }
 
 func newParams() *Params {
@@ -146,6 +147,12 @@ func main() {
 				Description: "Force the installation, overwriting any version of the State Tool already installed",
 				Value:       &params.force,
 			},
+			{
+				Name:      "non-interactive",
+				Shorthand: "n",
+				Hidden:    true,
+				Value:     &params.nonInteractive,
+			},
 		},
 		[]*captain.Argument{},
 		func(ccmd *captain.Command, args []string) error {
@@ -209,6 +216,9 @@ func execute(out output.Outputer, prompt prompt.Prompter, cfg *config.Instance, 
 	}
 	out.Print(locale.Tl("remote_install_status_done", "[SUCCESS]✔ Done[/RESET]"))
 
+	if params.nonInteractive {
+		args = append(args, "-n") // forward to installer
+	}
 	env := []string{
 		constants.InstallerNoSubshell + "=true",
 	}

--- a/test/integration/remote_installer_int_test.go
+++ b/test/integration/remote_installer_int_test.go
@@ -47,7 +47,7 @@ func (suite *RemoteInstallIntegrationTestSuite) TestInstall() {
 			installPath := filepath.Join(ts.Dirs.Work, "install")
 			stateExePath := filepath.Join(installPath, "bin", constants.StateCmd+osutils.ExeExtension)
 
-			args := []string{}
+			args := []string{"-n"}
 			if tt.Version != "" {
 				args = append(args, "--version", tt.Version)
 			}

--- a/test/integration/uninstall_int_test.go
+++ b/test/integration/uninstall_int_test.go
@@ -50,7 +50,7 @@ func (suite *UninstallIntegrationTestSuite) install(ts *e2e.Session) string {
 	// Perform the installation.
 	cmd := "bash"
 	opts := []e2e.SpawnOptSetter{
-		e2e.OptArgs(script, appInstallDir),
+		e2e.OptArgs(script, appInstallDir, "-n"),
 		e2e.OptAppendEnv(constants.DisableRuntime + "=false"),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.AppInstallDirOverrideEnvVarName, appInstallDir)),
 		e2e.OptAppendEnv(fmt.Sprintf("%s=FOO", constants.OverrideSessionTokenEnvVarName)),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2704" title="DX-2704" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2704</a>  Nightly failure: TestRemoteInstallerIntegrationTest and TestUpdateIntegrationTest
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
These were previously hidden by an overall 1-hour test timeout on Windows.