### PR TITLE
Harmonize runtime sourcing messages across runners.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1161,13 +1161,13 @@ package_ingredient_alternatives_nolang:
 
     This may be because you have not installed a language for your project. Install a language by running "[ACTIONABLE]state languages install <language-name>[/RESET]".
 progress_search:
-  other: " • Searching for [ACTIONABLE]{{.V0}}[/RESET] in the ActiveState Catalog"
+  other: "• Searching for [ACTIONABLE]{{.V0}}[/RESET] in the ActiveState Catalog"
 progress_cve_search:
-  other: " • Checking for vulnerabilities (CVEs) on [ACTIONABLE]{{.V0}}[/RESET] and its dependencies"
+  other: "• Checking for vulnerabilities (CVEs) on [ACTIONABLE]{{.V0}}[/RESET] and its dependencies"
 setup_runtime:
   other: "Setting Up Runtime"
 progress_solve:
-  other: "Resolving Dependencies"
+  other: "• Resolving Dependencies"
 additional_dependencies:
   other: Installing {{.V0}} includes [ACTIONABLE]{{.V1}}[/RESET] direct dependencies.
 additional_total_dependencies:
@@ -1183,11 +1183,11 @@ progress_safe:
 progress_unsafe:
   other: " [ERROR]x Unsafe[/RESET]"
 progress_commit:
-  other: " • Creating commit"
+  other: "• Creating commit"
 progress_solve_preruntime:
-  other: " • Resolving Dependencies"
+  other: "• Resolving Dependencies"
 progress_pkg_nolang:
-  other: " • Searching for [ACTIONABLE]{{.V0}}[/RESET] across all languages in the ActiveState Catalog"
+  other: "• Searching for [ACTIONABLE]{{.V0}}[/RESET] across all languages in the ActiveState Catalog"
 progress_build_log:
   other: "Build Log [ACTIONABLE]{{.V0}}[/RESET]"
 progress_completed:

--- a/internal/runbits/cves/cves.go
+++ b/internal/runbits/cves/cves.go
@@ -155,11 +155,11 @@ func (c *CveReport) summarizeCVEs(vulnerabilities model.VulnerableIngredientsByL
 
 	switch {
 	case vulnerabilities.CountPrimary == 0:
-		out.Print("   " + locale.Tr("warning_vulnerable_indirectonly", strconv.Itoa(vulnerabilities.Count)))
+		out.Print("  " + locale.Tr("warning_vulnerable_indirectonly", strconv.Itoa(vulnerabilities.Count)))
 	case vulnerabilities.CountPrimary == vulnerabilities.Count:
-		out.Print("   " + locale.Tr("warning_vulnerable_directonly", strconv.Itoa(vulnerabilities.Count)))
+		out.Print("  " + locale.Tr("warning_vulnerable_directonly", strconv.Itoa(vulnerabilities.Count)))
 	default:
-		out.Print("   " + locale.Tr("warning_vulnerable", strconv.Itoa(vulnerabilities.CountPrimary), strconv.Itoa(vulnerabilities.Count-vulnerabilities.CountPrimary)))
+		out.Print("  " + locale.Tr("warning_vulnerable", strconv.Itoa(vulnerabilities.CountPrimary), strconv.Itoa(vulnerabilities.Count-vulnerabilities.CountPrimary)))
 	}
 
 	printVulnerabilities := func(vulnerableIngredients model.VulnerableIngredientsByLevel, name, color string) {
@@ -172,7 +172,7 @@ func (c *CveReport) summarizeCVEs(vulnerabilities model.VulnerableIngredientsByL
 				}
 				ings = append(ings, fmt.Sprintf("%s[CYAN]%s[/RESET]", prefix, strings.Join(vulns.CVEIDs, ", ")))
 			}
-			out.Print(fmt.Sprintf("    • [%s]%d %s:[/RESET] %s", color, vulnerableIngredients.Count, name, strings.Join(ings, ", ")))
+			out.Print(fmt.Sprintf("  • [%s]%d %s:[/RESET] %s", color, vulnerableIngredients.Count, name, strings.Join(ings, ", ")))
 		}
 	}
 
@@ -182,8 +182,8 @@ func (c *CveReport) summarizeCVEs(vulnerabilities model.VulnerableIngredientsByL
 	printVulnerabilities(vulnerabilities.Low, locale.Tl("cve_low", "Low"), "MAGENTA")
 
 	out.Print("")
-	out.Print("   " + locale.T("more_info_vulnerabilities"))
-	out.Print("   " + locale.T("disable_prompting_vulnerabilities"))
+	out.Print("  " + locale.T("more_info_vulnerabilities"))
+	out.Print("  " + locale.T("disable_prompting_vulnerabilities"))
 	out.Print("")
 }
 

--- a/internal/runbits/dependencies/changesummary.go
+++ b/internal/runbits/dependencies/changesummary.go
@@ -95,7 +95,7 @@ func OutputChangeSummary(out output.Outputer, newBuildPlan *buildplan.BuildPlan,
 	if numIndirect > 0 {
 		localeKey = "additional_total_dependencies"
 	}
-	out.Notice("   " + locale.Tr(localeKey, strings.Join(addedLocale, ", "), strconv.Itoa(len(directDependencies)), strconv.Itoa(numIndirect)))
+	out.Notice("  " + locale.Tr(localeKey, strings.Join(addedLocale, ", "), strconv.Itoa(len(directDependencies)), strconv.Itoa(numIndirect)))
 
 	// A direct dependency list item is of the form:
 	//   ├─ name@version (X dependencies)
@@ -104,9 +104,9 @@ func OutputChangeSummary(out output.Outputer, newBuildPlan *buildplan.BuildPlan,
 	// depending on whether or not it has subdependencies, and whether or not showUpdatedPackages is
 	// `true`.
 	for i, ingredient := range directDependencies {
-		prefix := " ├─"
+		prefix := "├─"
 		if i == len(directDependencies)-1 {
-			prefix = " └─"
+			prefix = "└─"
 		}
 
 		// Retrieve runtime dependencies, and then filter out any dependencies that are common between all added ingredients.

--- a/internal/runbits/dependencies/summary.go
+++ b/internal/runbits/dependencies/summary.go
@@ -23,12 +23,13 @@ func OutputSummary(out output.Outputer, directDependencies buildplan.Artifacts) 
 		return ingredients[i].Name < ingredients[j].Name
 	})
 
-	out.Notice(locale.Tl("setting_up_dependencies", "Setting up the following dependencies:"))
+	out.Notice("") // blank line
+	out.Notice(locale.Tl("setting_up_dependencies", "  Setting up the following dependencies:"))
 
 	for i, ingredient := range ingredients {
-		prefix := "├─"
+		prefix := "  ├─"
 		if i == len(ingredients)-1 {
-			prefix = "└─"
+			prefix = "  └─"
 		}
 
 		subdependencies := ""

--- a/internal/runbits/runtime/requirements/requirements.go
+++ b/internal/runbits/runtime/requirements/requirements.go
@@ -214,7 +214,7 @@ func (r *RequirementOperation) ExecuteRequirementOperation(ts *time.Time, requir
 	}
 
 	// Solve runtime
-	solveSpinner := output.StartSpinner(r.Output, locale.T("progress_solve_preruntime"), constants.TerminalAnimationInterval)
+	solveSpinner := output.StartSpinner(r.Output, locale.T("progress_solve"), constants.TerminalAnimationInterval)
 	commit, err := bp.StageCommit(params)
 	if err != nil {
 		solveSpinner.Stop(locale.T("progress_fail"))

--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -133,7 +133,7 @@ func (c *Commit) Run() (rerr error) {
 	pg.Stop(locale.T("progress_success"))
 	pg = nil
 
-	pgSolve := output.StartSpinner(out, locale.T("progress_solve_preruntime"), constants.TerminalAnimationInterval)
+	pgSolve := output.StartSpinner(out, locale.T("progress_solve"), constants.TerminalAnimationInterval)
 	defer func() {
 		if pgSolve != nil {
 			pgSolve.Stop(locale.T("progress_fail"))
@@ -163,6 +163,7 @@ func (c *Commit) Run() (rerr error) {
 		return errs.Wrap(err, "Could not report CVEs")
 	}
 
+	out.Notice("") // blank line
 	out.Print(output.Prepare(
 		locale.Tl(
 			"commit_success",

--- a/internal/runners/manifest/requirements.go
+++ b/internal/runners/manifest/requirements.go
@@ -76,6 +76,7 @@ func (o requirements) Print(out output.Outputer) {
 		requirementsOutput = append(requirementsOutput, requirementOutput)
 	}
 
+	out.Print("") // blank line
 	out.Print(struct {
 		Requirements []*requirementOutput `locale:"," opts:"hideDash,omitKey"`
 	}{

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -125,7 +125,7 @@ func (i *Import) Run(params *ImportRunParams) (rerr error) {
 		return locale.WrapError(err, "err_cannot_apply_changeset", "Could not apply changeset")
 	}
 
-	solveSpinner := output.StartSpinner(i.prime.Output(), locale.T("progress_solve_preruntime"), constants.TerminalAnimationInterval)
+	solveSpinner := output.StartSpinner(i.prime.Output(), locale.T("progress_solve"), constants.TerminalAnimationInterval)
 	msg := locale.T("commit_reqstext_message")
 	stagedCommit, err := bp.StageCommit(buildplanner.StageCommitParams{
 		Owner:        proj.Owner(),
@@ -163,6 +163,7 @@ func (i *Import) Run(params *ImportRunParams) (rerr error) {
 		return errs.Wrap(err, "Could not report CVEs")
 	}
 
+	out.Notice("") // blank line
 	_, err = runtime_runbit.Update(i.prime, trigger.TriggerImport, runtime_runbit.WithCommitID(stagedCommit.CommitID))
 	if err != nil {
 		return errs.Wrap(err, "Runtime update failed")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2929" title="DX-2929" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2929</a>  As a user I can expect the UI for runtimes to be consistent 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

- Remove leading space from bullets and lists.
- Use blank line separators properly.

Samples:

```
% ../cli/build/state checkout activestate-cli/small-python sm2
Checking out project: activestate-cli/small-python

• Resolving Dependencies ✔ Done

  Setting up the following dependencies:
  └─ python@3.10.10 

• Checking for vulnerabilities (CVEs) on python and its dependencies x Unsafe

  Warning: Dependency has 6 known vulnerabilities (CVEs)

  • 3 High: CVE-2024-7592, CVE-2023-24329, CVE-2023-36632
  • 3 Medium: CVE-2007-4559, CVE-2023-27043, CVE-2023-40217

  For more information on these vulnerabilities run 'state security open <ID>'.
  To disable prompting for vulnerabilities run 'state config set 
  security.prompt.enabled false'.

█ Sourcing Runtime

Checked out project ActiveState-CLI/small-python, located at
```

```
% ../../cli/build/state install requests@2.30
█ Installing Package

Operating on project ActiveState-CLI/small-python, located at 
/path/to/small-python.

• Searching for requests in the ActiveState Catalog ✔ Found
• Creating commit \• Resolving Dependencies ✔ Done
✔ Done

  Installing requests@2.30.0 includes 4 direct dependencies.
  ├─ certifi@2024.7.4
  ├─ charset-normalizer@3.3.2
  ├─ idna@3.7
  └─ urllib3@2.2.2

• Checking for vulnerabilities (CVEs) on requests and its dependencies x Unsafe

  Warning: Dependency has 1 known vulnerabilities (CVEs)

  • 1 Medium: CVE-2023-32681

  For more information on these vulnerabilities run 'state security open <ID>'.
  To disable prompting for vulnerabilities run 'state config set 
  security.prompt.enabled false'.

Package added: requests@2.30
Your local project has been updated.
Run state push to save changes to the platform.
```

(Note: the double-bullet in the example above is a known bug that will be addressed in another ticket.)

```
% ../../cli/build/state init org/project --language python
Initializing Project

• Resolving Dependencies ✔ Done

  Setting up the following dependencies:
  ├─ brotli@1.1.0 
  ├─ bzip2@1.0.8 
  ├─ expat@2.6.2 
  ├─ ffi@3.4.6 
  ├─ fontconfig@2.15.0 
  ├─ freetype2@2.13.2 
  ├─ gperf@3.1 
  ├─ libX11@1.8.7 
  ├─ libXau@1.0.9 
  ├─ libXdmcp@1.1.3 
  ├─ libXext@1.3.4 
  ├─ libpng@1.6.43 
  ├─ libpthread-stubs@0.1 
  ├─ libxcb@1.15 
  ├─ lzma@5.2.4 
  ├─ mozilla-ca-cert-bundle@2022-04-26 
  ├─ ncurses@6.5 
  ├─ openssl@3.3.1 (1 sub-dependencies)
  ├─ python@3.10.14 
  ├─ readline@8.2.10 
  ├─ sqlite3@3.46.0 
  ├─ tcltktix@8.6.14 
  ├─ x11-util-macros@1.19.3 
  ├─ xcb-proto@1.15.2 
  ├─ xorgproto@2022.1 
  ├─ xtrans@1.4.0 
  └─ zlib@1.3.1 

█ Sourcing Runtime
```