### PR TITLE
[SNOW] Use ':' as a package namespace separator instead of '/'.

### DIFF
--- a/internal/captain/values.go
+++ b/internal/captain/values.go
@@ -121,8 +121,8 @@ func (u *UsersValue) Type() string {
 
 // PackageValue represents a flag that supports specifying a package in the following formats:
 // - <name>
-// - <namespace>/<name>
-// - <namespace>/<name>@<version>
+// - <namespace>:<name>
+// - <namespace>:<name>@<version>
 type PackageValue struct {
 	Namespace string
 	Name      string
@@ -137,7 +137,7 @@ func (p *PackageValue) String() string {
 	}
 	name := p.Name
 	if p.Namespace != "" {
-		name = fmt.Sprintf("%s/%s", p.Namespace, p.Name)
+		name = fmt.Sprintf("%s:%s", p.Namespace, p.Name)
 	}
 	if p.Version == "" {
 		return name
@@ -151,12 +151,12 @@ func (p *PackageValue) Set(s string) error {
 		p.Version = strings.TrimSpace(v[1])
 		s = v[0]
 	}
-	if !strings.Contains(s, "/") {
+	if !strings.Contains(s, ":") {
 		p.Name = strings.TrimSpace(s)
 		return nil
 	}
-	v := strings.Split(s, "/")
-	p.Namespace = strings.TrimSpace(strings.Join(v[0:len(v)-1], "/"))
+	v := strings.Split(s, ":")
+	p.Namespace = strings.TrimSpace(strings.Join(v[0:len(v)-1], ":"))
 	p.Name = strings.TrimSpace(v[len(v)-1])
 	return nil
 }

--- a/internal/captain/values_test.go
+++ b/internal/captain/values_test.go
@@ -53,13 +53,13 @@ func TestPackageValue_Set(t *testing.T) {
 	}{
 		{
 			"namespace, name and version",
-			"namespace/path/name@1.0.0",
+			"namespace/path:name@1.0.0",
 			false,
 			&PackageValue{Namespace: "namespace/path", Name: "name", Version: "1.0.0"},
 		},
 		{
 			"namespace and name",
-			"namespace/path/name",
+			"namespace/path:name",
 			false,
 			&PackageValue{Namespace: "namespace/path", Name: "name"},
 		},
@@ -99,13 +99,13 @@ func TestPackageFlagNSRequired_Set(t *testing.T) {
 	}{
 		{
 			"namespace, name and version",
-			"namespace/path/name@1.0.0",
+			"namespace/path:name@1.0.0",
 			false,
 			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name", Version: "1.0.0"}},
 		},
 		{
 			"namespace and name",
-			"namespace/path/name",
+			"namespace/path:name",
 			false,
 			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name"}},
 		},

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -746,7 +746,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Indirect() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "private/ActiveState-CLI-Testing/language/python/django_dep", "--ts=now"),
+		e2e.OptArgs("install", "org/cli-integration-tests/language/python:django_dep", "--ts=now"),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectRe(`Warning: Dependency has \d indirect known vulnerabilities`, e2e.RuntimeSourcingTimeoutOpt)
@@ -755,30 +755,16 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Indirect() {
 	cp.ExpectExitCode(1)
 }
 
-func (suite *PackageIntegrationTestSuite) TestChangeSummary() {
-	suite.OnlyRunForTags(tagsuite.Package)
+func (suite *InstallIntegrationTestSuite) TestNamespace() {
+	suite.OnlyRunForTags(tagsuite.Install)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
-	cp.Expect("Successfully set")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
-
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "requests@2.31.0"),
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("install", "language/python:requests"),
 		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Resolving Dependencies")
-	cp.Expect("Done")
-	cp.Expect("Installing requests@2.31.0 includes 4 direct dependencies")
-	cp.Expect("├─ ")
-	cp.Expect("├─ ")
-	cp.Expect("├─ ")
-	cp.Expect("└─ ")
 	cp.Expect("Package added: requests", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2708" title="DX-2708" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2708</a>  Our commands parse the namespace via a colon separator
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also added an integration test for it.