### PR TITLE
Revert ':' namespace-name separator back to '/'.

### DIFF
--- a/internal/captain/values.go
+++ b/internal/captain/values.go
@@ -121,8 +121,8 @@ func (u *UsersValue) Type() string {
 
 // PackageValue represents a flag that supports specifying a package in the following formats:
 // - <name>
-// - <namespace>:<name>
-// - <namespace>:<name>@<version>
+// - <namespace>/<name>
+// - <namespace>/<name>@<version>
 type PackageValue struct {
 	Namespace string
 	Name      string
@@ -137,7 +137,7 @@ func (p *PackageValue) String() string {
 	}
 	name := p.Name
 	if p.Namespace != "" {
-		name = fmt.Sprintf("%s:%s", p.Namespace, p.Name)
+		name = fmt.Sprintf("%s/%s", p.Namespace, p.Name)
 	}
 	if p.Version == "" {
 		return name
@@ -151,12 +151,12 @@ func (p *PackageValue) Set(s string) error {
 		p.Version = strings.TrimSpace(v[1])
 		s = v[0]
 	}
-	if !strings.Contains(s, ":") {
+	if !strings.Contains(s, "/") {
 		p.Name = strings.TrimSpace(s)
 		return nil
 	}
-	v := strings.Split(s, ":")
-	p.Namespace = strings.TrimSpace(strings.Join(v[0:len(v)-1], ":"))
+	v := strings.Split(s, "/")
+	p.Namespace = strings.TrimSpace(strings.Join(v[0:len(v)-1], "/"))
 	p.Name = strings.TrimSpace(v[len(v)-1])
 	return nil
 }

--- a/internal/captain/values_test.go
+++ b/internal/captain/values_test.go
@@ -53,13 +53,13 @@ func TestPackageValue_Set(t *testing.T) {
 	}{
 		{
 			"namespace, name and version",
-			"namespace/path:name@1.0.0",
+			"namespace/path/name@1.0.0",
 			false,
 			&PackageValue{Namespace: "namespace/path", Name: "name", Version: "1.0.0"},
 		},
 		{
 			"namespace and name",
-			"namespace/path:name",
+			"namespace/path/name",
 			false,
 			&PackageValue{Namespace: "namespace/path", Name: "name"},
 		},
@@ -99,13 +99,13 @@ func TestPackageFlagNSRequired_Set(t *testing.T) {
 	}{
 		{
 			"namespace, name and version",
-			"namespace/path:name@1.0.0",
+			"namespace/path/name@1.0.0",
 			false,
 			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name", Version: "1.0.0"}},
 		},
 		{
 			"namespace and name",
-			"namespace/path:name",
+			"namespace/path/name",
 			false,
 			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name"}},
 		},

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1539,7 +1539,7 @@ uploadingredient_success:
     Revision: [ACTIONABLE]{{.V3}}[/RESET]
     Timestamp: [ACTIONABLE]{{.V4}}[/RESET]
 
-    You can install this package by running `[ACTIONABLE]state install {{.V1}}:{{.V0}} --ts now`[/RESET].
+    You can install this package by running `[ACTIONABLE]state install {{.V1}}/{{.V0}} --ts now`[/RESET].
 err_runtime_cache_invalid:
   other: Your runtime needs to be updated, please run '[ACTIONABLE]state refresh[/RESET]'.
 err_target_not_found:

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -762,27 +762,13 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Indirect() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "org/cli-integration-tests/language/python:django_dep", "--ts=now"),
+		e2e.OptArgs("install", "org/cli-integration-tests/language/python/django_dep", "--ts=now"),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectRe(`Warning: Dependency has \d indirect known vulnerabilities`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.Expect("Do you want to continue")
 	cp.SendLine("n")
 	cp.ExpectExitCode(1)
-}
-
-func (suite *InstallIntegrationTestSuite) TestNamespace() {
-	suite.OnlyRunForTags(tagsuite.Install)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
-	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("install", "language/python:requests"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Package added: requests", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectExitCode(0)
 }
 
 func TestPackageIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2812" title="DX-2812" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2812</a>  Revert colon separator for namespaces
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
