### PR TITLE
Fixed sub-dependency count numbers.

### DIFF
--- a/internal/runbits/dependencies/changesummary.go
+++ b/internal/runbits/dependencies/changesummary.go
@@ -80,7 +80,7 @@ func OutputChangeSummary(out output.Outputer, newBuildPlan *buildplan.BuildPlan,
 		}
 
 		subdependencies := ""
-		if numSubs := len(ingredient.RuntimeDependencies(false)); numSubs > 0 {
+		if numSubs := len(ingredient.RuntimeDependencies(true)); numSubs > 0 {
 			subdependencies = fmt.Sprintf(" ([ACTIONABLE]%s[/RESET] dependencies)", // intentional leading space
 				strconv.Itoa(numSubs))
 		}

--- a/internal/runbits/dependencies/changesummary.go
+++ b/internal/runbits/dependencies/changesummary.go
@@ -79,9 +79,8 @@ func OutputChangeSummary(out output.Outputer, newBuildPlan *buildplan.BuildPlan,
 			prefix = "└─"
 		}
 
-		ingredientDeps := ingredient.RuntimeDependencies(true)
 		subdependencies := ""
-		if numSubs := len(ingredientDeps); numSubs > 0 {
+		if numSubs := len(ingredient.RuntimeDependencies(false)); numSubs > 0 {
 			subdependencies = fmt.Sprintf(" ([ACTIONABLE]%s[/RESET] dependencies)", // intentional leading space
 				strconv.Itoa(numSubs))
 		}

--- a/internal/runbits/dependencies/summary.go
+++ b/internal/runbits/dependencies/summary.go
@@ -32,7 +32,7 @@ func OutputSummary(out output.Outputer, directDependencies buildplan.Artifacts) 
 		}
 
 		subdependencies := ""
-		if numSubs := len(ingredient.RuntimeDependencies(true)); numSubs > 0 {
+		if numSubs := len(ingredient.RuntimeDependencies(false)); numSubs > 0 {
 			subdependencies = locale.Tl("summary_subdeps", "([ACTIONABLE]{{.V0}}[/RESET] sub-dependencies)", strconv.Itoa(numSubs))
 		}
 

--- a/internal/runbits/dependencies/summary.go
+++ b/internal/runbits/dependencies/summary.go
@@ -32,7 +32,7 @@ func OutputSummary(out output.Outputer, directDependencies buildplan.Artifacts) 
 		}
 
 		subdependencies := ""
-		if numSubs := len(ingredient.RuntimeDependencies(false)); numSubs > 0 {
+		if numSubs := len(ingredient.RuntimeDependencies(true)); numSubs > 0 {
 			subdependencies = locale.Tl("summary_subdeps", "([ACTIONABLE]{{.V0}}[/RESET] sub-dependencies)", strconv.Itoa(numSubs))
 		}
 

--- a/pkg/buildplan/ingredient.go
+++ b/pkg/buildplan/ingredient.go
@@ -1,6 +1,7 @@
 package buildplan
 
 import (
+	"github.com/ActiveState/cli/internal/sliceutils"
 	"github.com/ActiveState/cli/pkg/buildplan/raw"
 	"github.com/go-openapi/strfmt"
 )
@@ -58,7 +59,8 @@ func (i Ingredients) ToNameMap() IngredientNameMap {
 }
 
 func (i *Ingredient) RuntimeDependencies(recursive bool) Ingredients {
-	return i.runtimeDependencies(recursive, make(map[strfmt.UUID]struct{}))
+	dependencies := i.runtimeDependencies(recursive, make(map[strfmt.UUID]struct{}))
+	return sliceutils.UniqueByProperty(dependencies, func(i *Ingredient) any { return i.IngredientID })
 }
 
 func (i *Ingredient) runtimeDependencies(recursive bool, seen map[strfmt.UUID]struct{}) Ingredients {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2872" title="DX-2872" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2872</a>  Wrong number of sub-dependencies
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Samples:

```
% ../cli/build/state checkout org/project              
Checking out project: org/project

Resolving Dependencies ✔ Done
Setting up the following dependencies:
└─ python@3.10.14 (28 sub-dependencies)
```

```
% ../../cli/build/state install pytorch
█ Installing Package

Operating on project org/project, located at /path/to/project.

 • Searching for pytorch in the ActiveState Catalog ✔ Found
 • Creating commit ✔ Done
 • Resolving Dependencies ✔ Done
Installing pytorch@1.13.0 includes 14 direct dependencies.
  ├─ astunparse@1.6.3 (3 dependencies)
  ├─ flit-core@3.9.0
  ├─ libmkl@2020.4 (3 dependencies)
  ├─ mkl-linux@2020.4.304
  ├─ mkl-mac@2020.4.301
  ├─ mkl-win@2020.4.311
  ├─ numpy@1.26.4 (4 dependencies)
  ├─ pytorch-linux@1.13.0
  ├─ pytorch-win64@1.13.0
  ├─ pyyaml@6.0.1
  ├─ six@1.16.0
  ├─ torch-binary@1.13.0
  ├─ typing-extensions@4.11.0
  └─ wheel@0.42.0 (1 dependencies)
```