### PR TITLE
Fixed nil pointer error with `state exec` and async runtimes.

### DIFF
--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -119,9 +119,16 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 
 	s.out.Notice(locale.Tr("operating_message", projectNamespace, projectDir))
 
-	rt, err := rtrunbit.SolveAndUpdate(s.auth, s.out, s.analytics, proj, nil, trigger, s.svcModel, s.cfg, rtrunbit.OptMinimalUI)
+	rt, commit, err := rtrunbit.Solve(s.auth, s.out, s.analytics, proj, nil, trigger, s.svcModel, s.cfg, rtrunbit.OptMinimalUI)
 	if err != nil {
-		return locale.WrapError(err, "err_activate_runtime", "Could not initialize a runtime for this project.")
+		return errs.Wrap(err, "Could not initialize runtime")
+	}
+
+	if !s.cfg.GetBool(constants.AsyncRuntimeConfig) {
+		err = rtrunbit.UpdateByReference(rt, commit, s.auth, proj, s.out, s.cfg, rtrunbit.OptMinimalUI)
+		if err != nil {
+			return errs.Wrap(err, "Could not setup runtime")
+		}
 	}
 
 	venv := virtualenvironment.New(rt)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2945" title="DX-2945" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2945</a>  Panic while run `state exec which` in the activated project
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
