### PR TITLE
Merge "PATH" with Window's "Path".

### DIFF
--- a/pkg/runtime/internal/envdef/environment.go
+++ b/pkg/runtime/internal/envdef/environment.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/errs"
@@ -340,7 +341,11 @@ func (ed *EnvironmentDefinition) GetEnvBasedOn(envLookup map[string]string) (map
 	for _, ev := range ed.Env {
 		pev := &ev
 		if pev.Inherit {
-			osValue, hasOsValue := envLookup[pev.Name]
+			name := pev.Name
+			if runtime.GOOS == "windows" && name == "PATH" {
+				name = "Path" // env vars are case-insensitive on Windows, and this is what it uses
+			}
+			osValue, hasOsValue := envLookup[name]
 			if hasOsValue {
 				osEv := ev
 				osEv.Values = []string{osValue}

--- a/pkg/runtime/internal/envdef/environment.go
+++ b/pkg/runtime/internal/envdef/environment.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/errs"
@@ -341,11 +340,7 @@ func (ed *EnvironmentDefinition) GetEnvBasedOn(envLookup map[string]string) (map
 	for _, ev := range ed.Env {
 		pev := &ev
 		if pev.Inherit {
-			name := pev.Name
-			if runtime.GOOS == "windows" && name == "PATH" {
-				name = "Path" // env vars are case-insensitive on Windows, and this is what it uses
-			}
-			osValue, hasOsValue := envLookup[name]
+			osValue, hasOsValue := envLookup[pev.Name]
 			if hasOsValue {
 				osEv := ev
 				osEv.Values = []string{osValue}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3012" title="DX-3012" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3012</a>  Windows - `state exec` regression
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This enables searching for exes in not just runtime PATH, but also Windows Path.

I believe this PR triggered the issue: https://github.com/ActiveState/cli/commit/d881640f32db1ffb3fb488a2b87f860cd6c82374, but I think it exposed the fact we aren't merging `PATH` and `Path` on Windows.