### PR TITLE
If the remote installer could not get an install payload, but no error happened, show a helpful error message.

### DIFF
--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -195,7 +195,7 @@ func execute(out output.Outputer, prompt prompt.Prompter, cfg *config.Instance, 
 	if err != nil {
 		return errs.Wrap(err, "Could not retrieve install package information")
 	} else if availableUpdate == nil {
-		return locale.NewError("remote_install_no_available_update", "Could not find package to install. Please try again later.")
+		return locale.NewError("remote_install_no_available_update", "Could not find installer to download. This could be due to networking issues or temporary maintenance. Please try again later.")
 	}
 
 	version := availableUpdate.Version

--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -194,6 +194,8 @@ func execute(out output.Outputer, prompt prompt.Prompter, cfg *config.Instance, 
 	availableUpdate, err := checker.CheckFor(channel, params.version)
 	if err != nil {
 		return errs.Wrap(err, "Could not retrieve install package information")
+	} else if availableUpdate == nil {
+		return locale.NewError("remote_install_no_available_update", "Could not find package to install. Please try again later.")
 	}
 
 	version := availableUpdate.Version


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2887" title="DX-2887" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2887</a>  Remote installer panic
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

See https://activestatef.atlassian.net/browse/DX-2887?focusedCommentId=53288 for the potential cause of `availableUpdate` being `nil`.

Note that we the logs will likely point to the source of failure, so we don't have to do any speculative logging.