### PR TITLE
Fixed `state import` for projects with complex language version constraints.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -145,8 +145,6 @@ err_unsupported_platform:
   other: "Unsupported platform: [NOTICE]{{.V0}}[/RESET]"
 err_detect_language:
   other: Could not detect which language to use
-err_language_not_found:
-  other: "Could not find language: [NOTICE]{{.V0}}@{{.V1}}[/RESET]"
 project_checkout_empty:
   other: You have not activated any projects yet
 building:
@@ -622,8 +620,6 @@ err_bundle_added:
   other: Failed to add bundle
 err_language_updated:
   other: Failed to update language
-package_err_cannot_fetch_checkpoint:
-  other: Cannot fetch checkpoint for package listing
 bundle_err_cannot_fetch_checkpoint:
   other: Cannot fetch checkpoint for bundle listing
 package_err_cannot_obtain_commit:
@@ -702,8 +698,6 @@ command_flag_invalid_value:
   other: "Invalid value for {{.V0}} flag: [NOTICE]{{.V1}}[/RESET]"
 command_cmd_no_such_cmd:
   other: "No such command: [NOTICE]{{.V0}}[/RESET]"
-err_fetch_languages:
-  other: "Could not retrieve languages for your project. Does your project exist on the Platform?"
 err_incompatible_move_file_dir:
   other: |
     Could not move [NOTICE]{{.V0}}[/RESET] to [NOTICE]{{.V1}}[/RESET].  One is a file, the other a directory.

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -112,17 +112,12 @@ func (i *Import) Run(params *ImportRunParams) error {
 		return locale.WrapError(err, "package_err_cannot_obtain_commit")
 	}
 
-	reqs, err := fetchCheckpoint(&latestCommit, i.auth)
+	language, err := model.LanguageByCommit(latestCommit, i.auth)
 	if err != nil {
-		return locale.WrapError(err, "package_err_cannot_fetch_checkpoint")
+		return locale.WrapError(err, "err_import_language", "Unable to get language from project")
 	}
 
-	lang, err := model.CheckpointToLanguage(reqs, i.auth)
-	if err != nil {
-		return locale.WrapExternalError(err, "err_import_language", "Your project does not have a language associated with it, please add a language first.")
-	}
-
-	changeset, err := fetchImportChangeset(reqsimport.Init(), params.FileName, lang.Name)
+	changeset, err := fetchImportChangeset(reqsimport.Init(), params.FileName, language.Name)
 	if err != nil {
 		return errs.Wrap(err, "Could not import changeset")
 	}

--- a/pkg/platform/model/checkpoints.go
+++ b/pkg/platform/model/checkpoints.go
@@ -186,22 +186,6 @@ func CheckpointToPlatforms(requirements []*gqlModel.Requirement) []strfmt.UUID {
 	return result
 }
 
-// CheckpointToLanguage returns the language from a checkpoint
-func CheckpointToLanguage(requirements []*gqlModel.Requirement, auth *authentication.Auth) (*Language, error) {
-	for _, req := range requirements {
-		if !NamespaceMatch(req.Namespace, NamespaceLanguageMatch) {
-			continue
-		}
-		lang, err := FetchLanguageByDetails(req.Requirement, req.VersionConstraint, auth)
-		if err != nil {
-			return nil, err
-		}
-		return lang, nil
-	}
-
-	return nil, locale.NewError("err_fetch_languages")
-}
-
 func PlatformNameToPlatformID(name string) (string, error) {
 	name = strings.ToLower(name)
 	if name == "darwin" {

--- a/pkg/platform/model/inventory.go
+++ b/pkg/platform/model/inventory.go
@@ -507,21 +507,6 @@ func FetchLanguageForCommit(commitID strfmt.UUID, auth *authentication.Auth) (*L
 	return &langs[0], nil
 }
 
-func FetchLanguageByDetails(name, version string, auth *authentication.Auth) (*Language, error) {
-	languages, err := FetchLanguages(auth)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, language := range languages {
-		if language.Name == name && language.Version == version {
-			return &language, nil
-		}
-	}
-
-	return nil, locale.NewInputError("err_language_not_found", "", name, version)
-}
-
 func FetchLanguageVersions(name string, auth *authentication.Auth) ([]string, error) {
 	languages, err := FetchLanguages(auth)
 	if err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2879" title="DX-2879" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2879</a>  `state init org/project --language=python@3.11` didn't add a language to my project
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

