### PR TITLE
 Added change summary and CVE report to `state import`

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1175,7 +1175,7 @@ package_ingredient_alternatives_nolang:
 progress_search:
   other: " • Searching for [ACTIONABLE]{{.V0}}[/RESET] in the ActiveState Catalog"
 progress_cve_search:
-  other: " • Searching for new vulnerabilities (CVEs) on [ACTIONABLE]{{.V0}}[/RESET] and any dependencies"
+  other: " • Checking for vulnerabilities (CVEs) on [ACTIONABLE]{{.V0}}[/RESET] and its dependencies"
 setup_runtime:
   other: "Setting Up Runtime"
 progress_solve:

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -3,14 +3,15 @@ package packages
 import (
 	"os"
 
-	"github.com/ActiveState/cli/internal/analytics"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
-	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
-	"github.com/ActiveState/cli/internal/prompt"
+	"github.com/ActiveState/cli/internal/runbits"
+	"github.com/ActiveState/cli/internal/runbits/cves"
+	"github.com/ActiveState/cli/internal/runbits/dependencies"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
 	"github.com/ActiveState/cli/pkg/buildscript"
@@ -18,20 +19,14 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/api"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/types"
 	"github.com/ActiveState/cli/pkg/platform/api/reqsimport"
-	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/platform/model/buildplanner"
 	"github.com/ActiveState/cli/pkg/platform/runtime/target"
-	"github.com/ActiveState/cli/pkg/project"
 )
 
 const (
 	defaultImportFile = "requirements.txt"
 )
-
-type configurable interface {
-	keypairs.Configurable
-}
 
 // Confirmer describes the behavior required to prompt a user for confirmation.
 type Confirmer interface {
@@ -61,13 +56,7 @@ func NewImportRunParams() *ImportRunParams {
 
 // Import manages the importing execution context.
 type Import struct {
-	auth *authentication.Auth
-	out  output.Outputer
-	prompt.Prompter
-	proj      *project.Project
-	cfg       configurable
-	analytics analytics.Dispatcher
-	svcModel  *model.SvcModel
+	prime primeable
 }
 
 type primeable interface {
@@ -82,47 +71,49 @@ type primeable interface {
 
 // NewImport prepares an importation execution context for use.
 func NewImport(prime primeable) *Import {
-	return &Import{
-		prime.Auth(),
-		prime.Output(),
-		prime.Prompt(),
-		prime.Project(),
-		prime.Config(),
-		prime.Analytics(),
-		prime.SvcModel(),
-	}
+	return &Import{prime}
 }
 
 // Run executes the import behavior.
 func (i *Import) Run(params *ImportRunParams) error {
 	logging.Debug("ExecuteImport")
 
-	if i.proj == nil {
+	proj := i.prime.Project()
+	if proj == nil {
 		return rationalize.ErrNoProject
 	}
 
-	i.out.Notice(locale.Tr("operating_message", i.proj.NamespaceString(), i.proj.Dir()))
+	out := i.prime.Output()
+	out.Notice(locale.Tr("operating_message", proj.NamespaceString(), proj.Dir()))
 
 	if params.FileName == "" {
 		params.FileName = defaultImportFile
 	}
 
-	latestCommit, err := localcommit.Get(i.proj.Dir())
+	latestCommit, err := localcommit.Get(proj.Dir())
 	if err != nil {
 		return locale.WrapError(err, "package_err_cannot_obtain_commit")
 	}
 
-	language, err := model.LanguageByCommit(latestCommit, i.auth)
+	auth := i.prime.Auth()
+	language, err := model.LanguageByCommit(latestCommit, auth)
 	if err != nil {
 		return locale.WrapError(err, "err_import_language", "Unable to get language from project")
 	}
+
+	pg := output.StartSpinner(out, locale.T("progress_commit"), constants.TerminalAnimationInterval)
+	defer func() {
+		if pg != nil {
+			pg.Stop(locale.T("progress_fail"))
+		}
+	}()
 
 	changeset, err := fetchImportChangeset(reqsimport.Init(), params.FileName, language.Name)
 	if err != nil {
 		return errs.Wrap(err, "Could not import changeset")
 	}
 
-	bp := buildplanner.NewBuildPlannerModel(i.auth)
+	bp := buildplanner.NewBuildPlannerModel(auth)
 	bs, err := bp.GetBuildScript(latestCommit.String())
 	if err != nil {
 		return locale.WrapError(err, "err_cannot_get_build_expression", "Could not get build expression")
@@ -134,8 +125,8 @@ func (i *Import) Run(params *ImportRunParams) error {
 
 	msg := locale.T("commit_reqstext_message")
 	commitID, err := bp.StageCommit(buildplanner.StageCommitParams{
-		Owner:        i.proj.Owner(),
-		Project:      i.proj.Name(),
+		Owner:        proj.Owner(),
+		Project:      proj.Name(),
 		ParentCommit: latestCommit.String(),
 		Description:  msg,
 		Script:       bs,
@@ -144,12 +135,51 @@ func (i *Import) Run(params *ImportRunParams) error {
 		return locale.WrapError(err, "err_commit_changeset", "Could not commit import changes")
 	}
 
-	if err := localcommit.Set(i.proj.Dir(), commitID.String()); err != nil {
+	pg.Stop(locale.T("progress_success"))
+	pg = nil
+
+	// Solve the runtime.
+	rt, rtCommit, err := runtime.Solve(auth, out, i.prime.Analytics(), proj, &commitID, target.TriggerImport, i.prime.SvcModel(), i.prime.Config(), runtime.OptNone)
+	if err != nil {
+		return errs.Wrap(err, "Could not solve runtime")
+	}
+
+	// Output change summary.
+	previousCommit, err := bp.FetchCommit(latestCommit, proj.Owner(), proj.Name(), nil)
+	if err != nil {
+		return errs.Wrap(err, "Failed to fetch build result for previous commit")
+	}
+	oldBuildPlan := previousCommit.BuildPlan()
+	out.Notice("") // blank line
+	dependencies.OutputChangeSummary(out, rtCommit.BuildPlan(), oldBuildPlan)
+
+	// Report CVEs.
+	if err := cves.Report(rtCommit.BuildPlan(), oldBuildPlan, i.prime); err != nil {
+		return errs.Wrap(err, "Could not report CVEs")
+	}
+
+	// Update the runtime.
+	if !i.prime.Config().GetBool(constants.AsyncRuntimeConfig) {
+		out.Notice("")
+
+		// refresh or install runtime
+		err = runtime.UpdateByReference(rt, rtCommit, auth, proj, out, runtime.OptNone)
+		if err != nil {
+			if !runbits.IsBuildError(err) {
+				// If the error is not a build error we want to retain the changes
+				if err2 := localcommit.Set(proj.Dir(), commitID.String()); err2 != nil {
+					return errs.Pack(err, locale.WrapError(err2, "err_package_update_commit_id"))
+				}
+			}
+			return errs.Wrap(err, "Failed to refresh runtime")
+		}
+	}
+
+	if err := localcommit.Set(proj.Dir(), commitID.String()); err != nil {
 		return locale.WrapError(err, "err_package_update_commit_id")
 	}
 
-	_, err = runtime.SolveAndUpdate(i.auth, i.out, i.analytics, i.proj, &commitID, target.TriggerImport, i.svcModel, i.cfg, runtime.OptOrderChanged)
-	return err
+	return nil
 }
 
 func fetchImportChangeset(cp ChangesetProvider, file string, lang string) (model.Changeset, error) {

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -154,7 +154,7 @@ func (i *Import) Run(params *ImportRunParams) error {
 	dependencies.OutputChangeSummary(out, rtCommit.BuildPlan(), oldBuildPlan)
 
 	// Report CVEs.
-	if err := cves.Report(rtCommit.BuildPlan(), oldBuildPlan, i.prime); err != nil {
+	if err := cves.NewCveReport(i.prime).Report(rtCommit.BuildPlan(), oldBuildPlan); err != nil {
 		return errs.Wrap(err, "Could not report CVEs")
 	}
 

--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -19,17 +18,12 @@ type ImportIntegrationTestSuite struct {
 }
 
 func (suite *ImportIntegrationTestSuite) TestImport_detached() {
-	suite.T().Skip("Skipping import test until DX-2444 is resolved: https://activestatef.atlassian.net/browse/DX-2444")
 	suite.OnlyRunForTags(tagsuite.Import)
-	if runtime.GOOS == "darwin" {
-		suite.T().Skip("Skipping mac for now as the builds are still too unreliable")
-		return
-	}
 
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.PrepareProject("ActiveState-CLI/Python3-Import", "ecc61737-f598-4ca4-aa4e-52403aabb76c")
+	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
 
 	contents := `requests
 	urllib3`
@@ -38,12 +32,23 @@ func (suite *ImportIntegrationTestSuite) TestImport_detached() {
 	err := os.WriteFile(importPath, []byte(strings.TrimSpace(contents)), 0644)
 	suite.Require().NoError(err)
 
-	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("import", importPath),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
-	)
+	ts.LoginAsPersistentUser() // for CVE reporting
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("import", importPath)
 	cp.Expect("Operating on project")
-	cp.Expect("ActiveState-CLI/Python3-Import")
+	cp.Expect("ActiveState-CLI/small-python")
+	cp.Expect("Creating commit")
+	cp.Expect("Resolving Dependencies")
+	cp.Expect("Installing") // note: cannot assert the order of requests, urllib3 in summary
+	cp.Expect("includes")
+	cp.Expect("dependencies")
+	cp.Expect("Checking for vulnerabilities")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("packages")
@@ -79,7 +84,6 @@ urllib3>=1.21.1,<=1.26.5
 )
 
 func (suite *ImportIntegrationTestSuite) TestImport() {
-	suite.T().Skip("Skipping import test until DX-2444 is resolved: https://activestatef.atlassian.net/browse/DX-2444")
 	suite.OnlyRunForTags(tagsuite.Import)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
@@ -88,7 +92,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 	namespace := fmt.Sprintf("%s/%s", user.Username, "Python3")
 
 	cp := ts.Spawn("init", "--language", "python", namespace, ts.Dirs.Work)
-	cp.Expect("successfully initialized")
+	cp.Expect("successfully initialized", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	reqsFilePath := filepath.Join(cp.WorkDirectory(), reqsFileName)
@@ -97,10 +101,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, badReqsData)
 
-		cp := ts.SpawnWithOpts(
-			e2e.OptArgs("import", "requirements.txt"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
-		)
+		cp = ts.Spawn("import", "requirements.txt")
 		cp.ExpectNotExitCode(0)
 	})
 
@@ -108,12 +109,13 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, reqsData)
 
-		cp := ts.SpawnWithOpts(
-			e2e.OptArgs("import", "requirements.txt"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
-		)
+		cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+		cp.ExpectExitCode(0)
 
-		cp = ts.Spawn("push")
+		cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
+		cp.ExpectExitCode(0)
+
+		cp = ts.Spawn("import", "requirements.txt")
 		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("import", "requirements.txt")
@@ -125,19 +127,25 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.SetT(suite.T())
 		ts.PrepareFile(reqsFilePath, complexReqsData)
 
-		cp := ts.SpawnWithOpts(
-			e2e.OptArgs("import", "requirements.txt"),
-			e2e.OptAppendEnv(constants.DisableRuntime+"=true"),
-		)
+		cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+		cp.ExpectExitCode(0)
+
+		cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
+		cp.ExpectExitCode(0)
+
+		cp = ts.Spawn("import", "requirements.txt")
+		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("packages")
 		cp.Expect("coverage")
+		cp.Expect("!3.5 → ")
 		cp.Expect("docopt")
+		cp.Expect(">=0.6.1 →")
 		cp.Expect("Mopidy-Dirble")
 		cp.Expect("requests")
-		cp.Expect("Auto") // DX-2272 will change this to 2.30.0
+		cp.Expect(">=2.2,<2.31.0 → 2.30.0")
 		cp.Expect("urllib3")
-		cp.Expect("Auto") // DX-2272 will change this to 1.26.5
+		cp.Expect(">=1.21.1,<=1.26.5 → 1.26.5")
 		cp.ExpectExitCode(0)
 	})
 	ts.IgnoreLogErrors()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2550" title="DX-2550" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2550</a>  Change and CVE information for `state import`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Also:
- Refactored to use a primer for passing to cve runbit.
- Enabled async runtime
- Fixed and re-enabled import integration tests that were disabled in the early buildplanner days