### PR TITLE
Preserve `--ts now` from a previous commit when running `state uninstall`.

### DIFF
--- a/internal/runners/packages/uninstall.go
+++ b/internal/runners/packages/uninstall.go
@@ -43,7 +43,7 @@ func (u *Uninstall) Run(params UninstallRunParams, nsType model.NamespaceType) (
 		nsTypeV = &nsType
 	}
 
-	ts, err := getTime(nil, u.prime.Auth(), u.prime.Project())
+	ts, err := getTime(&captain.TimeValue{}, u.prime.Auth(), u.prime.Project())
 	if err != nil {
 		return errs.Wrap(err, "Unable to get timestamp from params")
 	}

--- a/internal/runners/packages/uninstall.go
+++ b/internal/runners/packages/uninstall.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"github.com/ActiveState/cli/internal/captain"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
@@ -42,6 +43,11 @@ func (u *Uninstall) Run(params UninstallRunParams, nsType model.NamespaceType) (
 		nsTypeV = &nsType
 	}
 
+	ts, err := getTime(nil, u.prime.Auth(), u.prime.Project())
+	if err != nil {
+		return errs.Wrap(err, "Unable to get timestamp from params")
+	}
+
 	return requirements.NewRequirementOperation(u.prime).ExecuteRequirementOperation(
 		params.Package.Name,
 		"",
@@ -50,6 +56,6 @@ func (u *Uninstall) Run(params UninstallRunParams, nsType model.NamespaceType) (
 		bpModel.OperationRemoved,
 		ns,
 		nsTypeV,
-		nil,
+		ts,
 	)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2713" title="DX-2713" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2713</a>  Custom timestamp not preserved when running install
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
