### PR TITLE
Use ':' as namespace separator in buildscripts.

### DIFF
--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -21,7 +21,7 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl")
+		Req(name = "language:perl")
 	]
 )
 
@@ -47,7 +47,7 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl")
+		Req(name = "language:perl")
 	]
 )
 
@@ -88,11 +88,11 @@ sources = solve(
 		"96b7e6f2-bebf-564c-bc1c-f04482398f38"
 	],
 	requirements = [
-		Req(name = "language/python", version = Eq(value = "3.10.11")),
+		Req(name = "language:python", version = Eq(value = "3.10.11")),
 <<<<<<< local
-		Req(name = "language/python/requests")
+		Req(name = "language/python:requests")
 =======
-		Req(name = "language/python/requests", version = Eq(value = "2.30.0"))
+		Req(name = "language/python:requests", version = Eq(value = "2.30.0"))
 >>>>>>> remote
 	],
 	solver_version = null

--- a/internal/runbits/buildscript/testdata/buildscript1.as
+++ b/internal/runbits/buildscript/testdata/buildscript1.as
@@ -14,8 +14,8 @@ sources = solve(
 		"96b7e6f2-bebf-564c-bc1c-f04482398f38"
 	],
 	requirements = [
-		Req(name = "language/python", version = Eq(value = "3.10.11")),
-		Req(name = "language/python/requests")
+		Req(name = "language:python", version = Eq(value = "3.10.11")),
+		Req(name = "language/python:requests")
 	],
 	solver_version = null
 )

--- a/internal/runbits/buildscript/testdata/buildscript2.as
+++ b/internal/runbits/buildscript/testdata/buildscript2.as
@@ -14,8 +14,8 @@ sources = solve(
 		"96b7e6f2-bebf-564c-bc1c-f04482398f38"
 	],
 	requirements = [
-		Req(name = "language/python", version = Eq(value = "3.10.11")),
-		Req(name = "language/python/requests", version = Eq(value = "2.30.0"))
+		Req(name = "language:python", version = Eq(value = "3.10.11")),
+		Req(name = "language/python:requests", version = Eq(value = "2.30.0"))
 	],
 	solver_version = null
 )

--- a/pkg/platform/runtime/buildexpression/merge/merge_test.go
+++ b/pkg/platform/runtime/buildexpression/merge/merge_test.go
@@ -19,8 +19,8 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "language:perl"),
+		Req(name = "language/perl:DateTime")
 	]
 )
 
@@ -37,8 +37,8 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/JSON")
+		Req(name = "language:perl"),
+		Req(name = "language/perl:JSON")
 	]
 )
 
@@ -69,9 +69,9 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/JSON"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "language:perl"),
+		Req(name = "language/perl:JSON"),
+		Req(name = "language/perl:DateTime")
 	]
 )
 
@@ -88,9 +88,9 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/JSON"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "language:perl"),
+		Req(name = "language/perl:JSON"),
+		Req(name = "language/perl:DateTime")
 	]
 )
 
@@ -107,8 +107,8 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "language:perl"),
+		Req(name = "language/perl:DateTime")
 	]
 )
 
@@ -139,8 +139,8 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "language:perl"),
+		Req(name = "language/perl:DateTime")
 	]
 )
 
@@ -157,7 +157,7 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
+		Req(name = "language:perl"),
 	]
 )
 
@@ -173,8 +173,8 @@ runtime = solve(
 		"12345"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/JSON")
+		Req(name = "language:perl"),
+		Req(name = "language/perl:JSON")
 	]
 )
 

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -177,7 +177,7 @@ func transformRequirements(reqs *buildexpression.Var) *buildexpression.Var {
 //
 // into something like
 //
-//	Req(name = "<namespace>/<name>", version = <op>(value = "<version>"))
+//	Req(name = "<namespace>:<name>", version = <op>(value = "<version>"))
 func transformRequirement(req *buildexpression.Value) *buildexpression.Value {
 	newReq := &buildexpression.Value{
 		Ap: &buildexpression.Ap{
@@ -195,7 +195,7 @@ func transformRequirement(req *buildexpression.Value) *buildexpression.Value {
 			name += *arg.Value.Str
 
 		case buildexpression.RequirementNamespaceKey:
-			name = fmt.Sprintf("%s/%s", *arg.Value.Str, name)
+			name = fmt.Sprintf("%s:%s", *arg.Value.Str, name)
 
 		case buildexpression.RequirementVersionRequirementsKey:
 			version = transformVersion(arg)

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -33,8 +33,8 @@ runtime = solve(
 	at_time = at_time,
 	platforms = ["linux", "windows"],
 	requirements = [
-		Req(name = "language/python"),
-		Req(name = "language/python/requests", version = Eq(value = "3.10.10"))
+		Req(name = "language:python"),
+		Req(name = "language/python:requests", version = Eq(value = "3.10.10"))
 	]
 )
 
@@ -66,14 +66,14 @@ main = runtime
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python"`)},
+										"name", &Value{Str: ptr.To(`"language:python"`)},
 									}},
 								}}},
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python/requests"`)},
+										"name", &Value{Str: ptr.To(`"language/python:requests"`)},
 									}},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
@@ -102,7 +102,7 @@ func TestComplex(t *testing.T) {
 linux_runtime = solve(
 		at_time = at_time,
 		requirements=[
-			Req(name = "language/python")
+			Req(name = "language:python")
 		],
 		platforms=["67890"]
 )
@@ -110,7 +110,7 @@ linux_runtime = solve(
 win_runtime = solve(
 		at_time = at_time,
 		requirements=[
-			Req(name = "language/perl")
+			Req(name = "language:perl")
 		],
 		platforms=["12345"]
 )
@@ -140,7 +140,7 @@ main = merge(
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python"`)}},
+										"name", &Value{Str: ptr.To(`"language:python"`)}},
 									},
 								},
 							}},
@@ -162,7 +162,7 @@ main = merge(
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/perl"`)}},
+										"name", &Value{Str: ptr.To(`"language:perl"`)}},
 									},
 								},
 							}},
@@ -191,9 +191,9 @@ runtime = solve(
 	at_time = at_time,
 	platforms = ["96b7e6f2-bebf-564c-bc1c-f04482398f38", "96b7e6f2-bebf-564c-bc1c-f04482398f38"],
 	requirements = [
-		Req(name = "language/python"),
-		Req(name = "language/python/requests", version = Eq(value = "3.10.10")),
-		Req(name = "language/python/argparse", version = And(left = Gt(value = "1.0"), right = Lt(value = "2.0")))
+		Req(name = "language:python"),
+		Req(name = "language/python:requests", version = Eq(value = "3.10.10")),
+		Req(name = "language/python:argparse", version = And(left = Gt(value = "1.0"), right = Lt(value = "2.0")))
 	],
 	solver_version = 0
 )
@@ -230,7 +230,7 @@ func TestExample(t *testing.T) {
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python"`)}},
+										"name", &Value{Str: ptr.To(`"language:python"`)}},
 									},
 								},
 							}},
@@ -238,7 +238,7 @@ func TestExample(t *testing.T) {
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python/requests"`)}},
+										"name", &Value{Str: ptr.To(`"language/python:requests"`)}},
 									},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
@@ -254,7 +254,7 @@ func TestExample(t *testing.T) {
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python/argparse"`)}},
+										"name", &Value{Str: ptr.To(`"language/python:argparse"`)}},
 									},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
@@ -297,7 +297,7 @@ func TestString(t *testing.T) {
 runtime = solve(
 		at_time = at_time,
 		platforms=["12345", "67890"],
-		requirements=[Req(name = "language/python", version = Eq(value = "3.10.10"))]
+		requirements=[Req(name = "language:python", version = Eq(value = "3.10.10"))]
 )
 
 main = runtime
@@ -313,7 +313,7 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/python", version = Eq(value = "3.10.10"))
+		Req(name = "language:python", version = Eq(value = "3.10.10"))
 	]
 )
 
@@ -343,7 +343,7 @@ func TestJson(t *testing.T) {
 runtime = solve(
 		at_time = at_time,
 		requirements=[
-			Req(name = "language/python")
+			Req(name = "language:python")
 		],
 		platforms=["12345", "67890"]
 )

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -104,7 +104,7 @@ func marshalReq(args []*Value) ([]byte, error) {
 		}
 
 		switch {
-		// Marshal the name argument (e.g. name = "<namespace>/<name>") into
+		// Marshal the name argument (e.g. name = "<namespace>:<name>") into
 		// {"name": "<name>", "namespace": "<namespace>"}
 		case assignment.Key == buildexpression.RequirementNameKey && assignment.Value.Str != nil:
 			name, namespace := separateNamespace(*assignment.Value.Str)
@@ -162,10 +162,10 @@ func marshalReq(args []*Value) ([]byte, error) {
 func separateNamespace(combined string) (string, string) {
 	var name, namespace string
 	s := strings.Trim(combined, `"`)
-	lastSlashIndex := strings.LastIndex(s, "/")
-	if lastSlashIndex != -1 {
-		namespace = s[:lastSlashIndex]
-		name = s[lastSlashIndex+1:]
+	colonIndex := strings.Index(s, ":")
+	if colonIndex != -1 {
+		namespace = s[:colonIndex]
+		name = s[colonIndex+1:]
 	}
 
 	return name, namespace


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2712" title="DX-2712" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2712</a>  Buildscript requirements separate the namespace and name by a colon
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
