### PR TITLE
Fixed help section groupings.

### DIFF
--- a/cmd/state/internal/cmdtree/cmdtree.go
+++ b/cmd/state/internal/cmdtree/cmdtree.go
@@ -239,10 +239,10 @@ var (
 	ProjectUsageGroup     = captain.NewCommandGroup(locale.Tl("group_project_usages", "Project Usage"), 8)
 	PackagesGroup         = captain.NewCommandGroup(locale.Tl("group_packages", "Package Management"), 7)
 	PlatformGroup         = captain.NewCommandGroup(locale.Tl("group_tools", "Platform"), 6)
-	VCSGroup              = captain.NewCommandGroup(locale.Tl("group_vcs", "Version Control"), 5)
-	AutomationGroup       = captain.NewCommandGroup(locale.Tl("group_automation", "Automation"), 4)
-	UtilsGroup            = captain.NewCommandGroup(locale.Tl("group_utils", "Utilities"), 3)
-	AuthorGroup           = captain.NewCommandGroup(locale.Tl("group_author", "Author"), 6)
+	AuthorGroup           = captain.NewCommandGroup(locale.Tl("group_author", "Author"), 5)
+	VCSGroup              = captain.NewCommandGroup(locale.Tl("group_vcs", "Version Control"), 4)
+	AutomationGroup       = captain.NewCommandGroup(locale.Tl("group_automation", "Automation"), 3)
+	UtilsGroup            = captain.NewCommandGroup(locale.Tl("group_utils", "Utilities"), 2)
 )
 
 func newGlobalOptions() *globalOptions {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2858" title="DX-2858" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2858</a>  `state --help` shows `Platform` section twice
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
AuthorGroup and PlatformGroup were sharing the same index, resulting in an order clash.