### PR TITLE
`state artifacts` warns if build has not finished

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1556,6 +1556,8 @@ commit_success:
     Run '[ACTIONABLE]state refresh[/RESET]' to update your local runtime.
 warn_has_failed_artifacts:
   other: "Warning: This project has failed builds, and some artifacts will be missing as a result.\n"
+warn_build_not_complete:
+  other: "Warning: This project has not finished building all artifacts, this is only reporting on artifacts that have finished building.\n"
 err_build_artifacts_failed:
   other: |
     The following artifacts failed to build, please refer to their logs for more information:

--- a/internal/runners/artifacts/artifacts.go
+++ b/internal/runners/artifacts/artifacts.go
@@ -53,6 +53,7 @@ type Artifacts struct {
 }
 
 type StructuredOutput struct {
+	BuildComplete      bool                  `json:"build_completed"`
 	HasFailedArtifacts bool                  `json:"has_failed_artifacts"`
 	Platforms          []*structuredPlatform `json:"platforms"`
 }
@@ -106,8 +107,8 @@ func (b *Artifacts) Run(params *Params) (rerr error) {
 		b.out.Notice(locale.Tr("operating_message", b.project.NamespaceString(), b.project.Dir()))
 	}
 
-	terminalArtfMap, hasFailedArtifacts, err := getTerminalArtifactMap(
-		b.project, params.Namespace, params.CommitID, b.auth, b.analytics, b.svcModel, b.out, b.config)
+	terminalArtfMap, buildComplete, hasFailedArtifacts, err := getTerminalArtifactMap(
+		b.project, params.Namespace, params.CommitID, b.auth, b.out)
 	if err != nil {
 		return errs.Wrap(err, "Could not get terminal artifact map")
 	}
@@ -117,7 +118,7 @@ func (b *Artifacts) Run(params *Params) (rerr error) {
 		return errs.Wrap(err, "Could not get platforms")
 	}
 
-	out := &StructuredOutput{HasFailedArtifacts: hasFailedArtifacts}
+	out := &StructuredOutput{HasFailedArtifacts: hasFailedArtifacts, BuildComplete: buildComplete}
 	for term, artifacts := range terminalArtfMap {
 		if !strings.Contains(term, "platform:") {
 			continue
@@ -180,6 +181,9 @@ func (b *Artifacts) Run(params *Params) (rerr error) {
 }
 
 func (b *Artifacts) outputPlain(out *StructuredOutput, fullID bool) error {
+	if !out.BuildComplete {
+		b.out.Error(locale.T("warn_build_not_complete"))
+	}
 	if out.HasFailedArtifacts {
 		b.out.Error(locale.T("warn_has_failed_artifacts"))
 	}
@@ -223,17 +227,14 @@ func getTerminalArtifactMap(
 	namespace *project.Namespaced,
 	commit string,
 	auth *authentication.Auth,
-	an analytics.Dispatcher,
-	svcModel *model.SvcModel,
-	out output.Outputer,
-	cfg Configurable) (_ buildplan.TerminalArtifactMap, hasFailedArtifacts bool, rerr error) {
+	out output.Outputer) (_ buildplan.TerminalArtifactMap, completed bool, hasFailedArtifacts bool, rerr error) {
 	if pj == nil && !namespace.IsValid() {
-		return nil, false, rationalize.ErrNoProject
+		return nil, false, false, rationalize.ErrNoProject
 	}
 
 	commitID := strfmt.UUID(commit)
 	if commitID != "" && !strfmt.IsUUID(commitID.String()) {
-		return nil, false, &errInvalidCommitId{errs.New("Invalid commit ID"), commitID.String()}
+		return nil, false, false, &errInvalidCommitId{errs.New("Invalid commit ID"), commitID.String()}
 	}
 
 	namespaceProvided := namespace.IsValid()
@@ -257,13 +258,13 @@ func getTerminalArtifactMap(
 	case !namespaceProvided && !commitIdProvided:
 		localCommitID, err := localcommit.Get(pj.Path())
 		if err != nil {
-			return nil, false, errs.Wrap(err, "Could not get local commit")
+			return nil, false, false, errs.Wrap(err, "Could not get local commit")
 		}
 
 		bp := model.NewBuildPlannerModel(auth)
 		buildPlan, err = bp.FetchBuildResult(localCommitID, pj.Owner(), pj.Name())
 		if err != nil {
-			return nil, false, errs.Wrap(err, "Failed to fetch build plan")
+			return nil, false, false, errs.Wrap(err, "Failed to fetch build plan")
 		}
 
 	// Return artifact map from the given commitID for the current project.
@@ -271,31 +272,31 @@ func getTerminalArtifactMap(
 		bp := model.NewBuildPlannerModel(auth)
 		buildPlan, err = bp.FetchBuildResult(commitID, pj.Owner(), pj.Name())
 		if err != nil {
-			return nil, false, errs.Wrap(err, "Failed to fetch build plan")
+			return nil, false, false, errs.Wrap(err, "Failed to fetch build plan")
 		}
 
 	// Return the artifact map for the latest commitID of the given project.
 	case namespaceProvided && !commitIdProvided:
 		pj, err := model.FetchProjectByName(namespace.Owner, namespace.Project)
 		if err != nil {
-			return nil, false, locale.WrapInputError(err, "err_fetch_project", "", namespace.String())
+			return nil, false, false, locale.WrapInputError(err, "err_fetch_project", "", namespace.String())
 		}
 
 		branch, err := model.DefaultBranchForProject(pj)
 		if err != nil {
-			return nil, false, errs.Wrap(err, "Could not grab branch for project")
+			return nil, false, false, errs.Wrap(err, "Could not grab branch for project")
 		}
 
 		commitUUID, err := model.BranchCommitID(namespace.Owner, namespace.Project, branch.Label)
 		if err != nil {
-			return nil, false, errs.Wrap(err, "Could not get commit ID for project")
+			return nil, false, false, errs.Wrap(err, "Could not get commit ID for project")
 		}
 		commitID = *commitUUID
 
 		bp := model.NewBuildPlannerModel(auth)
 		buildPlan, err = bp.FetchBuildResult(commitID, namespace.Owner, namespace.Project)
 		if err != nil {
-			return nil, false, errs.Wrap(err, "Failed to fetch build plan")
+			return nil, false, false, errs.Wrap(err, "Failed to fetch build plan")
 		}
 
 	// Return the artifact map for the given commitID of the given project.
@@ -303,24 +304,26 @@ func getTerminalArtifactMap(
 		bp := model.NewBuildPlannerModel(auth)
 		buildPlan, err = bp.FetchBuildResult(commitID, namespace.Owner, namespace.Project)
 		if err != nil {
-			return nil, false, errs.Wrap(err, "Failed to fetch build plan")
+			return nil, false, false, errs.Wrap(err, "Failed to fetch build plan")
 		}
 
 	default:
-		return nil, false, errs.New("Unhandled case")
+		return nil, false, false, errs.New("Unhandled case")
 	}
+
+	buildComplete := buildPlan.BuildStatus == bpModel.Completed
 
 	bpm, err := buildplan.NewMapFromBuildPlan(buildPlan.Build, false, false, nil, true)
 	if err != nil {
-		return nil, false, errs.Wrap(err, "Could not get buildplan")
+		return nil, buildComplete, false, errs.Wrap(err, "Could not get buildplan")
 	}
 
 	// Communicate whether there were failed artifacts
 	for _, artifact := range buildPlan.Build.Artifacts {
 		if !bpModel.IsSuccessArtifactStatus(artifact.Status) {
-			return bpm, true, nil
+			return bpm, buildComplete, true, nil
 		}
 	}
 
-	return bpm, false, nil
+	return bpm, buildComplete, false, nil
 }

--- a/internal/runners/artifacts/artifacts.go
+++ b/internal/runners/artifacts/artifacts.go
@@ -311,19 +311,17 @@ func getTerminalArtifactMap(
 		return nil, false, false, errs.New("Unhandled case")
 	}
 
-	buildComplete := buildPlan.BuildStatus == bpModel.Completed
-
 	bpm, err := buildplan.NewMapFromBuildPlan(buildPlan.Build, false, false, nil, true)
 	if err != nil {
-		return nil, buildComplete, false, errs.Wrap(err, "Could not get buildplan")
+		return nil, buildPlan.BuildReady, false, errs.Wrap(err, "Could not get buildplan")
 	}
 
 	// Communicate whether there were failed artifacts
 	for _, artifact := range buildPlan.Build.Artifacts {
 		if !bpModel.IsSuccessArtifactStatus(artifact.Status) {
-			return bpm, buildComplete, true, nil
+			return bpm, buildPlan.BuildReady, true, nil
 		}
 	}
 
-	return bpm, buildComplete, false, nil
+	return bpm, buildPlan.BuildReady, false, nil
 }

--- a/internal/runners/artifacts/download.go
+++ b/internal/runners/artifacts/download.go
@@ -79,8 +79,8 @@ func (d *Download) Run(params *DownloadParams) (rerr error) {
 		d.out.Notice(locale.Tr("operating_message", d.project.NamespaceString(), d.project.Dir()))
 	}
 
-	terminalArtfMap, _, err := getTerminalArtifactMap(
-		d.project, params.Namespace, params.CommitID, d.auth, d.analytics, d.svcModel, d.out, d.config)
+	terminalArtfMap, _, _, err := getTerminalArtifactMap(
+		d.project, params.Namespace, params.CommitID, d.auth, d.out)
 	if err != nil {
 		return errs.Wrap(err, "Could not get build plan map")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2703" title="DX-2703" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2703</a>  `state artifacts --all` just after publishing the ingredient have no `whl` files or package of the published ingredient on the first attempt.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
