### PR TITLE
Change error message when trying to make a commit with no buildscript changes.

### DIFF
--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -61,7 +61,7 @@ func rationalizeError(err *error) {
 	case errors.Is(*err, ErrNoChanges):
 		*err = errs.WrapUserFacing(*err, locale.Tl(
 			"commit_notice_no_change",
-			"No change to the buildscript was found.",
+			"Your buildscript contains no new changes. No commit necessary.",
 		), errs.SetInput())
 
 	case errs.Matches(*err, buildscript_runbit.ErrBuildscriptNotExist):

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -34,7 +34,7 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	suite.Require().NoError(err) // verify validity
 
 	cp := ts.Spawn("commit")
-	cp.Expect("No change")
+	cp.Expect("no new changes")
 	cp.ExpectExitCode(1)
 
 	_, err = buildscript_runbit.ScriptFromProject(proj)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2841" title="DX-2841" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2841</a>  As a user I can expect `state commit` to tell me when I have nothing new to commit
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
