### PR TITLE
Forward top-level build planner errors to the user.

### DIFF
--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -343,6 +343,11 @@ func ProcessCommitError(commit *Commit, fallbackMessage string) error {
 			commit.Type, commit.Message,
 			locale.NewInputError("err_buildplanner_parse_error", "The platform failed to parse the build expression, received message: {{.V0}}. Path: {{.V1}}", commit.Message, commit.ParseError.Path),
 		}
+	case ValidationErrorType:
+		return &CommitError{
+			commit.Type, commit.Message,
+			locale.NewInputError("err_buildplanner_validation_error", "The platform encountered a validation error, received message: {{.V0}}", commit.Message),
+		}
 	case ForbiddenErrorType:
 		return &CommitError{
 			commit.Type, commit.Message,

--- a/pkg/platform/model/buildplanner.go
+++ b/pkg/platform/model/buildplanner.go
@@ -557,7 +557,7 @@ func processBuildPlannerError(bpErr error, fallbackMessage string) error {
 			return &bpModel.BuildPlannerError{Err: locale.NewInputError("err_buildplanner_deprecated", "Encountered deprecation error: {{.V0}}", graphqlErr.Message)}
 		}
 	}
-	return &bpModel.BuildPlannerError{Err: errs.Wrap(bpErr, fallbackMessage)}
+	return &bpModel.BuildPlannerError{Err: locale.NewInputError("err_buildplanner", "{{.V0}}: Encountered unexpected error: {{.V1}}", fallbackMessage, bpErr.Error())}
 }
 
 var versionRe = regexp.MustCompile(`^\d+(\.\d+)*$`)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2706" title="DX-2706" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2706</a>  stageCommit forwards errors to the user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This results in errors like:

```
~/work/testing/small-python
❯ ~/work/cli/build/state commit
█ Commit Changes

 • Creating commit x Failed

 x failed to stage commit: Encountered unexpected error: Request failed: graphql: BuildExpr validation error for the commit : let.wheels should be an Ap with name 'solve', was 'make_wheel'

█ Need More Help?
 • Run → 'state commit --help' for general help.
 • Ask For Help → https://community.activestate.com/c/state-tool/.
```