### PR TITLE
If two artifacts provide the same file, re-link or re-copy that file from the artifact left after the other was undeployed/uninstalled.

### DIFF
--- a/internal/smartlink/smartlink.go
+++ b/internal/smartlink/smartlink.go
@@ -47,7 +47,7 @@ func Link(src, dest string) error {
 	}
 
 	if fileutils.IsDir(src) {
-		if err := os.MkdirAll(dest, 0755); err != nil {
+		if err := fileutils.Mkdir(dest); err != nil {
 			return errs.Wrap(err, "could not create directory %s", dest)
 		}
 		entries, err := os.ReadDir(src)
@@ -62,10 +62,9 @@ func Link(src, dest string) error {
 		return nil
 	}
 
-	if destDir := filepath.Dir(dest); !fileutils.DirExists(destDir) {
-		if err := os.MkdirAll(destDir, 0755); err != nil {
-			return errs.Wrap(err, "could not create directory %s", destDir)
-		}
+	destDir := filepath.Dir(dest)
+	if err := fileutils.MkdirUnlessExists(destDir); err != nil {
+		return errs.Wrap(err, "could not create directory %s", destDir)
 	}
 
 	// Multiple artifacts can supply the same file. We do not have a better solution for this at the moment other than

--- a/pkg/runtime/depot.go
+++ b/pkg/runtime/depot.go
@@ -345,10 +345,12 @@ func (d *depot) getSharedFilesToRedeploy(id strfmt.UUID, deploy deployment, path
 						logging.Debug("More than one artifact provides '%s'", relativeDeployedFile)
 						logging.Debug("Will redeploy '%s' to '%s'", newSrc, deployedFile)
 						redeploy[deployedFile] = newSrc
+						goto nextDeployedFile
 					}
 				}
 			}
 		}
+	nextDeployedFile:
 	}
 
 	return redeploy, nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2913" title="DX-2913" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2913</a>  We track individual file ownership on the artifact level
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The idea behind this PR is to:
- Retain the current of behavior of not modifying any currently deployed files. That is, if two artifacts both provide the same file, the one installed first "wins".
- Change the behavior of deleting any currently deployed files from an artifact. If two artifacts both provide the same file, when one of them is uninstalled, re-link or copy the file from the remaining artifact that is still installed.

For example, given the following two packages:

- `state install hello`, which provides a *bin/main* executable such that `state exec main` prints `Hello world!`.
- `state install hello-again`, which provides a *bin/main* executable such that `state exec main` prints `Hello world again!`.

Here's a scenario:
1. `state install hello`
2. `state install hello-again`
3. `state exec main` --> prints `Hello world!` from `hello`, which "wins" by providing *bin/main* first.
4. `state uninstall hello` --> identifies that `hello-again` also provides *bin/main*, and re-links/re-deploys it after uninstalling `hello`.
5. `state exec main` --> prints `Hello world again!`
6. `state uninstall hello-again` --> removes everything as expected.
7. `state exec main` --> errors saying that `main` was not found.

Please note this is an "extreme" scenario. In all likelihood, artifacts providing the same file will provide the same bits, so the contents will not matter. The file merely needs to exist. Therefore, this PR effectively does reference counting and will not completely remove a file until no more artifacts reference it.