### PR TITLE
Wrapped lines should match indentation of first line.

### DIFF
--- a/internal/colorize/cropped.go
+++ b/internal/colorize/cropped.go
@@ -1,5 +1,9 @@
 package colorize
 
+import (
+	"regexp"
+)
+
 type CroppedLines []CroppedLine
 
 type CroppedLine struct {
@@ -16,7 +20,15 @@ func (c CroppedLines) String() string {
 	return result
 }
 
+var indentRegexp = regexp.MustCompile(`^([ ]+)`)
+
 func GetCroppedText(text string, maxLen int, includeLineEnds bool) CroppedLines {
+	indent := ""
+	if indentMatch := indentRegexp.FindStringSubmatch(text); indentMatch != nil {
+		indent = indentMatch[0]
+		maxLen -= len(indent)
+	}
+
 	entries := make([]CroppedLine, 0)
 	colorCodes := colorRx.FindAllStringSubmatchIndex(text, -1)
 
@@ -55,7 +67,7 @@ func GetCroppedText(text string, maxLen int, includeLineEnds bool) CroppedLines 
 				}
 				// Extract the word from the current line if it doesn't start the line.
 				if i > 0 && i < len(entry.Line)-1 {
-					wrapped = entry.Line[i:]
+					wrapped = indent + entry.Line[i:]
 					entry.Line = entry.Line[:i]
 					entry.Length -= wrappedLength
 					isLineEnd = true // emulate for wrapping purposes

--- a/internal/runbits/dependencies/changesummary.go
+++ b/internal/runbits/dependencies/changesummary.go
@@ -63,7 +63,7 @@ func OutputChangeSummary(out output.Outputer, newBuildPlan *buildplan.BuildPlan,
 	if numIndirect > 0 {
 		localeKey = "additional_total_dependencies"
 	}
-	out.Notice(locale.Tr(localeKey, strings.Join(addedLocale, ", "), strconv.Itoa(len(directDependencies)), strconv.Itoa(numIndirect)))
+	out.Notice("   " + locale.Tr(localeKey, strings.Join(addedLocale, ", "), strconv.Itoa(len(directDependencies)), strconv.Itoa(numIndirect)))
 
 	// A direct dependency list item is of the form:
 	//   ├─ name@version (X dependencies)
@@ -72,9 +72,9 @@ func OutputChangeSummary(out output.Outputer, newBuildPlan *buildplan.BuildPlan,
 	// depending on whether or not it has subdependencies, and whether or not showUpdatedPackages is
 	// `true`.
 	for i, ingredient := range directDependencies {
-		prefix := "├─"
+		prefix := " ├─"
 		if i == len(directDependencies)-1 {
-			prefix = "└─"
+			prefix = " └─"
 		}
 
 		ingredientDeps := ingredient.RuntimeDependencies(true)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2856" title="DX-2856" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2856</a>  ARTIFACTS: When providing wrong commit ID we get wrong error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Sample output:

```
% ../../cli/build/state install pytorch
█ Installing Package

Operating on project mitchell-as/newpy, located at 
/Users/mitchellb/tmp/newpy.

 • Searching for pytorch in the ActiveState Catalog ✔ Found
 • Creating commit ✔ Done
 • Resolving Dependencies ✔ Done
   Installing libmkl@2020.4, six@1.16.0, pyyaml@6.0.1, 
   torch-binary@1.13.0, pytorch-linux@1.13.0, 
   mkl-linux@2020.4.304, mkl-mac@2020.4.301, mkl-win@2020.4.311, 
   pytorch-win64@1.13.0, wheel@0.42.0, pytorch@1.13.0, 
   flit-core@3.9.0, astunparse@1.6.3, typing-extensions@4.11.0, 
   numpy@1.26.4 includes 47 direct dependencies.
   ├─ astunparse@1.6.3 (420 dependencies)
   ├─ brotli@1.1.0 (420 dependencies)
   ├─ bzip2@1.0.8 (420 dependencies)
   ├─ certifi@2024.2.2 (420 dependencies)
   ├─ charset-normalizer@3.3.2 (420 dependencies)
   ├─ expat@2.6.0 (420 dependencies)
   ├─ ffi@3.4.4 (420 dependencies)
   ├─ flit-core@3.9.0 (420 dependencies)
   ├─ fontconfig@2.15.0 (420 dependencies)
   ├─ freetype2@2.13.0 (420 dependencies)
   ├─ gperf@3.1 (420 dependencies)
   ├─ idna@3.7 (420 dependencies)
   ├─ libX11@1.8.7 (420 dependencies)
   ├─ libXau@1.0.9 (420 dependencies)
   ├─ libXdmcp@1.1.3 (420 dependencies)
   ├─ libXext@1.3.4 (420 dependencies)
   ├─ libmkl@2020.4 (420 dependencies)
   ├─ libpng@1.6.42 (420 dependencies)
   ├─ libpthread-stubs@0.1 (420 dependencies)
   ├─ libxcb@1.15 (420 dependencies)
   ├─ libxcrypt@4.4.23 (420 dependencies)
   ├─ lzma@5.2.4 (420 dependencies)
   ├─ mkl-linux@2020.4.304 (420 dependencies)
   ├─ mkl-mac@2020.4.301
   ├─ mozilla-ca-cert-bundle@2022-04-26 (420 dependencies)
   ├─ ncurses@6.4.20240302 (420 dependencies)
   ├─ numpy@1.26.4 (420 dependencies)
   ├─ openssl@3.3.0 (420 dependencies)
   ├─ python@3.10.14 (420 dependencies)
   ├─ pytorch@1.13.0 (420 dependencies)
   ├─ pytorch-linux@1.13.0 (420 dependencies)
   ├─ pytorch-win64@1.13.0
   ├─ pyyaml@6.0.1 (420 dependencies)
   ├─ readline@8.2.10 (420 dependencies)
   ├─ requests@2.30.0 (420 dependencies)
   ├─ six@1.16.0 (420 dependencies)
   ├─ sqlite3@3.45.1 (420 dependencies)
   ├─ tcltktix@8.6.14 (420 dependencies)
   ├─ torch-binary@1.13.0
   ├─ typing-extensions@4.11.0 (420 dependencies)
   ├─ urllib3@2.2.1 (420 dependencies)
   ├─ wheel@0.42.0 (420 dependencies)
   ├─ x11-util-macros@1.19.3 (420 dependencies)
   ├─ xcb-proto@1.15.2 (420 dependencies)
   ├─ xorgproto@2022.1 (420 dependencies)
   ├─ xtrans@1.4.0 (420 dependencies)
   └─ zlib@1.3.1 (420 dependencies)
```