### PR TITLE
Revert allowing a "reconfigure" installation.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -288,7 +288,6 @@ func execute(out output.Outputer, cfg *config.Instance, an analytics.Dispatcher,
 	}
 	// Older state tools did not bake in meta information, in this case we allow overwriting regardless of channel
 	targetingSameChannel := installedChannel == "" || installedChannel == constants.ChannelName
-	stateToolInstalledAndFunctional := stateToolInstalled && installationIsOnPATH(params.path) && targetingSameChannel
 
 	// If this is a fresh installation we ensure that the target directory is empty
 	if !stateToolInstalled && fileutils.DirExists(params.path) && !params.force {
@@ -310,9 +309,9 @@ func execute(out output.Outputer, cfg *config.Instance, an analytics.Dispatcher,
 	}
 	an.Event(anaConst.CatInstallerFunnel, route)
 
-	// Check if state tool already installed and functional
-	if stateToolInstalledAndFunctional && !params.isUpdate && !params.force {
-		logging.Debug("Cancelling out because State Tool is already installed and functional")
+	// Check if state tool already installed
+	if !params.isUpdate && !params.force && stateToolInstalled && !targetingSameChannel {
+		logging.Debug("Cancelling out because State Tool is already installed")
 		out.Print(fmt.Sprintf("State Tool Package Manager is already installed at [NOTICE]%s[/RESET]. To reinstall use the [ACTIONABLE]--force[/RESET] flag.", installPath))
 		an.Event(anaConst.CatInstallerFunnel, "already-installed")
 		params.isUpdate = true

--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -254,19 +254,3 @@ func installedOnPath(installRoot, channel string) (bool, string, error) {
 
 	return false, installRoot, nil
 }
-
-// installationIsOnPATH returns whether the installed State Tool root is on $PATH or %PATH%.
-func installationIsOnPATH(installRoot string) bool {
-	// This is not using appinfo on purpose because we want to deal with legacy installation formats, which appinfo does not
-	stateCmd := constants.StateCmd + osutils.ExeExtension
-
-	exeOnPATH := osutils.FindExeOnPATH(stateCmd)
-	if exeOnPATH == "" {
-		return false
-	}
-	onPATH, err := fileutils.PathContainsParent(exeOnPATH, installRoot)
-	if err != nil {
-		multilog.Error("Unable to determine if state tool on PATH is in path to install to: %v", err)
-	}
-	return onPATH
-}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2826" title="DX-2826" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2826</a>  Regression: Upgrade for same branch different version is stopped with `State Tool Package Manager is already installed` message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This is in direct conflict with [DX-2047](https://activestatef.atlassian.net/browse/DX-2047), which came after [DX-1189](https://activestatef.atlassian.net/browse/DX-1189) (the ticket this reverted code was for).

[DX-2047]: https://activestatef.atlassian.net/browse/DX-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1189]: https://activestatef.atlassian.net/browse/DX-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ