### PR TITLE
Refactor integration tests to use empty project by default.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     env:
       ACTIVESTATE_CI: true
-      ACTIVESTATE_CLI_DISABLE_RUNTIME: true
       SHELL: bash
       GITHUB_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_SHA_OVERRIDE: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -406,7 +405,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       ACTIVESTATE_CI: true
-      ACTIVESTATE_CLI_DISABLE_RUNTIME: true
       SHELL: bash
       GITHUB_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_SHA_OVERRIDE: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -33,7 +33,6 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 	env = append(env, []string{
 		constants.ConfigEnvVarName + "=" + dirs.Config,
 		constants.CacheEnvVarName + "=" + dirs.Cache,
-		constants.DisableRuntime + "=true",
 		constants.ActivatedStateEnvVarName + "=",
 		constants.E2ETestEnvVarName + "=true",
 		constants.DisableUpdates + "=true",

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -342,6 +342,13 @@ func (s *Session) CommitID() string {
 	return pjfile.LegacyCommitID()
 }
 
+// PrepareEmptyProject creates a checkout of the empty ActiveState-CLI/Empty project without using
+// `state checkout`.
+func (s *Session) PrepareEmptyProject() {
+	s.PrepareActiveStateYAML(fmt.Sprintf("project: https://%s/%s", constants.DefaultAPIHost, "ActiveState-CLI/Empty"))
+	s.PrepareCommitIdFile("6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
+}
+
 // PrepareProject creates a very simple activestate.yaml file for the given org/project and, if a
 // commit ID is given, an .activestate/commit file.
 func (s *Session) PrepareProject(namespace, commitID string) {

--- a/pkg/platform/runtime/setup/setup.go
+++ b/pkg/platform/runtime/setup/setup.go
@@ -2,7 +2,6 @@ package setup
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -433,6 +432,10 @@ func (s *Setup) updateExecutors(artifacts []strfmt.UUID) error {
 		return errs.Wrap(err, "Could not save combined environment file")
 	}
 
+	if edGlobal == nil {
+		return nil // this can happen if there are no runtime artifacts
+	}
+
 	exePaths, err := edGlobal.ExecutablePaths()
 	if err != nil {
 		return locale.WrapError(err, "err_deploy_execpaths", "Could not retrieve runtime executable paths")
@@ -496,14 +499,6 @@ func (s *Setup) fetchAndInstallArtifactsFromBuildPlan(bp *buildplan.BuildPlan, i
 		if aErr != nil {
 			return nil, nil, aErr
 		}
-	}
-
-	if len(allArtifacts) == 0 {
-		v, err := json.Marshal(bp.Artifacts())
-		if err != nil {
-			return nil, nil, err
-		}
-		return nil, nil, errs.New("did not find any artifacts that match our platform (%s), full artifacts list: %s", platformID, v)
 	}
 
 	resolver, err := selectArtifactResolver(bp)

--- a/pkg/platform/runtime/store/store.go
+++ b/pkg/platform/runtime/store/store.go
@@ -216,7 +216,8 @@ func (s *Store) UpdateEnviron(orderedArtifacts []strfmt.UUID) (*envdef.Environme
 
 func (s *Store) updateEnviron(orderedArtifacts []strfmt.UUID, artifacts StoredArtifactMap) (*envdef.EnvironmentDefinition, error) {
 	if len(orderedArtifacts) == 0 {
-		return nil, errs.New("Environment cannot be updated if no artifacts were installed")
+		logging.Debug("Environment cannot be updated if no artifacts were installed")
+		return nil, nil
 	}
 
 	var rtGlobal *envdef.EnvironmentDefinition

--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -53,7 +53,10 @@ func (suite *ActivateIntegrationTestSuite) TestActivateWithoutRuntime() {
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	cp := ts.Spawn("activate", "ActiveState-CLI/Python2")
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("activate", "ActiveState-CLI/Empty"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+	)
 	cp.Expect("Skipping runtime setup")
 	cp.Expect("Activated")
 	cp.ExpectInput()
@@ -134,10 +137,8 @@ func (suite *ActivateIntegrationTestSuite) TestActivateUsingCommitID() {
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "ActiveState-CLI/Python3#6d9280e7-75eb-401a-9e71-0d99759fbad3", "--path", ts.Dirs.Work),
-	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp := ts.Spawn("activate", "ActiveState-CLI/Empty#6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8", "--path", ts.Dirs.Work)
+	cp.Expect("Activated")
 	cp.ExpectInput()
 
 	cp.SendLine("exit")
@@ -151,12 +152,9 @@ func (suite *ActivateIntegrationTestSuite) TestActivateNotOnPath() {
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "activestate-cli/small-python", "--path", ts.Dirs.Work),
-	)
-	cp.Expect("Skipping runtime setup")
+	cp := ts.Spawn("activate", "activestate-cli/empty", "--path", ts.Dirs.Work)
 	cp.Expect("Activated")
-	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
+	cp.ExpectInput()
 
 	if runtime.GOOS == "windows" {
 		cp.SendLine("doskey /macros | findstr state=")
@@ -182,10 +180,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 	defer close()
 
 	projectName := "Python-LinuxWorks"
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "cli-integration-tests/"+projectName, "--path="+ts.Dirs.Work),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("activate", "cli-integration-tests/"+projectName, "--path="+ts.Dirs.Work)
 
 	if runtime.GOOS == "linux" {
 		cp.Expect("Creating a Virtual Environment")
@@ -228,7 +223,6 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		e2e.OptAppendEnv(extraEnv...),
 	)
 
@@ -262,11 +256,11 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 
 	// test that existing environment variables are inherited by the activated shell
 	if runtime.GOOS == "windows" {
-		cp.SendLine(fmt.Sprintf("echo %%%s%%", constants.DisableRuntime))
+		cp.SendLine(fmt.Sprintf("echo %%%s%%", constants.E2ETestEnvVarName))
 	} else {
-		cp.SendLine("echo $" + constants.DisableRuntime)
+		cp.SendLine("echo $" + constants.E2ETestEnvVarName)
 	}
-	cp.Expect("false")
+	cp.Expect("true")
 
 	// test that other executables that use python work as well
 	pipExe := "pip" + version
@@ -288,7 +282,6 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 	cp = ts.SpawnCmdWithOpts(
 		executor,
 		e2e.OptArgs("-c", "import sys; print(sys.copyright);"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("ActiveState Software Inc.", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -304,10 +297,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_PythonPath() {
 
 	namespace := "ActiveState-CLI/Python3"
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", namespace),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("activate", namespace)
 
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	// ensure that shell is functional
@@ -360,9 +350,8 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_SpaceInCacheDir() {
 	suite.Require().NoError(err)
 
 	cp := ts.SpawnWithOpts(
-		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.CacheEnvVarName, cacheDir)),
-		e2e.OptAppendEnv(fmt.Sprintf(`%s=""`, constants.DisableRuntime)),
 		e2e.OptArgs("activate", "ActiveState-CLI/Python3"),
+		e2e.OptAppendEnv(fmt.Sprintf("%s=%s", constants.CacheEnvVarName, cacheDir)),
 	)
 
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
@@ -384,10 +373,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePerlCamel() {
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "ActiveState-CLI/Perl"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("activate", "ActiveState-CLI/Perl")
 
 	cp.Expect("Downloading", termtest.OptExpectTimeout(40*time.Second))
 	cp.Expect("Installing", termtest.OptExpectTimeout(140*time.Second))
@@ -419,18 +405,13 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_Subdir() {
 
 	// Create the project file at the root of the temp dir
 	content := strings.TrimSpace(fmt.Sprintf(`
-project: "https://platform.activestate.com/ActiveState-CLI/Python3"
+project: "https://platform.activestate.com/ActiveState-CLI/Empty"
 branch: %s
 version: %s
 `, constants.ChannelName, constants.Version))
 
 	ts.PrepareActiveStateYAML(content)
-	ts.PrepareCommitIdFile("59404293-e5a9-4fd0-8843-77cd4761b5b5")
-
-	// Pull to ensure we have an up to date config file
-	cp := ts.Spawn("pull")
-	cp.Expect("activestate.yaml has been updated to")
-	cp.ExpectExitCode(0)
+	ts.PrepareCommitIdFile("6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	// Activate in the subdirectory
 	c2 := ts.SpawnWithOpts(
@@ -458,29 +439,24 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_NamespaceWins() {
 	// Create the project file at the root of the temp dir
 	ts.PrepareProject("ActiveState-CLI/Python3", "59404293-e5a9-4fd0-8843-77cd4761b5b5")
 
-	// Pull to ensure we have an up to date config file
-	cp := ts.Spawn("pull")
-	cp.Expect("activestate.yaml has been updated to")
-	cp.ExpectExitCode(0)
-
 	// Activate in the subdirectory
-	c2 := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "ActiveState-CLI/Python2"), // activate a different namespace
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("activate", "ActiveState-CLI/Empty"), // activate a different namespace
 		e2e.OptWD(targetPath),
 		e2e.OptAppendEnv(constants.DisableLanguageTemplates+"=true"),
 	)
-	c2.Expect("ActiveState-CLI/Python2")
-	c2.Expect("Activated")
+	cp.Expect("ActiveState-CLI/Empty")
+	cp.Expect("Activated")
 
-	c2.ExpectInput()
+	cp.ExpectInput()
 	if runtime.GOOS == "windows" {
-		c2.SendLine("@echo %cd%")
+		cp.SendLine("@echo %cd%")
 	} else {
-		c2.SendLine("pwd")
+		cp.SendLine("pwd")
 	}
-	c2.Expect(identifyPath)
-	c2.SendLine("exit")
-	c2.ExpectExitCode(0)
+	cp.Expect(identifyPath)
+	cp.SendLine("exit")
+	cp.ExpectExitCode(0)
 }
 
 func (suite *ActivateIntegrationTestSuite) TestActivate_InterruptedInstallation() {
@@ -493,8 +469,8 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_InterruptedInstallation(
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	cp := ts.SpawnShellWithOpts("bash", e2e.OptAppendEnv(constants.DisableRuntime+"=false"))
-	cp.SendLine("state deploy install ActiveState-CLI/small-python")
+	cp := ts.SpawnShellWithOpts("bash")
+	cp.SendLine("state deploy install ActiveState-CLI/Empty")
 	cp.Expect("Installing Runtime") // Ensure we don't send Ctrl+C too soon
 	cp.SendCtrlC()
 	cp.Expect("User interrupted")
@@ -511,23 +487,19 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_FromCache() {
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "ActiveState-CLI/small-python", "--path", ts.Dirs.Work),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	// Note: cannot use Empty project since we need artifacts to download and install.
+	// Pick the langless project, which just has some small, non-language artifacts.
+	cp := ts.Spawn("activate", "ActiveState-CLI/langless", "--path", ts.Dirs.Work)
 	cp.Expect("Downloading")
 	cp.Expect("Installing")
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 
 	suite.assertCompletedStatusBarReport(cp.Output())
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 
 	// next activation is cached
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "ActiveState-CLI/small-python", "--path", ts.Dirs.Work),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("activate", "ActiveState-CLI/langless", "--path", ts.Dirs.Work)
 
 	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("exit")
@@ -565,10 +537,9 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_AlreadyActive() {
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	namespace := "ActiveState-CLI/Python3"
+	namespace := "ActiveState-CLI/Empty"
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("activate", namespace))
-	cp.Expect("Skipping runtime setup")
+	cp := ts.Spawn("activate", namespace)
 	cp.Expect("Activated")
 	// ensure that shell is functional
 	cp.ExpectInput()
@@ -586,10 +557,9 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_AlreadyActive_SameNamesp
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	namespace := "ActiveState-CLI/Python3"
+	namespace := "ActiveState-CLI/Empty"
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("activate", namespace))
-	cp.Expect("Skipping runtime setup")
+	cp := ts.Spawn("activate", namespace)
 	cp.Expect("Activated")
 	// ensure that shell is functional
 	cp.ExpectInput()
@@ -607,10 +577,9 @@ func (suite *ActivateIntegrationTestSuite) TestActivate_AlreadyActive_DifferentN
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	namespace := "ActiveState-CLI/Python3"
+	namespace := "ActiveState-CLI/Empty"
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("activate", namespace))
-	cp.Expect("Skipping runtime setup")
+	cp := ts.Spawn("activate", namespace)
 	cp.Expect("Activated")
 	// ensure that shell is functional
 	cp.ExpectInput()
@@ -632,6 +601,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateBranch() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace, "--branch", "firstbranch"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
 	)
 	cp.Expect("Skipping runtime setup")
 	cp.Expect("Activated")
@@ -649,7 +619,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivateBranchNonExistant() {
 
 	namespace := "ActiveState-CLI/Branches"
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("activate", namespace, "--branch", "does-not-exist"))
+	cp := ts.Spawn("activate", namespace, "--branch", "does-not-exist")
 
 	cp.Expect("has no branch")
 }
@@ -662,14 +632,11 @@ func (suite *ActivateIntegrationTestSuite) TestActivateArtifactsCached() {
 	close := suite.addForegroundSvc(ts)
 	defer close()
 
-	namespace := "ActiveState-CLI/Python3"
+	namespace := "ActiveState-CLI/langless"
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", namespace),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("activate", namespace)
 
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 
@@ -694,14 +661,11 @@ func (suite *ActivateIntegrationTestSuite) TestActivateArtifactsCached() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("activate", namespace),
-		e2e.OptAppendEnv(
-			constants.DisableRuntime+"=false",
-			"VERBOSE=true", // Necessary to assert "Fetched cached artifact"
-		),
+		e2e.OptAppendEnv("VERBOSE=true"), // Necessary to assert "Fetched cached artifact"
 	)
 
 	cp.Expect("Fetched cached artifact")
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect("Activated")
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 }

--- a/test/integration/analytics_int_test.go
+++ b/test/integration/analytics_int_test.go
@@ -54,7 +54,6 @@ func (suite *AnalyticsIntegrationTestSuite) TestHeartbeats() {
 	sleepTime = sleepTime + (sleepTime / 2)
 
 	env := []string{
-		constants.DisableRuntime + "=false",
 		fmt.Sprintf("%s=%d", constants.HeartbeatIntervalEnvVarName, heartbeatInterval),
 	}
 
@@ -475,9 +474,8 @@ func (suite *AnalyticsIntegrationTestSuite) TestAttempts() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate", "ActiveState-CLI/Alternate-Python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-		e2e.OptAppendEnv(constants.DisableActivateEventsEnvVarName+"=false"),
 		e2e.OptWD(ts.Dirs.Work),
+		e2e.OptAppendEnv(constants.DisableActivateEventsEnvVarName+"=false"),
 	)
 
 	cp.Expect("Creating a Virtual Environment")
@@ -519,7 +517,8 @@ func (suite *AnalyticsIntegrationTestSuite) TestHeapEvents() {
 
 	ts.LoginAsPersistentUser()
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("activate", "ActiveState-CLI/Alternate-Python"),
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("activate", "ActiveState-CLI/Alternate-Python"),
 		e2e.OptWD(ts.Dirs.Work),
 	)
 
@@ -559,14 +558,16 @@ func (suite *AnalyticsIntegrationTestSuite) TestConfigEvents() {
 	ts := e2e.New(suite.T(), true)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("config", "set", "optin.unstable", "false"),
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("config", "set", "optin.unstable", "false"),
 		e2e.OptWD(ts.Dirs.Work),
 	)
 	cp.Expect("Successfully set config key")
 
 	time.Sleep(time.Second) // Ensure state-svc has time to report events
 
-	cp = ts.SpawnWithOpts(e2e.OptArgs("config", "set", "optin.unstable", "true"),
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("config", "set", "optin.unstable", "true"),
 		e2e.OptWD(ts.Dirs.Work),
 	)
 	cp.Expect("Successfully set config key")
@@ -612,7 +613,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestCIAndInteractiveDimensions() {
 			if !interactive {
 				args = append(args, "--non-interactive")
 			}
-			cp := ts.SpawnWithOpts(e2e.OptArgs(args...))
+			cp := ts.Spawn(args...)
 			cp.Expect("ActiveState CLI")
 			cp.ExpectExitCode(0)
 

--- a/test/integration/api_int_test.go
+++ b/test/integration/api_int_test.go
@@ -20,7 +20,7 @@ func (suite *ApiIntegrationTestSuite) TestRequestHeaders() {
 	defer ts.Close()
 
 	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/Python3", "."),
+		e2e.OptArgs("checkout", "ActiveState-CLI/Empty", "."),
 		e2e.OptAppendEnv(constants.PlatformApiPrintRequestsEnvVarName+"=true", "VERBOSE=true"),
 	)
 	// e.g. User-Agent: state/0.38.0-SHA0deadbeef0; release (Windows; 10.0.22621; x86_64)

--- a/test/integration/auth_int_test.go
+++ b/test/integration/auth_int_test.go
@@ -46,11 +46,11 @@ func (suite *AuthIntegrationTestSuite) TestAuthToken() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn(tagsuite.Auth, "--token", e2e.PersistentToken, "-n")
+	cp := ts.Spawn("auth", "--token", e2e.PersistentToken, "-n")
 	cp.Expect("logged in", termtest.OptExpectTimeout(40*time.Second))
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn(tagsuite.Auth, "--non-interactive")
+	cp = ts.Spawn("auth", "--non-interactive")
 	cp.Expect("logged in", termtest.OptExpectTimeout(40*time.Second))
 	cp.ExpectExitCode(0)
 
@@ -59,7 +59,7 @@ func (suite *AuthIntegrationTestSuite) TestAuthToken() {
 }
 
 func (suite *AuthIntegrationTestSuite) interactiveLogin(ts *e2e.Session, username, password string) {
-	cp := ts.Spawn(tagsuite.Auth, "--prompt")
+	cp := ts.Spawn("auth", "--prompt")
 	cp.Expect("username:")
 	cp.SendLine(username)
 	cp.Expect("password:")
@@ -68,20 +68,20 @@ func (suite *AuthIntegrationTestSuite) interactiveLogin(ts *e2e.Session, usernam
 	cp.ExpectExitCode(0)
 
 	// still logged in?
-	c2 := ts.Spawn(tagsuite.Auth)
+	c2 := ts.Spawn("auth")
 	c2.Expect("You are logged in")
 	c2.ExpectExitCode(0)
 }
 
 func (suite *AuthIntegrationTestSuite) loginFlags(ts *e2e.Session, username string) {
-	cp := ts.Spawn(tagsuite.Auth, "--username", username, "--password", "bad-password")
+	cp := ts.Spawn("auth", "--username", username, "--password", "bad-password")
 	cp.Expect("You are not authorized, did you provide valid login credentials?")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 }
 
 func (suite *AuthIntegrationTestSuite) ensureLogout(ts *e2e.Session) {
-	cp := ts.Spawn(tagsuite.Auth, "--prompt")
+	cp := ts.Spawn("auth", "--prompt")
 	cp.Expect("username:")
 	cp.SendCtrlC()
 }
@@ -101,7 +101,7 @@ func (suite *AuthIntegrationTestSuite) authOutput(method string) {
 
 	expected := string(data)
 	ts.LoginAsPersistentUser()
-	cp := ts.Spawn(tagsuite.Auth, "--output", method)
+	cp := ts.Spawn("auth", "--output", method)
 	cp.Expect(`"}`)
 	cp.ExpectExitCode(0)
 	suite.Contains(cp.Output(), string(expected))

--- a/test/integration/branch_int_test.go
+++ b/test/integration/branch_int_test.go
@@ -40,12 +40,9 @@ func (suite *BranchIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Branches", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	ts.PrepareProject("ActiveState-CLI/Branches", e2e.CommitIDNotChecked)
 
-	cp = ts.Spawn("branch", "-o", "json")
+	cp := ts.Spawn("branch", "-o", "json")
 	cp.Expect(`"branchID":`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)

--- a/test/integration/buildscript_int_test.go
+++ b/test/integration/buildscript_int_test.go
@@ -22,19 +22,19 @@ func (suite *BuildScriptIntegrationTestSuite) TestBuildScript_NeedsReset() {
 	defer ts.Close()
 
 	ts.PrepareActiveStateYAML(fmt.Sprintf("project: https://%s/%s?commitID=%s\nconfig_version: %d\n",
-		constants.DefaultAPIHost, "ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b", projectfile.ConfigVersion))
+		constants.DefaultAPIHost, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8", projectfile.ConfigVersion))
 
 	cp := ts.Spawn("config", "set", constants.OptinBuildscriptsConfig, "true")
 	cp.ExpectExitCode(0)
 
 	suite.Require().NoFileExists(filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName))
 
-	cp = ts.SpawnWithOpts(e2e.OptArgs("refresh"), e2e.OptAppendEnv(constants.DisableRuntime+"=false"))
+	cp = ts.Spawn("refresh")
 	cp.Expect("Your project is missing its buildscript file")
 	cp.ExpectExitCode(1)
 
-	cp = ts.SpawnWithOpts(e2e.OptArgs("reset", "LOCAL"), e2e.OptAppendEnv(constants.DisableRuntime+"=false"))
-	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
+	cp = ts.Spawn("reset", "LOCAL")
+	cp.ExpectExitCode(0)
 
 	suite.Require().FileExists(filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName), ts.DebugMessage(""))
 }

--- a/test/integration/bundle_int_test.go
+++ b/test/integration/bundle_int_test.go
@@ -64,29 +64,22 @@ func (suite *BundleIntegrationTestSuite) TestJSON() {
 	suite.OnlyRunForTags(tagsuite.Bundle, tagsuite.JSON)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
+	suite.PrepareActiveStateYAML(ts)
 
 	cp := ts.Spawn("bundles", "search", "Email", "--language", "Perl", "-o", "json")
 	cp.Expect(`"Name":"Email"`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/Bundles", "."),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Checked out project")
+	cp = ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("bundles", "install", "Testing", "--output", "json"),
-	)
+	cp = ts.Spawn("bundles", "install", "Testing", "--output", "json")
 	cp.Expect(`"name":"Testing"`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("bundles", "uninstall", "Testing", "-o", "editor"),
-	)
+	cp = ts.Spawn("bundles", "uninstall", "Testing", "-o", "editor")
 	cp.Expect(`"name":"Testing"`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)

--- a/test/integration/bundle_int_test.go
+++ b/test/integration/bundle_int_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"testing"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -71,7 +72,7 @@ func (suite *BundleIntegrationTestSuite) TestJSON() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/Bundles", "."),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -45,15 +45,11 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	data = bytes.ReplaceAll(data, []byte("casestyle"), []byte("case"))
 	suite.Require().NoError(fileutils.WriteFile(scriptPath, data), "Update buildscript")
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("commit"),
-	)
+	cp = ts.Spawn("commit")
 	cp.Expect("successfully created")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("pkg"),
-	)
+	cp = ts.Spawn("pkg")
 	cp.Expect("case ", e2e.RuntimeSourcingTimeoutOpt) // note: intentional trailing whitespace to not match 'casestyle'
 	cp.ExpectExitCode(0)
 }

--- a/test/integration/condition_int_test.go
+++ b/test/integration/condition_int_test.go
@@ -5,10 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ActiveState/cli/internal/constants"
-	"github.com/ActiveState/cli/internal/testhelpers/suite"
-
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 )
 
@@ -23,9 +21,7 @@ func (suite *ConditionIntegrationTestSuite) TestCondition() {
 
 	suite.PrepareActiveStateYAML(ts)
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("run", "test"),
-	)
+	cp := ts.Spawn("run", "test")
 	cp.Expect(`projectNameValue`)
 	cp.Expect(`projectOwnerValue`)
 	cp.Expect(`projectNamespaceValue`)
@@ -35,24 +31,17 @@ func (suite *ConditionIntegrationTestSuite) TestCondition() {
 	cp.Expect(`shellValue`)
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("activate"),
-		e2e.OptAppendEnv(constants.DisableActivateEventsEnvVarName+"=false"),
-	)
+	cp = ts.Spawn("activate")
 	cp.Expect(`Activation Event Ran`)
 	cp.ExpectInput()
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("run", "complex-true"),
-	)
+	cp = ts.Spawn("run", "complex-true")
 	cp.Expect(`I exist`)
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("run", "complex-false"),
-	)
+	cp = ts.Spawn("run", "complex-false")
 	cp.ExpectExitCode(1)
 }
 
@@ -63,9 +52,7 @@ func (suite *ConditionIntegrationTestSuite) TestMixin() {
 
 	suite.PrepareActiveStateYAML(ts)
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("run", "MixinUser"),
-	)
+	cp := ts.Spawn("run", "MixinUser")
 	cp.ExpectExitCode(0)
 	suite.Assert().NotContains(cp.Output(), "authenticated: yes", "expected not to be authenticated, output was:\n%s.", cp.Output())
 	suite.Assert().NotContains(cp.Output(), e2e.PersistentUsername, "expected not to be authenticated, output was:\n%s", cp.Output())
@@ -73,9 +60,7 @@ func (suite *ConditionIntegrationTestSuite) TestMixin() {
 	ts.LoginAsPersistentUser()
 	defer ts.LogoutUser()
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("run", "MixinUser"),
-	)
+	cp = ts.Spawn("run", "MixinUser")
 	cp.Expect("authenticated: yes")
 	cp.Expect(e2e.PersistentUsername)
 	cp.ExpectExitCode(0)
@@ -88,9 +73,7 @@ func (suite *ConditionIntegrationTestSuite) TestConditionOSName() {
 
 	suite.PrepareActiveStateYAML(ts)
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("run", "OSName"),
-	)
+	cp := ts.Spawn("run", "OSName")
 	switch runtime.GOOS {
 	case "windows":
 		cp.Expect(`using-windows`)
@@ -109,9 +92,7 @@ func (suite *ConditionIntegrationTestSuite) TestConditionSyntaxError() {
 
 	suite.PrepareActiveStateYAMLWithSyntaxError(ts)
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("run", "test"),
-	)
+	cp := ts.Spawn("run", "test")
 	cp.Expect(`not defined`) // for now we aren't passing the error up the chain, so invalid syntax will lead to empty result
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
@@ -119,7 +100,7 @@ func (suite *ConditionIntegrationTestSuite) TestConditionSyntaxError() {
 
 func (suite *ConditionIntegrationTestSuite) PrepareActiveStateYAML(ts *e2e.Session) {
 	asyData := strings.TrimSpace(`
-project: https://platform.activestate.com/ActiveState-CLI/test
+project: https://platform.activestate.com/ActiveState-CLI/Empty
 constants:
   - name: projectName
     value: invalidProjectName
@@ -218,11 +199,11 @@ events:
 `)
 
 	ts.PrepareActiveStateYAML(asyData)
-	ts.PrepareCommitIdFile("9090c128-e948-4388-8f7f-96e2c1e00d98")
+	ts.PrepareCommitIdFile("6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 }
 func (suite *ConditionIntegrationTestSuite) PrepareActiveStateYAMLWithSyntaxError(ts *e2e.Session) {
 	asyData := strings.TrimSpace(`
-project: https://platform.activestate.com/ActiveState-CLI/test
+project: https://platform.activestate.com/ActiveState-CLI/Empty
 scripts:
   - name: test
     language: bash
@@ -237,7 +218,7 @@ scripts:
 `)
 
 	ts.PrepareActiveStateYAML(asyData)
-	ts.PrepareCommitIdFile("9090c128-e948-4388-8f7f-96e2c1e00d98")
+	ts.PrepareCommitIdFile("6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 }
 
 func TestConditionIntegrationTestSuite(t *testing.T) {

--- a/test/integration/cve_int_test.go
+++ b/test/integration/cve_int_test.go
@@ -80,16 +80,13 @@ func (suite *CveIntegrationTestSuite) TestJSON() {
 
 	ts.LoginAsPersistentUser()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Perl", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	ts.PrepareEmptyProject()
 
-	cp = ts.Spawn("cve", "-o", "editor")
+	cp := ts.Spawn("cve", "-o", "editor")
 	cp.Expect(`"project":`)
 	cp.Expect(`"commitID":`)
 	cp.ExpectExitCode(0)
-	// AssertValidJSON(suite.T(), cp) // report is too large to fit in terminal snapshot
+	AssertValidJSON(suite.T(), cp)
 }
 
 func TestCveIntegrationTestSuite(t *testing.T) {

--- a/test/integration/deploy_int_test.go
+++ b/test/integration/deploy_int_test.go
@@ -35,23 +35,18 @@ func (suite *DeployIntegrationTestSuite) deploy(ts *e2e.Session, prj string, tar
 	var cp *e2e.SpawnedCmd
 	switch runtime.GOOS {
 	case "windows":
-		cp = ts.SpawnWithOpts(
-			e2e.OptArgs("deploy", prj, "--path", targetPath),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-		)
+		cp = ts.Spawn("deploy", prj, "--path", targetPath)
 	case "darwin":
 		// On MacOS the command is the same as Linux, however some binaries
 		// already exist at /usr/local/bin so we use the --force flag
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", prj, "--path", targetPath, "--force"),
 			e2e.OptAppendEnv("SHELL=bash"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	default:
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", prj, "--path", targetPath),
 			e2e.OptAppendEnv("SHELL=bash"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	}
 
@@ -98,13 +93,11 @@ func (suite *DeployIntegrationTestSuite) TestDeployPerl() {
 			"cmd.exe",
 			e2e.OptArgs("/k", filepath.Join(targetPath, "bin", "shell.bat")),
 			e2e.OptAppendEnv("PATHEXT=.COM;.EXE;.BAT;.LNK", "SHELL="),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	} else {
 		cp = ts.SpawnCmdWithOpts(
 			"/bin/bash",
 			e2e.OptAppendEnv("PROMPT_COMMAND="),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 		cp.SendLine(fmt.Sprintf("source %s\n", filepath.Join(targetPath, "bin", "shell.sh")))
 	}
@@ -174,13 +167,11 @@ func (suite *DeployIntegrationTestSuite) TestDeployPython() {
 			"cmd.exe",
 			e2e.OptArgs("/k", filepath.Join(targetPath, "bin", "shell.bat")),
 			e2e.OptAppendEnv("PATHEXT=.COM;.EXE;.BAT;.LNK", "SHELL="),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	} else {
 		cp = ts.SpawnCmdWithOpts(
 			"/bin/bash",
 			e2e.OptAppendEnv("PROMPT_COMMAND="),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 		cp.SendLine(fmt.Sprintf("source %s\n", filepath.Join(targetPath, "bin", "shell.sh")))
 	}
@@ -241,10 +232,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployInstall() {
 }
 
 func (suite *DeployIntegrationTestSuite) InstallAndAssert(ts *e2e.Session, targetPath string) {
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "install", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("deploy", "install", "ActiveState-CLI/Python3", "--path", targetPath)
 
 	cp.Expect("Installing Runtime")
 	cp.Expect("Installing", e2e.RuntimeSourcingTimeoutOpt)
@@ -268,10 +256,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 	suite.Require().NoError(err)
 
 	// Install step is required
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
@@ -281,13 +266,9 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 		cp = ts.SpawnWithOpts(
 			e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath),
 			e2e.OptAppendEnv("SHELL=bash"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 		)
 	} else {
-		cp = ts.SpawnWithOpts(
-			e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-		)
+		cp = ts.Spawn("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath)
 	}
 
 	cp.Expect("Configuring shell", e2e.RuntimeSourcingTimeoutOpt)
@@ -295,10 +276,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployConfigure() {
 	suite.AssertConfig(ts, targetID.String())
 
 	if runtime.GOOS == "windows" {
-		cp = ts.SpawnWithOpts(
-			e2e.OptArgs("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath, "--user"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-		)
+		cp = ts.Spawn("deploy", "configure", "ActiveState-CLI/Python3", "--path", targetPath, "--user")
 		cp.Expect("Configuring shell", e2e.RuntimeSourcingTimeoutOpt)
 		cp.ExpectExitCode(0)
 
@@ -345,25 +323,16 @@ func (suite *DeployIntegrationTestSuite) TestDeploySymlink() {
 	suite.Require().NoError(err)
 
 	// Install step is required
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 	suite.InstallAndAssert(ts, targetPath)
 
 	if runtime.GOOS != "darwin" {
-		cp = ts.SpawnWithOpts(
-			e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-		)
+		cp = ts.Spawn("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath)
 	} else {
-		cp = ts.SpawnWithOpts(
-			e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath, "--force"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-		)
+		cp = ts.Spawn("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath, "--force")
 	}
 
 	if runtime.GOOS != "windows" {
@@ -387,19 +356,13 @@ func (suite *DeployIntegrationTestSuite) TestDeployReport() {
 	suite.Require().NoError(err)
 
 	// Install step is required
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "report", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("deploy", "report", "ActiveState-CLI/Python3", "--path", targetPath)
 	cp.Expect("need to run the install step")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 	suite.InstallAndAssert(ts, targetPath)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "report", "ActiveState-CLI/Python3", "--path", targetPath),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("deploy", "report", "ActiveState-CLI/Python3", "--path", targetPath)
 	cp.Expect("Deployment Information")
 	cp.Expect(targetID.String()) // expect bin dir
 	if runtime.GOOS == "windows" {
@@ -429,7 +392,6 @@ func (suite *DeployIntegrationTestSuite) TestDeployTwice() {
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath),
 		e2e.OptAppendEnv(fmt.Sprintf("PATH=%s", pathDir)), // Avoid conflicts
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.ExpectExitCode(0)
 
@@ -442,7 +404,6 @@ func (suite *DeployIntegrationTestSuite) TestDeployTwice() {
 	cpx := ts.SpawnWithOpts(
 		e2e.OptArgs("deploy", "symlink", "ActiveState-CLI/Python3", "--path", targetPath),
 		e2e.OptAppendEnv(fmt.Sprintf("PATH=%s", pathDir)), // Avoid conflicts
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cpx.ExpectExitCode(0)
 }
@@ -466,10 +427,7 @@ func (suite *DeployIntegrationTestSuite) TestDeployUninstall() {
 	suite.InstallAndAssert(ts, targetDir)
 
 	// Uninstall deployed runtime.
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "uninstall", "--path", filepath.Join(ts.Dirs.Work, "target")),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("deploy", "uninstall", "--path", filepath.Join(ts.Dirs.Work, "target"))
 	cp.Expect("Uninstall Deployed Runtime")
 	cp.Expect("Successful")
 	cp.ExpectExitCode(0)
@@ -477,29 +435,20 @@ func (suite *DeployIntegrationTestSuite) TestDeployUninstall() {
 	suite.True(fileutils.IsDir(ts.Dirs.Work), "Work dir was unexpectedly deleted")
 
 	// Trying to uninstall again should fail
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "uninstall", "--path", filepath.Join(ts.Dirs.Work, "target")),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("deploy", "uninstall", "--path", filepath.Join(ts.Dirs.Work, "target"))
 	cp.Expect("no deployed runtime")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 	suite.True(fileutils.IsDir(ts.Dirs.Work), "Work dir was unexpectedly deleted")
 
 	// Trying to uninstall in a non-deployment directory should fail.
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "uninstall"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("deploy", "uninstall")
 	cp.Expect("no deployed runtime")
 	cp.ExpectExitCode(1)
 	suite.True(fileutils.IsDir(ts.Dirs.Work), "Work dir was unexpectedly deleted")
 
 	// Trying to uninstall in a non-deployment directory should not delete that directory.
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("deploy", "uninstall", "--path", ts.Dirs.Work),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("deploy", "uninstall", "--path", ts.Dirs.Work)
 	cp.Expect("no deployed runtime")
 	cp.ExpectExitCode(1)
 	suite.True(fileutils.IsDir(ts.Dirs.Work), "Work dir was unexpectedly deleted")

--- a/test/integration/events_int_test.go
+++ b/test/integration/events_int_test.go
@@ -15,13 +15,9 @@ type EventsIntegrationTestSuite struct {
 	tagsuite.Suite
 }
 
-func (suite *EventsIntegrationTestSuite) TestEvents() {
-	suite.OnlyRunForTags(tagsuite.Events)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
+func (suite *EventsIntegrationTestSuite) prepareASY(ts *e2e.Session) {
 	ts.PrepareActiveStateYAML(strings.TrimSpace(`
-project: https://platform.activestate.com/ActiveState-CLI/Python3
+project: https://platform.activestate.com/ActiveState-CLI/Empty
 scripts:
   - name: before
     language: bash
@@ -43,7 +39,15 @@ events:
     scope: ["activate"]
     value: after
 `))
-	ts.PrepareCommitIdFile("fbc613d6-b0b1-4f84-b26e-4aa5869c4e54")
+	ts.PrepareCommitIdFile("6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
+}
+
+func (suite *EventsIntegrationTestSuite) TestEvents() {
+	suite.OnlyRunForTags(tagsuite.Events)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	suite.prepareASY(ts)
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate"),
@@ -80,12 +84,9 @@ func (suite *EventsIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Python3", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	suite.prepareASY(ts)
 
-	cp = ts.Spawn("events", "-o", "json")
+	cp := ts.Spawn("events", "-o", "json")
 	cp.Expect(`[{"event":`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)

--- a/test/integration/executor_int_test.go
+++ b/test/integration/executor_int_test.go
@@ -27,17 +27,12 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorForwards() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/Python3"),
-	)
-	cp.Expect("Checked out project")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Python3")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp = ts.Spawn("shell", "ActiveState-CLI/Python3")
+	cp.Expect("Activated")
 	cp.ExpectInput()
 
 	cp.SendLine("python3 -c \"import sys; print(sys.copyright)\"")
@@ -54,17 +49,12 @@ func (suite *ExecutorIntegrationTestSuite) TestExecutorExitCode() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/Python3"),
-	)
-	cp.Expect("Checked out project")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Python3")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp = ts.Spawn("shell", "ActiveState-CLI/Python3")
+	cp.Expect("Activated")
 	cp.ExpectInput()
 
 	cp.SendLine("python3 -c \"exit(42)\"")

--- a/test/integration/export_int_test.go
+++ b/test/integration/export_int_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -42,12 +41,9 @@ func (suite *ExportIntegrationTestSuite) TestExport_Env() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.PrepareProject("ActiveState-CLI/Export", "5397f645-da8a-4591-b106-9d7fa99545fe")
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("export", "env"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect(`PATH: `, e2e.RuntimeSourcingTimeoutOpt)
+	ts.PrepareEmptyProject()
+	cp := ts.Spawn("export", "env")
+	cp.Expect(`PATH: `)
 	cp.ExpectExitCode(0)
 
 	suite.Assert().NotContains(cp.Output(), "ACTIVESTATE_ACTIVATED")
@@ -75,16 +71,13 @@ func (suite *ExportIntegrationTestSuite) TestExport_Runtime() {
 	suite.OnlyRunForTags(tagsuite.Export)
 	ts := e2e.New(suite.T(), false)
 
-	ts.PrepareProject("ActiveState-CLI/Export", "5397f645-da8a-4591-b106-9d7fa99545fe")
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("export", "runtime"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	ts.PrepareEmptyProject()
+	cp := ts.Spawn("export", "runtime")
 	cp.Expect("Project Path: ")
 	cp.Expect("Runtime Path: ")
 	cp.Expect("Executables Path: ")
 	cp.Expect("Environment Variables:") // intentional lack of trailing space
-	cp.Expect(` - PATH: `, e2e.RuntimeSourcingTimeoutOpt)
+	cp.Expect(` - PATH: `)
 	cp.ExpectExitCode(0)
 }
 
@@ -98,17 +91,10 @@ func (suite *ExportIntegrationTestSuite) TestJSON() {
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/small-python", "."),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
+	ts.PrepareEmptyProject()
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("export", "env", "-o", "json"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
+	cp = ts.Spawn("export", "env", "-o", "json")
+	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
 	ts.LoginAsPersistentUser()
@@ -123,9 +109,7 @@ func (suite *ExportIntegrationTestSuite) TestJSON() {
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("export", "runtime", "-o", "json"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"))
+	cp = ts.Spawn("export", "runtime", "-o", "json")
 	cp.Expect(`{"project":"`)
 	cp.Expect(`"}}`)
 	cp.ExpectExitCode(0)

--- a/test/integration/fork_int_test.go
+++ b/test/integration/fork_int_test.go
@@ -16,7 +16,7 @@ type ForkIntegrationTestSuite struct {
 }
 
 func (suite *ForkIntegrationTestSuite) cleanup(ts *e2e.Session) {
-	cp := ts.Spawn(tagsuite.Auth, "logout")
+	cp := ts.Spawn("auth", "logout")
 	cp.ExpectExitCode(0)
 	ts.Close()
 }
@@ -45,7 +45,7 @@ func (suite *ForkIntegrationTestSuite) TestFork_FailNameExists() {
 	defer suite.cleanup(ts)
 	ts.LoginAsPersistentUser()
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("fork", "ActiveState-CLI/Python3", "--org", e2e.PersistentUsername))
+	cp := ts.Spawn("fork", "ActiveState-CLI/Python3", "--org", e2e.PersistentUsername)
 	cp.Expect("You already have a project with the name 'Python3'", termtest.OptExpectTimeout(30*time.Second))
 	cp.ExpectNotExitCode(0)
 	ts.IgnoreLogErrors()

--- a/test/integration/hello_int_example_test.go
+++ b/test/integration/hello_int_example_test.go
@@ -18,11 +18,9 @@ func (suite *HelloIntegrationTestSuite) TestHello() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
+	ts.PrepareEmptyProject()
 
-	cp = ts.Spawn("_hello", "Person")
+	cp := ts.Spawn("_hello", "Person")
 	cp.Expect("Hello, Person!")
 	cp.ExpectExitCode(0)
 
@@ -32,7 +30,7 @@ func (suite *HelloIntegrationTestSuite) TestHello() {
 	ts.IgnoreLogErrors()
 
 	cp = ts.Spawn("_hello", "Person", "--extra")
-	cp.Expect("Project: ActiveState-CLI/small-python")
+	cp.Expect("Project: ActiveState-CLI/Empty")
 	cp.Expect("Current commit message:")
 	cp.ExpectExitCode(0)
 

--- a/test/integration/history_int_test.go
+++ b/test/integration/history_int_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -19,17 +18,9 @@ func (suite *HistoryIntegrationTestSuite) TestHistory_History() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.LoginAsPersistentUser()
+	ts.PrepareProject("ActiveState-CLI/History", "b5b327f8-468e-4999-a23e-8bee886e6b6d")
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/History")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
-
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("history"),
-		e2e.OptWD(filepath.Join(ts.Dirs.Work, "History")),
-	)
+	cp := ts.Spawn("history")
 	cp.Expect("Operating on project")
 	cp.Expect("ActiveState-CLI/History")
 	cp.Expect("Commit")
@@ -56,12 +47,9 @@ func (suite *HistoryIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/History", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	ts.PrepareProject("ActiveState-CLI/History", "b5b327f8-468e-4999-a23e-8bee886e6b6d")
 
-	cp = ts.Spawn("history", "-o", "json")
+	cp := ts.Spawn("history", "-o", "json")
 	cp.Expect(`[{"hash":`)
 	cp.Expect(`"changes":[{`)
 	cp.Expect(`"operation":"updated"`)

--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -28,10 +29,7 @@ func (suite *ImportIntegrationTestSuite) TestImport_detached() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Python3-Import", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
+	ts.PrepareProject("ActiveState-CLI/Python3-Import", "ecc61737-f598-4ca4-aa4e-52403aabb76c")
 
 	contents := `requests
 	urllib3`
@@ -40,7 +38,10 @@ func (suite *ImportIntegrationTestSuite) TestImport_detached() {
 	err := os.WriteFile(importPath, []byte(strings.TrimSpace(contents)), 0644)
 	suite.Require().NoError(err)
 
-	cp = ts.Spawn("import", importPath)
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("import", importPath),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+	)
 	cp.Expect("Operating on project")
 	cp.Expect("ActiveState-CLI/Python3-Import")
 	cp.ExpectExitCode(0)
@@ -96,7 +97,10 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, badReqsData)
 
-		cp := ts.Spawn("import", "requirements.txt")
+		cp := ts.SpawnWithOpts(
+			e2e.OptArgs("import", "requirements.txt"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+		)
 		cp.ExpectNotExitCode(0)
 	})
 
@@ -104,8 +108,10 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, reqsData)
 
-		cp := ts.Spawn("import", "requirements.txt")
-		cp.ExpectExitCode(0)
+		cp := ts.SpawnWithOpts(
+			e2e.OptArgs("import", "requirements.txt"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+		)
 
 		cp = ts.Spawn("push")
 		cp.ExpectExitCode(0)
@@ -119,8 +125,10 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, complexReqsData)
 
-		cp := ts.Spawn("import", "requirements.txt")
-		cp.ExpectExitCode(0)
+		cp := ts.SpawnWithOpts(
+			e2e.OptArgs("import", "requirements.txt"),
+			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+		)
 
 		cp = ts.Spawn("packages")
 		cp.Expect("coverage")

--- a/test/integration/info_int_test.go
+++ b/test/integration/info_int_test.go
@@ -57,7 +57,7 @@ func (suite *InfoIntegrationTestSuite) TestJSON() {
 	cp.Expect(`"authors":`)
 	cp.Expect(`"version":`)
 	cp.ExpectExitCode(0)
-	//AssertValidJSON(suite.T(), cp)
+	//AssertValidJSON(suite.T(), cp) // currently too big to fit in terminal snapshot
 
 	cp = ts.Spawn("info", "pylint@9.9.9", "--language", "python", "--output", "editor")
 	cp.Expect(`"error":`)

--- a/test/integration/install_int_test.go
+++ b/test/integration/install_int_test.go
@@ -20,8 +20,12 @@ func (suite *InstallIntegrationTestSuite) TestInstall() {
 	defer ts.Close()
 
 	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
-	cp := ts.SpawnWithOpts(e2e.OptArgs("install", "trender"), e2e.OptAppendEnv(constants.DisableRuntime+"=false"))
-	cp.Expect("Package added", e2e.RuntimeSourcingTimeoutOpt)
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("install", "trender")
+	cp.Expect("Package added")
 	cp.ExpectExitCode(0)
 }
 
@@ -31,7 +35,7 @@ func (suite *InstallIntegrationTestSuite) TestInstall_InvalidCommit() {
 	defer ts.Close()
 
 	ts.PrepareProject("ActiveState-CLI/small-python", "malformed-commit-id")
-	cp := ts.SpawnWithOpts(e2e.OptArgs("install", "trender"))
+	cp := ts.Spawn("install", "trender")
 	cp.Expect("invalid commit ID")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
@@ -43,7 +47,7 @@ func (suite *InstallIntegrationTestSuite) TestInstall_NoMatches_NoAlternatives()
 	defer ts.Close()
 
 	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
-	cp := ts.SpawnWithOpts(e2e.OptArgs("install", "I-dont-exist"))
+	cp := ts.Spawn("install", "I-dont-exist")
 	cp.Expect("No results found for search term")
 	cp.Expect("find alternatives") // This verifies no alternatives were found
 	cp.ExpectExitCode(1)
@@ -60,7 +64,7 @@ func (suite *InstallIntegrationTestSuite) TestInstall_NoMatches_Alternatives() {
 	defer ts.Close()
 
 	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
-	cp := ts.SpawnWithOpts(e2e.OptArgs("install", "database"))
+	cp := ts.Spawn("install", "database")
 	cp.Expect("No results found for search term")
 	cp.Expect("did you mean") // This verifies alternatives were found
 	cp.ExpectExitCode(1)
@@ -77,11 +81,9 @@ func (suite *InstallIntegrationTestSuite) TestInstall_BuildPlannerError() {
 	defer ts.Close()
 
 	ts.PrepareProject("ActiveState-CLI/small-python", "d8f26b91-899c-4d50-8310-2c338786aa0f")
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("install", "trender@999.0"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Could not plan build, platform responded with", e2e.RuntimeSourcingTimeoutOpt)
+
+	cp := ts.Spawn("install", "trender@999.0")
+	cp.Expect("Could not plan build, platform responded with")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 
@@ -96,11 +98,12 @@ func (suite *InstallIntegrationTestSuite) TestInstall_Resolved() {
 	defer ts.Close()
 
 	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("install", "requests"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Package added", e2e.RuntimeSourcingTimeoutOpt)
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("install", "requests")
+	cp.Expect("Package added")
 	cp.ExpectExitCode(0)
 
 	// Run `state packages` to verify a full package version was resolved.

--- a/test/integration/invite_int_test.go
+++ b/test/integration/invite_int_test.go
@@ -18,7 +18,7 @@ func (suite *InviteIntegrationTestSuite) TestInvite_NotAuthenticated() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.PrepareProject("ActiveState-CLI/Invite-Test", e2e.CommitIDNotChecked)
+	ts.PrepareEmptyProject()
 
 	cp := ts.Spawn("invite", "test-user@test.com")
 	cp.Expect("You need to authenticate")

--- a/test/integration/manifest_int_test.go
+++ b/test/integration/manifest_int_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"testing"
 
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -20,17 +19,11 @@ func (suite *ManifestIntegrationTestSuite) TestManifest() {
 
 	ts.LoginAsPersistentUser()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState/cli#9eee7512-b2ab-4600-b78b-ab0cf2e817d8", "."),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("checkout", "ActiveState/cli#9eee7512-b2ab-4600-b78b-ab0cf2e817d8", ".")
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("manifest"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Operating on project: ActiveState/cli", e2e.RuntimeSourcingTimeoutOpt)
+	cp = ts.Spawn("manifest")
+	cp.Expect("Operating on project: ActiveState/cli")
 	cp.Expect("Name")
 	cp.Expect("python")
 	cp.Expect("3.9.13")
@@ -48,14 +41,10 @@ func (suite *ManifestIntegrationTestSuite) TestManifest_JSON() {
 
 	ts.LoginAsPersistentUser()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState/cli#9eee7512-b2ab-4600-b78b-ab0cf2e817d8", "."),
-	)
+	cp := ts.Spawn("checkout", "ActiveState/cli#9eee7512-b2ab-4600-b78b-ab0cf2e817d8", ".")
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("manifest", "--output", "json"),
-	)
+	cp = ts.Spawn("manifest", "--output", "json")
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 	cp.Expect(`"requirements":`)

--- a/test/integration/migrator_int_test.go
+++ b/test/integration/migrator_int_test.go
@@ -22,9 +22,9 @@ func (suite *MigratorIntegrationTestSuite) TestMigrator() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+	ts.PrepareEmptyProject()
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("refresh"))
+	cp := ts.Spawn("refresh")
 	cp.ExpectExitCode(0)
 
 	suite.Require().Contains(string(fileutils.ReadFileUnsafe(filepath.Join(ts.Dirs.Work, constants.ConfigFileName))),
@@ -39,11 +39,11 @@ func (suite *MigratorIntegrationTestSuite) TestMigrator_Buildscripts() {
 	cp := ts.Spawn("config", "set", constants.OptinBuildscriptsConfig, "true")
 	cp.ExpectExitCode(0)
 
-	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+	ts.PrepareEmptyProject()
 
 	suite.Require().NoFileExists(filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName))
 
-	cp = ts.SpawnWithOpts(e2e.OptArgs("refresh"), e2e.OptAppendEnv(constants.DisableRuntime+"=false"))
+	cp = ts.Spawn("refresh")
 	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 
 	suite.Require().FileExists(filepath.Join(ts.Dirs.Work, constants.BuildScriptFileName), ts.DebugMessage(""))

--- a/test/integration/msg_int_test.go
+++ b/test/integration/msg_int_test.go
@@ -24,7 +24,7 @@ func (suite *MsgIntegrationTestSuite) TestMessage_None() {
 
 	// We test on config as it just dumps help and has minimal output
 	// The base state command would also work, but it's output is more verbose and termtest likes to cut off content if it's too long
-	cp := ts.SpawnWithOpts(e2e.OptArgs("config"))
+	cp := ts.Spawn("config")
 	cp.Expect("Usage:")
 	cp.ExpectExitCode(0)
 

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -272,9 +272,9 @@ func (suite *PackageIntegrationTestSuite) TestPackage_detached_operation() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
 	suite.Run("install non-existing", func() {
@@ -318,12 +318,18 @@ func (suite *PackageIntegrationTestSuite) TestPackage_operation() {
 	cp := ts.Spawn("fork", "ActiveState-CLI/Packages", "--org", user.Username, "--name", "python3-pkgtest")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("checkout", namespace, ".")
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("checkout", namespace, "."),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+	)
 	cp.Expect("Skipping runtime setup")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("history", "--output=json")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
 	suite.Run("install", func() {
@@ -363,12 +369,18 @@ func (suite *PackageIntegrationTestSuite) TestPackage_operation_multiple() {
 	cp := ts.Spawn("fork", "ActiveState-CLI/Packages", "--org", user.Username, "--name", "python3-pkgtest")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("checkout", namespace, ".")
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("checkout", namespace, "."),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+	)
 	cp.Expect("Skipping runtime setup")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("history", "--output=json")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
 	suite.Run("install", func() {
@@ -399,15 +411,12 @@ func (suite *PackageIntegrationTestSuite) TestPackage_Duplicate() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareEmptyProject()
+
+	cp := ts.Spawn("install", "shared/zlib") // install
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("install", "requests") // install
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("install", "requests") // install again
+	cp = ts.Spawn("install", "shared/zlib") // install again
 	cp.Expect("already installed")
 	cp.ExpectNotExitCode(0)
 	ts.IgnoreLogErrors()
@@ -458,16 +467,12 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 	cp.ExpectExitCode(0)
 	// AssertValidJSON(suite.T(), cp) // currently too large to fit terminal window to validate
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/Packages-Perl", "."),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/Packages-Perl", "b2feab96-f700-47a3-85ef-2ec44c390c6b")
+
+	cp = ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "Text-CSV", "-o", "json"),
-	)
+	cp = ts.Spawn("install", "Text-CSV", "-o", "json")
 	cp.Expect(`{"name":"Text-CSV"`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
@@ -477,9 +482,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("uninstall", "Text-CSV", "-o", "json"),
-	)
+	cp = ts.Spawn("uninstall", "Text-CSV", "-o", "json")
 	cp.Expect(`{"name":"Text-CSV"`)
 	cp.ExpectExitCode(0)
 	AssertValidJSON(suite.T(), cp)
@@ -499,15 +502,18 @@ func (suite *PackageIntegrationTestSuite) TestNormalize() {
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python", "."),
 		e2e.OptWD(dir),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
 	)
 	cp.Expect("Skipping runtime setup")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
+	cp = ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("install", "Charset_normalizer"),
 		e2e.OptWD(dir),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	// Even though we are not sourcing a runtime it can still take time to resolve
 	// the dependencies and create the commit
@@ -521,6 +527,7 @@ func (suite *PackageIntegrationTestSuite) TestNormalize() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/small-python", "."),
 		e2e.OptWD(anotherDir),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
 	)
 	cp.Expect("Skipping runtime setup")
 	cp.Expect("Checked out project")
@@ -529,7 +536,6 @@ func (suite *PackageIntegrationTestSuite) TestNormalize() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("install", "charset-normalizer"),
 		e2e.OptWD(anotherDir),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("charset-normalizer", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
@@ -541,15 +547,12 @@ func (suite *PackageIntegrationTestSuite) TestInstall_InvalidVersion() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "pytest@999.9999.9999"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("install", "pytest@999.9999.9999")
 	// User facing error from build planner
 	// We only assert the state tool curated part of the error as the underlying build planner error may change
 	cp.Expect("Could not plan build")
@@ -562,18 +565,15 @@ func (suite *PackageIntegrationTestSuite) TestUpdate_InvalidVersion() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "pytest") // install
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "pytest@999.9999.9999"),      // update
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"), // We DO want to test the runtime part, just not for every step
-	)
+	cp = ts.Spawn("install", "pytest@999.9999.9999") // update
 	// User facing error from build planner
 	// We only assert the state tool curated part of the error as the underlying build planner error may change
 	cp.Expect("Could not plan build")
@@ -586,9 +586,9 @@ func (suite *PackageIntegrationTestSuite) TestUpdate() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "pytest@7.3.2") // install
@@ -604,11 +604,8 @@ func (suite *PackageIntegrationTestSuite) TestUpdate() {
 	cp.Expect("7.3.2")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "pytest@7.4.0"),              // update
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"), // We DO want to test the runtime part, just not for every step
-	)
-	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
+	cp = ts.Spawn("install", "pytest@7.4.0") // update
+	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("history")
 	cp.Expect("pytest")
@@ -626,22 +623,12 @@ func (suite *PackageIntegrationTestSuite) TestRuby() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI-Testing/Ruby", "."),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	ts.PrepareProject("ActiveState-CLI-Testing/Ruby", "72fadc10-ed8c-4be6-810b-b3de6e017c57")
+
+	cp := ts.Spawn("install", "rake")
 	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "rake"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
-
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("exec", "rake", "--", "--version"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("exec", "rake", "--", "--version")
 	cp.ExpectRe(`rake, version \d+\.\d+\.\d+`)
 	cp.ExpectExitCode(0)
 }
@@ -656,8 +643,7 @@ func (suite *PackageIntegrationTestSuite) TestProjectWithOfflineInstallerAndDock
 	ts.LoginAsPersistentUser() // needed for Enterprise-tier features
 
 	cp := ts.Spawn("checkout", "ActiveState-CLI/Python-OfflineInstaller-Docker", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }
 
@@ -666,15 +652,12 @@ func (suite *PackageIntegrationTestSuite) TestResolved() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "requests"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("install", "requests")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("packages")
@@ -689,15 +672,12 @@ func (suite *PackageIntegrationTestSuite) TestCVE_NoPrompt() {
 
 	ts.LoginAsPersistentUser()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "urllib3@2.0.2"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("install", "urllib3@2.0.2")
 	cp.Expect("Warning: Dependency has 2 known vulnerabilities")
 	cp.ExpectExitCode(0)
 }
@@ -709,9 +689,9 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Prompt() {
 
 	ts.LoginAsPersistentUser()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLi/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("config", "set", "security.prompt.level", "high")
@@ -720,10 +700,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Prompt() {
 	cp = ts.Spawn("config", "set", "security.prompt.enabled", "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "urllib3@2.0.2"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("install", "urllib3@2.0.2")
 	cp.Expect("Warning: Dependency has 2 known vulnerabilities")
 	cp.Expect("Do you want to continue")
 	cp.SendLine("y")
@@ -740,16 +717,13 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Indirect() {
 
 	ts.LoginAsPersistentUser()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "private/ActiveState-CLI-Testing/language/python/django_dep", "--ts=now"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.ExpectRe(`Warning: Dependency has \d indirect known vulnerabilities`, e2e.RuntimeSourcingTimeoutOpt)
+	cp = ts.Spawn("install", "private/ActiveState-CLI-Testing/language/python/django_dep", "--ts=now")
+	cp.ExpectRe(`Warning: Dependency has \d indirect known vulnerabilities`)
 	cp.Expect("Do you want to continue")
 	cp.SendLine("n")
 	cp.ExpectExitCode(1)
@@ -764,14 +738,9 @@ func (suite *PackageIntegrationTestSuite) TestChangeSummary() {
 	cp.Expect("Successfully set")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "requests@2.31.0"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("install", "requests@2.31.0")
 	cp.Expect("Resolving Dependencies")
 	cp.Expect("Done")
 	cp.Expect("Installing requests@2.31.0 includes 4 direct dependencies")

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -460,7 +460,7 @@ func (suite *PackageIntegrationTestSuite) TestJSON() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("checkout", "ActiveState-CLI/Packages-Perl", "."),
-		e2e.OptAppendEnv("ACTIVESTATE_CLI_DISABLE_RUNTIME=false"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)

--- a/test/integration/pjfile_int_test.go
+++ b/test/integration/pjfile_int_test.go
@@ -29,9 +29,7 @@ languages:
         platform: Windows10Label,Linux64Label
 `))
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("scripts"),
-	)
+	cp := ts.Spawn("scripts")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 }

--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -124,9 +124,7 @@ func (suite *PrepareIntegrationTestSuite) TestResetExecutors() {
 	suite.Require().NoError(err)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "ActiveState-CLI/small-python", "--path", ts.Dirs.Work, "--default"),
-	)
+	cp := ts.Spawn("activate", "ActiveState-CLI/small-python", "--path", ts.Dirs.Work, "--default")
 	cp.Expect("This project will always be available for use")
 	cp.Expect("Downloading")
 	cp.Expect("Installing")

--- a/test/integration/progress_int_test.go
+++ b/test/integration/progress_int_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"testing"
 
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
@@ -19,21 +18,15 @@ func (suite *ProgressIntegrationTestSuite) TestProgress() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty")
 	cp.Expect(locale.T("install_runtime"))
 	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
 	suite.Assert().NotContains(cp.Output(), "...")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/small-python", "small-python2", "--non-interactive"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect(locale.T("setup_runtime"))
+	cp = ts.Spawn("checkout", "ActiveState-CLI/Empty", "Empty2", "--non-interactive")
 	cp.Expect("...")
+	cp.Expect(locale.T("setup_runtime"))
 	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }

--- a/test/integration/projects_int_test.go
+++ b/test/integration/projects_int_test.go
@@ -21,25 +21,12 @@ func (suite *ProjectsIntegrationTestSuite) TestProjects() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/small-python"))
-	cp.ExpectExitCode(0)
-	cp = ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/Python3"))
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty")
 	cp.ExpectExitCode(0)
 
 	// Verify local checkouts and executables are grouped together under projects.
-	cp = ts.SpawnWithOpts(e2e.OptArgs("projects"))
-	cp.Expect("Python3")
-	cp.Expect("Local Checkout")
-	if runtime.GOOS != "windows" {
-		cp.Expect(ts.Dirs.Work)
-	} else {
-		// Windows uses the long path here.
-		longPath, _ := fileutils.GetLongPathName(ts.Dirs.Work)
-		cp.Expect(longPath)
-	}
-	cp.Expect("Executables")
-	cp.Expect(ts.Dirs.Cache)
-	cp.Expect("small-python")
+	cp = ts.Spawn("projects")
+	cp.Expect("Empty")
 	cp.Expect("Local Checkout")
 	if runtime.GOOS != "windows" {
 		cp.Expect(ts.Dirs.Work)
@@ -58,9 +45,7 @@ func (suite *ProjectsIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python")
-	cp.ExpectExitCode(0)
-	cp = ts.Spawn("checkout", "ActiveState-CLI/Python3")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty")
 	cp.ExpectExitCode(0)
 	cp = ts.Spawn("projects", "-o", "json")
 	cp.Expect(`[{"name":`)
@@ -87,8 +72,8 @@ func (suite *ProjectsIntegrationTestSuite) TestEdit_Name() {
 	// What we expect the project name to be and what we want to change it to.
 	// This can change if the test failed previously.
 	var (
-		originalName = fmt.Sprintf("Edit-Test-%s", runtime.GOOS)
-		newName      = fmt.Sprintf("Edit-Rename-%s", runtime.GOOS)
+		originalName = fmt.Sprintf("Edit-Test2-%s", runtime.GOOS)
+		newName      = fmt.Sprintf("Edit-Rename2-%s", runtime.GOOS)
 	)
 
 	cp := ts.Spawn("checkout", fmt.Sprintf("ActiveState-CLI/%s", originalName))
@@ -169,9 +154,9 @@ func (suite *ProjectsIntegrationTestSuite) TestMove() {
 	ts.LoginAsPersistentUser()
 
 	// Just test interactivity, since we only have one integration test org.
-	cp := ts.Spawn("projects", "move", "ActiveState-CLI/small-python", "ActiveState-CLI")
+	cp := ts.Spawn("projects", "move", "ActiveState-CLI/Empty", "ActiveState-CLI")
 	cp.Expect("You are about to move")
-	cp.Expect("ActiveState-CLI/small-python")
+	cp.Expect("ActiveState-CLI/Empty")
 	cp.Expect("ActiveState-CLI")
 	cp.Expect("Continue? (y/N)")
 	cp.SendLine("n")

--- a/test/integration/refresh_int_test.go
+++ b/test/integration/refresh_int_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -21,35 +20,23 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 
 	suite.PrepareActiveStateYAML(ts, "ActiveState-CLI/Branches", "main", "35af7414-b44b-4fd7-aa93-2ecad337ed2b")
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("refresh"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("refresh")
 	cp.Expect("Setting Up Runtime")
 	cp.Expect("Runtime updated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("exec", "--", "python3", "-c", "import requests"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("exec", "--", "python3", "-c", "import requests")
 	cp.Expect("ModuleNotFoundError")
 	cp.ExpectExitCode(1)
 	ts.IgnoreLogErrors()
 
 	suite.PrepareActiveStateYAML(ts, "ActiveState-CLI/Branches", "secondbranch", "46c83477-d580-43e2-a0c6-f5d3677517f1")
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("refresh"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("refresh")
 	cp.Expect("Setting Up Runtime")
 	cp.Expect("Runtime updated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("exec", "--", "python3", "-c", "import requests"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("exec", "--", "python3", "-c", "import requests")
 	cp.ExpectExitCode(0, e2e.RuntimeSourcingTimeoutOpt)
 
 	cp = ts.Spawn("refresh")
@@ -63,14 +50,14 @@ func (suite *RefreshIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	suite.PrepareActiveStateYAML(ts, "ActiveState-CLI/Branches", "main", "35af7414-b44b-4fd7-aa93-2ecad337ed2b")
+	ts.PrepareEmptyProject()
 
 	cp := ts.Spawn("refresh", "-o", "json")
 	cp.Expect(`"namespace":`)
 	cp.Expect(`"path":`)
 	cp.Expect(`"executables":`)
 	cp.ExpectExitCode(0)
-	// AssertValidJSON(suite.T(), cp) // cannot assert here due to "Skipping runtime setup" notice
+	AssertValidJSON(suite.T(), cp)
 }
 
 func (suite *RefreshIntegrationTestSuite) PrepareActiveStateYAML(ts *e2e.Session, namespace, branch, commitID string) {

--- a/test/integration/revert_int_test.go
+++ b/test/integration/revert_int_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"path/filepath"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -19,18 +18,16 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	suite.OnlyRunForTags(tagsuite.Revert)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	ts.LoginAsPersistentUser()
 
 	namespace := "ActiveState-CLI/Revert"
-	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", namespace))
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
-	wd := filepath.Join(ts.Dirs.Work, "Revert")
+	ts.PrepareProject(namespace, "903bf49a-6719-47f0-ae70-450d69532ece")
 
 	// Revert the commit that added urllib3.
 	commitID := "1f4f4f7d-7883-400e-b2ad-a5803c018ecd"
-	cp = ts.SpawnWithOpts(e2e.OptArgs("revert", commitID), e2e.OptWD(wd))
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("revert", commitID),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+	)
 	cp.Expect(fmt.Sprintf("Operating on project %s", namespace))
 	cp.Expect("You are about to revert the following commit:")
 	cp.Expect(commitID)
@@ -39,10 +36,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	cp.ExpectExitCode(0)
 
 	// Verify the commit history has both the new revert commit and all prior history.
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("history"),
-		e2e.OptWD(wd),
-	)
+	cp = ts.Spawn("history")
 	cp.Expect("Reverted commit for commit " + commitID)
 	cp.Expect("- urllib3")
 	cp.Expect("+ argparse") // parent commit
@@ -50,10 +44,7 @@ func (suite *RevertIntegrationTestSuite) TestRevert() {
 	cp.Expect("+ python")   // initial commit
 
 	// Verify that argparse still exists (it was not reverted along with urllib3).
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "Revert"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("shell", "Revert")
 	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("python3")
 	cp.Expect("3.9.15")
@@ -71,16 +62,19 @@ func (suite *RevertIntegrationTestSuite) TestRevertRemote() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Revert", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	ts.PrepareProject("ActiveState-CLI/Revert", "75ae9c67-df55-4a95-be6f-b7975e5bb523")
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "requests")
 	cp.Expect("Package added")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("revert", "REMOTE", "--non-interactive")
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("revert", "REMOTE", "--non-interactive"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+	)
 	cp.Expect("Successfully reverted")
 	cp.ExpectExitCode(0)
 
@@ -95,17 +89,12 @@ func (suite *RevertIntegrationTestSuite) TestRevert_failsOnCommitNotInHistory() 
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	namespace := "ActiveState-CLI/small-python"
-	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", namespace))
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
-	wd := filepath.Join(ts.Dirs.Work, "small-python")
+	ts.PrepareEmptyProject()
 
 	// valid commit id not from project
 	commitID := "cb9b1aab-8e40-4a1d-8ad6-5ea112da40f1" // from Perl-5.32
-	cp = ts.SpawnWithOpts(e2e.OptArgs("revert", commitID), e2e.OptWD(wd))
-	cp.Expect(fmt.Sprintf("Operating on project %s", namespace))
+	cp := ts.Spawn("revert", commitID)
+	cp.Expect("Operating on project ActiveState-CLI/Empty")
 	cp.SendLine("Y")
 	cp.Expect(commitID)
 	cp.Expect("not found")
@@ -117,30 +106,25 @@ func (suite *RevertIntegrationTestSuite) TestRevertTo() {
 	suite.OnlyRunForTags(tagsuite.Revert)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	ts.LoginAsPersistentUser()
 
 	namespace := "ActiveState-CLI/Revert"
-	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", namespace))
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
-	wd := filepath.Join(ts.Dirs.Work, "Revert")
+	ts.PrepareProject(namespace, "903bf49a-6719-47f0-ae70-450d69532ece")
 
 	// Revert the commit that added urllib3.
 	commitID := "1f4f4f7d-7883-400e-b2ad-a5803c018ecd"
-	cp = ts.SpawnWithOpts(e2e.OptArgs("revert", "--to", commitID), e2e.OptWD(wd))
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("revert", "--to", commitID),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+	)
 	cp.Expect(fmt.Sprintf("Operating on project %s", namespace))
-	cp.SendLine("Y")
 	cp.Expect("You are about to revert to the following commit:")
 	cp.Expect(commitID)
+	cp.SendLine("Y")
 	cp.Expect("Successfully reverted to commit:")
 	cp.ExpectExitCode(0)
 
 	// Verify the commit history has both the new revert commit and all prior history.
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("history"),
-		e2e.OptWD(wd),
-	)
+	cp = ts.Spawn("history")
 	cp.Expect("Revert to commit " + commitID)
 	cp.Expect("- argparse") // effectively reverting previous commit
 	cp.Expect("+ argparse") // commit being effectively reverted
@@ -153,17 +137,12 @@ func (suite *RevertIntegrationTestSuite) TestRevertTo_failsOnCommitNotInHistory(
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	namespace := "ActiveState-CLI/small-python"
-	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", namespace))
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
-	wd := filepath.Join(ts.Dirs.Work, "small-python")
+	ts.PrepareEmptyProject()
 
 	// valid commit id not from project
 	commitID := "cb9b1aab-8e40-4a1d-8ad6-5ea112da40f1" // from Perl-5.32
-	cp = ts.SpawnWithOpts(e2e.OptArgs("revert", "--to", commitID), e2e.OptWD(wd))
-	cp.Expect(fmt.Sprintf("Operating on project %s", namespace))
+	cp := ts.Spawn("revert", "--to", commitID)
+	cp.Expect("Operating on project ActiveState-CLI/Empty")
 	cp.SendLine("Y")
 	cp.Expect(commitID)
 	cp.Expect("not found")
@@ -176,15 +155,15 @@ func (suite *RevertIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Revert", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
+	ts.PrepareProject("ActiveState-CLI/Revert", "903bf49a-6719-47f0-ae70-450d69532ece")
 
-	cp = ts.Spawn("revert", "--to", "1f4f4f7d-7883-400e-b2ad-a5803c018ecd", "-o", "json")
-	cp.Expect(`{"current_commit_id":`)
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("revert", "--to", "1f4f4f7d-7883-400e-b2ad-a5803c018ecd", "-o", "json"),
+		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
+	)
+	cp.Expect(`{"current_commit_id":`, e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
-	// AssertValidJSON(suite.T(), cp) // cannot assert here due to "Skipping runtime setup" notice
+	AssertValidJSON(suite.T(), cp)
 }
 
 func TestRevertIntegrationTestSuite(t *testing.T) {

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -10,14 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ActiveState/cli/internal/testhelpers/suite"
-
 	"github.com/ActiveState/termtest"
 
-	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 	"github.com/ActiveState/cli/pkg/project"
 )
@@ -26,15 +24,14 @@ type RunIntegrationTestSuite struct {
 	tagsuite.Suite
 }
 
-func (suite *RunIntegrationTestSuite) createProjectFile(ts *e2e.Session, pythonVersion int) {
+func (suite *RunIntegrationTestSuite) createProjectFile(ts *e2e.Session, name, commitID string) {
 	root := environment.GetRootPathUnsafe()
 	interruptScript := filepath.Join(root, "test", "integration", "assets", "run", "interrupt.go")
 	err := fileutils.CopyFile(interruptScript, filepath.Join(ts.Dirs.Work, "interrupt.go"))
 	suite.Require().NoError(err)
 
-	// ActiveState-CLI/Python3 is just a place-holder that is never used
 	configFileContent := strings.TrimPrefix(fmt.Sprintf(`
-project: https://platform.activestate.com/ActiveState-CLI/Python%d
+project: https://platform.activestate.com/%s
 scripts:
   - name: test-interrupt
     description: A script that sleeps for a very long time.  It should be interrupted.  The first interrupt does not terminate.
@@ -70,10 +67,10 @@ scripts:
       exit 123
     standalone: true
     language: bash
-`, pythonVersion), "\n")
+`, name), "\n")
 
 	ts.PrepareActiveStateYAML(configFileContent)
-	ts.PrepareCommitIdFile("fbc613d6-b0b1-4f84-b26e-4aa5869c4e54")
+	ts.PrepareCommitIdFile(commitID)
 }
 
 func (suite *RunIntegrationTestSuite) SetupTest() {
@@ -105,15 +102,17 @@ func (suite *RunIntegrationTestSuite) TestInActivatedEnv() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	suite.createProjectFile(ts, 3)
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	cp := ts.Spawn("activate")
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
+	cp.Expect("Activated")
+	cp.ExpectInput()
 
+	// We're on Linux CI, so it's okay to use the OS's installed Python for this test.
+	// It's costly to source our own for this test.
 	cp.SendLine(fmt.Sprintf("%s run testMultipleLanguages", ts.Exe))
 	cp.Expect("Operating on project")
-	cp.Expect("ActiveState-CLI/Python3")
+	cp.Expect("ActiveState-CLI/Empty")
 	cp.Expect("3")
 
 	cp.SendLine(fmt.Sprintf("%s run test-interrupt", cp.Executable()))
@@ -142,11 +141,11 @@ func (suite *RunIntegrationTestSuite) TestScriptBashSubshell() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	suite.createProjectFile(ts, 3)
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	cp := ts.SpawnWithOpts(e2e.OptArgs("activate"), e2e.OptAppendEnv("SHELL=bash"))
-	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
+	cp.Expect("Activated")
+	cp.ExpectInput()
 
 	cp.SendLine("helloWorld")
 	cp.Expect("Hello World!")
@@ -163,7 +162,7 @@ func (suite *RunIntegrationTestSuite) TestOneInterrupt() {
 	}
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	suite.createProjectFile(ts, 3)
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	cp := ts.Spawn("run", "test-interrupt")
 	cp.Expect("Start of script")
@@ -184,9 +183,7 @@ func (suite *RunIntegrationTestSuite) TestTwoInterrupts() {
 	}
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	suite.createProjectFile(ts, 3)
-
-	ts.LoginAsPersistentUser()
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	cp := ts.Spawn("run", "test-interrupt")
 	cp.Expect("Start of script")
@@ -206,7 +203,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Help() {
 	suite.OnlyRunForTags(tagsuite.Run)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	suite.createProjectFile(ts, 3)
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	cp := ts.Spawn("run", "-h")
 	cp.Expect("Usage")
@@ -218,7 +215,7 @@ func (suite *RunIntegrationTestSuite) TestRun_ExitCode() {
 	suite.OnlyRunForTags(tagsuite.Run, tagsuite.ExitCode)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
-	suite.createProjectFile(ts, 3)
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	cp := ts.Spawn("run", "nonZeroExit")
 	cp.ExpectExitCode(123)
@@ -229,12 +226,9 @@ func (suite *RunIntegrationTestSuite) TestRun_Unauthenticated() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	suite.createProjectFile(ts, 2)
+	suite.createProjectFile(ts, "ActiveState-CLI/Python2", "fbc613d6-b0b1-4f84-b26e-4aa5869c4e54")
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("activate")
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
 
@@ -251,7 +245,7 @@ func (suite *RunIntegrationTestSuite) TestRun_DeprecatedLackingLanguage() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	suite.createProjectFile(ts, 3)
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	cp := ts.Spawn("run", "helloWorld")
 	cp.Expect("Deprecation Warning", termtest.OptExpectTimeout(5*time.Second))
@@ -263,7 +257,7 @@ func (suite *RunIntegrationTestSuite) TestRun_BadLanguage() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	suite.createProjectFile(ts, 3)
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	asyFilename := filepath.Join(ts.Dirs.Work, "activestate.yaml")
 	asyFile, err := os.OpenFile(asyFilename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -294,10 +288,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("activate"),
-		e2e.OptAppendEnv(
-			constants.DisableRuntime+"=false",
-			"PERL_VERSION=does_not_exist",
-		),
+		e2e.OptAppendEnv("PERL_VERSION=does_not_exist"),
 	)
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
@@ -313,7 +304,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Args() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	suite.createProjectFile(ts, 3)
+	suite.createProjectFile(ts, "ActiveState-CLI/Empty", "6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8")
 
 	asyFilename := filepath.Join(ts.Dirs.Work, "activestate.yaml")
 	asyFile, err := os.OpenFile(asyFilename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -87,10 +87,7 @@ func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/test-interrupt-small-python#863c45e2-3626-49b6-893c-c15e85a17241", "."),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("checkout", "ActiveState-CLI/test-interrupt-small-python#863c45e2-3626-49b6-893c-c15e85a17241", ".")
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 
 	targetDir := target.ProjectDirToTargetDir(ts.Dirs.Work, ts.Dirs.Cache)
@@ -101,8 +98,7 @@ func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("pull"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false",
-			constants.RuntimeSetupWaitEnvVarName+"=true"),
+		e2e.OptAppendEnv(constants.RuntimeSetupWaitEnvVarName+"=true"),
 	)
 	time.Sleep(30 * time.Second)
 	cp.SendCtrlC() // cancel pull/update
@@ -121,22 +117,14 @@ func (suite *RuntimeIntegrationTestSuite) TestInUse() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Perl-5.36", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.ExpectExitCode(0)
+	ts.PrepareProject("ActiveState-CLI/Empty", "b55d0e63-db48-43c4-8341-e2b7a1cc134c")
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("shell")
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("perl")
 	time.Sleep(1 * time.Second) // allow time for perl to start up
 
-	cp2 := ts.SpawnWithOpts(
-		e2e.OptArgs("install", "DateTime"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp2 := ts.Spawn("install", "DateTime")
 	cp2.Expect("currently in use", e2e.RuntimeSourcingTimeoutOpt)
 	cp2.Expect("perl")
 	cp2.ExpectNotExitCode(0)
@@ -175,24 +163,16 @@ func (suite *RuntimeIntegrationTestSuite) TestBuildInProgress() {
 	cp.Expect("Successfully published")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("checkout", "ActiveState-CLI/Perl-5.36", ".")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	ts.PrepareEmptyProject()
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("install", "private/"+e2e.PersistentUsername+"/hello-world", "--ts", "now"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("install", "private/"+e2e.PersistentUsername+"/hello-world", "--ts", "now")
 	cp.Expect("Build Log")
 	cp.Expect("Building")
 	cp.Expect("All dependencies have been installed and verified", e2e.RuntimeBuildSourcingTimeoutOpt)
 	cp.Expect("Package added: hello-world")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("exec", "main"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("exec", "main")
 	cp.Expect("Hello world!")
 	cp.ExpectExitCode(0)
 }

--- a/test/integration/scripts_int_test.go
+++ b/test/integration/scripts_int_test.go
@@ -15,7 +15,7 @@ type ScriptsIntegrationTestSuite struct {
 
 func (suite *ScriptsIntegrationTestSuite) setupConfigFile(ts *e2e.Session) {
 	configFileContent := strings.TrimSpace(`
-project: "https://platform.activestate.com/ScriptOrg/ScriptProject"
+project: "https://platform.activestate.com/ActiveState-CLI/Empty?branch=main&commitID=6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8"
 scripts:
   - name: first-script
     value: echo "first script"

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -33,20 +33,14 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python")
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	args := []string{"small-python", "ActiveState-CLI/small-python"}
 	for _, arg := range args {
-		cp := ts.SpawnWithOpts(
-			e2e.OptArgs("shell", arg),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-		)
-		cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+		cp := ts.Spawn("shell", arg)
+		cp.Expect("Activated")
 		cp.ExpectInput()
 
 		cp.SendLine("python3 --version")
@@ -72,9 +66,7 @@ func (suite *ShellIntegrationTestSuite) TestShell() {
 	// Check for project not checked out.
 	args = []string{"Python-3.9", "ActiveState-CLI/Python-3.9"}
 	for _, arg := range args {
-		cp := ts.SpawnWithOpts(
-			e2e.OptArgs("shell", arg),
-		)
+		cp := ts.Spawn("shell", arg)
 		cp.Expect("Cannot find the Python-3.9 project")
 		cp.ExpectExitCode(1)
 	}
@@ -87,22 +79,16 @@ func (suite *ShellIntegrationTestSuite) TestDefaultShell() {
 	defer ts.Close()
 
 	// Checkout.
-	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/small-python"))
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out project")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty")
+	cp.Expect("Checked out")
 	cp.ExpectExitCode(0)
 
 	// Use.
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("use", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
+	cp = ts.Spawn("use", "ActiveState-CLI/Empty")
+	cp.Expect("Switched to project")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell"),
-	)
+	cp = ts.Spawn("shell")
 	cp.Expect("Activated")
 	cp.ExpectInput()
 	cp.SendLine("exit")
@@ -115,9 +101,7 @@ func (suite *ShellIntegrationTestSuite) TestCwdShell() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "ActiveState-CLI/small-python"),
-	)
+	cp := ts.Spawn("activate", "ActiveState-CLI/Empty")
 	cp.Expect("Activated")
 	cp.ExpectInput()
 	cp.SendLine("exit")
@@ -125,7 +109,7 @@ func (suite *ShellIntegrationTestSuite) TestCwdShell() {
 
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell"),
-		e2e.OptWD(filepath.Join(ts.Dirs.Work, "small-python")),
+		e2e.OptWD(filepath.Join(ts.Dirs.Work, "Empty")),
 	)
 	cp.Expect("Activated")
 	cp.ExpectInput()
@@ -139,9 +123,7 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate", "ActiveState-CLI/small-python"),
-	)
+	cp := ts.Spawn("activate", "ActiveState-CLI/Empty")
 	cp.Expect("Activated")
 	cp.ExpectInput()
 	cp.SendLine("exit")
@@ -152,7 +134,7 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 	suite.Require().NoError(err)
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "ActiveState-CLI/small-python"),
+		e2e.OptArgs("shell", "ActiveState-CLI/Empty"),
 		e2e.OptWD(subdir),
 	)
 	cp.Expect("Activated")
@@ -166,7 +148,7 @@ func (suite *ShellIntegrationTestSuite) TestCd() {
 	cp.SendLine("exit")
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "ActiveState-CLI/small-python", "--cd"),
+		e2e.OptArgs("shell", "ActiveState-CLI/Empty", "--cd"),
 		e2e.OptWD(subdir),
 	)
 	cp.Expect("Activated")
@@ -188,22 +170,18 @@ func (suite *ShellIntegrationTestSuite) TestDefaultNoLongerExists() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("checkout", "ActiveState-CLI/Python3"))
-	cp.Expect("Skipping runtime setup")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("use", "ActiveState-CLI/Empty")
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
-	err := os.RemoveAll(filepath.Join(ts.Dirs.Work, "Python3"))
+	err := os.RemoveAll(filepath.Join(ts.Dirs.Work, "Empty"))
 	suite.Require().NoError(err)
 
-	cp = ts.SpawnWithOpts(e2e.OptArgs("shell"))
+	cp = ts.Spawn("shell")
 	cp.Expect("Cannot find your project")
 	cp.ExpectExitCode(1)
 }
@@ -216,7 +194,7 @@ func (suite *ShellIntegrationTestSuite) TestUseShellUpdates() {
 
 	suite.SetupRCFile(ts)
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Python3")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
@@ -230,9 +208,8 @@ func (suite *ShellIntegrationTestSuite) TestUseShellUpdates() {
 	}
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("use", "ActiveState-CLI/Python3"),
+		e2e.OptArgs("use", "ActiveState-CLI/Empty"),
 		e2e.OptAppendEnv("SHELL=bash"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
@@ -273,14 +250,9 @@ func (suite *ShellIntegrationTestSuite) TestRuby() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI-Testing/Ruby", ".")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
+	ts.PrepareProject("ActiveState-CLI-Testing/Ruby", "72fadc10-ed8c-4be6-810b-b3de6e017c57")
 
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("shell")
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	cp.SendLine("ruby -v")
@@ -297,7 +269,7 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 
 	var ss subshell.SubShell
 	var rcFile string
-	env := []string{constants.DisableRuntime + "=false"}
+	env := []string{}
 	switch runtime.GOOS {
 	case "darwin":
 		ss = &zsh.SubShell{}
@@ -316,19 +288,19 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 	suite.Require().Equal(filepath.Dir(rcFile), ts.Dirs.HomeDir, "rc file not in test suite homedir")
 	suite.Require().Contains(string(fileutils.ReadFileUnsafe(rcFile)), "State Tool is operating on project")
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "small-python"),
+		e2e.OptArgs("shell", "Empty"),
 		e2e.OptAppendEnv(env...))
 	cp.Expect("Activated")
 	suite.Assert().NotContains(cp.Snapshot(), "State Tool is operating on project")
 	cp.SendLine(fmt.Sprintf(`export HOME="%s"`, ts.Dirs.HomeDir)) // some shells do not forward this
 
 	cp.SendLine(ss.Binary()) // platform-specific shell (zsh on macOS, bash on Linux, etc.)
-	cp.Expect("State Tool is operating on project ActiveState-CLI/small-python")
+	cp.Expect("State Tool is operating on project ActiveState-CLI/Empty")
 	cp.SendLine("exit") // subshell within a subshell
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
@@ -342,24 +314,24 @@ func (suite *ShellIntegrationTestSuite) TestPs1() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell", "small-python"),
+		e2e.OptArgs("shell", "Empty"),
 	)
 	cp.Expect("Activated")
-	cp.Expect("[ActiveState-CLI/small-python]")
+	cp.Expect("[ActiveState-CLI/Empty]")
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("config", "set", constants.PreservePs1ConfigKey, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("shell", "small-python")
+	cp = ts.Spawn("shell", "Empty")
 	cp.Expect("Activated")
-	suite.Assert().NotContains(cp.Snapshot(), "[ActiveState-CLI/small-python]")
+	suite.Assert().NotContains(cp.Snapshot(), "[ActiveState-CLI/Empty]")
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 }
@@ -370,24 +342,21 @@ func (suite *ShellIntegrationTestSuite) TestProjectOrder() {
 	defer ts.Close()
 
 	// First, set up a new project with a subproject.
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Perl-5.32", "project")
-	cp.Expect("Skipping runtime setup")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Empty", "project")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 	projectDir := filepath.Join(ts.Dirs.Work, "project")
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/Perl-5.32", "subproject"),
+		e2e.OptArgs("checkout", "ActiveState-CLI/Empty", "subproject"),
 		e2e.OptWD(projectDir),
 	)
-	cp.Expect("Skipping runtime setup")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 	subprojectDir := filepath.Join(projectDir, "subproject")
 
 	// Then set up a separate project and make it the default.
-	cp = ts.Spawn("checkout", "ActiveState-CLI/Perl-5.32", "default")
-	cp.Expect("Skipping runtime setup")
+	cp = ts.Spawn("checkout", "ActiveState-CLI/Empty", "default")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 	defaultDir := filepath.Join(ts.Dirs.Work, "default")
@@ -395,9 +364,7 @@ func (suite *ShellIntegrationTestSuite) TestProjectOrder() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("use"),
 		e2e.OptWD(defaultDir),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
-	cp.Expect("Setting Up Runtime", e2e.RuntimeSourcingTimeoutOpt)
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.Expect(defaultDir)
 	cp.ExpectExitCode(0)
@@ -420,7 +387,6 @@ func (suite *ShellIntegrationTestSuite) TestProjectOrder() {
 	cp = ts.SpawnWithOpts(
 		e2e.OptArgs("shell"),
 		e2e.OptWD(projectDir),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
 	)
 	cp.Expect("Opening shell", e2e.RuntimeSourcingTimeoutOpt)
 	cp.Expect(projectDir)
@@ -475,7 +441,6 @@ func (suite *ShellIntegrationTestSuite) TestScriptAlias() {
 	defer ts.Close()
 
 	cp := ts.Spawn("checkout", "ActiveState-CLI/Perl-5.32", ".")
-	cp.Expect("Skipping runtime setup")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
@@ -501,10 +466,7 @@ events:`, lang, splat), 1)
 	suite.Require().NoError(fileutils.WriteFile(asyFilename, []byte(contents)))
 
 	// Verify that running a script as a command with an argument containing special characters works.
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("shell"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp = ts.Spawn("shell")
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	cp.SendLine(`args "<3"`)

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -297,7 +297,7 @@ func (suite *ShellIntegrationTestSuite) TestNestedShellNotification() {
 
 	var ss subshell.SubShell
 	var rcFile string
-	env := []string{"ACTIVESTATE_CLI_DISABLE_RUNTIME=false"}
+	env := []string{constants.DisableRuntime + "=false"}
 	switch runtime.GOOS {
 	case "darwin":
 		ss = &zsh.SubShell{}

--- a/test/integration/shells_int_test.go
+++ b/test/integration/shells_int_test.go
@@ -35,10 +35,7 @@ func (suite *ShellsIntegrationTestSuite) TestShells() {
 	}
 
 	// Checkout the first instance. It doesn't matter which shell is used.
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("checkout", "ActiveState-CLI/small-python"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
+	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python")
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
@@ -52,7 +49,7 @@ func (suite *ShellsIntegrationTestSuite) TestShells() {
 			}
 
 			// Run the checkout in a particular shell.
-			cp = ts.SpawnShellWithOpts(shell)
+			cp = ts.SpawnShellWithOpts(shell, e2e.OptAppendEnv(constants.DisableRuntime+"=true"))
 			cp.SendLine(e2e.QuoteCommand(shell, ts.ExecutablePath(), "checkout", "ActiveState-CLI/small-python", string(shell)))
 			cp.Expect("Checked out project")
 			cp.SendLine("exit")
@@ -62,7 +59,7 @@ func (suite *ShellsIntegrationTestSuite) TestShells() {
 
 			// There are 2 or more instances checked out, so we should get a prompt in whichever shell we
 			// use.
-			cp = ts.SpawnShellWithOpts(shell, e2e.OptAppendEnv(constants.DisableRuntime+"=false"))
+			cp = ts.SpawnShellWithOpts(shell)
 			cp.SendLine(e2e.QuoteCommand(shell, ts.ExecutablePath(), "shell", "small-python"))
 			cp.Expect("Multiple project paths")
 

--- a/test/integration/show_int_test.go
+++ b/test/integration/show_int_test.go
@@ -24,13 +24,7 @@ func (suite *ShowIntegrationTestSuite) TestShow() {
 
 	suite.PrepareProject(ts)
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("activate"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
-
-	cp = ts.Spawn("show")
+	cp := ts.Spawn("show")
 	cp.Expect(`Name`)
 	cp.Expect(`Show`)
 	cp.Expect(`Organization`)
@@ -65,7 +59,7 @@ func (suite *ShowIntegrationTestSuite) TestShowWithoutBranch() {
 
 	ts.PrepareProject("cli-integration-tests/Show", "e8f3b07b-502f-4763-83c1-763b9b952e18")
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("show"))
+	cp := ts.Spawn("show")
 	cp.ExpectExitCode(0)
 
 	contents, err := fileutils.ReadFile(filepath.Join(ts.Dirs.Work, constants.ConfigFileName))
@@ -105,12 +99,9 @@ func (suite *ShowIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	suite.PrepareProject(ts)
 
-	cp = ts.Spawn("show", "-o", "json")
+	cp := ts.Spawn("show", "-o", "json")
 	cp.Expect(`"project_url":`)
 	cp.Expect(`"name":`)
 	cp.Expect(`"platforms":`)

--- a/test/integration/switch_int_test.go
+++ b/test/integration/switch_int_test.go
@@ -24,7 +24,7 @@ func (suite *SwitchIntegrationTestSuite) TestSwitch_Branch() {
 	err := ts.ClearCache()
 	suite.Require().NoError(err)
 
-	ts.PrepareProject("ActiveState-CLI/Branches", "b5b327f8-468e-4999-a23e-8bee886e6b6d")
+	ts.PrepareEmptyProject()
 	pjfilepath := filepath.Join(ts.Dirs.Work, constants.ConfigFileName)
 
 	pj, err := project.FromPath(pjfilepath)
@@ -33,9 +33,9 @@ func (suite *SwitchIntegrationTestSuite) TestSwitch_Branch() {
 	mainBranchCommitID := ts.CommitID()
 	suite.Require().NoError(err)
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("switch", "secondbranch"))
+	cp := ts.Spawn("switch", "mingw")
 	cp.Expect("Operating on project")
-	cp.Expect("ActiveState-CLI/Branches")
+	cp.Expect("ActiveState-CLI/Empty")
 	cp.Expect("Successfully switched to branch:")
 	if runtime.GOOS != "windows" {
 		cp.ExpectExitCode(0)
@@ -46,7 +46,7 @@ func (suite *SwitchIntegrationTestSuite) TestSwitch_Branch() {
 	suite.Require().NoError(err)
 	suite.Require().NoError(err)
 	suite.NotEqual(mainBranchCommitID, ts.CommitID(), "commitID was not updated after switching branches", pj.Dir())
-	suite.Equal("secondbranch", pj.BranchName(), "branch was not updated after switching branches")
+	suite.Equal("mingw", pj.BranchName(), "branch was not updated after switching branches")
 }
 
 func (suite *SwitchIntegrationTestSuite) TestSwitch_CommitID() {
@@ -57,7 +57,7 @@ func (suite *SwitchIntegrationTestSuite) TestSwitch_CommitID() {
 	err := ts.ClearCache()
 	suite.Require().NoError(err)
 
-	ts.PrepareProject("ActiveState-CLI/History", "b5b327f8-468e-4999-a23e-8bee886e6b6d")
+	ts.PrepareEmptyProject()
 	pjfilepath := filepath.Join(ts.Dirs.Work, constants.ConfigFileName)
 
 	pj, err := project.FromPath(pjfilepath)
@@ -65,7 +65,7 @@ func (suite *SwitchIntegrationTestSuite) TestSwitch_CommitID() {
 	suite.Require().Equal("main", pj.BranchName(), "branch was not set to 'main' after pull")
 	originalCommitID := ts.CommitID()
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("switch", "efce7c7a-c61a-4b04-bb00-f8e7edfd247f"))
+	cp := ts.SpawnWithOpts(e2e.OptArgs("switch", "265f9914-ad4d-4e0a-a128-9d4e8c5db820"))
 	cp.Expect("Successfully switched to commit:")
 	if runtime.GOOS != "windows" {
 		cp.ExpectExitCode(0)
@@ -85,7 +85,7 @@ func (suite *SwitchIntegrationTestSuite) TestSwitch_CommitID_NotInHistory() {
 	err := ts.ClearCache()
 	suite.Require().NoError(err)
 
-	ts.PrepareProject("ActiveState-CLI/History", "b5b327f8-468e-4999-a23e-8bee886e6b6d")
+	ts.PrepareEmptyProject()
 	pjfilepath := filepath.Join(ts.Dirs.Work, constants.ConfigFileName)
 
 	pj, err := project.FromPath(pjfilepath)
@@ -93,7 +93,7 @@ func (suite *SwitchIntegrationTestSuite) TestSwitch_CommitID_NotInHistory() {
 	suite.Require().Equal("main", pj.BranchName(), "branch was not set to 'main' after pull")
 	originalCommitID := ts.CommitID()
 
-	cp := ts.SpawnWithOpts(e2e.OptArgs("switch", "76dff77a-66b9-43e3-90be-dc75917dd661"))
+	cp := ts.Spawn("switch", "76dff77a-66b9-43e3-90be-dc75917dd661")
 	cp.Expect("Commit does not belong")
 	if runtime.GOOS != "windows" {
 		cp.ExpectExitCode(1)
@@ -111,15 +111,12 @@ func (suite *SwitchIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Branches", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	ts.PrepareEmptyProject()
 
-	cp = ts.Spawn("switch", "firstbranch", "--output", "json")
+	cp := ts.Spawn("switch", "mingw", "--output", "json")
 	cp.Expect(`"branch":`)
 	cp.ExpectExitCode(0)
-	// AssertValidJSON(suite.T(), cp) // cannot assert here due to "Skipping runtime setup" notice
+	AssertValidJSON(suite.T(), cp)
 }
 
 func TestSwitchIntegrationTestSuite(t *testing.T) {

--- a/test/integration/update_lock_int_test.go
+++ b/test/integration/update_lock_int_test.go
@@ -219,12 +219,9 @@ func (suite *UpdateIntegrationTestSuite) TestJSON() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Python3", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
+	ts.PrepareEmptyProject()
 
-	cp = ts.Spawn("update", "lock", "-o", "json")
+	cp := ts.Spawn("update", "lock", "-o", "json")
 	cp.Expect(`"channel":`)
 	cp.Expect(`"version":`)
 	cp.ExpectExitCode(0)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2828" title="DX-2828" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2828</a>  Update our integration tests to use a project with a minimal runtime
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Also, do not disable runtimes by default in integration tests. Tests that want to disable runtimes should opt-in.

We are switching to empty projects for most integration tests, so disabling runtimes by default will no longer be necessary for the sake of speed.

Some things to note:

- We prefer `ts.PrepareProject()` instead of `state checkout`, as checkouts source the runtime (even if `async_runtime` is enabled).
- The following commands do not support `async_runtime`, and manually disable runtimes in the tests:
  - `state init`
  - `state import`
  - `state revert`
  - `state switch`
- There is no noticeable performance improvement or detriment with these changes. The lone data point when running "Test: all" is:
  - Linux: before: 43 mins; after: 44 mins
  - macOS: before: 47 mins; after: 49 mins
  - Windows: before: 1 hour 3 mins; after: 1 hour 4 mins
  - Note: the "after" times were done during the day, as opposed to the "before" times being done at night. CI might be a bit busier during the day, and quieter at night.