### PR TITLE
Always show executable dir in JSON output, even if async runtime is enabled.

### DIFF
--- a/internal/runners/checkout/checkout.go
+++ b/internal/runners/checkout/checkout.go
@@ -117,10 +117,9 @@ func (u *Checkout) Run(params *Params) (rerr error) {
 		return errs.Wrap(err, "Could not setup runtime")
 	}
 
-	var execDir string
 	var checkoutStatement string
+	execDir := setup.ExecDir(rti.Target().Dir())
 	if !u.config.GetBool(constants.AsyncRuntimeConfig) {
-		execDir = setup.ExecDir(rti.Target().Dir())
 		checkoutStatement = locale.Tr("checkout_project_statement", proj.NamespaceString(), proj.Dir(), execDir)
 	} else {
 		checkoutStatement = locale.Tr("checkout_project_statement_async", proj.NamespaceString(), proj.Dir())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2910" title="DX-2910" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2910</a>  CHECKOUT: Using -o json with the checkout command sometimes has missing parts in the JSON output
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
