### PR TITLE
Fixed disabling of security prompts in e2e tests.

### DIFF
--- a/internal/runbits/cves/cves.go
+++ b/internal/runbits/cves/cves.go
@@ -128,7 +128,7 @@ func (c *CveReport) shouldPromptForSecurity(vulnerabilities model.VulnerableIngr
 
 	promptLevel := c.prime.Config().GetString(constants.SecurityPromptLevelConfig)
 
-	logging.Debug("Prompt level: ", promptLevel)
+	logging.Debug("Prompt level: %s", promptLevel)
 	switch promptLevel {
 	case vulnModel.SeverityCritical:
 		return vulnerabilities.Critical.Count > 0

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -182,7 +182,7 @@ func new(t *testing.T, retainDirs, updatePath bool, extraEnv ...string) *Session
 	err = fileutils.Touch(filepath.Join(dirs.Base, installation.InstallDirMarker))
 	require.NoError(session.T, err)
 
-	cfg, err := config.New()
+	cfg, err := config.NewCustom(dirs.Config, singlethread.New(), true)
 	require.NoError(session.T, err)
 
 	if err := cfg.Set(constants.SecurityPromptConfig, false); err != nil {

--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -38,9 +38,6 @@ func (suite *ImportIntegrationTestSuite) TestImport_detached() {
 	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
-	cp.ExpectExitCode(0)
-
 	cp = ts.Spawn("import", importPath)
 	cp.Expect("Operating on project")
 	cp.Expect("ActiveState-CLI/small-python")
@@ -110,9 +107,6 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 		cp.ExpectExitCode(0)
 
-		cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
-		cp.ExpectExitCode(0)
-
 		cp = ts.Spawn("import", "requirements.txt")
 		cp.ExpectExitCode(0)
 
@@ -126,9 +120,6 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		ts.PrepareFile(reqsFilePath, complexReqsData)
 
 		cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
-		cp.ExpectExitCode(0)
-
-		cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
 		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("import", "requirements.txt")

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -630,10 +630,7 @@ func (suite *PackageIntegrationTestSuite) TestProjectWithOfflineInstallerAndDock
 
 	ts.LoginAsPersistentUser() // needed for Enterprise-tier features
 
-	cp := ts.Spawn("config", "set", constants.SecurityPromptConfig, "false")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("checkout", "ActiveState-CLI/Python-OfflineInstaller-Docker", ".")
+	cp := ts.Spawn("checkout", "ActiveState-CLI/Python-OfflineInstaller-Docker", ".")
 	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }
@@ -688,16 +685,13 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Prompt() {
 	cp = ts.Spawn("config", "set", "security.prompt.level", "high")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("config", "set", "security.prompt.enabled", "true")
+	cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "true")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "urllib3@2.0.2")
 	cp.Expect("Warning: Dependency has 2 known vulnerabilities")
 	cp.Expect("Do you want to continue")
 	cp.SendLine("y")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("config", "set", "security.prompt.enabled", "false")
 	cp.ExpectExitCode(0)
 }
 
@@ -711,6 +705,9 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Indirect() {
 	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
 
 	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "true")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "private/ActiveState-CLI-Testing/language/python/django_dep", "--ts=now")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3018" title="DX-3018" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3018</a>  Nightly failures: non-checkout tests that checkout projects with lots of CVEs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
