### PR TITLE
Remote installer should forward "--force" to installer.

### DIFF
--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -216,6 +216,9 @@ func execute(out output.Outputer, prompt prompt.Prompter, cfg *config.Instance, 
 	if params.nonInteractive {
 		args = append(args, "-n") // forward to installer
 	}
+	if params.force {
+		args = append(args, "--force") // forward to installer
+	}
 	env := []string{
 		constants.InstallerNoSubshell + "=true",
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2853" title="DX-2853" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2853</a>  Windows installer can't overwrite existing install and provides incorrect instructions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
