### PR TITLE
Change summary should only output line separator if there is a summary to show.

### DIFF
--- a/internal/runbits/cves/cves.go
+++ b/internal/runbits/cves/cves.go
@@ -184,6 +184,7 @@ func (c *CveReport) summarizeCVEs(vulnerabilities model.VulnerableIngredientsByL
 	out.Print("")
 	out.Print("   " + locale.T("more_info_vulnerabilities"))
 	out.Print("   " + locale.T("disable_prompting_vulnerabilities"))
+	out.Print("")
 }
 
 func (c *CveReport) promptForSecurity() (bool, error) {

--- a/internal/runbits/dependencies/changesummary.go
+++ b/internal/runbits/dependencies/changesummary.go
@@ -68,6 +68,7 @@ func OutputChangeSummary(out output.Outputer, report *response.ImpactReportResul
 	}
 
 	// Output a summary of changes.
+	out.Notice("") // blank line
 	localeKey := "additional_dependencies"
 	if numIndirect > 0 {
 		localeKey = "additional_total_dependencies"

--- a/internal/runbits/runtime/requirements/requirements.go
+++ b/internal/runbits/runtime/requirements/requirements.go
@@ -258,7 +258,6 @@ func (r *RequirementOperation) ExecuteRequirementOperation(ts *time.Time, requir
 	}
 	solveSpinner.Stop(locale.T("progress_success"))
 
-	r.Output.Notice("") // blank line
 	dependencies.OutputChangeSummary(r.prime.Output(), impactReport, rtCommit.BuildPlan())
 
 	// Report CVEs

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -171,7 +171,6 @@ func (i *Import) Run(params *ImportRunParams) (rerr error) {
 	solveSpinner.Stop(locale.T("progress_success"))
 
 	// Output change summary.
-	out.Notice("") // blank line
 	dependencies.OutputChangeSummary(i.prime.Output(), impactReport, rtCommit.BuildPlan())
 
 	// Report CVEs.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2962" title="DX-2962" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2962</a>  Row gap between messages when install language
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also output trailing line separator for CVE info.

```
% ../../cli/build/state languages install python@3.9
█ Installing Language (Beta)

Beta Feature: This feature is still in beta and may be unstable.

Operating on project org/project, located at /path/to/project.

 • Searching for python in the ActiveState Catalog ✔ Found
 • Creating commit ✔ Done
 • Resolving Dependencies ✔ Done
 • Checking for vulnerabilities (CVEs) on python and its dependencies x Unsafe

   Warning: Dependency has 2 known vulnerabilities (CVEs)

    • 1 High: CVE-2023-36632
    • 1 Medium: CVE-2023-27043

   For more information on these vulnerabilities run 'state security open <ID>'.
   To disable prompting for vulnerabilities run 'state config set security.prompt.enabled false'.

Language updated: python@3.9
Your local project has been updated.
Run state push to save changes to the platform.
```