### PR TITLE
UpdateByReference respect async runtimes

### DIFF
--- a/internal/runbits/requirements/requirements.go
+++ b/internal/runbits/requirements/requirements.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/runbits"
-	"github.com/ActiveState/cli/internal/runbits/buildscript"
+	buildscript_runbit "github.com/ActiveState/cli/internal/runbits/buildscript"
 	"github.com/ActiveState/cli/internal/runbits/dependencies"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	runbit "github.com/ActiveState/cli/internal/runbits/runtime"
@@ -281,7 +281,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(ts *time.Time, requir
 			}
 
 			// refresh or install runtime
-			err = runbit.UpdateByReference(rt, rtCommit, r.Auth, r.Project, r.Output, runbit.OptMinimalUI)
+			err = runbit.UpdateByReference(rt, rtCommit, r.Auth, r.Project, r.Output, r.Config, runbit.OptMinimalUI)
 			if err != nil {
 				if !runbits.IsBuildError(err) {
 					// If the error is not a build error we want to retain the changes

--- a/internal/runbits/runtime/refresh.go
+++ b/internal/runbits/runtime/refresh.go
@@ -176,9 +176,15 @@ func UpdateByReference(
 	auth *authentication.Auth,
 	proj *project.Project,
 	out output.Outputer,
+	cfg Configurable,
 	opts Opts,
 ) (rerr error) {
 	defer rationalizeError(auth, proj, &rerr)
+
+	if cfg.GetBool(constants.AsyncRuntimeConfig) {
+		logging.Debug("Skipping runtime update due to async runtime")
+		return nil
+	}
 
 	if rt.NeedsUpdate() {
 		if !bitflags.Has(opts, OptMinimalUI) {

--- a/internal/runners/checkout/checkout.go
+++ b/internal/runners/checkout/checkout.go
@@ -112,7 +112,7 @@ func (u *Checkout) Run(params *Params) (rerr error) {
 		return errs.Wrap(err, "Could not checkout project")
 	}
 	dependencies.OutputSummary(u.out, commit.BuildPlan().RequestedArtifacts())
-	err = runtime.UpdateByReference(rti, commit, u.auth, proj, u.out, runtime.OptNone)
+	err = runtime.UpdateByReference(rti, commit, u.auth, proj, u.out, u.config, runtime.OptNone)
 	if err != nil {
 		return errs.Wrap(err, "Could not setup runtime")
 	}

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ActiveState/cli/internal/runbits/buildscript"
+	buildscript_runbit "github.com/ActiveState/cli/internal/runbits/buildscript"
 	"github.com/ActiveState/cli/internal/runbits/errors"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
 	"github.com/ActiveState/cli/pkg/platform/model/buildplanner"
@@ -292,7 +292,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		return errs.Wrap(err, "Could not initialize runtime")
 	}
 	dependencies.OutputSummary(r.out, commit.BuildPlan().RequestedArtifacts())
-	err = runtime.UpdateByReference(rti, commit, r.auth, proj, r.out, runtime.OptNone)
+	err = runtime.UpdateByReference(rti, commit, r.auth, proj, r.out, r.config, runtime.OptNone)
 	if err != nil {
 		return errs.Wrap(err, "Could not setup runtime after init")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2738" title="DX-2738" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2738</a>  As a user I can use the state tool without sourcing the runtime
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Fixes failure found during QA process.