### PR TITLE
Show failed artifact error messages and logs in `state artifacts`.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1562,7 +1562,15 @@ commit_success:
 builds_dl_downloading:
   other: Downloading {{.V0}}
 warn_has_failed_artifacts:
-  other: "Warning: This project has failed builds, and some artifacts will be missing as a result.\n"
+  other: "[ERROR]Some artifacts failed to build. Please see error messages and logs above for further details.[/RESET]"
+artifact_status_failed:
+  other: Failed
+artifact_status_failed_message:
+  other: Message
+artifact_status_failed_log:
+  other: Log
+artifact_status_skipped:
+  other: Skipped
 artifact_status_building:
   other: Building
 warn_build_not_complete:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2751" title="DX-2751" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2751</a>  As a user I can run `state artifacts` and see what platforms/artifacts are failing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Sample:

![image](https://github.com/ActiveState/cli/assets/12902397/1936fca8-99dc-4117-81c2-5918e29a3be8)
