### PR TITLE
Don't wrap input errors in buildplanner errors

### DIFF
--- a/pkg/platform/model/buildplanner/build.go
+++ b/pkg/platform/model/buildplanner/build.go
@@ -123,6 +123,12 @@ func processBuildPlannerError(bpErr error, fallbackMessage string) error {
 			return &response.BuildPlannerError{Err: locale.NewExternalError("err_buildplanner_deprecated", "Encountered deprecation error: {{.V0}}", graphqlErr.Message)}
 		}
 	}
+	if locale.IsInputError(bpErr) {
+		// If this is an input error then we shouldn't wrap it in a vague buildplanner error that's "unexpected",
+		// because evidently we expected it or we wouldn't mark it an input error.
+		// https://activestatef.atlassian.net/browse/DX-2957
+		return bpErr
+	}
 	return &response.BuildPlannerError{Err: locale.NewExternalError("err_buildplanner", "{{.V0}}: Encountered unexpected error: {{.V1}}", fallbackMessage, bpErr.Error())}
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2951" title="DX-2951" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2951</a>  Unhandled errors when project is not found
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
