### PR TITLE
Fix autoupdate checks

### DIFF
--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -542,7 +542,9 @@ func (c *Command) Find(args []string) (*Command, error) {
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not find child command with args: %s", strings.Join(args, " "))
 	}
-	if cmd, ok := cobraMapping[foundCobra]; ok {
+	cmd, ok := cobraMapping[foundCobra]
+	// The cobra find command will return the parent command if the child command is not found.
+	if ok && cmd != c {
 		return cmd, nil
 	}
 	return nil, locale.NewError("err_captain_cmd_find", "Could not find child Command with args: {{.V0}}", strings.Join(args, " "))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2824" title="DX-2824" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2824</a>  `state --version` after install doesn't show version available
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This fixes a couple of issues but we should have some follow up work planned for a more robust fix.

I found that the cobra search command will return the parent command if it can't find an appropriate child, at least in the case of `state --version` it will strip the flag and return the parent command if there are no more arguments.

Since we want to run the autoupdate check for `state --version` we have to update the handling in `main.go`. In going through this I found that we have 3 separate checks for "Should we run autoupdate". These should be centralized however I didn't address this for the bug fix as this is targeting an RC4 that we would like to release soon.

Lastly, we check the modification time of the installed binary and will _not_ run the autoupdate if the file is less than 24 hours old. I did not modify that as part of this PR but I can if we no longer desire that behaviour.