### PR TITLE
Mark client buildplanner API errors as input errors, not external errors.

### DIFF
--- a/internal/runbits/requirements/rationalize.go
+++ b/internal/runbits/requirements/rationalize.go
@@ -41,7 +41,7 @@ func (r *RequirementOperation) rationalizeError(err *error) {
 	// We communicate buildplanner errors verbatim as the intend is that these are curated by the buildplanner
 	case errors.As(*err, &buildPlannerErr):
 		*err = errs.WrapUserFacing(*err,
-			buildPlannerErr.LocalizedError(),
+			buildPlannerErr.LocaleError(),
 			errs.SetIf(buildPlannerErr.InputError(), errs.SetInput()))
 
 	// Headless

--- a/internal/runbits/runtime/rationalize.go
+++ b/internal/runbits/runtime/rationalize.go
@@ -65,7 +65,7 @@ func rationalizeError(auth *authentication.Auth, proj *project.Project, rerr *er
 	// We communicate buildplanner errors verbatim as the intend is that these are curated by the buildplanner
 	case errors.As(*rerr, &buildPlannerErr):
 		*rerr = errs.WrapUserFacing(*rerr,
-			buildPlannerErr.LocalizedError(),
+			buildPlannerErr.LocaleError(),
 			errs.SetIf(buildPlannerErr.InputError(), errs.SetInput()))
 
 	// User has modified the buildscript and needs to run `state commit`

--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -70,7 +70,7 @@ func rationalizeError(err *error) {
 	// We communicate buildplanner errors verbatim as the intend is that these are curated by the buildplanner
 	case errors.As(*err, &buildPlannerErr):
 		*err = errs.WrapUserFacing(*err,
-			buildPlannerErr.LocalizedError(),
+			buildPlannerErr.LocaleError(),
 			errs.SetIf(buildPlannerErr.InputError(), errs.SetInput()))
 	}
 }

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -265,7 +265,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		Description: locale.T("commit_message_add_initial"),
 	})
 	if err != nil {
-		return locale.WrapError(err, "err_init_commit", "Could not create project")
+		return errs.Wrap(err, "Could not create project")
 	}
 
 	if err := localcommit.Set(proj.Dir(), commitID.String()); err != nil {

--- a/pkg/platform/api/buildplanner/response/shared.go
+++ b/pkg/platform/api/buildplanner/response/shared.go
@@ -23,10 +23,10 @@ func (e *BuildPlannerError) InputError() bool {
 	return true
 }
 
-// LocalizedError returns the error message to be displayed to the user.
+// LocaleError returns the error message to be displayed to the user.
 // This function is added so that BuildPlannerErrors will be displayed
 // to the user
-func (e *BuildPlannerError) LocalizedError() string {
+func (e *BuildPlannerError) LocaleError() string {
 	return e.Error()
 }
 

--- a/pkg/platform/model/buildplanner/build.go
+++ b/pkg/platform/model/buildplanner/build.go
@@ -28,8 +28,7 @@ const (
 	pollTimeout        = 30 * time.Second
 	buildStatusTimeout = 24 * time.Hour
 
-	codeExtensionKey   = "code"
-	statusExtensionKey = "status"
+	codeExtensionKey = "code"
 )
 
 type Commit struct {
@@ -118,11 +117,6 @@ func processBuildPlannerError(bpErr error, fallbackMessage string) error {
 		code, ok := graphqlErr.Extensions[codeExtensionKey].(string)
 		if ok && code == clientDeprecationErrorKey {
 			return &response.BuildPlannerError{Err: locale.NewExternalError("err_buildplanner_deprecated", "Encountered deprecation error: {{.V0}}", graphqlErr.Message)}
-		}
-		if status, ok := graphqlErr.Extensions[statusExtensionKey].(float64); ok {
-			if status >= 400 && status < 500 {
-				return locale.NewInputError("err_buildplanner_api_input_error", "{{.V0}}: {{.V1}}", fallbackMessage, bpErr.Error())
-			}
 		}
 	}
 	return &response.BuildPlannerError{Err: locale.NewExternalError("err_buildplanner", "{{.V0}}: Encountered unexpected error: {{.V1}}", fallbackMessage, bpErr.Error())}

--- a/pkg/platform/model/buildplanner/build.go
+++ b/pkg/platform/model/buildplanner/build.go
@@ -28,7 +28,8 @@ const (
 	pollTimeout        = 30 * time.Second
 	buildStatusTimeout = 24 * time.Hour
 
-	codeExtensionKey = "code"
+	codeExtensionKey   = "code"
+	statusExtensionKey = "status"
 )
 
 type Commit struct {
@@ -117,6 +118,11 @@ func processBuildPlannerError(bpErr error, fallbackMessage string) error {
 		code, ok := graphqlErr.Extensions[codeExtensionKey].(string)
 		if ok && code == clientDeprecationErrorKey {
 			return &response.BuildPlannerError{Err: locale.NewExternalError("err_buildplanner_deprecated", "Encountered deprecation error: {{.V0}}", graphqlErr.Message)}
+		}
+		if status, ok := graphqlErr.Extensions[statusExtensionKey].(float64); ok {
+			if status >= 400 && status < 500 {
+				return locale.NewInputError("err_buildplanner_api_input_error", "{{.V0}}: {{.V1}}", fallbackMessage, bpErr.Error())
+			}
 		}
 	}
 	return &response.BuildPlannerError{Err: locale.NewExternalError("err_buildplanner", "{{.V0}}: Encountered unexpected error: {{.V1}}", fallbackMessage, bpErr.Error())}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2877" title="DX-2877" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2877</a>  state init should give error about invalid formatting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Sample:

```
% ../../cli/build/state init mitchell-as/foo/bar --language python
Initializing Project

 x Failed to create project: Encountered unexpected error: Request failed: graphql: 
mono_api.create_project: Project name can only contain alphanumeric, '.' or '-' characters.
```