### PR TITLE
Support new `Req()` function in buildexpression requirements.

### DIFF
--- a/pkg/buildscript/internal/buildexpression/buildexpression_test.go
+++ b/pkg/buildscript/internal/buildexpression/buildexpression_test.go
@@ -71,6 +71,13 @@ func TestNew(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "newObjects",
+			args: args{
+				filename: "buildexpression-new-objects.json",
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/buildscript/internal/buildexpression/testdata/buildexpression-new-objects.json
+++ b/pkg/buildscript/internal/buildexpression/testdata/buildexpression-new-objects.json
@@ -1,0 +1,35 @@
+{
+  "let": {
+    "runtime": {
+      "state_tool_artifacts_v1": {
+        "build_flags": [],
+        "src": "$sources"
+      }
+    },
+    "sources": {
+      "solve": {
+        "at_time": "$at_time",
+        "platforms": [
+          "0fa42e8c-ac7b-5dd7-9407-8aa15f9b993a",
+          "78977bc8-0f32-519d-80f3-9043f059398c",
+          "96b7e6f2-bebf-564c-bc1c-f04482398f38"
+        ],
+        "requirements": [
+          {
+            "Req": {
+              "name": "python",
+              "namespace": "language",
+              "version": {
+                "Eq": {
+                  "value": "3.10.10"
+                }
+              }
+            }
+          }
+        ],
+        "solver_version": null
+      }
+    },
+    "in": "$runtime"
+  }
+}

--- a/pkg/buildscript/internal/raw/marshal.go
+++ b/pkg/buildscript/internal/raw/marshal.go
@@ -81,7 +81,7 @@ func marshalFromBuildExpression(expr *buildexpression.BuildExpression, atTime *t
 	}
 
 	for _, assignment := range expr.Let.Assignments {
-		if assignment.Name == buildexpression.RequirementsKey {
+		if assignment.Name == buildexpression.RequirementsKey && isLegacyRequirementsList(assignment) {
 			assignment = transformRequirements(assignment)
 		}
 		buf.WriteString(assignmentString(assignment))

--- a/pkg/buildscript/internal/raw/transforms.go
+++ b/pkg/buildscript/internal/raw/transforms.go
@@ -16,6 +16,10 @@ func indent(s string) string {
 	return fmt.Sprintf("\t%s", strings.ReplaceAll(s, "\n", "\n\t"))
 }
 
+func isLegacyRequirementsList(list *buildexpression.Var) bool {
+	return len(*list.Value.List) > 0 && (*list.Value.List)[0].Object != nil
+}
+
 // transformRequirements transforms a buildexpression list of requirements in object form into a
 // list of requirements in function-call form, which is how requirements are represented in
 // buildscripts.
@@ -122,7 +126,7 @@ func transformVersion(requirements *buildexpression.Var) *buildexpression.Ap {
 }
 
 func assignmentString(a *buildexpression.Var) string {
-	if a.Name == buildexpression.RequirementsKey {
+	if a.Name == buildexpression.RequirementsKey && isLegacyRequirementsList(a) {
 		a = transformRequirements(a)
 	}
 	return fmt.Sprintf("%s = %s", a.Name, valueString(a.Value))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2799" title="DX-2799" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2799</a>  Update buildscripts to support Req() functions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

It looks exactly like how we've been translating from it to the old requirement objects, so drop this translation if that's what's coming in.

Marshaling requirements into a `Req()` function will be done later. We continue to marshal requirements into objects for now via https://github.com/ActiveState/cli/blob/411e9b41a872a12d319e291fcec66c42062fa0de/pkg/buildscript/internal/raw/translate.go#L85-L88 and https://github.com/ActiveState/cli/blob/411e9b41a872a12d319e291fcec66c42062fa0de/pkg/buildscript/internal/raw/translate.go#L107.