### PR TITLE
Implement error interface instead of including error object field in struct.

### DIFF
--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -78,8 +78,11 @@ var errNoOwner = errs.New("Could not find organization")
 var errNoLanguage = errs.New("No language specified")
 
 type errUnrecognizedLanguage struct {
-	error
 	Name string
+}
+
+func (e errUnrecognizedLanguage) Error() string {
+	return fmt.Sprintf("unrecognized language: %s", e.Name)
 }
 
 // New returns a prepared ptr to Initialize instance.
@@ -183,12 +186,12 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 
 	// Require 'python', 'python@3', or 'python@2' instead of 'python3' or 'python2'.
 	if languageName == language.Python3.String() || languageName == language.Python2.String() {
-		return &errUnrecognizedLanguage{Name: languageName}
+		return &errUnrecognizedLanguage{languageName}
 	}
 
 	lang := language.MakeByNameAndVersion(languageName, languageVersion)
 	if !lang.Recognized() {
-		return &errUnrecognizedLanguage{Name: languageName}
+		return &errUnrecognizedLanguage{languageName}
 	}
 
 	version, err := deriveVersion(lang, languageVersion, r.auth)
@@ -327,7 +330,7 @@ func getKnownVersions(lang language.Language, auth *authentication.Auth) ([]stri
 	}
 
 	if len(pkgs) == 0 {
-		return nil, &errUnrecognizedLanguage{Name: lang.Requirement()}
+		return nil, &errUnrecognizedLanguage{lang.Requirement()}
 	}
 
 	knownVersions := make([]string, len(pkgs))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2911" title="DX-2911" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2911</a>  INIT: Using wrong language name cause `invalid memory address or nil pointer dereference` error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
