### PR TITLE
Pack in more error details instead of overwriting the original permission error.

### DIFF
--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -341,7 +341,7 @@ func WriteFile(filePath string, data []byte) (rerr error) {
 	if err != nil {
 		if !fileExists {
 			target := filepath.Dir(filePath)
-			err = fmt.Errorf("access to target %q is denied", target)
+			err = errs.Pack(err, fmt.Errorf("access to target %q is denied", target))
 		}
 		return errs.Wrap(err, "os.OpenFile %s failed", filePath)
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2684" title="DX-2684" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2684</a>  Rollbar: checkout []: MUST ADDRESS: Error does not have localization: execute failed:     Checkout failed:         Could not create projectfile:             os.OpenFile C:\activestate.yaml failed: access to target "C:\\" is denied
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
