### PR TITLE
Fixed error message for invalid commit ID given to `state artifacts`.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1514,6 +1514,8 @@ err_country_blocked:
   other: This service is not available in your region.
 err_commit_id_invalid:
   other: "Your activestate.yaml contains an invalid commit ID: '{{.V0}}'. Please run '[ACTIONABLE]state reset[/RESET]' to fix it."
+err_commit_id_invalid_given:
+  other: "Invalid commit ID: '{{.V0}}'."
 err_shortcutdir_writable:
   other: Could not continue as we don't have permission to create [ACTIONABLE]{{.V0}}[/RESET].
 move_prompt:

--- a/internal/runners/artifacts/rationalize.go
+++ b/internal/runners/artifacts/rationalize.go
@@ -22,7 +22,7 @@ func rationalizeCommonError(err *error, auth *authentication.Auth) {
 
 	case errors.As(*err, &invalidCommitIdErr):
 		*err = errs.WrapUserFacing(
-			*err, locale.Tr("err_commit_id_invalid", invalidCommitIdErr.id),
+			*err, locale.Tr("err_commit_id_invalid_given", invalidCommitIdErr.id),
 			errs.SetInput())
 
 	case errors.As(*err, &projectNotFoundErr):


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2856" title="DX-2856" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2856</a>  ARTIFACTS: When providing wrong commit ID we get wrong error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
