### PR TITLE
Indent CVE summaries

### DIFF
--- a/internal/colorize/cropped.go
+++ b/internal/colorize/cropped.go
@@ -2,6 +2,7 @@ package colorize
 
 import (
 	"regexp"
+	"strings"
 )
 
 type CroppedLines []CroppedLine
@@ -26,6 +27,9 @@ func GetCroppedText(text string, maxLen int, includeLineEnds bool) CroppedLines 
 	indent := ""
 	if indentMatch := indentRegexp.FindStringSubmatch(text); indentMatch != nil {
 		indent = indentMatch[0]
+		if len(text) > len(indent) && strings.HasPrefix(text[len(indent):], "• ") {
+			indent += "  "
+		}
 		maxLen -= len(indent)
 	}
 

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1308,9 +1308,9 @@ warning_vulnerable_directonly:
   other: |
     [ERROR]Warning: Dependency has {{.V0}} known vulnerabilities (CVEs)[/RESET]
 more_info_vulnerabilities:
-  other: |
-    For more information on these vulnerabilities run '[ACTIONABLE]state security open <ID>[/RESET]'.
-    To disable prompting for vulnerabilities run '[ACTIONABLE]state config set security.prompt.enable false[/RESET]'.
+  other: For more information on these vulnerabilities run '[ACTIONABLE]state security open <ID>[/RESET]'.
+disable_prompting_vulnerabilities:
+  other: To disable prompting for vulnerabilities run '[ACTIONABLE]state config set security.prompt.enable false[/RESET]'.
 prompt_continue_pkg_operation:
   other: |
     Do you want to continue installing this dependency despite its vulnerabilities?

--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -704,11 +704,11 @@ func (r *RequirementOperation) summarizeCVEs(out output.Outputer, vulnerabilitie
 
 	switch {
 	case vulnerabilities.CountPrimary == 0:
-		out.Print(locale.Tr("warning_vulnerable_indirectonly", strconv.Itoa(vulnerabilities.Count)))
+		out.Print("   " + locale.Tr("warning_vulnerable_indirectonly", strconv.Itoa(vulnerabilities.Count)))
 	case vulnerabilities.CountPrimary == vulnerabilities.Count:
-		out.Print(locale.Tr("warning_vulnerable_directonly", strconv.Itoa(vulnerabilities.Count)))
+		out.Print("   " + locale.Tr("warning_vulnerable_directonly", strconv.Itoa(vulnerabilities.Count)))
 	default:
-		out.Print(locale.Tr("warning_vulnerable", strconv.Itoa(vulnerabilities.CountPrimary), strconv.Itoa(vulnerabilities.Count-vulnerabilities.CountPrimary)))
+		out.Print("   " + locale.Tr("warning_vulnerable", strconv.Itoa(vulnerabilities.CountPrimary), strconv.Itoa(vulnerabilities.Count-vulnerabilities.CountPrimary)))
 	}
 
 	printVulnerabilities := func(vulnerableIngredients model.VulnerableIngredientsByLevel, name, color string) {
@@ -721,7 +721,7 @@ func (r *RequirementOperation) summarizeCVEs(out output.Outputer, vulnerabilitie
 				}
 				ings = append(ings, fmt.Sprintf("%s[CYAN]%s[/RESET]", prefix, strings.Join(vulns.CVEIDs, ", ")))
 			}
-			out.Print(fmt.Sprintf(" • [%s]%d %s:[/RESET] %s", color, vulnerableIngredients.Count, name, strings.Join(ings, ", ")))
+			out.Print(fmt.Sprintf("    • [%s]%d %s:[/RESET] %s", color, vulnerableIngredients.Count, name, strings.Join(ings, ", ")))
 		}
 	}
 
@@ -731,7 +731,8 @@ func (r *RequirementOperation) summarizeCVEs(out output.Outputer, vulnerabilitie
 	printVulnerabilities(vulnerabilities.Low, locale.Tl("cve_low", "Low"), "MAGENTA")
 
 	out.Print("")
-	out.Print(locale.T("more_info_vulnerabilities"))
+	out.Print("   " + locale.T("more_info_vulnerabilities"))
+	out.Print("   " + locale.T("disable_prompting_vulnerabilities"))
 }
 
 func (r *RequirementOperation) promptForSecurity() (bool, error) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2865" title="DX-2865" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2865</a>  CVE information should be indented when installing packages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Sample:

```
   └─ zlib@1.3.1 (636 dependencies)

 • Searching for new vulnerabilities (CVEs) on pytorch and any dependencies x Unsafe

   Warning: Dependency has 1 direct and 3 indirect known vulnerabilities 
   (CVEs)
    • 1 Critical: pytorch@1.13.0: CVE-2022-45907
    • 1 High: python@3.10.14: CVE-2023-36632
    • 2 Medium: requests@2.30.0: CVE-2023-32681, python@3.10.14: 
      CVE-2023-27043

   For more information on these vulnerabilities run 'state security open 
   <ID>'.
   To disable prompting for vulnerabilities run 'state config set 
   security.prompt.enable false'.

█ Updating Runtime
```