### PR TITLE
Do not show `state commit` progressbar until we are sure there is something to commit.

### DIFF
--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -82,13 +82,6 @@ func (c *Commit) Run() (rerr error) {
 		return rationalize.ErrNoProject
 	}
 
-	pg := output.StartSpinner(c.out, locale.T("progress_commit"), constants.TerminalAnimationInterval)
-	defer func() {
-		if pg != nil {
-			pg.Stop(locale.T("progress_fail") + "\n")
-		}
-	}()
-
 	// Get buildscript.as representation
 	script, err := buildscript_runbit.ScriptFromProject(c.proj)
 	if err != nil {
@@ -115,6 +108,13 @@ func (c *Commit) Run() (rerr error) {
 	if equals {
 		return ErrNoChanges
 	}
+
+	pg := output.StartSpinner(c.out, locale.T("progress_commit"), constants.TerminalAnimationInterval)
+	defer func() {
+		if pg != nil {
+			pg.Stop(locale.T("progress_fail") + "\n")
+		}
+	}()
 
 	stagedCommitID, err := bp.StageCommit(buildplanner.StageCommitParams{
 		Owner:        c.proj.Owner(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2841" title="DX-2841" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2841</a>  As a user I can expect `state commit` to tell me when I have nothing new to commit
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
