### PR TITLE
Use powershell scripts instead of batch scripts for `state exec`.

### DIFF
--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -182,8 +182,8 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 	lang := language.Bash
 	scriptArgs := fmt.Sprintf(`%q "$@"`, exeTarget)
 	if strings.Contains(s.subshell.Binary(), "cmd") {
-		lang = language.Batch
-		scriptArgs = fmt.Sprintf("@ECHO OFF\n%q %%*", exeTarget)
+		lang = language.PowerShell
+		scriptArgs = fmt.Sprintf("& %q @args\nexit $LASTEXITCODE", exeTarget)
 	}
 
 	sf, err := scriptfile.New(lang, "state-exec", scriptArgs)

--- a/internal/subshell/sscommon/sscommon.go
+++ b/internal/subshell/sscommon/sscommon.go
@@ -131,7 +131,13 @@ func runWithCmd(env []string, name string, args ...string) (rerr error) {
 	case ".bat":
 		// Use powershell to run the bat file because passing arguments with special characters to
 		// batch files has limitations.
-		ps1Script := fmt.Sprintf("& %q @args\nexit $LASTEXITCODE", name)
+		ps1Script := fmt.Sprintf(`
+		try {
+			& %q @args
+			exit $LASTEXITCODE
+		} catch {
+			exit 1 # file not found
+		}`, name)
 		ps1File, err := fileutils.WriteTempFile("*.ps1", []byte(ps1Script))
 		if err != nil {
 			return errs.Wrap(err, "Unable to write temporary powershell script")

--- a/internal/subshell/sscommon/sscommon.go
+++ b/internal/subshell/sscommon/sscommon.go
@@ -131,13 +131,7 @@ func runWithCmd(env []string, name string, args ...string) (rerr error) {
 	case ".bat":
 		// Use powershell to run the bat file because passing arguments with special characters to
 		// batch files has limitations.
-		ps1Script := fmt.Sprintf(`
-		try {
-			& %q @args
-			exit $LASTEXITCODE
-		} catch {
-			exit 1 # file not found
-		}`, name)
+		ps1Script := fmt.Sprintf("& %q @args\nexit $LASTEXITCODE", name)
 		ps1File, err := fileutils.WriteTempFile("*.ps1", []byte(ps1Script))
 		if err != nil {
 			return errs.Wrap(err, "Unable to write temporary powershell script")

--- a/internal/subshell/sscommon/sscommon.go
+++ b/internal/subshell/sscommon/sscommon.go
@@ -1,14 +1,12 @@
 package sscommon
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/osutils"
@@ -109,7 +107,7 @@ func runWithBash(env []string, name string, args ...string) error {
 	return runDirect(env, "bash", "-c", quotedArgs)
 }
 
-func runWithCmd(env []string, name string, args ...string) (rerr error) {
+func runWithCmd(env []string, name string, args ...string) error {
 	ext := filepath.Ext(name)
 	switch ext {
 	case ".py":
@@ -119,7 +117,6 @@ func runWithCmd(env []string, name string, args ...string) (rerr error) {
 			return err
 		}
 		name = pythonPath
-
 	case ".pl":
 		args = append([]string{name}, args...)
 		perlPath, err := binaryPathCmd(env, "perl")
@@ -127,27 +124,11 @@ func runWithCmd(env []string, name string, args ...string) (rerr error) {
 			return err
 		}
 		name = perlPath
-
 	case ".bat":
-		// Use powershell to run the bat file because passing arguments with special characters to
-		// batch files has limitations.
-		ps1Script := fmt.Sprintf("& %q @args\nexit $LASTEXITCODE", name)
-		ps1File, err := fileutils.WriteTempFile("*.ps1", []byte(ps1Script))
-		if err != nil {
-			return errs.Wrap(err, "Unable to write temporary powershell script")
-		}
-		defer func() {
-			err = os.Remove(ps1File)
-			if err != nil {
-				rerr = errs.Pack(rerr, errs.Wrap(err, "Could not remove temporary powershell script"))
-			}
-		}()
-		return runWithCmd(env, ps1File, args...)
-
+		// No action required
 	case ".ps1":
 		args = append([]string{"-executionpolicy", "bypass", "-file", name}, args...)
 		name = "powershell"
-
 	case ".sh":
 		bashPath, err := osutils.BashifyPath(name)
 		if err != nil {
@@ -158,7 +139,6 @@ func runWithCmd(env []string, name string, args ...string) (rerr error) {
 		}
 		args = append([]string{bashPath}, args...)
 		name = "bash"
-
 	default:
 		return locale.NewInputError("err_sscommon_unsupported_language", "", ext)
 	}

--- a/internal/subshell/sscommon/sscommon.go
+++ b/internal/subshell/sscommon/sscommon.go
@@ -127,7 +127,7 @@ func runWithCmd(env []string, name string, args ...string) error {
 	case ".bat":
 		// No action required
 	case ".ps1":
-		args = append([]string{"-file", name}, args...)
+		args = append([]string{"-executionpolicy", "bypass", "-file", name}, args...)
 		name = "powershell"
 	case ".sh":
 		bashPath, err := osutils.BashifyPath(name)

--- a/test/integration/exec_int_test.go
+++ b/test/integration/exec_int_test.go
@@ -197,6 +197,28 @@ func (suite *ExecIntegrationTestSuite) TestExecWithPath() {
 
 }
 
+func (suite *ExecIntegrationTestSuite) TestExecPerlArgs() {
+	suite.OnlyRunForTags(tagsuite.Exec)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Perl-5.32", ".")
+	cp.Expect("Skipping runtime setup")
+	cp.Expect("Checked out")
+	cp.ExpectExitCode(0)
+
+	suite.NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "testargs.pl"), []byte(`
+printf "Argument: '%s'.\n", $ARGV[0];
+`)))
+
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("exec", "perl", "testargs.pl", "<3"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("Argument: '<3'", e2e.RuntimeSourcingTimeoutOpt)
+	cp.ExpectExitCode(0)
+}
+
 func TestExecIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(ExecIntegrationTestSuite))
 }

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/ActiveState/cli/pkg/project"
 	"github.com/ActiveState/cli/pkg/projectfile"
 )
 
@@ -311,6 +312,43 @@ func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
 	cp.Expect("v5.32.0")
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
+}
+
+func (suite *RunIntegrationTestSuite) TestRun_Args() {
+	suite.OnlyRunForTags(tagsuite.Run)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	suite.createProjectFile(ts, 3)
+
+	asyFilename := filepath.Join(ts.Dirs.Work, "activestate.yaml")
+	asyFile, err := os.OpenFile(asyFilename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	suite.Require().NoError(err, "config is opened for appending")
+	defer asyFile.Close()
+
+	lang := project.DefaultScriptLanguage()[0].String()
+	cmd := `if [ "$1" = "<3" ]; then echo heart; fi`
+	if runtime.GOOS == "windows" {
+		cmd = `@echo off
+      if "%1"=="<3" (echo heart)` // need to match indent of YAML below
+	}
+	_, err = asyFile.WriteString(strings.TrimPrefix(fmt.Sprintf(`
+  - name: args
+    language: %s
+    value: |
+      %s
+`, lang, cmd), "\n"))
+	suite.Require().NoError(err, "extra config is appended")
+
+	arg := "<3"
+	if runtime.GOOS == "windows" {
+		// The '<' needs to be escaped with '^', and I don't know why. There is no way around it.
+		// The other exec and shell integration tests that test arg passing do not need this escape.
+		// Only this batch test does.
+		arg = "^<3"
+	}
+	cp := ts.Spawn("run", "args", arg)
+	cp.Expect("heart", termtest.OptExpectTimeout(5*time.Second))
 }
 
 func TestRunIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2673" title="DX-2673" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2673</a>  Get rid of batch files for running user commands
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Passing arguments through batch is not reliable, especially arguments with special characters like '<' in them.

On Windows, Go -> cmd -> executor/exe argument passthrough via `%*` is problematic because the batch script doesn't know how to do parameter escaping if a parameter contains special characters. Instead, use Go -> pwsh -> executor/exe so that powershell correctly forwards arguments.

This PR adds the following new integration tests:

- `state exec` uses powershell under the hood so that something like `state exec perl testargs.pl "<3"` works as expected (the original bug report) without the user needing to know anything about escaping.
- `state run foo "^<3"` where `foo` is a batch script explicitly written by the user works, but requires the '^' escape (presumably the user knows this, as I mention in a stand-alone comment). Note that State Tool invokes the user-defined batch script; it doesn't create its own script to facilitate running this.
- Within `state shell`, `foo "<3"` where `foo` is a powershell script explicitly written by the user works as expected. Note that State Tool invokes the user-defined script (whether it be powershell or batch); it doesn't create its own script to facilitate running this one.
