### PR TITLE
Revert being able to pass a branch name to `state reset`.

### DIFF
--- a/cmd/state/internal/cmdtree/reset.go
+++ b/cmd/state/internal/cmdtree/reset.go
@@ -19,9 +19,9 @@ func newResetCommand(prime *primer.Values, globals *globalOptions) *captain.Comm
 		[]*captain.Flag{},
 		[]*captain.Argument{
 			{
-				Name:        locale.Tl("arg_state_reset_target", "target"),
-				Description: locale.Tl("arg_state_reset_target_description", "The commit ID or branch name to reset to. If not specified, resets local checkout to be equal to the project on the platform"),
-				Value:       &params.Target,
+				Name:        locale.Tl("arg_state_reset_commitid", "CommitID"),
+				Description: locale.Tl("arg_state_reset_commitid_description", "Reset to the given commit. If not specified, resets local checkout to be equal to the project on the platform"),
+				Value:       &params.CommitID,
 			},
 		},
 		func(ccmd *captain.Command, args []string) error {

--- a/internal/runners/reset/reset.go
+++ b/internal/runners/reset/reset.go
@@ -23,8 +23,8 @@ import (
 const local = "LOCAL"
 
 type Params struct {
-	Force  bool
-	Target string
+	Force    bool
+	CommitID string
 }
 
 type Reset struct {
@@ -67,7 +67,7 @@ func (r *Reset) Run(params *Params) error {
 
 	var commitID strfmt.UUID
 	switch {
-	case params.Target == "":
+	case params.CommitID == "":
 		latestCommit, err := model.BranchCommitID(r.project.Owner(), r.project.Name(), r.project.BranchName())
 		if err != nil {
 			return locale.WrapError(err, "err_reset_latest_commit", "Could not get latest commit ID")
@@ -81,22 +81,18 @@ func (r *Reset) Run(params *Params) error {
 		}
 		commitID = *latestCommit
 
-	case params.Target == local:
+	case params.CommitID == local:
 		localCommitID, err := localcommit.Get(r.project.Dir())
 		if err != nil {
 			return errs.Wrap(err, "Unable to get local commit")
 		}
 		commitID = localCommitID
 
-	case !strfmt.IsUUID(params.Target):
-		branch, err := model.BranchForProjectNameByName(r.project.Owner(), r.project.Name(), params.Target)
-		if err != nil {
-			return errs.Wrap(err, "Could not get branch")
-		}
-		commitID = strfmt.UUID(*branch.CommitID)
+	case !strfmt.IsUUID(params.CommitID):
+		return locale.NewInputError("err_reset_invalid_commitid", "Invalid commit ID")
 
 	default:
-		commitID = strfmt.UUID(params.Target)
+		commitID = strfmt.UUID(params.CommitID)
 
 		history, err := model.CommitHistoryFromID(commitID, r.auth)
 		if err != nil || len(history) == 0 {

--- a/test/integration/reset_int_test.go
+++ b/test/integration/reset_int_test.go
@@ -55,25 +55,6 @@ func (suite *ResetIntegrationTestSuite) TestReset() {
 	cp.ExpectNotExitCode(0)
 }
 
-func (suite *ResetIntegrationTestSuite) TestRevertToBranch() {
-	suite.OnlyRunForTags(tagsuite.Reset)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Branches#46c83477-d580-43e2-a0c6-f5d3677517f1", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("reset", "main", "-n")
-	cp.Expect("Successfully reset to commit: 35af7414-b44b-4fd7-aa93-2ecad337ed2b")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("reset", "does-not-exist")
-	cp.Expect("This project has no branch with label matching 'does-not-exist'")
-	cp.ExpectNotExitCode(0)
-}
-
 func (suite *ResetIntegrationTestSuite) TestJSON() {
 	suite.OnlyRunForTags(tagsuite.Reset, tagsuite.JSON)
 	ts := e2e.New(suite.T(), false)
@@ -84,7 +65,7 @@ func (suite *ResetIntegrationTestSuite) TestJSON() {
 	cp.Expect("Checked out")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("reset", "main", "-o", "json")
+	cp = ts.Spawn("reset", "35af7414-b44b-4fd7-aa93-2ecad337ed2b", "-o", "json")
 	cp.Expect(`{"commitID":"35af7414-b44b-4fd7-aa93-2ecad337ed2b"}`)
 	cp.ExpectExitCode(0)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2743" title="DX-2743" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2743</a>  Revert Passing a branch to `state reset`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
