### PR TITLE
Fix `state reset LOCAL` buildscript failure

### DIFF
--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -2,11 +2,12 @@ package runtime
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/ActiveState/cli/internal/runbits/buildscript"
+	buildscript_runbit "github.com/ActiveState/cli/internal/runbits/buildscript"
 	"github.com/ActiveState/cli/pkg/buildplan"
 	bpResp "github.com/ActiveState/cli/pkg/platform/api/buildplanner/response"
 	bpModel "github.com/ActiveState/cli/pkg/platform/model/buildplanner"
@@ -120,6 +121,7 @@ func (r *Runtime) NeedsUpdate() bool {
 }
 
 func (r *Runtime) validateCache() error {
+	fmt.Println("Validating cache")
 	if r.target.ProjectDir() == "" {
 		return nil
 	}
@@ -168,12 +170,12 @@ func (r *Runtime) validateBuildScript() error {
 		}
 	}
 
-	equals, err := script.Equals(cachedScript)
-	if err != nil {
-		return errs.Wrap(err, "Could not compare buildscript")
-	}
-
 	if cachedScript != nil {
+		equals, err := script.Equals(cachedScript)
+		if err != nil {
+			return errs.Wrap(err, "Could not compare buildscript")
+		}
+
 		if script != nil && !equals {
 			return NeedsCommitError
 		}

--- a/pkg/platform/runtime/runtime.go
+++ b/pkg/platform/runtime/runtime.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +120,6 @@ func (r *Runtime) NeedsUpdate() bool {
 }
 
 func (r *Runtime) validateCache() error {
-	fmt.Println("Validating cache")
 	if r.target.ProjectDir() == "" {
 		return nil
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2814" title="DX-2814" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2814</a>  User advised to run `state reset Local` due to missing its buildscript file and fail with `Invalid commit ID`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I couldn't reproduce the `Invalid commit ID` error that Mark ran into however I did run into a panic while trying to repro. This PR fixes it.