### PR TITLE
Do not require filepath argument to `state publish --edit`.

### DIFF
--- a/cmd/state/internal/cmdtree/publish.go
+++ b/cmd/state/internal/cmdtree/publish.go
@@ -117,7 +117,6 @@ func newPublish(prime *primer.Values) *captain.Command {
 				Name:        locale.Tl("filepath", "filepath"),
 				Description: locale.Tl("author_upload_filepath_description", "A tar.gz or zip archive containing the source files of the ingredient."),
 				Value:       &params.Filepath,
-				Required:    true,
 			},
 		},
 		func(_ *captain.Command, _ []string) error {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2701" title="DX-2701" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2701</a>  `state publish --edit` fail work without path to the file 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The runner performs the necessary check and raises an input error if neither filepath nor --edit were provided.