### PR TITLE
Add timeout for complex import test.

### DIFF
--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/ActiveState/termtest"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -122,7 +125,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("import", "requirements.txt")
-		cp.ExpectExitCode(0)
+		cp.ExpectExitCode(0, termtest.OptExpectTimeout(30*time.Second))
 
 		cp = ts.Spawn("packages")
 		cp.Expect("coverage")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3026" title="DX-3026" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3026</a>  Nightly failure: TestImportIntegrationTestSuite/TestImport/complex_requirements.txt
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The default timeout is too low for this test.