### PR TITLE
Only remove the installation.InstallDirMarker after binaries were successfully removed.

### DIFF
--- a/internal/assets/contents/scripts/removePaths.bat
+++ b/internal/assets/contents/scripts/removePaths.bat
@@ -32,17 +32,19 @@ echo "Waiting for process %exe% with PID %pid% to end..." >> %logfile%
 echo "Process %exe% has ended" >> %logfile%
 set success=true
 for %%i in (%paths%) do (
-    echo "Attempting to remove path %%i" >> %logfile%
-    if exist "%%i\" (
-        rmdir /s /q %%i 2>>&1 >> %logfile%
-    ) else if exist "%%i" (
-        del /f /q %%i 2>>&1 >> %logfile%
-    )
-    if exist "%%i" (
-        echo "Could not remove path: %%i" >> %logfile%
-        set success=false
-    ) else (
-        echo "Successfully removed path %%i" >> %logfile%
+    if "%success%"=="true" (
+        echo "Attempting to remove path %%i" >> %logfile%
+        if exist "%%i\" (
+            rmdir /s /q %%i 2>>&1 >> %logfile%
+        ) else if exist "%%i" (
+            del /f /q %%i 2>>&1 >> %logfile%
+        )
+        if exist "%%i" (
+            echo "Could not remove path: %%i" >> %logfile%
+            set success=false
+        ) else (
+            echo "Successfully removed path %%i" >> %logfile%
+        )
     )
 )
 

--- a/internal/runners/clean/run_lin_mac.go
+++ b/internal/runners/clean/run_lin_mac.go
@@ -205,14 +205,13 @@ func cleanInstallDir(dir string, cfg *config.Instance) error {
 	}
 
 	var asFiles = []string{
-		installation.InstallDirMarker,
 		constants.StateInstallerCmd + osutils.ExeExtension,
 	}
 
-	// Remove all of the state tool executables and finally the
-	// bin directory
+	// Remove all of the state tool executables, bin directory, and finally the install marker.
 	asFiles = append(asFiles, execs...)
 	asFiles = append(asFiles, installation.BinDirName)
+	asFiles = append(asFiles, installation.InstallDirMarker)
 
 	for _, file := range asFiles {
 		f := filepath.Join(dir, file)

--- a/internal/runners/clean/run_win.go
+++ b/internal/runners/clean/run_win.go
@@ -116,14 +116,19 @@ func removeInstall(logFile string, params *UninstallParams, cfg *config.Instance
 		return locale.WrapError(err, "err_state_exec")
 	}
 
-	// Schedule removal of the entire install directory.
+	// Schedule ordered removal of the entire install directory.
 	// This is because Windows often thinks the installation.InstallDirMarker and
 	// constants.StateInstallerCmd files are still in use.
 	installDir, err := installation.InstallPathFromExecPath()
 	if err != nil {
 		return errs.Wrap(err, "Could not get installation path")
 	}
-	paths := []string{stateExec, installDir}
+	paths := []string{
+		stateExec,
+		filepath.Join(installDir, installation.BinDirName),
+		filepath.Join(installDir, installation.InstallDirMarker), // should be after bin
+		installDir,
+	}
 	if params.All {
 		paths = append(paths, cfg.ConfigPath()) // also remove the config directory
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2870" title="DX-2870" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2870</a>  Could not register config listener:  Could not determine install root from exec:
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Otherwise, if removal of state-svc failed and it's scheduled for auto-start, it'll constantly fail to detect the install root and send the error to rollbar.