### PR TITLE
On Linux, sort platform IDs by closest libc version to local libc version.

### DIFF
--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -2,7 +2,9 @@ package model
 
 import (
 	"fmt"
+	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -22,6 +24,7 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_client/inventory_operations"
 	"github.com/ActiveState/cli/pkg/platform/api/inventory/inventory_models"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/sysinfo"
 )
 
 func init() {
@@ -328,6 +331,7 @@ func filterPlatformIDs(hostPlatform, hostArch string, platformIDs []strfmt.UUID,
 
 	var pids []strfmt.UUID
 	var fallback []strfmt.UUID
+	libcMap := make(map[strfmt.UUID]float64)
 	for _, platformID := range platformIDs {
 		for _, rtPf := range runtimePlatforms {
 			if rtPf.PlatformID == nil || platformID != *rtPf.PlatformID {
@@ -343,9 +347,22 @@ func filterPlatformIDs(hostPlatform, hostArch string, platformIDs []strfmt.UUID,
 				continue
 			}
 
-			if libcVersion != "" && rtPf.LibcVersion != nil &&
-				rtPf.LibcVersion.Version != nil && libcVersion != *rtPf.LibcVersion.Version {
-				continue
+			if rtPf.LibcVersion != nil && rtPf.LibcVersion.Version != nil {
+				if libcVersion != "" && libcVersion != *rtPf.LibcVersion.Version {
+					continue
+				}
+				// Convert the libc version to a major-minor float and map it to the platform ID for
+				// subsequent comparisons.
+				regex := regexp.MustCompile(`^\d+\D\d+`)
+				versionString := regex.FindString(*rtPf.LibcVersion.Version)
+				if versionString == "" {
+					return nil, errs.New("Unable to parse libc string '%s'", *rtPf.LibcVersion.Version)
+				}
+				version, err := strconv.ParseFloat(versionString, 32)
+				if err != nil {
+					return nil, errs.Wrap(err, "libc version is not a number: %s", versionString)
+				}
+				libcMap[platformID] = version
 			}
 
 			platformArch := platformArchToHostArch(
@@ -364,14 +381,57 @@ func filterPlatformIDs(hostPlatform, hostArch string, platformIDs []strfmt.UUID,
 		}
 	}
 
-	if len(pids) > 0 {
-		return pids, nil
-	}
-	if len(fallback) > 0 {
-		return fallback, nil
+	if len(pids) == 0 && len(fallback) == 0 {
+		return nil, &ErrNoMatchingPlatform{hostPlatform, hostArch, libcVersion}
+	} else if len(pids) == 0 {
+		pids = fallback
 	}
 
-	return nil, &ErrNoMatchingPlatform{hostPlatform, hostArch, libcVersion}
+	if runtime.GOOS == "linux" {
+		// Sort platforms by closest matching libc version.
+		// Note: for macOS, the Platform gives a libc version based on libSystem, while sysinfo.Libc()
+		// returns the clang version, which is something different altogether. At this time, the pid
+		// list to return contains only one Platform, so sorting is not an issue and unnecessary.
+		// When it does become necessary, DX-2780 will address this.
+		// Note: the Platform does not specify libc on Windows, so this sorting is not applicable on
+		// Windows.
+		libc, err := sysinfo.Libc()
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to get system libc")
+		}
+		localLibc, err := strconv.ParseFloat(libc.Version(), 32)
+		if err != nil {
+			return nil, errs.Wrap(err, "Libc version is not a number: %s", libc.Version())
+		}
+		sort.SliceStable(pids, func(i, j int) bool {
+			libcI, existsI := libcMap[pids[i]]
+			libcJ, existsJ := libcMap[pids[j]]
+			less := false
+			switch {
+			case !existsI || !existsJ:
+				break
+			case localLibc >= libcI && localLibc >= libcJ:
+				// If both platform libc versions are less than to the local libc version, prefer the
+				// greater of the two.
+				less = libcI > libcJ
+			case localLibc < libcI && localLibc < libcJ:
+				// If both platform libc versions are greater than the local libc version, prefer the lesser
+				// of the two.
+				less = libcI < libcJ
+			case localLibc >= libcI && localLibc < libcJ:
+				// If only one of the platform libc versions is greater than local libc version, prefer the
+				// other one.
+				less = true
+			case localLibc < libcI && localLibc >= libcJ:
+				// If only one of the platform libc versions is greater than local libc version, prefer the
+				// other one.
+				less = false
+			}
+			return less
+		})
+	}
+
+	return pids, nil
 }
 
 func fetchLibcVersion(cfg Configurable) (string, error) {

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/go-openapi/strfmt"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
-	"github.com/ActiveState/cli/internal/logging"
 	configMediator "github.com/ActiveState/cli/internal/mediators/config"
-	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/pkg/platform/api"
 	hsInventory "github.com/ActiveState/cli/pkg/platform/api/hasura_inventory"
 	hsInventoryModel "github.com/ActiveState/cli/pkg/platform/api/hasura_inventory/model"
@@ -400,13 +399,10 @@ func filterPlatformIDs(hostPlatform, hostArch string, platformIDs []strfmt.UUID,
 		if err != nil {
 			return nil, errs.Wrap(err, "Unable to get system libc")
 		}
-		logging.Debug("Detected system libc: %v", libc)
 		localLibc, err := strconv.ParseFloat(libc.Version(), 32)
 		if err != nil {
 			return nil, errs.Wrap(err, "Libc version is not a number: %s", libc.Version())
 		}
-		logging.Debug("libcMap: %v", libcMap)
-		logging.Debug("Unsorted pids: %v", pids)
 		sort.SliceStable(pids, func(i, j int) bool {
 			libcI, existsI := libcMap[pids[i]]
 			libcJ, existsJ := libcMap[pids[j]]
@@ -433,7 +429,6 @@ func filterPlatformIDs(hostPlatform, hostArch string, platformIDs []strfmt.UUID,
 			}
 			return less
 		})
-		logging.Debug("Sorted pids: %v", pids)
 	}
 
 	return pids, nil

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/go-openapi/strfmt"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/logging"
 	configMediator "github.com/ActiveState/cli/internal/mediators/config"
+	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/pkg/platform/api"
 	hsInventory "github.com/ActiveState/cli/pkg/platform/api/hasura_inventory"
 	hsInventoryModel "github.com/ActiveState/cli/pkg/platform/api/hasura_inventory/model"
@@ -399,10 +400,13 @@ func filterPlatformIDs(hostPlatform, hostArch string, platformIDs []strfmt.UUID,
 		if err != nil {
 			return nil, errs.Wrap(err, "Unable to get system libc")
 		}
+		logging.Debug("Detected system libc: %v", libc)
 		localLibc, err := strconv.ParseFloat(libc.Version(), 32)
 		if err != nil {
 			return nil, errs.Wrap(err, "Libc version is not a number: %s", libc.Version())
 		}
+		logging.Debug("libcMap: %v", libcMap)
+		logging.Debug("Unsorted pids: %v", pids)
 		sort.SliceStable(pids, func(i, j int) bool {
 			libcI, existsI := libcMap[pids[i]]
 			libcJ, existsJ := libcMap[pids[j]]
@@ -429,6 +433,7 @@ func filterPlatformIDs(hostPlatform, hostArch string, platformIDs []strfmt.UUID,
 			}
 			return less
 		})
+		logging.Debug("Sorted pids: %v", pids)
 	}
 
 	return pids, nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2756" title="DX-2756" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2756</a>  Improve platform detection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Consider a Linux Platform project configured with the following libc's: `[2.17, 2.28]`:

System LibC | `state checkout` selects Platform project with LibC
-----------------|------------------
2.15 | 2.17
2.17 | 2.17
2.20 | 2.17
2.26 | 2.17
2.28 | 2.28
2.30 | 2.28