### PR TITLE
Switch back to a previous macos GitHub runner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           - 1.20.x
         sys:
           - {os: ubuntu-latest}
-          - {os: macos-latest, shell: zsh}
+          - {os: macos-12, shell: zsh}
           - {os: windows-2019}
       fail-fast: false
     runs-on: ${{ matrix.sys.os }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2777" title="DX-2777" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2777</a>  ST install fail on Mac
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

macos-11 is deprecated, but macos-12 is okay and should produce amd64 binaries instead of just arm ones.