### PR TITLE
Mark top-level "state-install" payload dir as legacy, but still check for it.

### DIFF
--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -316,7 +316,7 @@ func installationDir(ts *e2e.Session) string {
 
 func (suite *InstallerIntegrationTestSuite) SetupSuite() {
 	rootPath := environment.GetRootPathUnsafe()
-	localPayload := filepath.Join(rootPath, "build", "payload", constants.ToplevelInstallArchiveDir)
+	localPayload := filepath.Join(rootPath, "build", "payload", constants.LegacyToplevelInstallArchiveDir)
 	suite.Require().DirExists(localPayload, "locally generated payload exists")
 
 	installerExe := filepath.Join(localPayload, constants.StateInstallerCmd+osutils.ExeExtension)

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -492,8 +492,9 @@ const InstallerName = "State Installer"
 // StateExecutorCmd is the name of the state executor binary
 const StateExecutorCmd = "state-exec"
 
-// ToplevelInstallArchiveDir is the top-level directory for files in an installation archive
-const ToplevelInstallArchiveDir = "state-install"
+// LegacyToplevelInstallArchiveDir is the top-level directory for files in an installation archive
+// This constant will be removed in DX-2081.
+const LegacyToplevelInstallArchiveDir = "state-install"
 
 // FirstMultiFileStateToolVersion is the State Tool version that introduced multi-file updates
 const FirstMultiFileStateToolVersion = "0.29.0"

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -142,7 +142,11 @@ func (u *UpdateInstaller) DownloadAndUnpack() (string, error) {
 		return "", errs.Wrap(err, "Could not download and unpack update")
 	}
 
-	u.tmpDir = filepath.Join(tmpDir, constants.ToplevelInstallArchiveDir)
+	payloadDir := tmpDir
+	if legacyDir := filepath.Join(tmpDir, constants.LegacyToplevelInstallArchiveDir); fileutils.DirExists(legacyDir) {
+		payloadDir = legacyDir
+	}
+	u.tmpDir = payloadDir
 	return u.tmpDir, nil
 }
 

--- a/scripts/ci/payload-generator/main.go
+++ b/scripts/ci/payload-generator/main.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	defaultInputDir     = filepath.Join(environment.GetRootPathUnsafe(), "build")
-	defaultOutputDir    = filepath.Join(defaultInputDir, "payload", constants.ToplevelInstallArchiveDir)
+	defaultOutputDir    = filepath.Join(defaultInputDir, "payload", constants.LegacyToplevelInstallArchiveDir)
 	defaultOutputBinDir = filepath.Join(defaultOutputDir, "bin")
 
 	log = func(msg string, vals ...any) {

--- a/scripts/ci/update-generator/main.go
+++ b/scripts/ci/update-generator/main.go
@@ -25,7 +25,7 @@ import (
 var (
 	rootPath         = environment.GetRootPathUnsafe()
 	defaultBuildDir  = filepath.Join(rootPath, "build")
-	defaultInputDir  = filepath.Join(defaultBuildDir, "payload", constants.ToplevelInstallArchiveDir)
+	defaultInputDir  = filepath.Join(defaultBuildDir, "payload", constants.LegacyToplevelInstallArchiveDir)
 	defaultOutputDir = filepath.Join(rootPath, "public")
 )
 

--- a/test/integration/upgen_int_test.go
+++ b/test/integration/upgen_int_test.go
@@ -56,7 +56,7 @@ func (suite *UpdateGenIntegrationTestSuite) TestUpdateBits() {
 
 	cp.ExpectExitCode(0)
 
-	baseDir := filepath.Join(tempPath, constants.ToplevelInstallArchiveDir)
+	baseDir := filepath.Join(tempPath, constants.LegacyToplevelInstallArchiveDir)
 	suite.FileExists(filepath.Join(baseDir, installation.BinDirName, constants.StateCmd+osutils.ExeExtension))
 	suite.FileExists(filepath.Join(baseDir, installation.BinDirName, constants.StateSvcCmd+osutils.ExeExtension))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2734" title="DX-2734" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2734</a>  Prepare for getting rid of `state-install` root folder in our payloads
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
