### PR TITLE
`state import` uses a private namespace if added packages do not have one.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -488,3 +488,6 @@ const ActiveStateCIEnvVarName = "ACTIVESTATE_CI"
 
 // OverrideSandbox is the environment variable to set when overriding the sandbox for integration tests.
 const OverrideSandbox = "ACTIVESTATE_TEST_OVERRIDE_SANDBOX"
+
+// PlatformPrivateNamespace is the namespace for private packages.
+const PlatformPrivateNamespace = "private"

--- a/internal/runbits/org/org.go
+++ b/internal/runbits/org/org.go
@@ -1,0 +1,63 @@
+package org
+
+import (
+	"strings"
+
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/pkg/platform/authentication"
+	"github.com/ActiveState/cli/pkg/platform/model"
+	"github.com/ActiveState/cli/pkg/project"
+)
+
+var ErrNoOwner = errs.New("Could not find organization")
+
+type configurer interface {
+	GetString(string) string
+}
+
+// Get returns the name of an organization/owner in order of precedence:
+// - Returns the normalized form of the given org name.
+// - Returns the name of the most recently used org.
+// - Returns the name of the first org you are a member of.
+func Get(desiredOrg string, auth *authentication.Auth, cfg configurer) (string, error) {
+	orgs, err := model.FetchOrganizations(auth)
+	if err != nil {
+		return "", errs.Wrap(err, "Unable to get the user's writable orgs")
+	}
+
+	// Prefer the desired org if it's valid
+	if desiredOrg != "" {
+		// Match the case of the organization.
+		// Otherwise the incorrect case will be written to the project file.
+		for _, org := range orgs {
+			if strings.EqualFold(org.URLname, desiredOrg) {
+				return org.URLname, nil
+			}
+		}
+		// Return desiredOrg for error reporting
+		return desiredOrg, ErrNoOwner
+	}
+
+	// Use the last used namespace if it's valid
+	lastUsed := cfg.GetString(constants.LastUsedNamespacePrefname)
+	if lastUsed != "" {
+		ns, err := project.ParseNamespace(lastUsed)
+		if err != nil {
+			return "", errs.Wrap(err, "Unable to parse last used namespace")
+		}
+
+		for _, org := range orgs {
+			if strings.EqualFold(org.URLname, ns.Owner) {
+				return org.URLname, nil
+			}
+		}
+	}
+
+	// Use the first org if there is one
+	if len(orgs) > 0 {
+		return orgs[0].URLname, nil
+	}
+
+	return "", ErrNoOwner
+}

--- a/internal/runbits/org/org.go
+++ b/internal/runbits/org/org.go
@@ -12,6 +12,14 @@ import (
 
 var ErrNoOwner = errs.New("Could not find organization")
 
+type ErrOwnerNotFound struct {
+	DesiredOwner string
+}
+
+func (e ErrOwnerNotFound) Error() string {
+	return "could not find this organization"
+}
+
 type configurer interface {
 	GetString(string) string
 }
@@ -35,8 +43,7 @@ func Get(desiredOrg string, auth *authentication.Auth, cfg configurer) (string, 
 				return org.URLname, nil
 			}
 		}
-		// Return desiredOrg for error reporting
-		return desiredOrg, ErrNoOwner
+		return "", &ErrOwnerNotFound{desiredOrg}
 	}
 
 	// Use the last used namespace if it's valid

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/buildscript"
 	"github.com/ActiveState/cli/internal/runbits/dependencies"
 	"github.com/ActiveState/cli/internal/runbits/errors"
+	"github.com/ActiveState/cli/internal/runbits/org"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
@@ -76,8 +77,6 @@ type errProjectExists struct {
 	error
 	path string
 }
-
-var errNoOwner = errs.New("Could not find organization")
 
 var errNoLanguage = errs.New("No language specified")
 
@@ -209,7 +208,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		}
 	}
 
-	resolvedOwner, err = r.getOwner(paramOwner)
+	resolvedOwner, err = org.Get(paramOwner, r.auth, r.config)
 	if err != nil {
 		return errs.Wrap(err, "Unable to determine owner")
 	}
@@ -403,48 +402,6 @@ func deriveVersion(lang language.Language, version string, auth *authentication.
 	}
 
 	return version, nil
-}
-
-func (i *Initialize) getOwner(desiredOwner string) (string, error) {
-	orgs, err := model.FetchOrganizations(i.auth)
-	if err != nil {
-		return "", errs.Wrap(err, "Unable to get the user's writable orgs")
-	}
-
-	// Prefer the desired owner if it's valid
-	if desiredOwner != "" {
-		// Match the case of the organization.
-		// Otherwise the incorrect case will be written to the project file.
-		for _, org := range orgs {
-			if strings.EqualFold(org.URLname, desiredOwner) {
-				return org.URLname, nil
-			}
-		}
-		// Return desiredOwner for error reporting
-		return desiredOwner, errNoOwner
-	}
-
-	// Use the last used namespace if it's valid
-	lastUsed := i.config.GetString(constants.LastUsedNamespacePrefname)
-	if lastUsed != "" {
-		ns, err := project.ParseNamespace(lastUsed)
-		if err != nil {
-			return "", errs.Wrap(err, "Unable to parse last used namespace")
-		}
-
-		for _, org := range orgs {
-			if strings.EqualFold(org.URLname, ns.Owner) {
-				return org.URLname, nil
-			}
-		}
-	}
-
-	// Use the first org if there is one
-	if len(orgs) > 0 {
-		return orgs[0].URLname, nil
-	}
-
-	return "", errNoOwner
 }
 
 func (i *Initialize) getProjectName(desiredProject string, lang string) string {

--- a/internal/runners/initialize/rationalize.go
+++ b/internal/runners/initialize/rationalize.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/language"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/runbits/org"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	bpResp "github.com/ActiveState/cli/pkg/platform/api/buildplanner/response"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/types"
@@ -40,7 +41,7 @@ func rationalizeError(owner, project string, rerr *error) {
 			errs.SetInput(),
 		)
 
-	case errors.Is(*rerr, errNoOwner):
+	case errors.Is(*rerr, org.ErrNoOwner):
 		*rerr = errs.WrapUserFacing(*rerr,
 			locale.Tr("err_init_invalid_org", owner),
 			errs.SetInput(),

--- a/internal/runners/initialize/rationalize.go
+++ b/internal/runners/initialize/rationalize.go
@@ -17,6 +17,7 @@ func rationalizeError(owner, project string, rerr *error) {
 	var pcErr *bpResp.ProjectCreatedError
 	var projectExistsErr *errProjectExists
 	var unrecognizedLanguageErr *errUnrecognizedLanguage
+	var ownerNotFoundErr *org.ErrOwnerNotFound
 
 	switch {
 	case rerr == nil:
@@ -41,9 +42,15 @@ func rationalizeError(owner, project string, rerr *error) {
 			errs.SetInput(),
 		)
 
+	case errors.As(*rerr, &ownerNotFoundErr):
+		*rerr = errs.WrapUserFacing(*rerr,
+			locale.Tr("err_init_invalid_org", ownerNotFoundErr.DesiredOwner),
+			errs.SetInput(),
+		)
+
 	case errors.Is(*rerr, org.ErrNoOwner):
 		*rerr = errs.WrapUserFacing(*rerr,
-			locale.Tr("err_init_invalid_org", owner),
+			locale.Tl("err_init_cannot_find_org", "Please specify an owner for the project to initialize."),
 			errs.SetInput(),
 		)
 

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -11,6 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/runbits/cves"
 	"github.com/ActiveState/cli/internal/runbits/dependencies"
+	"github.com/ActiveState/cli/internal/runbits/org"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
@@ -74,7 +76,8 @@ func NewImport(prime primeable) *Import {
 }
 
 // Run executes the import behavior.
-func (i *Import) Run(params *ImportRunParams) error {
+func (i *Import) Run(params *ImportRunParams) (rerr error) {
+	defer rationalizeError(i.prime.Auth(), &rerr)
 	logging.Debug("ExecuteImport")
 
 	proj := i.prime.Project()
@@ -118,7 +121,7 @@ func (i *Import) Run(params *ImportRunParams) error {
 		return locale.WrapError(err, "err_cannot_get_build_expression", "Could not get build expression")
 	}
 
-	if err := applyChangeset(changeset, bs); err != nil {
+	if err := i.applyChangeset(changeset, bs); err != nil {
 		return locale.WrapError(err, "err_cannot_apply_changeset", "Could not apply changeset")
 	}
 
@@ -185,7 +188,7 @@ func fetchImportChangeset(cp ChangesetProvider, file string, lang string) (model
 	return changeset, err
 }
 
-func applyChangeset(changeset model.Changeset, bs *buildscript.BuildScript) error {
+func (i *Import) applyChangeset(changeset model.Changeset, bs *buildscript.BuildScript) error {
 	for _, change := range changeset {
 		var expressionOperation types.Operation
 		switch change.Operation {
@@ -197,9 +200,21 @@ func applyChangeset(changeset model.Changeset, bs *buildscript.BuildScript) erro
 			expressionOperation = types.OperationUpdated
 		}
 
+		namespace := change.Namespace
+		if namespace == "" {
+			if !i.prime.Auth().Authenticated() {
+				return rationalize.ErrNotAuthenticated
+			}
+			name, err := org.Get("", i.prime.Auth(), i.prime.Config())
+			if err != nil {
+				return errs.Wrap(err, "Unable to get an org for the user")
+			}
+			namespace = fmt.Sprintf("%s/%s", constants.PlatformPrivateNamespace, name)
+		}
+
 		req := types.Requirement{
 			Name:      change.Requirement,
-			Namespace: change.Namespace,
+			Namespace: namespace,
 		}
 
 		for _, constraint := range change.VersionConstraints {

--- a/internal/runners/packages/rationalize.go
+++ b/internal/runners/packages/rationalize.go
@@ -49,7 +49,7 @@ func rationalizeError(auth *authentication.Auth, err *error) {
 			)
 		case types.NoChangeSinceLastCommitErrorType:
 			*err = errs.WrapUserFacing(*err,
-				locale.Tl("err_packages_exists", "That package is already installed."),
+				locale.Tl("err_packages_exist", "The requested package(s) is already installed."),
 				errs.SetInput(),
 			)
 		default:
@@ -63,6 +63,12 @@ func rationalizeError(auth *authentication.Auth, err *error) {
 	case errors.As(*err, &requirementNotFoundErr):
 		*err = errs.WrapUserFacing(*err,
 			locale.Tr("err_remove_requirement_not_found", requirementNotFoundErr.Name),
+			errs.SetInput(),
+		)
+
+	case errors.Is(*err, rationalize.ErrNotAuthenticated):
+		*err = errs.WrapUserFacing(*err,
+			locale.Tl("err_import_unauthenticated", "Could not import requirements into a private namespace because you are not authenticated. Please authenticate using '[ACTIONABLE]state auth[/RESET]' and try again."),
 			errs.SetInput(),
 		)
 	}

--- a/pkg/platform/api/reqsimport/reqsimport.go
+++ b/pkg/platform/api/reqsimport/reqsimport.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/ActiveState/cli/internal/language"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/pkg/platform/api"
@@ -68,13 +67,6 @@ func (ri *ReqsImport) Changeset(data []byte, lang string) ([]*mono_models.Commit
 	reqPayload := &TranslationReqMsg{
 		Data:     string(data),
 		Language: lang,
-	}
-	if lang == "" {
-		// The endpoint requires a valid language name. It is not present in the requirements read and
-		// returned. When coupled with "unformatted=true", the language has no bearing on the
-		// translation, so just pick one.
-		reqPayload.Language = language.Python3.Requirement()
-		reqPayload.Unformatted = true
 	}
 	respPayload := &TranslationRespMsg{}
 

--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -116,7 +116,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("import", "requirements.txt")
-		cp.Expect("No new changes")
+		cp.Expect("already installed")
 		cp.ExpectNotExitCode(0)
 	})
 

--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
+	"github.com/ActiveState/cli/internal/testhelpers/osutil"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
 )
@@ -145,6 +146,41 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		cp.Expect(">=1.21.1,<=1.26.5 → 1.26.5")
 		cp.ExpectExitCode(0)
 	})
+	ts.IgnoreLogErrors()
+}
+
+func (suite *ImportIntegrationTestSuite) TestImportCycloneDx() {
+	suite.OnlyRunForTags(tagsuite.Import)
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	ts.LoginAsPersistentUser() // needed to read orgs for private namespace
+
+	ts.PrepareEmptyProject()
+
+	jsonSbom := filepath.Join(osutil.GetTestDataDir(), "import", "cyclonedx", "bom.json")
+	xmlSbom := filepath.Join(osutil.GetTestDataDir(), "import", "cyclonedx", "bom.xml")
+
+	for _, sbom := range []string{jsonSbom, xmlSbom} {
+		suite.Run("import "+sbom, func() {
+			cp := ts.Spawn("import", sbom)
+			cp.Expect("Creating commit")
+			cp.Expect("Done")
+			cp.ExpectNotExitCode(0) // solve should fail due to private namespace
+
+			cp = ts.Spawn("history")
+			cp.Expect("Import from requirements file")
+			cp.Expect("+ body-parser 1.19.0")
+			cp.Expect("namespace: private/")
+			cp.Expect("+ bytes 3.1.0")
+			cp.Expect("namespace: private/")
+			cp.ExpectExitCode(0)
+
+			cp = ts.Spawn("reset", "-n")
+			cp.ExpectExitCode(0)
+		})
+	}
+
 	ts.IgnoreLogErrors()
 }
 

--- a/test/integration/testdata/import/cyclonedx/bom.json
+++ b/test/integration/testdata/import/cyclonedx/bom.json
@@ -1,0 +1,117 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.2",
+  "serialNumber": "urn:uuid:1f860713-54b9-4253-ba5a-9554851904af",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2020-08-03T03:20:53.771Z",
+    "tools": [
+      {
+        "vendor": "CycloneDX",
+        "name": "Node.js module",
+        "version": "2.0.0"
+      }
+    ],
+    "component": {
+      "type": "library",
+      "bom-ref": "pkg:npm/juice-shop@11.1.2",
+      "name": "juice-shop",
+      "version": "11.1.2",
+      "description": "Probably the most modern and sophisticated insecure web application",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/juice-shop@11.1.2",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://owasp-juice.shop"
+        },
+        {
+          "type": "issue-tracker",
+          "url": "https://github.com/bkimminich/juice-shop/issues"
+        },
+        {
+          "type": "vcs",
+          "url": "git+https://github.com/bkimminich/juice-shop.git"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/body-parser@1.19.0",
+      "name": "body-parser",
+      "version": "1.19.0",
+      "description": "Node.js body parsing middleware",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/body-parser@1.19.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/expressjs/body-parser#readme"
+        },
+        {
+          "type": "issue-tracker",
+          "url": "https://github.com/expressjs/body-parser/issues"
+        },
+        {
+          "type": "vcs",
+          "url": "git+https://github.com/expressjs/body-parser.git"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/bytes@3.1.0",
+      "name": "bytes",
+      "version": "3.1.0",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/bytes@3.1.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/visionmedia/bytes.js#readme"
+        },
+        {
+          "type": "issue-tracker",
+          "url": "https://github.com/visionmedia/bytes.js/issues"
+        },
+        {
+          "type": "vcs",
+          "url": "git+https://github.com/visionmedia/bytes.js.git"
+        }
+      ]
+    }
+  ]
+}

--- a/test/integration/testdata/import/cyclonedx/bom.xml
+++ b/test/integration/testdata/import/cyclonedx/bom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:d6aa76fa-e488-480d-9ad0-f67765dfd015" version="1">
+    <metadata>
+        <timestamp>2020-08-03T03:19:55.999Z</timestamp>
+        <tools>
+            <tool>
+                <vendor>CycloneDX</vendor>
+                <name>Node.js module</name>
+                <version>2.0.0</version>
+            </tool>
+        </tools>
+        <component type="library" bom-ref="pkg:npm/juice-shop@11.1.2">
+            <name>juice-shop</name>
+            <version>11.1.2</version>
+            <description>
+                <![CDATA[Probably the most modern and sophisticated insecure web application]]>
+            </description>
+            <licenses>
+                <license>
+                    <id>MIT</id>
+                </license>
+            </licenses>
+            <purl>pkg:npm/juice-shop@11.1.2</purl>
+            <externalReferences>
+                <reference type="website">
+                    <url>https://owasp-juice.shop</url>
+                </reference>
+                <reference type="issue-tracker">
+                    <url>https://github.com/bkimminich/juice-shop/issues</url>
+                </reference>
+                <reference type="vcs">
+                    <url>git+https://github.com/bkimminich/juice-shop.git</url>
+                </reference>
+            </externalReferences>
+        </component>
+    </metadata>
+    <components>
+        <component type="library" bom-ref="pkg:npm/body-parser@1.19.0">
+            <name>body-parser</name>
+            <version>1.19.0</version>
+            <description>
+                <![CDATA[Node.js body parsing middleware]]>
+            </description>
+            <hashes>
+                <hash alg="SHA-1">96b2709e57c9c4e09a6fd66a8fd979844f69f08a</hash>
+            </hashes>
+            <licenses>
+                <license>
+                    <id>MIT</id>
+                </license>
+            </licenses>
+            <purl>pkg:npm/body-parser@1.19.0</purl>
+            <externalReferences>
+                <reference type="website">
+                    <url>https://github.com/expressjs/body-parser#readme</url>
+                </reference>
+                <reference type="issue-tracker">
+                    <url>https://github.com/expressjs/body-parser/issues</url>
+                </reference>
+                <reference type="vcs">
+                    <url>git+https://github.com/expressjs/body-parser.git</url>
+                </reference>
+            </externalReferences>
+        </component>
+        <component type="library" bom-ref="pkg:npm/bytes@3.1.0">
+            <name>bytes</name>
+            <version>3.1.0</version>
+            <description>
+                <![CDATA[Utility to parse a string bytes to bytes and vice-versa]]>
+            </description>
+            <hashes>
+                <hash alg="SHA-1">f6cf7933a360e0588fa9fde85651cdc7f805d1f6</hash>
+            </hashes>
+            <licenses>
+                <license>
+                    <id>MIT</id>
+                </license>
+            </licenses>
+            <purl>pkg:npm/bytes@3.1.0</purl>
+            <externalReferences>
+                <reference type="website">
+                    <url>https://github.com/visionmedia/bytes.js#readme</url>
+                </reference>
+                <reference type="issue-tracker">
+                    <url>https://github.com/visionmedia/bytes.js/issues</url>
+                </reference>
+                <reference type="vcs">
+                    <url>git+https://github.com/visionmedia/bytes.js.git</url>
+                </reference>
+            </externalReferences>
+        </component>
+    </components>
+</bom>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2941" title="DX-2941" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2941</a>  Users can import and create projects from CycloneDX SBOMs using `state import`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This can happen with language-agnostic formats like CycloneDX and SPDX.