### PR TITLE
Added change summary and CVE report to `state import`

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1179,7 +1179,7 @@ package_ingredient_alternatives_nolang:
 progress_search:
   other: " • Searching for [ACTIONABLE]{{.V0}}[/RESET] in the ActiveState Catalog"
 progress_cve_search:
-  other: " • Searching for new vulnerabilities (CVEs) on [ACTIONABLE]{{.V0}}[/RESET] and any dependencies"
+  other: " • Checking for vulnerabilities (CVEs) on [ACTIONABLE]{{.V0}}[/RESET] and its dependencies"
 setup_runtime:
   other: "Setting Up Runtime"
 progress_solve:

--- a/internal/runbits/cves/cves.go
+++ b/internal/runbits/cves/cves.go
@@ -1,0 +1,186 @@
+package cves
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/logging"
+	configMediator "github.com/ActiveState/cli/internal/mediators/config"
+	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/internal/prompt"
+	"github.com/ActiveState/cli/internal/rtutils/ptr"
+	"github.com/ActiveState/cli/pkg/buildplan"
+	vulnModel "github.com/ActiveState/cli/pkg/platform/api/vulnerabilities/model"
+	"github.com/ActiveState/cli/pkg/platform/api/vulnerabilities/request"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/model"
+)
+
+func init() {
+	configMediator.RegisterOption(constants.SecurityPromptConfig, configMediator.Bool, true)
+	configMediator.RegisterOption(constants.SecurityPromptLevelConfig, configMediator.String, vulnModel.SeverityCritical)
+}
+
+func Report(out output.Outputer, newBuildPlan *buildplan.BuildPlan, oldBuildPlan *buildplan.BuildPlan, auth *authentication.Auth, prmpt prompt.Prompter, cfg *config.Instance) error {
+	changeset := newBuildPlan.DiffArtifacts(oldBuildPlan, false)
+	if shouldSkipReporting(changeset, auth) {
+		logging.Debug("Skipping CVE reporting")
+		return nil
+	}
+
+	var ingredients []*request.Ingredient
+	for _, artifact := range changeset.Added {
+		for _, ing := range artifact.Ingredients {
+			ingredients = append(ingredients, &request.Ingredient{
+				Namespace: ing.Namespace,
+				Name:      ing.Name,
+				Version:   ing.Version,
+			})
+		}
+	}
+
+	for _, change := range changeset.Updated {
+		if !change.VersionsChanged() {
+			continue // For CVE reporting we only care about ingredient changes
+		}
+
+		for _, ing := range change.To.Ingredients {
+			ingredients = append(ingredients, &request.Ingredient{
+				Namespace: ing.Namespace,
+				Name:      ing.Name,
+				Version:   ing.Version,
+			})
+		}
+	}
+
+	names := make([]string, len(ingredients))
+	for i, ing := range ingredients {
+		names[i] = ing.Name
+	}
+
+	pg := output.StartSpinner(out, locale.Tr("progress_cve_search", strings.Join(names, ", ")), constants.TerminalAnimationInterval)
+
+	ingredientVulnerabilities, err := model.FetchVulnerabilitiesForIngredients(auth, ingredients)
+	if err != nil {
+		return errs.Wrap(err, "Failed to retrieve vulnerabilities")
+	}
+
+	// No vulnerabilities, nothing further to do here
+	if len(ingredientVulnerabilities) == 0 {
+		logging.Debug("No vulnerabilities found for ingredients")
+		pg.Stop(locale.T("progress_safe"))
+		pg = nil
+		return nil
+	}
+
+	pg.Stop(locale.T("progress_unsafe"))
+	pg = nil
+
+	vulnerabilities := model.CombineVulnerabilities(ingredientVulnerabilities, names...)
+	summarizeCVEs(out, vulnerabilities)
+
+	if prmpt != nil && shouldPromptForSecurity(cfg, vulnerabilities) {
+		cont, err := promptForSecurity(prmpt)
+		if err != nil {
+			return errs.Wrap(err, "Failed to prompt for security")
+		}
+
+		if !cont {
+			if !prmpt.IsInteractive() {
+				return errs.AddTips(
+					locale.NewInputError("err_pkgop_security_prompt", "Operation aborted due to security prompt"),
+					locale.Tl("more_info_prompt", "To disable security prompting run: [ACTIONABLE]state config set security.prompt.enabled false[/RESET]"),
+				)
+			}
+			return locale.NewInputError("err_pkgop_security_prompt", "Operation aborted due to security prompt")
+		}
+	}
+
+	return nil
+}
+
+func shouldSkipReporting(changeset buildplan.ArtifactChangeset, auth *authentication.Auth) bool {
+	if !auth.Authenticated() {
+		return true
+	}
+
+	return len(changeset.Added) == 0 && len(changeset.Updated) == 0
+}
+
+func shouldPromptForSecurity(cfg *config.Instance, vulnerabilities model.VulnerableIngredientsByLevels) bool {
+	if !cfg.GetBool(constants.SecurityPromptConfig) || vulnerabilities.Count == 0 {
+		return false
+	}
+
+	promptLevel := cfg.GetString(constants.SecurityPromptLevelConfig)
+
+	logging.Debug("Prompt level: ", promptLevel)
+	switch promptLevel {
+	case vulnModel.SeverityCritical:
+		return vulnerabilities.Critical.Count > 0
+	case vulnModel.SeverityHigh:
+		return vulnerabilities.Critical.Count > 0 ||
+			vulnerabilities.High.Count > 0
+	case vulnModel.SeverityMedium:
+		return vulnerabilities.Critical.Count > 0 ||
+			vulnerabilities.High.Count > 0 ||
+			vulnerabilities.Medium.Count > 0
+	case vulnModel.SeverityLow:
+		return vulnerabilities.Critical.Count > 0 ||
+			vulnerabilities.High.Count > 0 ||
+			vulnerabilities.Medium.Count > 0 ||
+			vulnerabilities.Low.Count > 0
+	}
+
+	return false
+}
+
+func summarizeCVEs(out output.Outputer, vulnerabilities model.VulnerableIngredientsByLevels) {
+	out.Print("")
+
+	switch {
+	case vulnerabilities.CountPrimary == 0:
+		out.Print("   " + locale.Tr("warning_vulnerable_indirectonly", strconv.Itoa(vulnerabilities.Count)))
+	case vulnerabilities.CountPrimary == vulnerabilities.Count:
+		out.Print("   " + locale.Tr("warning_vulnerable_directonly", strconv.Itoa(vulnerabilities.Count)))
+	default:
+		out.Print("   " + locale.Tr("warning_vulnerable", strconv.Itoa(vulnerabilities.CountPrimary), strconv.Itoa(vulnerabilities.Count-vulnerabilities.CountPrimary)))
+	}
+
+	printVulnerabilities := func(vulnerableIngredients model.VulnerableIngredientsByLevel, name, color string) {
+		if vulnerableIngredients.Count > 0 {
+			ings := []string{}
+			for _, vulns := range vulnerableIngredients.Ingredients {
+				prefix := ""
+				if vulnerabilities.Count > vulnerabilities.CountPrimary {
+					prefix = fmt.Sprintf("%s@%s: ", vulns.IngredientName, vulns.IngredientVersion)
+				}
+				ings = append(ings, fmt.Sprintf("%s[CYAN]%s[/RESET]", prefix, strings.Join(vulns.CVEIDs, ", ")))
+			}
+			out.Print(fmt.Sprintf("    • [%s]%d %s:[/RESET] %s", color, vulnerableIngredients.Count, name, strings.Join(ings, ", ")))
+		}
+	}
+
+	printVulnerabilities(vulnerabilities.Critical, locale.Tl("cve_critical", "Critical"), "RED")
+	printVulnerabilities(vulnerabilities.High, locale.Tl("cve_high", "High"), "ORANGE")
+	printVulnerabilities(vulnerabilities.Medium, locale.Tl("cve_medium", "Medium"), "YELLOW")
+	printVulnerabilities(vulnerabilities.Low, locale.Tl("cve_low", "Low"), "MAGENTA")
+
+	out.Print("")
+	out.Print("   " + locale.T("more_info_vulnerabilities"))
+	out.Print("   " + locale.T("disable_prompting_vulnerabilities"))
+}
+
+func promptForSecurity(prmpt prompt.Prompter) (bool, error) {
+	confirm, err := prmpt.Confirm("", locale.Tr("prompt_continue_pkg_operation"), ptr.To(false))
+	if err != nil {
+		return false, locale.WrapError(err, "err_pkgop_confirm", "Need a confirmation.")
+	}
+
+	return confirm, nil
+}

--- a/internal/runbits/requirements/install.go
+++ b/internal/runbits/requirements/install.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/cves"
 	"github.com/ActiveState/cli/internal/runbits/dependencies"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
@@ -200,9 +201,7 @@ func (r *RequirementOperation) Install(ts *time.Time, requirements ...*Requireme
 	dependencies.OutputChangeSummary(r.Output, rtCommit.BuildPlan(), oldBuildPlan)
 
 	// Report CVEs.
-	changedArtifacts := rtCommit.BuildPlan().DiffArtifacts(oldBuildPlan, false)
-	err = r.cveReport(changedArtifacts)
-	if err != nil {
+	if err := cves.Report(r.Output, rtCommit.BuildPlan(), oldBuildPlan, r.Auth, r.Prompt, r.Config); err != nil {
 		return errs.Wrap(err, "Could not report CVEs")
 	}
 

--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -10,7 +10,9 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
+	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/runbits/buildscript"
+	"github.com/ActiveState/cli/internal/runbits/cves"
 	"github.com/ActiveState/cli/internal/runbits/dependencies"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
@@ -30,6 +32,7 @@ type primeable interface {
 	primer.Analyticer
 	primer.SvcModeler
 	primer.Configurer
+	primer.Prompter
 }
 
 type Commit struct {
@@ -39,6 +42,7 @@ type Commit struct {
 	analytics analytics.Dispatcher
 	svcModel  *model.SvcModel
 	cfg       *config.Instance
+	prompt    prompt.Prompter
 }
 
 func New(p primeable) *Commit {
@@ -49,6 +53,7 @@ func New(p primeable) *Commit {
 		analytics: p.Analytics(),
 		svcModel:  p.SvcModel(),
 		cfg:       p.Config(),
+		prompt:    p.Prompt(),
 	}
 }
 
@@ -173,6 +178,11 @@ func (c *Commit) Run() (rerr error) {
 
 	// Output dependency list.
 	dependencies.OutputChangeSummary(c.out, rtCommit.BuildPlan(), oldBuildPlan)
+
+	// Report CVEs.
+	if err := cves.Report(c.out, rtCommit.BuildPlan(), oldBuildPlan, c.auth, c.prompt, c.cfg); err != nil {
+		return errs.Wrap(err, "Could not report CVEs")
+	}
 
 	c.out.Print(output.Prepare(
 		locale.Tl(

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -4,13 +4,17 @@ import (
 	"os"
 
 	"github.com/ActiveState/cli/internal/analytics"
+	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/prompt"
+	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/cves"
+	"github.com/ActiveState/cli/internal/runbits/dependencies"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
 	"github.com/ActiveState/cli/pkg/buildscript"
@@ -28,10 +32,6 @@ import (
 const (
 	defaultImportFile = "requirements.txt"
 )
-
-type configurable interface {
-	keypairs.Configurable
-}
 
 // Confirmer describes the behavior required to prompt a user for confirmation.
 type Confirmer interface {
@@ -61,11 +61,11 @@ func NewImportRunParams() *ImportRunParams {
 
 // Import manages the importing execution context.
 type Import struct {
-	auth *authentication.Auth
-	out  output.Outputer
-	prompt.Prompter
+	auth      *authentication.Auth
+	out       output.Outputer
+	prompt    prompt.Prompter
 	proj      *project.Project
-	cfg       configurable
+	cfg       *config.Instance
 	analytics analytics.Dispatcher
 	svcModel  *model.SvcModel
 }
@@ -117,6 +117,13 @@ func (i *Import) Run(params *ImportRunParams) error {
 		return locale.WrapError(err, "err_import_language", "Unable to get language from project")
 	}
 
+	pg := output.StartSpinner(i.out, locale.T("progress_commit"), constants.TerminalAnimationInterval)
+	defer func() {
+		if pg != nil {
+			pg.Stop(locale.T("progress_fail"))
+		}
+	}()
+
 	changeset, err := fetchImportChangeset(reqsimport.Init(), params.FileName, language.Name)
 	if err != nil {
 		return errs.Wrap(err, "Could not import changeset")
@@ -144,12 +151,51 @@ func (i *Import) Run(params *ImportRunParams) error {
 		return locale.WrapError(err, "err_commit_changeset", "Could not commit import changes")
 	}
 
+	pg.Stop(locale.T("progress_success"))
+	pg = nil
+
+	// Solve the runtime.
+	rt, rtCommit, err := runtime.Solve(i.auth, i.out, i.analytics, i.proj, &commitID, target.TriggerImport, i.svcModel, i.cfg, runtime.OptNone)
+	if err != nil {
+		return errs.Wrap(err, "Could not solve runtime")
+	}
+
+	// Output change summary.
+	previousCommit, err := bp.FetchCommit(latestCommit, i.proj.Owner(), i.proj.Name(), nil)
+	if err != nil {
+		return errs.Wrap(err, "Failed to fetch build result for previous commit")
+	}
+	oldBuildPlan := previousCommit.BuildPlan()
+	i.out.Notice("") // blank line
+	dependencies.OutputChangeSummary(i.out, rtCommit.BuildPlan(), oldBuildPlan)
+
+	// Report CVEs.
+	if err := cves.Report(i.out, rtCommit.BuildPlan(), oldBuildPlan, i.auth, i.prompt, i.cfg); err != nil {
+		return errs.Wrap(err, "Could not report CVEs")
+	}
+
+	// Update the runtime.
+	if !i.cfg.GetBool(constants.AsyncRuntimeConfig) {
+		i.out.Notice("")
+
+		// refresh or install runtime
+		err = runtime.UpdateByReference(rt, rtCommit, i.auth, i.proj, i.out, runtime.OptNone)
+		if err != nil {
+			if !runbits.IsBuildError(err) {
+				// If the error is not a build error we want to retain the changes
+				if err2 := localcommit.Set(i.proj.Dir(), commitID.String()); err2 != nil {
+					return errs.Pack(err, locale.WrapError(err2, "err_package_update_commit_id"))
+				}
+			}
+			return errs.Wrap(err, "Failed to refresh runtime")
+		}
+	}
+
 	if err := localcommit.Set(i.proj.Dir(), commitID.String()); err != nil {
 		return locale.WrapError(err, "err_package_update_commit_id")
 	}
 
-	_, err = runtime.SolveAndUpdate(i.auth, i.out, i.analytics, i.proj, &commitID, target.TriggerImport, i.svcModel, i.cfg, runtime.OptOrderChanged)
-	return err
+	return nil
 }
 
 func fetchImportChangeset(cp ChangesetProvider, file string, lang string) (model.Changeset, error) {

--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -19,17 +18,12 @@ type ImportIntegrationTestSuite struct {
 }
 
 func (suite *ImportIntegrationTestSuite) TestImport_detached() {
-	suite.T().Skip("Skipping import test until DX-2444 is resolved: https://activestatef.atlassian.net/browse/DX-2444")
 	suite.OnlyRunForTags(tagsuite.Import)
-	if runtime.GOOS == "darwin" {
-		suite.T().Skip("Skipping mac for now as the builds are still too unreliable")
-		return
-	}
 
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.PrepareProject("ActiveState-CLI/Python3-Import", "ecc61737-f598-4ca4-aa4e-52403aabb76c")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
 
 	contents := `requests
 	urllib3`
@@ -38,12 +32,23 @@ func (suite *ImportIntegrationTestSuite) TestImport_detached() {
 	err := os.WriteFile(importPath, []byte(strings.TrimSpace(contents)), 0644)
 	suite.Require().NoError(err)
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("import", importPath),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
-	)
+	ts.LoginAsPersistentUser() // for CVE reporting
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("import", importPath)
 	cp.Expect("Operating on project")
-	cp.Expect("ActiveState-CLI/Python3-Import")
+	cp.Expect("ActiveState-CLI/small-python")
+	cp.Expect("Creating commit")
+	cp.Expect("Resolving Dependencies")
+	cp.Expect("Installing") // note: cannot assert the order of requests, urllib3 in summary
+	cp.Expect("includes")
+	cp.Expect("dependencies")
+	cp.Expect("Checking for vulnerabilities")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("packages")
@@ -79,7 +84,6 @@ urllib3>=1.21.1,<=1.26.5
 )
 
 func (suite *ImportIntegrationTestSuite) TestImport() {
-	suite.T().Skip("Skipping import test until DX-2444 is resolved: https://activestatef.atlassian.net/browse/DX-2444")
 	suite.OnlyRunForTags(tagsuite.Import)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
@@ -88,7 +92,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 	namespace := fmt.Sprintf("%s/%s", user.Username, "Python3")
 
 	cp := ts.Spawn("init", "--language", "python", namespace, ts.Dirs.Work)
-	cp.Expect("successfully initialized")
+	cp.Expect("successfully initialized", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	reqsFilePath := filepath.Join(cp.WorkDirectory(), reqsFileName)
@@ -97,10 +101,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, badReqsData)
 
-		cp := ts.SpawnWithOpts(
-			e2e.OptArgs("import", "requirements.txt"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
-		)
+		cp = ts.Spawn("import", "requirements.txt")
 		cp.ExpectNotExitCode(0)
 	})
 
@@ -108,12 +109,13 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, reqsData)
 
-		cp := ts.SpawnWithOpts(
-			e2e.OptArgs("import", "requirements.txt"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
-		)
+		cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+		cp.ExpectExitCode(0)
 
-		cp = ts.Spawn("push")
+		cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
+		cp.ExpectExitCode(0)
+
+		cp = ts.Spawn("import", "requirements.txt")
 		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("import", "requirements.txt")
@@ -125,19 +127,25 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, complexReqsData)
 
-		cp := ts.SpawnWithOpts(
-			e2e.OptArgs("import", "requirements.txt"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
-		)
+		cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+		cp.ExpectExitCode(0)
+
+		cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
+		cp.ExpectExitCode(0)
+
+		cp = ts.Spawn("import", "requirements.txt")
+		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("packages")
 		cp.Expect("coverage")
+		cp.Expect("!3.5 → ")
 		cp.Expect("docopt")
+		cp.Expect(">=0.6.1 →")
 		cp.Expect("Mopidy-Dirble")
 		cp.Expect("requests")
-		cp.Expect("Auto") // DX-2272 will change this to 2.30.0
+		cp.Expect(">=2.2,<2.31.0 → 2.30.0")
 		cp.Expect("urllib3")
-		cp.Expect("Auto") // DX-2272 will change this to 1.26.5
+		cp.Expect(">=1.21.1,<=1.26.5 → 1.26.5")
 		cp.ExpectExitCode(0)
 	})
 	ts.IgnoreLogErrors()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2550" title="DX-2550" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2550</a>  Change and CVE information for `state import`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Also:
- Moved CVE reporting into its own runbit
- Enabled async runtime for `state import`
- Fixed and re-enabled import integration tests that were disabled in the early buildplanner days
- Added CVE reporting to `state commit` since it can benefit from that new runbit.