### PR TITLE
Still raise an error if the buildscript does not exist.

### DIFF
--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -140,6 +140,14 @@ func (r *Runtime) validateBuildScript() error {
 		return nil
 	}
 
+	script, err := buildscript.ScriptFromProject(r.target)
+	if err != nil {
+		if errs.Matches(err, buildscript.ErrBuildscriptNotExist) {
+			return errs.Pack(err, NeedsBuildscriptResetError)
+		}
+		return errs.Wrap(err, "Could not get buildscript from project")
+	}
+
 	cachedCommitID, err := r.store.CommitID()
 	if err != nil {
 		logging.Debug("No commit ID to read; refresh needed")
@@ -149,14 +157,6 @@ func (r *Runtime) validateBuildScript() error {
 	if cachedCommitID != r.target.CommitUUID().String() {
 		logging.Debug("Runtime commit ID does not match project commit ID; refresh needed")
 		return nil
-	}
-
-	script, err := buildscript.ScriptFromProject(r.target)
-	if err != nil {
-		if errs.Matches(err, buildscript.ErrBuildscriptNotExist) {
-			return errs.Pack(err, NeedsBuildscriptResetError)
-		}
-		return errs.Wrap(err, "Could not get buildscript from project")
 	}
 
 	cachedScript, err := r.store.BuildScript()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2757" title="DX-2757" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2757</a>  Nightly failure: TestBuildScriptIntegrationTestSuite/TestBuildScript_NeedsReset
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Just don't worry about asserting changes if the  runtime commit does not match the local commit.