### PR TITLE
Fix `state exec` not working when `optin.unstable.async_runtime` is enabled.

### DIFF
--- a/internal/runbits/runtime/refresh.go
+++ b/internal/runbits/runtime/refresh.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"strings"
+
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -40,9 +42,8 @@ type Configurable interface {
 	GetBool(key string) bool
 }
 
-var overrideAsyncTriggers = map[target.Trigger]bool{
+var overrideAsyncTriggersMap = map[target.Trigger]bool{
 	target.TriggerRefresh:  true,
-	target.TriggerExec:     true,
 	target.TriggerActivate: true,
 	target.TriggerShell:    true,
 	target.TriggerScript:   true,
@@ -72,7 +73,7 @@ func SolveAndUpdate(
 		return nil, rationalize.ErrHeadless
 	}
 
-	if cfg.GetBool(constants.AsyncRuntimeConfig) && !overrideAsyncTriggers[trigger] {
+	if cfg.GetBool(constants.AsyncRuntimeConfig) && !overrideAsyncTriggers(trigger) {
 		logging.Debug("Skipping runtime solve due to async runtime")
 		return nil, nil
 	}
@@ -109,6 +110,10 @@ func SolveAndUpdate(
 	}
 
 	return rt, nil
+}
+
+func overrideAsyncTriggers(trigger target.Trigger) bool {
+	return overrideAsyncTriggersMap[trigger] || strings.HasPrefix(string(trigger), string(target.TriggerExec))
 }
 
 func Solve(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2868" title="DX-2868" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2868</a>  `state exec` throws nil pointer error when `optin.unstable.async_runtime` is enabled.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
