### PR TITLE
`state reset LOCAL` should be case-insensitive.

### DIFF
--- a/internal/runners/reset/reset.go
+++ b/internal/runners/reset/reset.go
@@ -1,6 +1,8 @@
 package reset
 
 import (
+	"strings"
+
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
@@ -81,7 +83,7 @@ func (r *Reset) Run(params *Params) error {
 		}
 		commitID = *latestCommit
 
-	case params.CommitID == local:
+	case strings.EqualFold(params.CommitID, local):
 		localCommitID, err := localcommit.Get(r.project.Dir())
 		if err != nil {
 			return errs.Wrap(err, "Unable to get local commit")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2814" title="DX-2814" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2814</a>  User advised to run `state reset Local` due to missing its buildscript file and fail with `Invalid commit ID`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
