### PR TITLE
Fixed crash running `state export runtime` with async runtimes enabled.

### DIFF
--- a/internal/runbits/runtime/refresh.go
+++ b/internal/runbits/runtime/refresh.go
@@ -48,6 +48,7 @@ var overrideAsyncTriggers = map[target.Trigger]bool{
 	target.TriggerScript:   true,
 	target.TriggerDeploy:   true,
 	target.TriggerUse:      true,
+	target.TriggerExport:   true,
 }
 
 // SolveAndUpdate should be called after runtime mutations.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2916" title="DX-2916" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2916</a>  Crash with async runtime and `state export runtime`.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
