### PR TITLE
Run integration tests in restricted powershell mode on Windows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,6 +293,12 @@ jobs:
           state run deploy-installers
           state run deploy-remote-installer
 
+      - # === Set restricted powershell permissions ===
+        name: Restrict powershell permissions
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-ExecutionPolicy -ExecutionPolicy Restricted
+
       - # === Integration Tests ===
         name: Integration Tests
         id: integration_tests


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2989" title="DX-2989" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2989</a>  We integration test our remote-installer with restricted powershell permissions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This ensures we can install/run/operate the State Tool on client machines with this common configuration.