### PR TITLE
Do not accidentally send a "revision = 0" buildexpression requirement field.

### DIFF
--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -111,7 +111,7 @@ var versionRe = regexp.MustCompile(`^\d(\.\d+)*$`)
 type Requirement struct {
 	Name          string
 	Version       string
-	Revision      int
+	Revision      *int
 	BitWidth      int // Only needed for platform requirements
 	Namespace     *model.Namespace
 	NamespaceType *model.NamespaceType
@@ -202,7 +202,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(ts *time.Time, requir
 		stageCommitReqs = append(stageCommitReqs, model.StageCommitRequirement{
 			Name:      requirement.Name,
 			Version:   requirement.versionRequirements,
-			Revision:  ptr.To(requirement.Revision),
+			Revision:  requirement.Revision,
 			Namespace: *requirement.Namespace,
 			Operation: requirement.Operation,
 		})

--- a/internal/runners/packages/install.go
+++ b/internal/runners/packages/install.go
@@ -46,9 +46,7 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 			req.NamespaceType = &nsType
 		}
 
-		if params.Revision.Int != nil {
-			req.Revision = *params.Revision.Int
-		}
+		req.Revision = params.Revision.Int
 
 		reqs = append(reqs, req)
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2765" title="DX-2765" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2765</a>  State pull creates merge conflict when there shouldn't be one
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
