### PR TITLE
Consider a build ready if all of its installed artifacts are.

### DIFF
--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -614,7 +614,12 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(bp *buildplan.BuildPlan, i
 		s.analytics.Event(anaConsts.CatRuntimeDebug, anaConsts.ActRuntimeDownload, dimensions)
 	}
 
-	err = s.installArtifactsFromBuild(bp.IsBuildReady(), bp.Engine(), recipeID, artifactsToInstall, installFunc, logFilePath)
+	buildReady := bp.IsBuildReady()
+	if !buildReady && len(artifactsToInstall.Filter(buildplan.FilterSuccessfulArtifacts())) == len(artifactsToInstall) {
+		// Even though the build may not be complete, all of the necessary artifacts are ready.
+		buildReady = true
+	}
+	err = s.installArtifactsFromBuild(buildReady, bp.Engine(), recipeID, artifactsToInstall, installFunc, logFilePath)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2874" title="DX-2874" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2874</a>  Build log is bogus
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
If a build is not ready, but all artifacts to install are, the buildlog streamer will be invoked and wait unnecessarily.