### PR TITLE
Fix merge conflict from DX-2713 to v44

### DIFF
--- a/internal/runners/packages/uninstall.go
+++ b/internal/runners/packages/uninstall.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"github.com/ActiveState/cli/internal/captain"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
@@ -49,5 +50,10 @@ func (u *Uninstall) Run(params UninstallRunParams, nsType model.NamespaceType) (
 		reqs = append(reqs, req)
 	}
 
-	return requirements.NewRequirementOperation(u.prime).ExecuteRequirementOperation(nil, reqs...)
+	ts, err := getTime(&captain.TimeValue{}, u.prime.Auth(), u.prime.Project())
+	if err != nil {
+		return errs.Wrap(err, "Unable to get timestamp from params")
+	}
+
+	return requirements.NewRequirementOperation(u.prime).ExecuteRequirementOperation(ts, reqs...)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2713" title="DX-2713" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2713</a>  Custom timestamp not preserved when running install
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

`state uninstall` has been updated to accept multiple requirements, so there was a merge conflict to fix.