### PR TITLE
Only raise an error about buildscript having local changes if the runtime commit matches the local commit.

### DIFF
--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -61,6 +61,13 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	)
 	cp.Expect("successfully created")
 	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("pkg"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
+	)
+	cp.Expect("case ", e2e.RuntimeSourcingTimeoutOpt) // note: intentional trailing whitespace to not match 'casestyle'
+	cp.ExpectExitCode(0)
 }
 
 func (suite *CommitIntegrationTestSuite) TestCommitAtTimeChange() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2750" title="DX-2750" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2750</a>  `commit` requests `refresh` and put the flow to a loop
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


`state commit` changes the local commit ID, but does not source the runtime. Running `state refresh` checks for buildscript changes, and will always find them because the runtime has not yet been sourced. This results in the loop.

We could fix this by sourcing the runtime immediately after `state commit`, but I recall a ticket that wanted to decouple this behavior, hence the solution in this PR.