### PR TITLE
Defined the color Orange for Windows console output.

### DIFF
--- a/internal/output/colorstyle/console_windows.go
+++ b/internal/output/colorstyle/console_windows.go
@@ -20,11 +20,13 @@ var consoleStyleMap = map[Style]uint16{
 	Black:   0,
 	Red:     consoleRed,
 	Green:   consoleGreen,
-	Yellow:  consoleRed | consoleGreen,
+	Yellow:  consoleRed | consoleGreen | consoleIntensity,
 	Blue:    consoleBlue,
 	Magenta: consoleRed | consoleBlue,
 	Cyan:    consoleGreen | consoleBlue,
-	White:   consoleRed | consoleGreen | consoleBlue}
+	White:   consoleRed | consoleGreen | consoleBlue,
+	Orange:  consoleRed | consoleGreen,
+}
 
 const (
 	consoleBlue      = uint16(0x0001)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2744" title="DX-2744" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2744</a>  `state languages install python@3.9` on Windows missing CVE severity 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


![image](https://github.com/ActiveState/cli/assets/12902397/52e35ee8-6675-4bcb-85ac-2dfa97b119bc)

The windows console does not have orange like the ansi consoles. Since the non-bolded/highlighted version of the mix between red and green (yellow) is more orange than the bolded/highlighted version of that color, I've named them orange and yellow, respectively.