### PR TITLE
Notify the user when the remote installer is running the downloaded installer.

### DIFF
--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -210,6 +210,7 @@ func execute(out output.Outputer, prompt prompt.Prompter, cfg *config.Instance, 
 	}
 	out.Print(locale.Tl("remote_install_status_done", "[SUCCESS]✔ Done[/RESET]"))
 
+	out.Print(locale.Tl("remote_install_status_running", "• Running Installer..."))
 	if params.nonInteractive {
 		args = append(args, "-n") // forward to installer
 	}

--- a/test/integration/remote_installer_int_test.go
+++ b/test/integration/remote_installer_int_test.go
@@ -67,6 +67,8 @@ func (suite *RemoteInstallIntegrationTestSuite) TestInstall() {
 
 			cp.Expect("Terms of Service")
 			cp.SendLine("Y")
+			cp.Expect("Downloading")
+			cp.Expect("Running Installer...")
 			cp.Expect("Installing")
 			cp.Expect("Installation Complete")
 			cp.Expect("Press ENTER to exit")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2854" title="DX-2854" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2854</a>  Installer makes me wait for a suprisingly long download step before telling me that the state tool is already installed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
