### PR TITLE
Use volume-specific depot for Windows runtimes not on the main volume.

### DIFF
--- a/pkg/runtime/depot.go
+++ b/pkg/runtime/depot.go
@@ -45,8 +45,11 @@ type depot struct {
 	fsMutex   *sync.Mutex
 }
 
-func newDepot() (*depot, error) {
+func newDepot(volume string) (*depot, error) {
 	depotPath := filepath.Join(storage.CachePath(), depotName)
+	if volume != "" { // Windows volume label for this depot
+		depotPath = filepath.Join(volume+"\\", "activestate", depotName)
+	}
 
 	result := &depot{
 		config: depotConfig{

--- a/pkg/runtime/depot.go
+++ b/pkg/runtime/depot.go
@@ -210,6 +210,10 @@ func (d *depot) DeployViaCopy(id strfmt.UUID, relativeSrc, absoluteDest string) 
 		return errs.Wrap(err, "failed to resolve path")
 	}
 
+	if err := d.validateVolume(absoluteDest); err != nil {
+		return errs.Wrap(err, "volume validation failed")
+	}
+
 	if err := fileutils.MkdirUnlessExists(absoluteDest); err != nil {
 		return errs.Wrap(err, "failed to create path")
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/installation/storage"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/pkg/buildplan"
 	"github.com/ActiveState/cli/pkg/runtime/internal/envdef"
@@ -46,7 +47,16 @@ func New(path string) (*Runtime, error) {
 		return nil, errs.Wrap(err, "Could not create runtime directory")
 	}
 
-	depot, err := newDepot()
+	// Windows does not support hard-linking across drives, so determine if the runtime path is on a
+	// separate drive than the default depot path. If so, use a drive-specific depot path when
+	// initializing the depot.
+	runtimeVolume := filepath.VolumeName(path)
+	storageVolume := filepath.VolumeName(storage.CachePath())
+	if runtimeVolume == storageVolume {
+		runtimeVolume = ""
+	}
+
+	depot, err := newDepot(runtimeVolume)
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not create depot")
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
-	"github.com/ActiveState/cli/internal/installation/storage"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/pkg/buildplan"
 	"github.com/ActiveState/cli/pkg/runtime/internal/envdef"
@@ -47,16 +46,8 @@ func New(path string) (*Runtime, error) {
 		return nil, errs.Wrap(err, "Could not create runtime directory")
 	}
 
-	// Windows does not support hard-linking across drives, so determine if the runtime path is on a
-	// separate drive than the default depot path. If so, use a drive-specific depot path when
-	// initializing the depot.
-	runtimeVolume := filepath.VolumeName(path)
-	storageVolume := filepath.VolumeName(storage.CachePath())
-	if runtimeVolume == storageVolume {
-		runtimeVolume = ""
-	}
-
-	depot, err := newDepot(runtimeVolume)
+	runtimePath := path
+	depot, err := newDepot(runtimePath)
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not create depot")
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -46,7 +46,7 @@ func New(path string) (*Runtime, error) {
 		return nil, errs.Wrap(err, "Could not create runtime directory")
 	}
 
-	runtimePath := path
+	runtimePath := path // for readability; if we need to pass more info to the depot, use a struct
 	depot, err := newDepot(runtimePath)
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not create depot")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2943" title="DX-2943" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2943</a>  We support setting up a runtime on the non-windows drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
