### PR TITLE
Improve installer error messages

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -130,7 +130,12 @@ fi
 # Fetch version info.
 $FETCH $INSTALLERTMPDIR/info.json $JSONURL
 if [ $? -ne 0 -o ! -z "`grep -o Invalid $INSTALLERTMPDIR/info.json`" ]; then
-	error "Could not download a State Tool installer for the given command line arguments"
+  error_message=$(grep -o '"message":"[^"]*"' $INSTALLERTMPDIR/info.json | cut -d':' -f2 | sed 's/"//g')
+  if [ -n "$error_message" ]; then
+    error "Could not download a State Tool installer, recieved error message: $error_message"
+  else
+      error "Could not download a State Tool installer for the given command line arguments"
+  fi
 	exit 1
 fi
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2787" title="DX-2787" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2787</a>  Improve error message while can't find the requested branch or version
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This updates both the `install.sh` and `install.ps1` to relay the error message from the installer service. It produces the following outputs.

```
❯ ./installers/install.sh -b version/bogus
Fetching URL: https://platform.activestate.com/sv/state-update/api/v1/info?channel=version/bogus&source=install&platform=windows
Using command curl -sS -o
Could not download a State Tool installer, recieved error message: Invalid channel, platform or target-version
```

```
C:\Users\Mike\work\cli>powershell -Command "& .\installers\install.ps1" -b version/bogus
Could not download, retrying...
Could not download, retrying...
Could not download, retrying...
Could not download, retrying...
Could not download, retrying...
Could not download, retrying...
download : Could not download after 5 retries. Received error: Invalid channel, platform or target-version
At C:\Users\Mike\work\cli\installers\install.ps1:170 char:48
+     $infoJson = ConvertFrom-Json -InputObject (download $jsonURL)
+                                                ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,download
 
C:\Users\Mike\work\cli\installers\install.ps1 : Unable to retrieve the latest version number
At line:1 char:1
+ & .\installers\install.ps1 -b version/bogus
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,install.ps1
 
C:\Users\Mike\work\cli\installers\install.ps1 : Exception of type 'Microsoft.PowerShell.Commands.WriteErrorException' was thrown.
At line:1 char:1
+ & .\installers\install.ps1 -b version/bogus
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,install.ps1
```