### PR TITLE
Always update the runtime for the commands that use it.

### DIFF
--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -44,6 +44,7 @@ type Opts struct {
 	CommitID            strfmt.UUID
 	Commit              *bpModel.Commit
 	ValidateBuildscript bool
+	NoAsync             bool
 }
 
 type SetOpt func(*Opts)
@@ -77,6 +78,12 @@ func WithCommitID(commitID strfmt.UUID) SetOpt {
 func WithoutBuildscriptValidation() SetOpt {
 	return func(opts *Opts) {
 		opts.ValidateBuildscript = false
+	}
+}
+
+func WithoutAsync() SetOpt {
+	return func(opts *Opts) {
+		opts.NoAsync = true
 	}
 }
 
@@ -204,7 +211,7 @@ func Update(
 
 	// Async runtimes should still do everything up to the actual update itself, because we still want to raise
 	// any errors regarding solves, buildscripts, etc.
-	if prime.Config().GetBool(constants.AsyncRuntimeConfig) {
+	if prime.Config().GetBool(constants.AsyncRuntimeConfig) && !opts.NoAsync {
 		logging.Debug("Skipping runtime update due to async runtime")
 		return rt, nil
 	}

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -176,7 +176,7 @@ func (r *Activate) Run(params *ActivateParams) (rerr error) {
 		}
 	}
 
-	rt, err := runtime_runbit.Update(r.prime, trigger.TriggerActivate, runtime_runbit.WithoutHeaders())
+	rt, err := runtime_runbit.Update(r.prime, trigger.TriggerActivate, runtime_runbit.WithoutHeaders(), runtime_runbit.WithoutAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_could_not_activate_venv", "Could not activate project")
 	}

--- a/internal/runners/deploy/deploy.go
+++ b/internal/runners/deploy/deploy.go
@@ -182,7 +182,7 @@ func (d *Deploy) install(params *Params, commitID strfmt.UUID) (rerr error) {
 	pg := progress.NewRuntimeProgressIndicator(d.output)
 	defer rtutils.Closer(pg.Close, &rerr)
 
-	if _, err := runtime_runbit.Update(d.prime, trigger.TriggerDeploy, runtime_runbit.WithTargetDir(params.Path)); err != nil {
+	if _, err := runtime_runbit.Update(d.prime, trigger.TriggerDeploy, runtime_runbit.WithTargetDir(params.Path), runtime_runbit.WithoutAsync()); err != nil {
 		return locale.WrapError(err, "err_deploy_runtime_err", "Could not initialize runtime")
 	}
 

--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -125,7 +125,7 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 
 	s.out.Notice(locale.Tr("operating_message", projectNamespace, projectDir))
 
-	rt, err := runtime_runbit.Update(s.prime, trigger, runtime_runbit.WithoutHeaders())
+	rt, err := runtime_runbit.Update(s.prime, trigger, runtime_runbit.WithoutHeaders(), runtime_runbit.WithoutAsync())
 	if err != nil {
 		return errs.Wrap(err, "Could not initialize runtime")
 	}

--- a/internal/runners/refresh/refresh.go
+++ b/internal/runners/refresh/refresh.go
@@ -83,7 +83,7 @@ func (r *Refresh) Run(params *Params) error {
 		return locale.NewInputError("refresh_runtime_uptodate")
 	}
 
-	rti, err := runtime_runbit.Update(r.prime, trigger.TriggerRefresh, runtime_runbit.WithoutHeaders())
+	rti, err := runtime_runbit.Update(r.prime, trigger.TriggerRefresh, runtime_runbit.WithoutHeaders(), runtime_runbit.WithoutAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_refresh_runtime_new", "Could not update runtime for this project.")
 	}

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -91,7 +91,7 @@ func (u *Shell) Run(params *Params) error {
 		return locale.NewInputError("err_shell_commit_id_mismatch")
 	}
 
-	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerShell, runtime_runbit.WithoutHeaders())
+	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerShell, runtime_runbit.WithoutHeaders(), runtime_runbit.WithoutAsync())
 	if err != nil {
 		return locale.WrapExternalError(err, "err_shell_runtime_new", "Could not start a shell/prompt for this project.")
 	}

--- a/internal/runners/use/use.go
+++ b/internal/runners/use/use.go
@@ -90,7 +90,7 @@ func (u *Use) Run(params *Params) error {
 		return locale.NewInputError("err_use_commit_id_mismatch")
 	}
 
-	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerUse, runtime_runbit.WithoutHeaders())
+	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerUse, runtime_runbit.WithoutHeaders(), runtime_runbit.WithoutAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_use_runtime_new", "Cannot use this project.")
 	}

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -82,7 +82,7 @@ func (s *ScriptRun) NeedsActivation() bool {
 
 // PrepareVirtualEnv sets up the relevant runtime and prepares the environment.
 func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
-	rt, err := runtime_runbit.Update(s.prime, trigger.TriggerScript, runtime_runbit.WithoutHeaders())
+	rt, err := runtime_runbit.Update(s.prime, trigger.TriggerScript, runtime_runbit.WithoutHeaders(), runtime_runbit.WithoutAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_activate_runtime", "Could not initialize a runtime for this project.")
 	}

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -504,6 +504,28 @@ func (suite *ShellIntegrationTestSuite) TestWindowsShells() {
 	cp.ExpectExitCode(0)
 }
 
+func (suite *ShellIntegrationTestSuite) TestAsync() {
+	suite.OnlyRunForTags(tagsuite.Shell)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
+	cp.Expect("Checked out project")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("shell")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.SendLine("python3 --version")
+	cp.Expect("Python 3.10")
+	cp.SendLine("exit")
+	cp.Expect("Deactivated")
+	cp.ExpectExit() // exit code varies depending on shell; just assert the shell exited
+}
+
 func TestShellIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(ShellIntegrationTestSuite))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2967" title="DX-2967" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2967</a>  `state shell` with `optin.unstable.async_runtime` does not work.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Ignoring the async runtime config option makes those commands unusable.