### PR TITLE
Only show requested packages in change summary.

### DIFF
--- a/internal/runbits/dependencies/changesummary.go
+++ b/internal/runbits/dependencies/changesummary.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-openapi/strfmt"
-
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
@@ -23,10 +21,7 @@ const showUpdatedPackages = true
 // OutputChangeSummary looks over the given build plans, and computes and lists the additional
 // dependencies being installed for the requested packages, if any.
 func OutputChangeSummary(out output.Outputer, newBuildPlan *buildplan.BuildPlan, oldBuildPlan *buildplan.BuildPlan) {
-	requested := make(map[strfmt.UUID]bool)
-	for _, a := range newBuildPlan.RequestedArtifacts() {
-		requested[a.ArtifactID] = true
-	}
+	requested := newBuildPlan.RequestedArtifacts().ToIDMap()
 
 	addedString := []string{}
 	addedLocale := []string{}

--- a/internal/runbits/dependencies/changesummary.go
+++ b/internal/runbits/dependencies/changesummary.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-openapi/strfmt"
+
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
@@ -21,18 +23,23 @@ const showUpdatedPackages = true
 // OutputChangeSummary looks over the given build plans, and computes and lists the additional
 // dependencies being installed for the requested packages, if any.
 func OutputChangeSummary(out output.Outputer, newBuildPlan *buildplan.BuildPlan, oldBuildPlan *buildplan.BuildPlan) {
+	requested := make(map[strfmt.UUID]bool)
+	for _, a := range newBuildPlan.RequestedArtifacts() {
+		requested[a.ArtifactID] = true
+	}
+
 	addedString := []string{}
 	addedLocale := []string{}
-	added := buildplan.Ingredients{}
 	dependencies := buildplan.Ingredients{}
 	directDependencies := buildplan.Ingredients{}
 	changeset := newBuildPlan.DiffArtifacts(oldBuildPlan, false)
 	for _, a := range changeset.Added {
-		added = append(added, a.Ingredients...)
-		for _, i := range a.Ingredients {
-			v := fmt.Sprintf("%s@%s", i.Name, i.Version)
+		if _, exists := requested[a.ArtifactID]; exists {
+			v := fmt.Sprintf("%s@%s", a.Name(), a.Version())
 			addedString = append(addedLocale, v)
 			addedLocale = append(addedLocale, fmt.Sprintf("[ACTIONABLE]%s[/RESET]", v))
+		}
+		for _, i := range a.Ingredients {
 			dependencies = append(dependencies, i.RuntimeDependencies(true)...)
 			directDependencies = append(dependencies, i.RuntimeDependencies(false)...)
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2851" title="DX-2851" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2851</a>  Nightly failure: Change summaries show wrong requested package
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Samples:

```
>"..\..\cli\build\state.exe" install pytorch
█ Installing Package

Operating on project org/project, located at path/to/project.

 • Searching for pytorch in the ActiveState Catalog ✔ Found
 • Creating commit ✔ Done
 • Resolving Dependencies ✔ Done
Installing pytorch@1.13.0 includes 10 direct dependencies.
  ├─ astunparse@1.6.3 (3 dependencies)
  ├─ flit-core@3.9.0
  ├─ libmkl@2020.4 (1 dependencies)
  ├─ mkl-win@2020.4.311
  ├─ numpy@1.26.4 (2 dependencies)
  ├─ pytorch-win64@1.13.0
  ├─ pyyaml@6.0.1
  ├─ six@1.16.0
  ├─ typing-extensions@4.11.0
  └─ wheel@0.42.0 (1 dependencies)
```

```
>"..\..\cli\build\state.exe" install datetime scipy
█ Installing Package

Operating on project org/project, located at path/to/project.

 • Searching for datetime, scipy in the ActiveState Catalog ✔ Found
 • Creating commit ✔ Done
 • Resolving Dependencies ✔ Done
Installing scipy@1.13.0, datetime@5.5 includes 3 direct dependencies.
  ├─ ifort-distributables@2021.3.0
  ├─ pytz@2024.1
  └─ zope-interface@6.4.post1
```