### PR TITLE
Fixed `state manifest` to show resolved versions for non-auto packages.

### DIFF
--- a/internal/runners/manifest/version.go
+++ b/internal/runners/manifest/version.go
@@ -40,11 +40,11 @@ func resolveVersion(req types.Requirement, bpReqs buildplan.Ingredients) *resolv
 		requested = platformModel.BuildPlannerVersionConstraintsToString(req.VersionRequirement)
 	} else {
 		requested = locale.Tl("manifest_version_auto", "auto")
-		for _, bpr := range bpReqs {
-			if bpr.Namespace == req.Namespace && bpr.Name == req.Name {
-				resolved = bpr.Version
-				break
-			}
+	}
+	for _, bpr := range bpReqs {
+		if bpr.Namespace == req.Namespace && bpr.Name == req.Name {
+			resolved = bpr.Version
+			break
 		}
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2893" title="DX-2893" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2893</a>  `state manifest` does not show the resolved version and JSON output has the same value in the `resolved` key as `requested`.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
