### PR TITLE
Do not report to rollbar any fish and zsh completion writing errors.

### DIFF
--- a/internal/subshell/fish/fish.go
+++ b/internal/subshell/fish/fish.go
@@ -91,7 +91,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	fpath := filepath.Join(homeDir, ".config/fish/completions", constants.CommandName+".fish")
 	err = fileutils.WriteFile(fpath, []byte(completionScript))
 	if err != nil {
-		return errs.Wrap(err, "Could not write completions script")
+		logging.Debug("Could not write completions script '%s', likely due to non-admin privileges", fpath)
 	}
 
 	return nil

--- a/internal/subshell/zsh/zsh.go
+++ b/internal/subshell/zsh/zsh.go
@@ -98,7 +98,7 @@ func (v *SubShell) WriteCompletionScript(completionScript string) error {
 	logging.Debug("Writing to %s: %s", fpath, completionScript)
 	err := fileutils.WriteFile(fpath, []byte(completionScript))
 	if err != nil {
-		return errs.Wrap(err, "Could not write completions script")
+		logging.Debug("Could not write completions script '%s', likely due to non-admin privileges", fpath)
 	}
 
 	homeDir, err := user.HomeDir()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2683" title="DX-2683" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2683</a>  Rollbar: _prepare []: prepare error, message: Could not generate completions script, error received: Writing completion data failed., error: Writing completion data failed:     Could not write completions script:
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This was already done for bash, but not for zsh or fish.

Reference: https://github.com/ActiveState/cli/blob/58fda728095d13066f58ad1ec66b6f8264e2c2c8/internal/subshell/bash/bash.go#L112