### PR TITLE
Fixed macOS init integration test to infer language from a non-Camel project.

### DIFF
--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -123,11 +123,11 @@ func (suite *InitIntegrationTestSuite) TestInit_InferLanguageFromUse() {
 	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("checkout", "ActiveState-CLI/Python3")
+	cp = ts.Spawn("checkout", "ActiveState-CLI/small-python")
 	cp.Expect("Checked out project")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("use", "Python3")
+	cp = ts.Spawn("use", "small-python")
 	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2976" title="DX-2976" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-2976</a>  Nightly failure: TestInitIntegrationTestSuite/TestInit_InferLanguageFromUse
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

