### PR TITLE
Fix merge conflicts from dx-2707 into v44

### DIFF
--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -21,7 +21,7 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl")
+		Req(name = "perl", namespace = "language")
 	]
 )
 
@@ -47,7 +47,7 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl")
+		Req(name = "perl", namespace = "language")
 	]
 )
 
@@ -88,11 +88,11 @@ sources = solve(
 		"96b7e6f2-bebf-564c-bc1c-f04482398f38"
 	],
 	requirements = [
-		Req(name = "language/python", version = Eq(value = "3.10.11")),
+		Req(name = "python", namespace = "language", version = Eq(value = "3.10.11")),
 <<<<<<< local
-		Req(name = "language/python/requests")
+		Req(name = "requests", namespace = "language/python")
 =======
-		Req(name = "language/python/requests", version = Eq(value = "2.30.0"))
+		Req(name = "requests", namespace = "language/python", version = Eq(value = "2.30.0"))
 >>>>>>> remote
 	],
 	solver_version = null

--- a/internal/runbits/buildscript/testdata/buildscript1.as
+++ b/internal/runbits/buildscript/testdata/buildscript1.as
@@ -14,8 +14,8 @@ sources = solve(
 		"96b7e6f2-bebf-564c-bc1c-f04482398f38"
 	],
 	requirements = [
-		Req(name = "language/python", version = Eq(value = "3.10.11")),
-		Req(name = "language/python/requests")
+		Req(name = "python", namespace = "language", version = Eq(value = "3.10.11")),
+		Req(name = "requests", namespace = "language/python")
 	],
 	solver_version = null
 )

--- a/internal/runbits/buildscript/testdata/buildscript2.as
+++ b/internal/runbits/buildscript/testdata/buildscript2.as
@@ -14,8 +14,8 @@ sources = solve(
 		"96b7e6f2-bebf-564c-bc1c-f04482398f38"
 	],
 	requirements = [
-		Req(name = "language/python", version = Eq(value = "3.10.11")),
-		Req(name = "language/python/requests", version = Eq(value = "2.30.0"))
+		Req(name = "python", namespace = "language", version = Eq(value = "3.10.11")),
+		Req(name = "requests", namespace = "language/python", version = Eq(value = "2.30.0"))
 	],
 	solver_version = null
 )

--- a/pkg/platform/api/buildplanner/model/buildplan.go
+++ b/pkg/platform/api/buildplanner/model/buildplan.go
@@ -391,11 +391,6 @@ func ProcessCommitError(commit *Commit, fallbackMessage string) error {
 			commit.Type, commit.Error.Message,
 			locale.NewInputError("err_buildplanner_no_change_since_last_commit", "No new changes to commit."),
 		}, commit.Error.Message)
-	case ValidationErrorType:
-		return &CommitError{
-			commit.Type, commit.Error.Message,
-			locale.NewInputError("err_buildplanner_validation_error", "Invalid request: {{.V0}}", commit.Message),
-		}
 	default:
 		return errs.New(fallbackMessage)
 	}

--- a/pkg/platform/runtime/buildexpression/merge/merge_test.go
+++ b/pkg/platform/runtime/buildexpression/merge/merge_test.go
@@ -19,8 +19,8 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "perl", namespace = "language"),
+		Req(name = "DateTime", namespace = "language/perl")
 	]
 )
 
@@ -37,8 +37,8 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/JSON")
+		Req(name = "perl", namespace = "language"),
+		Req(name = "JSON", namespace = "language/perl")
 	]
 )
 
@@ -69,9 +69,9 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/JSON"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "perl", namespace = "language"),
+		Req(name = "JSON", namespace = "language/perl"),
+		Req(name = "DateTime", namespace = "language/perl")
 	]
 )
 
@@ -88,8 +88,8 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "perl", namespace = "language"),
+		Req(name = "DateTime", namespace = "language/perl")
 	]
 )
 
@@ -106,9 +106,9 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/JSON"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "perl", namespace = "language"),
+		Req(name = "JSON", namespace = "language/perl"),
+		Req(name = "DateTime", namespace = "language/perl")
 	]
 )
 
@@ -139,8 +139,8 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/DateTime")
+		Req(name = "perl", namespace = "language"),
+		Req(name = "DateTime", namespace = "language/perl")
 	]
 )
 
@@ -157,7 +157,7 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/perl"),
+		Req(name = "perl", namespace = "language"),
 	]
 )
 
@@ -173,8 +173,8 @@ runtime = solve(
 		"12345"
 	],
 	requirements = [
-		Req(name = "language/perl"),
-		Req(name = "language/perl/JSON")
+		Req(name = "perl", namespace = "language"),
+		Req(name = "JSON", namespace = "language/perl")
 	]
 )
 

--- a/pkg/platform/runtime/buildscript/buildscript.go
+++ b/pkg/platform/runtime/buildscript/buildscript.go
@@ -186,7 +186,7 @@ func transformRequirements(reqs *buildexpression.Var) *buildexpression.Var {
 //
 // into something like
 //
-//	Req(name = "<namespace>/<name>", version = <op>(value = "<version>"))
+//	Req(name = "<name>", namespace = "<namespace>", version = <op>(value = "<version>"))
 func transformRequirement(req *buildexpression.Value) *buildexpression.Value {
 	newReq := &buildexpression.Value{
 		Ap: &buildexpression.Ap{
@@ -195,35 +195,19 @@ func transformRequirement(req *buildexpression.Value) *buildexpression.Value {
 		},
 	}
 
-	// Extract namespace, name, and version from requirement object.
-	name := ""
-	var version *buildexpression.Ap
 	for _, arg := range *req.Object {
-		switch arg.Name {
-		case buildexpression.RequirementNameKey:
-			name += *arg.Value.Str
+		name := arg.Name
+		value := arg.Value
 
-		case buildexpression.RequirementNamespaceKey:
-			name = fmt.Sprintf("%s/%s", *arg.Value.Str, name)
-
-		case buildexpression.RequirementVersionRequirementsKey:
-			version = transformVersion(arg)
+		// Transform the version value from the requirement object.
+		if name == buildexpression.RequirementVersionRequirementsKey {
+			name = buildexpression.RequirementVersionKey
+			value = &buildexpression.Value{Ap: transformVersion(arg)}
 		}
-	}
 
-	// Add the arguments to the function transformation.
-	newReq.Ap.Arguments = append(newReq.Ap.Arguments, &buildexpression.Value{
-		Assignment: &buildexpression.Var{
-			Name:  buildexpression.RequirementNameKey,
-			Value: &buildexpression.Value{Str: ptr.To(name)},
-		},
-	})
-	if version != nil {
+		// Add the argument to the function transformation.
 		newReq.Ap.Arguments = append(newReq.Ap.Arguments, &buildexpression.Value{
-			Assignment: &buildexpression.Var{
-				Name:  buildexpression.RequirementVersionKey,
-				Value: &buildexpression.Value{Ap: version},
-			},
+			Assignment: &buildexpression.Var{Name: name, Value: value},
 		})
 	}
 

--- a/pkg/platform/runtime/buildscript/buildscript_test.go
+++ b/pkg/platform/runtime/buildscript/buildscript_test.go
@@ -33,8 +33,8 @@ runtime = solve(
 	at_time = at_time,
 	platforms = ["linux", "windows"],
 	requirements = [
-		Req(name = "language/python"),
-		Req(name = "language/python/requests", version = Eq(value = "3.10.10"))
+		Req(name = "python", namespace = "language"),
+		Req(name = "requests", namespace = "language/python", version = Eq(value = "3.10.10"))
 	]
 )
 
@@ -66,14 +66,20 @@ main = runtime
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python"`)},
+										"name", &Value{Str: ptr.To(`"python"`)},
+									}},
+									{Assignment: &Assignment{
+										"namespace", &Value{Str: ptr.To(`"language"`)},
 									}},
 								}}},
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python/requests"`)},
+										"name", &Value{Str: ptr.To(`"requests"`)},
+									}},
+									{Assignment: &Assignment{
+										"namespace", &Value{Str: ptr.To(`"language/python"`)},
 									}},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
@@ -102,7 +108,7 @@ func TestComplex(t *testing.T) {
 linux_runtime = solve(
 		at_time = at_time,
 		requirements=[
-			Req(name = "language/python")
+			Req(name = "python", namespace = "language")
 		],
 		platforms=["67890"]
 )
@@ -110,7 +116,7 @@ linux_runtime = solve(
 win_runtime = solve(
 		at_time = at_time,
 		requirements=[
-			Req(name = "language/perl")
+			Req(name = "perl", namespace = "language")
 		],
 		platforms=["12345"]
 )
@@ -140,8 +146,11 @@ main = merge(
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python"`)}},
-									},
+										"name", &Value{Str: ptr.To(`"python"`)},
+									}},
+									{Assignment: &Assignment{
+										"namespace", &Value{Str: ptr.To(`"language"`)},
+									}},
 								},
 							}},
 						}},
@@ -162,8 +171,11 @@ main = merge(
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/perl"`)}},
-									},
+										"name", &Value{Str: ptr.To(`"perl"`)},
+									}},
+									{Assignment: &Assignment{
+										"namespace", &Value{Str: ptr.To(`"language"`)},
+									}},
 								},
 							}},
 						}},
@@ -191,9 +203,9 @@ runtime = solve(
 	at_time = at_time,
 	platforms = ["96b7e6f2-bebf-564c-bc1c-f04482398f38", "96b7e6f2-bebf-564c-bc1c-f04482398f38"],
 	requirements = [
-		Req(name = "language/python"),
-		Req(name = "language/python/requests", version = Eq(value = "3.10.10")),
-		Req(name = "language/python/argparse", version = And(left = Gt(value = "1.0"), right = Lt(value = "2.0")))
+		Req(name = "python", namespace = "language"),
+		Req(name = "requests", namespace = "language/python", version = Eq(value = "3.10.10")),
+		Req(name = "argparse", namespace = "language/python", version = And(left = Gt(value = "1.0"), right = Lt(value = "2.0")))
 	],
 	solver_version = 0
 )
@@ -230,16 +242,22 @@ func TestExample(t *testing.T) {
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python"`)}},
-									},
+										"name", &Value{Str: ptr.To(`"python"`)},
+									}},
+									{Assignment: &Assignment{
+										"namespace", &Value{Str: ptr.To(`"language"`)},
+									}},
 								},
 							}},
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python/requests"`)}},
-									},
+										"name", &Value{Str: ptr.To(`"requests"`)},
+									}},
+									{Assignment: &Assignment{
+										"namespace", &Value{Str: ptr.To(`"language/python"`)},
+									}},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
 											Name: "Eq",
@@ -254,8 +272,11 @@ func TestExample(t *testing.T) {
 								Name: "Req",
 								Arguments: []*Value{
 									{Assignment: &Assignment{
-										"name", &Value{Str: ptr.To(`"language/python/argparse"`)}},
-									},
+										"name", &Value{Str: ptr.To(`"argparse"`)},
+									}},
+									{Assignment: &Assignment{
+										"namespace", &Value{Str: ptr.To(`"language/python"`)},
+									}},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
 											Name: "And",
@@ -297,7 +318,7 @@ func TestString(t *testing.T) {
 runtime = solve(
 		at_time = at_time,
 		platforms=["12345", "67890"],
-		requirements=[Req(name = "language/python", version = Eq(value = "3.10.10"))]
+		requirements=[Req(name = "python", namespace = "language", version = Eq(value = "3.10.10"))]
 )
 
 main = runtime
@@ -313,7 +334,7 @@ runtime = solve(
 		"67890"
 	],
 	requirements = [
-		Req(name = "language/python", version = Eq(value = "3.10.10"))
+		Req(name = "python", namespace = "language", version = Eq(value = "3.10.10"))
 	]
 )
 
@@ -345,7 +366,7 @@ func TestJson(t *testing.T) {
 runtime = solve(
 		at_time = at_time,
 		requirements=[
-			Req(name = "language/python")
+			Req(name = "python", namespace = "language")
 		],
 		platforms=["12345", "67890"]
 )

--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -104,12 +104,14 @@ func marshalReq(args []*Value) ([]byte, error) {
 		}
 
 		switch {
-		// Marshal the name argument (e.g. name = "<namespace>/<name>") into
-		// {"name": "<name>", "namespace": "<namespace>"}
+		// Marshal the name argument (e.g. name = "<name>") into {"name": "<name>"}
 		case assignment.Key == buildexpression.RequirementNameKey && assignment.Value.Str != nil:
-			name, namespace := separateNamespace(*assignment.Value.Str)
-			requirement[buildexpression.RequirementNameKey] = name
-			requirement[buildexpression.RequirementNamespaceKey] = namespace
+			requirement[buildexpression.RequirementNameKey] = strings.Trim(*assignment.Value.Str, `"`)
+
+		// Marshal the namespace argument (e.g. namespace = "<namespace>") into
+		// {"namespace": "<namespace>"}
+		case assignment.Key == buildexpression.RequirementNamespaceKey && assignment.Value.Str != nil:
+			requirement[buildexpression.RequirementNamespaceKey] = strings.Trim(*assignment.Value.Str, `"`)
 
 		// Marshal the version argument (e.g. version = <op>(value = "<version>")) into
 		// {"version_requirements": [{"comparator": "<op>", "version": "<version>"}]}
@@ -157,16 +159,4 @@ func marshalReq(args []*Value) ([]byte, error) {
 	}
 
 	return json.Marshal(requirement)
-}
-
-func separateNamespace(combined string) (string, string) {
-	var name, namespace string
-	s := strings.Trim(combined, `"`)
-	lastSlashIndex := strings.LastIndex(s, "/")
-	if lastSlashIndex != -1 {
-		namespace = s[:lastSlashIndex]
-		name = s[lastSlashIndex+1:]
-	}
-
-	return name, namespace
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2707" title="DX-2707" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2707</a>  Separate the Req  namespace and name in buildscript.as
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

There was a conflict in merge_test.go involving the location of the Perl JSON package regarding a test failure that was fixed on the v44 branch (https://github.com/ActiveState/cli/pull/3225/files#diff-1ebd8e286e3a9885c33bb17b9fdb14f4d2624f1d9dda84792bb018dd3352866e). Also remove a duplicate `case` statement introduced in another PR (https://github.com/ActiveState/cli/pull/3225/files#diff-14612946db10f18744a68890b9e353cf87d4da9104592d9fe4346264ed83ef77). Otherwise, the rest of the PR has already been reviewed.