### PR TITLE
Do not fail a disallowed envdef merge if the two vars are ultimately equivalent.

### DIFF
--- a/pkg/platform/runtime/envdef/environment.go
+++ b/pkg/platform/runtime/envdef/environment.go
@@ -247,11 +247,14 @@ func (ev EnvironmentVariable) Merge(other EnvironmentVariable) (*EnvironmentVari
 	case Disallowed:
 		if len(ev.Values) != 1 || len(other.Values) != 1 || (ev.Values[0] != other.Values[0]) {
 			sep := string(ev.Separator)
-			return nil, fmt.Errorf(
-				"cannot merge environment definitions: no join strategy for variable %s with values %s and %s",
-				ev.Name,
-				strings.Join(ev.Values, sep), strings.Join(other.Values, sep),
-			)
+			// It's possible that the merged env vars will still be equal, so only error if they are not.
+			if strings.Join(ev.Values, sep) != strings.Join(other.Values, sep) {
+				return nil, fmt.Errorf(
+					"cannot merge environment definitions: no join strategy for variable %s with values %s and %s",
+					ev.Name,
+					strings.Join(ev.Values, sep), strings.Join(other.Values, sep),
+				)
+			}
 
 		}
 	default:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2808" title="DX-2808" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2808</a>  Updating python2 (camel) runtime leads to `cannot merge environment` error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
