### PR TITLE
Do not accidentally send a "revision = 0" buildexpression requirement field.

### DIFF
--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -113,7 +113,7 @@ var versionRe = regexp.MustCompile(`^\d(\.\d+)*$`)
 type Requirement struct {
 	Name          string
 	Version       string
-	Revision      int
+	Revision      *int
 	BitWidth      int // Only needed for platform requirements
 	Namespace     *model.Namespace
 	NamespaceType *model.NamespaceType
@@ -204,7 +204,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(ts *time.Time, requir
 		stageCommitReqs = append(stageCommitReqs, model.StageCommitRequirement{
 			Name:      requirement.Name,
 			Version:   requirement.versionRequirements,
-			Revision:  ptr.To(requirement.Revision),
+			Revision:  requirement.Revision,
 			Namespace: *requirement.Namespace,
 			Operation: requirement.Operation,
 		})

--- a/internal/runners/packages/install.go
+++ b/internal/runners/packages/install.go
@@ -46,9 +46,7 @@ func (a *Install) Run(params InstallRunParams, nsType model.NamespaceType) (rerr
 			req.NamespaceType = &nsType
 		}
 
-		if params.Revision.Int != nil {
-			req.Revision = *params.Revision.Int
-		}
+		req.Revision = params.Revision.Int
 
 		reqs = append(reqs, req)
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2806" title="DX-2806" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2806</a>  Get revision fix into v0.44
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Backported to v44 RC3. This was previously approved in https://github.com/ActiveState/cli/pull/3283, a v45 ticket.