### PR TITLE
Do not output CVE report or prompt when in structured output mode.

### DIFF
--- a/internal/runbits/cves/cves.go
+++ b/internal/runbits/cves/cves.go
@@ -118,6 +118,10 @@ func (c *CveReport) shouldSkipReporting(changeset buildplan.ArtifactChangeset) b
 		return true
 	}
 
+	if c.prime.Output().Type().IsStructured() {
+		return true
+	}
+
 	return len(changeset.Added) == 0 && len(changeset.Updated) == 0
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3036" title="DX-3036" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3036</a>  Checkout using `-o json` have ERRORS in the log, sporadically 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This will also fix any current or future commands that use the CVE report output to still produce valid JSON output.