### PR TITLE
Fix `state exec` unable to run complex arguments

### DIFF
--- a/internal/osutils/exeutils_windows.go
+++ b/internal/osutils/exeutils_windows.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 
 	"github.com/thoas/go-funk"
+
+	"github.com/ActiveState/cli/internal/logging"
 )
 
 const ExeExtension = ".exe"
@@ -28,6 +30,7 @@ func Command(name string, arg ...string) *exec.Cmd {
 		// other characters that need escaping such as `<` and `>`.
 		// This can be dropped once we update to a Go version that fixes this bug: https://github.com/golang/go/issues/68313
 		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: makeCmdLine(cmd.Args)}
+		logging.Debug("Forcing command line: %s", cmd.SysProcAttr.CmdLine)
 	}
 
 	return cmd

--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -188,8 +188,8 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 	lang := language.Bash
 	scriptArgs := fmt.Sprintf(`%q "$@"`, exeTarget)
 	if strings.Contains(s.subshell.Binary(), "cmd") {
-		lang = language.PowerShell
-		scriptArgs = fmt.Sprintf("& %q @args\nexit $LASTEXITCODE", exeTarget)
+		lang = language.Batch
+		scriptArgs = fmt.Sprintf("@ECHO OFF\n%q %%*", exeTarget)
 	}
 
 	sf, err := scriptfile.New(lang, "state-exec", scriptArgs)

--- a/internal/subshell/sscommon/sscommon.go
+++ b/internal/subshell/sscommon/sscommon.go
@@ -127,7 +127,7 @@ func runWithCmd(env []string, name string, args ...string) error {
 	case ".bat":
 		// No action required
 	case ".ps1":
-		args = append([]string{"-executionpolicy", "bypass", "-file", name}, args...)
+		args = append([]string{"-file", name}, args...)
 		name = "powershell"
 	case ".sh":
 		bashPath, err := osutils.BashifyPath(name)

--- a/internal/subshell/sscommon/sscommon.go
+++ b/internal/subshell/sscommon/sscommon.go
@@ -15,7 +15,7 @@ import (
 )
 
 func NewCommand(command string, args []string, env []string) *exec.Cmd {
-	cmd := exec.Command(command, args...)
+	cmd := osutils.Command(command, args...)
 	if env != nil {
 		cmd.Env = append(os.Environ(), env...)
 	}
@@ -166,7 +166,7 @@ func binaryPathCmd(env []string, name string) (string, error) {
 func runDirect(env []string, name string, args ...string) (rerr error) {
 	logging.Debug("Running command: %s %s", name, strings.Join(args, " "))
 
-	runCmd := exec.Command(name, args...)
+	runCmd := osutils.Command(name, args...)
 	runCmd.Stdin, runCmd.Stdout, runCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	runCmd.Env = env
 

--- a/test/integration/exec_int_test.go
+++ b/test/integration/exec_int_test.go
@@ -197,28 +197,6 @@ func (suite *ExecIntegrationTestSuite) TestExecWithPath() {
 
 }
 
-func (suite *ExecIntegrationTestSuite) TestExecPerlArgs() {
-	suite.OnlyRunForTags(tagsuite.Exec)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-
-	cp := ts.Spawn("checkout", "ActiveState-CLI/Perl-5.32", ".")
-	cp.Expect("Skipping runtime setup")
-	cp.Expect("Checked out")
-	cp.ExpectExitCode(0)
-
-	suite.NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "testargs.pl"), []byte(`
-printf "Argument: '%s'.\n", $ARGV[0];
-`)))
-
-	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("exec", "perl", "testargs.pl", "<3"),
-		e2e.OptAppendEnv(constants.DisableRuntime+"=false"),
-	)
-	cp.Expect("Argument: '<3'", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectExitCode(0)
-}
-
 func TestExecIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(ExecIntegrationTestSuite))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2946" title="DX-2946" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2946</a>  `state exec` mangels arguments on windows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
