### PR TITLE
Update to merged commit even if buildscript merge failed.

### DIFF
--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -162,6 +162,13 @@ func (p *Pull) Run(params *PullParams) (rerr error) {
 			return errs.Wrap(err, "Unable to set local commit")
 		}
 
+		if p.cfg.GetBool(constants.OptinBuildscriptsConfig) {
+			err := p.mergeBuildScript(*remoteCommit, *localCommit)
+			if err != nil {
+				return errs.Wrap(err, "Could not merge local build script with remote changes")
+			}
+		}
+
 		p.out.Print(&pullOutput{
 			locale.Tr("pull_updated", remoteProject.String(), resultingCommit.String()),
 			true,
@@ -182,13 +189,6 @@ func (p *Pull) Run(params *PullParams) (rerr error) {
 }
 
 func (p *Pull) performMerge(remoteCommit, localCommit strfmt.UUID, namespace *project.Namespaced, branchName string, strategy bpModel.MergeStrategy) (strfmt.UUID, error) {
-	if p.cfg.GetBool(constants.OptinBuildscriptsConfig) {
-		err := p.mergeBuildScript(remoteCommit, localCommit)
-		if err != nil {
-			return "", errs.Wrap(err, "Could not merge local build script with remote changes")
-		}
-	}
-
 	p.out.Notice(output.Title(locale.Tl("pull_diverged", "Merging history")))
 	p.out.Notice(locale.Tr(
 		"pull_diverged_message",
@@ -212,11 +212,12 @@ func (p *Pull) performMerge(remoteCommit, localCommit strfmt.UUID, namespace *pr
 	if err != nil {
 		return "", locale.WrapError(err, "err_pull_getcommit", "Could not inspect resulting commit.")
 	}
-	changes, _ := commit.FormatChanges(cmit)
-	p.out.Notice(locale.Tl(
-		"pull_diverged_changes",
-		"The following changes will be merged:\n{{.V0}}\n", strings.Join(changes, "\n")),
-	)
+	if changes, _ := commit.FormatChanges(cmit); len(changes) > 0 {
+		p.out.Notice(locale.Tl(
+			"pull_diverged_changes",
+			"The following changes will be merged:\n{{.V0}}\n", strings.Join(changes, "\n")),
+		)
+	}
 
 	return resultCommit, nil
 }

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
+	"github.com/ActiveState/cli/pkg/localcommit"
 	bpModel "github.com/ActiveState/cli/pkg/platform/api/buildplanner/model"
 	"github.com/ActiveState/cli/pkg/platform/runtime/buildscript"
 	"github.com/ActiveState/cli/pkg/project"
@@ -110,6 +111,13 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	suite.Assert().Contains(string(bytes), "<<<<<<<", "No merge conflict markers are in build script")
 	suite.Assert().Contains(string(bytes), "=======", "No merge conflict markers are in build script")
 	suite.Assert().Contains(string(bytes), ">>>>>>>", "No merge conflict markers are in build script")
+
+	// Verify the local commit was updated to the merge commit.
+	// Note: even though the buildscript merge failed, a merge commit was still created. After resolving
+	// buildscript conflicts, `state commit` should have something new to commit.
+	commit, err := localcommit.Get(ts.Dirs.Work)
+	suite.Require().NoError(err)
+	suite.Assert().NotEqual(commit.String(), "447b8363-024c-4143-bf4e-c96989314fdf", "localcommit not updated to merged commit")
 }
 
 func (suite *PullIntegrationTestSuite) assertMergeStrategyNotification(ts *e2e.Session, strategy string) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2613" title="DX-2613" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2613</a>  Conflict resolution failed if user choose to resolve it in favor of the `local` 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
A buildscript merge conflict should not prevent an intermediate pull merge. Otherwise, conflict resolution in favor of the local changes followed by `state commit` would result in a "no changes found" error.