### PR TITLE
Fixed `state run -h` and `state clean` to show short description in usage text.

### DIFF
--- a/cmd/state/internal/cmdtree/run.go
+++ b/cmd/state/internal/cmdtree/run.go
@@ -28,7 +28,7 @@ func newRunCommand(prime *primer.Values) *captain.Command {
 		},
 		func(ccmd *captain.Command, args []string) error {
 			if name == "-h" || name == "--help" {
-				prime.Output().Print(ccmd.UsageText())
+				prime.Output().Print(ccmd.Help())
 				return nil
 			} else if name == "-v" || name == "--verbose" {
 				if len(args) > 1 {

--- a/internal/captain/command.go
+++ b/internal/captain/command.go
@@ -842,7 +842,14 @@ func (cmd *Command) Usage() error {
 		return errs.Wrap(err, "Could not execute template")
 	}
 
-	cmd.out.Print(out.String())
+	if writer := cmd.cobra.OutOrStdout(); writer != os.Stdout {
+		_, err := writer.Write(out.Bytes())
+		if err != nil {
+			return errs.Wrap(err, "Unable to write to cobra outWriter")
+		}
+	} else {
+		cmd.out.Print(out.String())
+	}
 
 	return nil
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2884" title="DX-2884" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2884</a>  `state run -h` missing description
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
