### PR TITLE
Do not use the default retryhttp client for `state update`; use a no-timeout client.

### DIFF
--- a/internal/updater/fetcher.go
+++ b/internal/updater/fetcher.go
@@ -26,7 +26,7 @@ type Fetcher struct {
 }
 
 func NewFetcher(an analytics.Dispatcher) *Fetcher {
-	return &Fetcher{retryhttp.DefaultClient, an}
+	return &Fetcher{retryhttp.NewClient(0, retryhttp.DefaultRetries), an}
 }
 
 func (f *Fetcher) Fetch(update *UpdateInstaller, targetDir string) error {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2947" title="DX-2947" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2947</a>  Impossible to update state tool on a slow network connection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The default client times out after 30 seconds, which prevents users with slow internet connections from successfully running `state update`.