### PR TITLE
Fixed wrapped length calculation.

### DIFF
--- a/internal/colorize/cropped.go
+++ b/internal/colorize/cropped.go
@@ -30,7 +30,6 @@ func GetCroppedText(text string, maxLen int, includeLineEnds bool) CroppedLines 
 		if len(text) > len(indent) && strings.HasPrefix(text[len(indent):], "• ") {
 			indent += "  "
 		}
-		maxLen -= len(indent)
 	}
 
 	entries := make([]CroppedLine, 0)
@@ -53,7 +52,7 @@ func GetCroppedText(text string, maxLen int, includeLineEnds bool) CroppedLines 
 		// Ensure the next position is not within a color tag and check conditions that would end this entry
 		if isLineEnd || (!inRange(pos+1, colorCodes) && (entry.Length == maxLen || pos == len(text)-1)) {
 			wrapped := ""
-			wrappedLength := 0
+			wrappedLength := len(indent)
 			nextCharIsSpace := pos+1 < len(text) && isSpace(text[pos+1])
 			if !isLineEnd && entry.Length == maxLen && !nextCharIsSpace && pos < len(text)-1 {
 				// Put the current word on the next line, if possible.
@@ -76,7 +75,7 @@ func GetCroppedText(text string, maxLen int, includeLineEnds bool) CroppedLines 
 					entry.Length -= wrappedLength
 					isLineEnd = true // emulate for wrapping purposes
 				} else {
-					wrappedLength = 0 // reset
+					wrappedLength = len(indent) // reset
 				}
 			}
 			entries = append(entries, entry)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2909" title="DX-2909" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2909</a>  PROJECTS: The help for the `delete` subcommand wraps to the next row
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Trimming `maxLen` was artificially reducing the length of the first line if it's indented. (Subsequent wrapped line length is okay.)