### PR TITLE
`state import` with SBOMs should still update the commit.

### DIFF
--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -1,8 +1,10 @@
 package packages
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
@@ -19,6 +21,7 @@ import (
 	"github.com/ActiveState/cli/pkg/buildscript"
 	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api"
+	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/response"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/types"
 	"github.com/ActiveState/cli/pkg/platform/api/reqsimport"
 	"github.com/ActiveState/cli/pkg/platform/model"
@@ -28,6 +31,8 @@ import (
 const (
 	defaultImportFile = "requirements.txt"
 )
+
+var errImportSbomSolve = errs.New("failed to solve SBOM")
 
 // Confirmer describes the behavior required to prompt a user for confirmation.
 type Confirmer interface {
@@ -143,7 +148,24 @@ func (i *Import) Run(params *ImportRunParams) (rerr error) {
 	// Solve the runtime.
 	rtCommit, err := bp.FetchCommit(stagedCommitId, proj.Owner(), proj.Name(), nil)
 	if err != nil {
-		return errs.Wrap(err, "Failed to fetch build result for previous commit")
+		var buildplannerErr *response.BuildPlannerError
+		if errors.As(err, &buildplannerErr) {
+			// When importing CycloneDX and SPDX SBOMs, we put all packages in the 'private/<org>'
+			// namespace, which will fail to solve. That is expected. However, we still want to update the
+			// local commit so the user can see what was imported, even if the runtime is not viable.
+			for _, verr := range buildplannerErr.ValidationErrors {
+				if strings.Contains(verr, "non-existent namespace: private/") {
+					if err := localcommit.Set(proj.Dir(), stagedCommitId.String()); err != nil {
+						return locale.WrapError(err, "err_package_update_commit_id")
+					}
+					return errImportSbomSolve
+				}
+			}
+		}
+
+		if err != nil {
+			return errs.Wrap(err, "Failed to fetch build result for staged commit")
+		}
 	}
 
 	// Output change summary.

--- a/internal/runners/packages/rationalize.go
+++ b/internal/runners/packages/rationalize.go
@@ -71,11 +71,5 @@ func rationalizeError(auth *authentication.Auth, err *error) {
 			locale.Tl("err_import_unauthenticated", "Could not import requirements into a private namespace because you are not authenticated. Please authenticate using '[ACTIONABLE]state auth[/RESET]' and try again."),
 			errs.SetInput(),
 		)
-
-	case errors.Is(*err, errImportSbomSolve):
-		*err = errs.WrapUserFacing(*err,
-			locale.Tl("err_import_sbom_solve", "Import finished, but your runtime could not be created because the SBOM's requirements do not exist on the Platform."),
-			errs.SetInput(),
-		)
 	}
 }

--- a/internal/runners/packages/rationalize.go
+++ b/internal/runners/packages/rationalize.go
@@ -71,5 +71,11 @@ func rationalizeError(auth *authentication.Auth, err *error) {
 			locale.Tl("err_import_unauthenticated", "Could not import requirements into a private namespace because you are not authenticated. Please authenticate using '[ACTIONABLE]state auth[/RESET]' and try again."),
 			errs.SetInput(),
 		)
+
+	case errors.Is(*err, errImportSbomSolve):
+		*err = errs.WrapUserFacing(*err,
+			locale.Tl("err_import_sbom_solve", "Import finished, but your runtime could not be created because the SBOM's requirements do not exist on the Platform."),
+			errs.SetInput(),
+		)
 	}
 }

--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -158,6 +158,9 @@ func (suite *ImportIntegrationTestSuite) TestImportCycloneDx() {
 
 	ts.PrepareEmptyProject()
 
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
 	jsonSbom := filepath.Join(osutil.GetTestDataDir(), "import", "cyclonedx", "bom.json")
 	xmlSbom := filepath.Join(osutil.GetTestDataDir(), "import", "cyclonedx", "bom.xml")
 
@@ -193,9 +196,12 @@ func (suite *ImportIntegrationTestSuite) TestImportSpdx() {
 
 	ts.PrepareEmptyProject()
 
+	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
 	jsonSbom := filepath.Join(osutil.GetTestDataDir(), "import", "spdx", "appbomination.spdx.json")
 
-	cp := ts.Spawn("import", jsonSbom)
+	cp = ts.Spawn("import", jsonSbom)
 	cp.Expect("Creating commit")
 	cp.Expect("Done")
 	cp.ExpectNotExitCode(0) // solve should fail due to private namespace


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2977" title="DX-2977" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2977</a>  Nightly failure: CycloneDX and SPDX SBOM imports
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

We expect the solve to fail, but we should still update the commit so the user can see what was added, even if the runtime is no longer viable.

Note: these tests were passing prior to the runtime refactor landing and the removal of `constants.DisableRuntime` in favor of the async runtime config option. The local commit was still being updated despite the runtime failing to solve. Now this is no longer the case, so this PR is trying to work around that.