### PR TITLE
Do not consider locale-wrapped errors to be unexpected errors.

### DIFF
--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -699,7 +699,10 @@ func (c *Command) cobraExecHandler(cobraCmd *cobra.Command, args []string) (rerr
 		}
 
 		if err := c.execute(c, args); err != nil {
-			return locale.WrapError(err, "unexpected_error", "Command failed due to unexpected error. For your convenience, this is the error chain:\n{{.V0}}", errs.JoinMessage(err))
+			if !locale.IsError(err) {
+				return locale.WrapError(err, "unexpected_error", "Command failed due to unexpected error. For your convenience, this is the error chain:\n{{.V0}}", errs.JoinMessage(err))
+			}
+			return errs.Wrap(err, "execute failed")
 		}
 
 		for _, handler := range c.TopParent().onExecStop {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2770" title="DX-2770" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2770</a>  Improve "execute failed" error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I discovered an error in the previous implementation when there are `locale.NewInputError()`s. In that case, you'd get a chain that includes "unexpected error", but that's not true.