### PR TITLE
Allow arbitrary key=value assignments to buildscript Req function.

### DIFF
--- a/pkg/platform/runtime/buildscript/json.go
+++ b/pkg/platform/runtime/buildscript/json.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-openapi/strfmt"
 
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildexpression"
 )
@@ -154,7 +155,8 @@ func marshalReq(args []*Value) ([]byte, error) {
 			requirement[buildexpression.RequirementVersionRequirementsKey] = &Value{List: &requirements}
 
 		default:
-			return nil, errs.New("Invalid or unknown argument: %v", assignment)
+			logging.Debug("Adding unknown argument: %v", assignment)
+			requirement[assignment.Key] = assignment.Value
 		}
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2724" title="DX-2724" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2724</a>  Nightly failure: TestPullIntegrationTestSuite/TestMergeBuildScript
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Incoming buildexpressions can start containing arbitrary key-value pairs, so we shouldn't be gatekeeping the `Req()` function. This could result in more obscure error messages from the platform (e.g. if the user typos a key), but it gives us more flexibility as buildexpressions remain in flux.
