### PR TITLE
Do not print update/deprecation warnings/messages when running `state update`.

### DIFF
--- a/cmd/state/internal/cmdtree/exechandlers/messenger/messenger.go
+++ b/cmd/state/internal/cmdtree/exechandlers/messenger/messenger.go
@@ -35,6 +35,10 @@ func (m *Messenger) OnExecStart(cmd *captain.Command, _ []string) error {
 		return nil
 	}
 
+	if cmd.Name() == "update" {
+		return nil // do not print update/deprecation warnings/messages when running `state update`
+	}
+
 	cmds := cmd.JoinedCommandNames()
 	flags := cmd.ActiveFlagNames()
 
@@ -58,6 +62,10 @@ func (m *Messenger) OnExecStop(cmd *captain.Command, _ []string) error {
 	if m.out.Type().IsStructured() {
 		// No point showing messaging on non-plain output (eg. json)
 		return nil
+	}
+
+	if cmd.Name() == "update" {
+		return nil // do not print update/deprecation warnings/messages when running `state update`
 	}
 
 	if err := m.PrintByPlacement(graph.MessagePlacementTypeAfterCmd); err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2728" title="DX-2728" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2728</a>  We print the `Older version...` message in the summary of the update when user updated to the latest
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
