### PR TITLE
Centralize condition for auto update checking.

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -242,7 +242,7 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 	}
 
 	// Check to see if this state tool version is different from the lock version.
-	if (childCmd == nil || !childCmd.SkipChecks() || childCmd.Name() != "update") && pj != nil && pj.IsLocked() {
+	if (childCmd == nil || !childCmd.SkipChecks()) && pj != nil && pj.IsLocked() {
 		if (pj.Version() != "" && pj.Version() != constants.Version) ||
 			(pj.Channel() != "" && pj.Channel() != constants.ChannelName) {
 			return errs.AddTips(

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -225,7 +225,7 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 	// Run the actual command
 	cmds := cmdtree.New(primer.New(pj, out, auth, prompter, sshell, conditional, cfg, ipcClient, svcmodel, an), args...)
 
-	childCmd, err := cmds.Command().Find(args[1:])
+	childCmd, err := cmds.Command().FindChild(args[1:])
 	if err != nil {
 		logging.Debug("Could not find child command, error: %v", err)
 	}

--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -234,23 +234,22 @@ func run(args []string, isInteractive bool, cfg *config.Instance, out output.Out
 	cmds.OnExecStart(msger.OnExecStart)
 	cmds.OnExecStop(msger.OnExecStop)
 
-	if childCmd != nil && !childCmd.SkipChecks() && !out.Type().IsStructured() {
-		// Auto update to latest state tool version
-		if updated, err := autoUpdate(svcmodel, args, cfg, an, out); err == nil && updated {
-			return nil // command will be run by updated exe
-		} else if err != nil {
-			multilog.Error("Failed to autoupdate: %v", err)
-		}
+	// Auto update to latest state tool version if possible.
+	if updated, err := autoUpdate(svcmodel, args, childCmd, cfg, an, out); err == nil && updated {
+		return nil // command will be run by updated exe
+	} else if err != nil {
+		multilog.Error("Failed to autoupdate: %v", err)
+	}
 
-		if childCmd.Name() != "update" && pj != nil && pj.IsLocked() {
-			if (pj.Version() != "" && pj.Version() != constants.Version) ||
-				(pj.Channel() != "" && pj.Channel() != constants.ChannelName) {
-				return errs.AddTips(
-					locale.NewInputError("lock_version_mismatch", "", pj.Source().Lock, constants.ChannelName, constants.Version),
-					locale.Tr("lock_update_legacy_version", constants.DocumentationURLLocking),
-					locale.T("lock_update_lock"),
-				)
-			}
+	// Check to see if this state tool version is different from the lock version.
+	if (childCmd == nil || !childCmd.SkipChecks() || childCmd.Name() != "update") && pj != nil && pj.IsLocked() {
+		if (pj.Version() != "" && pj.Version() != constants.Version) ||
+			(pj.Channel() != "" && pj.Channel() != constants.ChannelName) {
+			return errs.AddTips(
+				locale.NewInputError("lock_version_mismatch", "", pj.Source().Lock, constants.ChannelName, constants.Version),
+				locale.Tr("lock_update_legacy_version", constants.DocumentationURLLocking),
+				locale.T("lock_update_lock"),
+			)
 		}
 	}
 

--- a/internal/analytics/constants/constants.go
+++ b/internal/analytics/constants/constants.go
@@ -148,38 +148,46 @@ const ActCommandInputError = "command-input-error"
 // ActExecutorExit is the event action used for executor exit codes
 const ActExecutorExit = "executor-exit"
 
-// UpdateLabelSuccess is the sent if an auto-update was successful
+// UpdateLabelSuccess is sent if an auto-update was successful
 const UpdateLabelSuccess = "success"
 
-// UpdateLabelFailed is the sent if an auto-update failed
+// UpdateLabelFailed is sent if an auto-update failed
 const UpdateLabelFailed = "failure"
 
-// UpdateLabelTrue is the sent if we should auto-update
+// UpdateLabelTrue is sent if we should auto-update
 const UpdateLabelTrue = "true"
 
-// UpdateLabelForward is the sent if we should not auto-update as we are forwarding a command
+// UpdateLabelForward is sent if we should not auto-update as we are forwarding a command
 const UpdateLabelForward = "forward"
 
-// UpdateLabelUnitTest is the sent if we should not auto-update as we are running unit tests
+// UpdateLabelUnitTest is sent if we should not auto-update as we are running unit tests
 const UpdateLabelUnitTest = "unittest"
 
-// UpdateLabelConflict is the sent if we should not auto-update as the current command might conflict
+// UpdateLabelConflict is sent if we should not auto-update as the current command might conflict
 const UpdateLabelConflict = "conflict"
 
-// UpdateLabelDisabledEnv is the sent if we should not auto-update as the user has disabled auto-updates via the environment
+// UpdateLabelDisabledEnv is sent if we should not auto-update as the user has disabled auto-updates via the environment
 const UpdateLabelDisabledEnv = "disabled-env"
 
-// UpdateLabelDisabledConfig is the sent if we should not auto-update as the user has disabled auto-updates via the config
+// UpdateLabelDisabledConfig is sent if we should not auto-update as the user has disabled auto-updates via the config
 const UpdateLabelDisabledConfig = "disabled-config"
 
-// AutoUpdateLabelDisabledCI is the sent if we should not auto-update as we are on CI
+// AutoUpdateLabelDisabledCI is sent if we should not auto-update as we are on CI
 const UpdateLabelCI = "ci"
 
-// UpdateLabelFreshInstall is the sent if we should not auto-update as we are on a fresh install
+// UpdateLabelFreshInstall is sent if we should not auto-update as we are on a fresh install
 const UpdateLabelFreshInstall = "fresh-install"
 
-// UpdateLabelLocked is the sent if we should not auto-update as the state tool is locked
+// UpdateLabelLocked is sent if we should not auto-update as the state tool is locked
 const UpdateLabelLocked = "locked"
+
+// UpdateLabelSkipChecks is sent if we should not auto-update because the command explicitly skips
+// auto update checks.
+const UpdateLabelSkipChecks = "skip-checks"
+
+// UpdateLabelStructuredOutput is sent if we should not auto-update because we're running in
+// structured output (JSON) mode.
+const UpdateLabelStructuredOutput = "structured-output"
 
 // UpdateLabelTooFreq is the sent if we should not auto-update as the last check was too recent
 const UpdateLabelTooFreq = "too-frequent"

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -464,12 +464,16 @@ func (c *Command) AvailableChildren() []*Command {
 	return commands
 }
 
-func (c *Command) Find(args []string) (*Command, error) {
+func (c *Command) FindChild(args []string) (*Command, error) {
 	foundCobra, _, err := c.cobra.Find(args)
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not find child command with args: %s", strings.Join(args, " "))
 	}
 	if cmd, ok := cobraMapping[foundCobra]; ok {
+		if cmd.parent == nil {
+			// Cobra returns the parent command if no child was found, but we don't want that.
+			return nil, nil
+		}
 		return cmd, nil
 	}
 	return nil, locale.NewError("err_captain_cmd_find", "Could not find child Command with args: {{.V0}}", strings.Join(args, " "))

--- a/internal/runbits/errors/errors.go
+++ b/internal/runbits/errors/errors.go
@@ -177,7 +177,7 @@ func ReportError(err error, cmd *captain.Command, an analytics.Dispatcher) {
 	_, hasMarshaller := err.(output.Marshaller)
 
 	cmdName := cmd.Name()
-	childCmd, findErr := cmd.Find(os.Args[1:])
+	childCmd, findErr := cmd.FindChild(os.Args[1:])
 	if findErr != nil {
 		logging.Error("Could not find child command: %v", findErr)
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2836" title="DX-2836" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2836</a>  Improve handling of `Update Available` messaging
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Also fix `command.Find()` to return `nil` if no child was found and rename it `FindChild()` for clarity.

Note: one of the checks listed for centralization in the ticket, https://github.com/ActiveState/cli/blob/87205e082c99853af80009361b73dbe1ef4cd351/cmd/state/autoupdate.go#L56, actually needs to be separate because its conditional (https://github.com/ActiveState/cli/blob/87205e082c99853af80009361b73dbe1ef4cd351/internal/updater/updater.go#L122-L126) depends on the update's contents. The conditional result cannot be determined prior to downloading the update.