### PR TITLE
Buildscript should be able to read new 'Revision' and 'BuildFlag' functions

### DIFF
--- a/pkg/buildscript/internal/raw/structure.go
+++ b/pkg/buildscript/internal/raw/structure.go
@@ -46,12 +46,14 @@ type In struct {
 }
 
 var (
-	reqFuncName = "Req"
-	eqFuncName  = "Eq"
-	neFuncName  = "Ne"
-	gtFuncName  = "Gt"
-	gteFuncName = "Gte"
-	ltFuncName  = "Lt"
-	lteFuncName = "Lte"
-	andFuncName = "And"
+	reqFuncName       = "Req"
+	eqFuncName        = "Eq"
+	neFuncName        = "Ne"
+	gtFuncName        = "Gt"
+	gteFuncName       = "Gte"
+	ltFuncName        = "Lt"
+	lteFuncName       = "Lte"
+	andFuncName       = "And"
+	revisionFuncName  = "Revision"
+	buildFlagFuncName = "BuildFlag"
 )

--- a/pkg/buildscript/shared_test.go
+++ b/pkg/buildscript/shared_test.go
@@ -7,6 +7,12 @@ var atTime = "2000-01-01T00:00:00.000Z"
 var basicBuildScript = []byte(fmt.Sprintf(
 	`at_time = "%s"
 runtime = state_tool_artifacts(
+	build_flags = [
+		{
+			name = "foo",
+			value = "bar"
+		}
+	],
 	src = sources
 )
 sources = solve(
@@ -27,6 +33,12 @@ var basicBuildExpression = []byte(`{
     "in": "$runtime",
     "runtime": {
       "state_tool_artifacts": {
+        "build_flags": [
+          {
+            "name": "foo",
+            "value": "bar"
+          }
+        ],
         "src": "$sources"
       }
     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2799" title="DX-2799" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2799</a>  Update buildscripts to support Req() functions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also recognize 'constraints' key in 'Req' function.

Write support for the new functions will be addressed later.