### PR TITLE
Do not report silent installer errors to Rollbar.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -215,7 +215,9 @@ func main() {
 	an.Event(anaConst.CatInstallerFunnel, "pre-exec")
 	err = cmd.Execute(processedArgs[1:])
 	if err != nil {
-		errors.ReportError(err, cmd, an)
+		if !errs.IsSilent(err) {
+			errors.ReportError(err, cmd, an)
+		}
 		if locale.IsInputError(err) {
 			an.EventWithLabel(anaConst.CatInstaller, "input-error", errs.JoinMessage(err))
 			logging.Debug("Installer input error: " + errs.JoinMessage(err))

--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -215,9 +215,7 @@ func main() {
 	an.Event(anaConst.CatInstallerFunnel, "pre-exec")
 	err = cmd.Execute(processedArgs[1:])
 	if err != nil {
-		if !errs.IsSilent(err) {
-			errors.ReportError(err, cmd, an)
-		}
+		errors.ReportError(err, cmd, an)
 		if locale.IsInputError(err) {
 			an.EventWithLabel(anaConst.CatInstaller, "input-error", errs.JoinMessage(err))
 			logging.Debug("Installer input error: " + errs.JoinMessage(err))

--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -163,14 +163,6 @@ func main() {
 	err = cmd.Execute(os.Args[1:])
 	if err != nil {
 		errors.ReportError(err, cmd, an)
-		if locale.IsInputError(err) {
-			logging.Error("Installer input error: " + errs.JoinMessage(err))
-		} else if errs.IsExternalError(err) {
-			logging.Error("Installer external error: " + errs.JoinMessage(err))
-		} else {
-			multilog.Critical("Installer error: " + errs.JoinMessage(err))
-		}
-
 		exitCode, err = errors.ParseUserFacing(err)
 		if err != nil {
 			out.Error(err)

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -252,7 +252,7 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 	}
 
 	err = cmds.Execute(args[1:])
-	if err != nil && !errs.IsSilent(err) {
+	if err != nil {
 		cmdName := ""
 		if childCmd != nil {
 			cmdName = childCmd.JoinedSubCommandNames() + " "

--- a/internal/runbits/errors/errors.go
+++ b/internal/runbits/errors/errors.go
@@ -225,5 +225,5 @@ func ReportError(err error, cmd *captain.Command, an analytics.Dispatcher) {
 }
 
 func IsReportableError(err error) bool {
-	return !locale.IsInputError(err) && !errs.IsExternalError(err)
+	return !locale.IsInputError(err) && !errs.IsExternalError(err) && !errs.IsSilent(err)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2862" title="DX-2862" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2862</a>  Silenced errors should not be reported to rollbar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
There is a question of how we want to report silent errors to analytics. Right now, it reports "error" to the CatInstaller label, and "fail" to the CatInstallerFunnel label. If this is okay, then no further action is needed. Otherwise, please let me know.