### PR TITLE
Fix merge conflict from v44-RC5 to v45-RC1.

### DIFF
--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -2,7 +2,6 @@ package pull
 
 import (
 	"errors"
-	"path/filepath"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/analytics"
@@ -84,6 +83,14 @@ func (o *pullOutput) MarshalOutput(format output.Format) interface{} {
 
 func (o *pullOutput) MarshalStructured(format output.Format) interface{} {
 	return o
+}
+
+type ErrBuildScriptMergeConflict struct {
+	ProjectDir string
+}
+
+func (e *ErrBuildScriptMergeConflict) Error() string {
+	return "build script merge conflict"
 }
 
 func (p *Pull) Run(params *PullParams) (rerr error) {
@@ -174,16 +181,22 @@ func (p *Pull) Run(params *PullParams) (rerr error) {
 	}
 
 	if commitID != *resultingCommit {
-		err := localcommit.Set(p.project.Dir(), resultingCommit.String())
-		if err != nil {
-			return errs.Wrap(err, "Unable to set local commit")
-		}
-
 		if p.cfg.GetBool(constants.OptinBuildscriptsConfig) {
 			err := p.mergeBuildScript(*remoteCommit, *localCommit)
 			if err != nil {
+				if errs.Matches(err, &ErrBuildScriptMergeConflict{}) {
+					err2 := localcommit.Set(p.project.Dir(), remoteCommit.String())
+					if err2 != nil {
+						err = errs.Pack(err, errs.Wrap(err2, "Could not set local commit to remote commit after build script merge conflict"))
+					}
+				}
 				return errs.Wrap(err, "Could not merge local build script with remote changes")
 			}
+		}
+
+		err := localcommit.Set(p.project.Dir(), resultingCommit.String())
+		if err != nil {
+			return errs.Wrap(err, "Unable to set local commit")
 		}
 
 		p.out.Print(&pullOutput{
@@ -272,10 +285,7 @@ func (p *Pull) mergeBuildScript(remoteCommit, localCommit strfmt.UUID) error {
 		if err != nil {
 			return locale.WrapError(err, "err_diff_build_script", "Unable to generate differences between local and remote build script")
 		}
-		return locale.NewInputError(
-			"err_build_script_merge",
-			"Unable to automatically merge build scripts. Please resolve conflicts manually in '{{.V0}}' and then run '[ACTIONABLE]state commit[/RESET]'",
-			filepath.Join(p.project.Dir(), constants.BuildScriptFileName))
+		return &ErrBuildScriptMergeConflict{p.project.Dir()}
 	}
 
 	// Write the merged build expression as a local build script.

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -114,12 +114,14 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	suite.Assert().Contains(string(bytes), "=======", "No merge conflict markers are in build script")
 	suite.Assert().Contains(string(bytes), ">>>>>>>", "No merge conflict markers are in build script")
 
-	// Verify the local commit was updated to the merge commit.
-	// Note: even though the buildscript merge failed, a merge commit was still created. After resolving
-	// buildscript conflicts, `state commit` should have something new to commit.
+	// Verify the local commit was updated to the remote commit, not the merge commit.
+	// Note: even though the buildscript merge failed, a merge commit was still created (we just
+	// ignore it). After resolving buildscript conflicts, `state commit` should always have something
+	// new to commit.
+	remoteHeadCommit := "d908a758-6a81-40d4-b0eb-87069cd7f07d"
 	commit, err := localcommit.Get(ts.Dirs.Work)
 	suite.Require().NoError(err)
-	suite.Assert().NotEqual(commit.String(), "447b8363-024c-4143-bf4e-c96989314fdf", "localcommit not updated to merged commit")
+	suite.Assert().Equal(remoteHeadCommit, commit.String(), "localcommit should have been updated to remote commit")
 }
 
 func (suite *PullIntegrationTestSuite) assertMergeStrategyNotification(ts *e2e.Session, strategy string) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2842" title="DX-2842" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2842</a>  Merge commit and manual conflict created at same time
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The merge conflict was in `rationalize.go`. A new `errNoCommonParent` error and select `case` was introduced in v45 so in order to resolve the conflict I kept both local and incoming changes.