### PR TITLE
Fixed local changes not being preferred when resolving merge conflict.

### DIFF
--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -136,7 +136,7 @@ func (p *Pull) Run(params *PullParams) (rerr error) {
 		resultCommit, mergeErr := bp.MergeCommit(params)
 		if mergeErr != nil {
 			logging.Debug("Merge with fast-forward failed with error: %s, trying recursive overwrite", mergeErr.Error())
-			strategy = bpModel.MergeCommitStrategyRecursiveOverwriteOnConflict
+			strategy = bpModel.MergeCommitStrategyRecursiveKeepOnConflict
 			c, err := p.performMerge(*remoteCommit, *localCommit, remoteProject, p.project.BranchName(), strategy)
 			if err != nil {
 				p.notifyMergeStrategy(anaConst.LabelVcsConflictMergeStrategyFailed, *localCommit, remoteProject)

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -71,7 +71,7 @@ func (suite *PullIntegrationTestSuite) TestPull_Merge() {
 	cp.Expect("Merged")
 	cp.ExpectExitCode(0)
 
-	suite.assertMergeStrategyNotification(ts, string(bpModel.MergeCommitStrategyRecursiveOverwriteOnConflict))
+	suite.assertMergeStrategyNotification(ts, string(bpModel.MergeCommitStrategyRecursiveKeepOnConflict))
 }
 
 func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
@@ -101,6 +101,8 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	suite.Require().NoError(err) // just verify it's a valid build script
 
 	cp = ts.Spawn("pull")
+	cp.Expect("The following changes will be merged")
+	cp.Expect("requests (2.30.0 → Auto)")
 	cp.Expect("Unable to automatically merge build scripts")
 	cp.ExpectNotExitCode(0)
 	ts.IgnoreLogErrors()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2796" title="DX-2796" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2796</a>  `state pull` says a merge will favor local changes, but it actually overwrites them
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
