### PR TITLE
Added marshaling and pre-unmarshaling hooks for buildscript <-> buildexpression.

### DIFF
--- a/pkg/buildscript/unmarshal_buildexpression.go
+++ b/pkg/buildscript/unmarshal_buildexpression.go
@@ -43,6 +43,22 @@ const (
 	inKey  = "in"
 )
 
+type PreUnmarshalerFunc func(map[string]interface{}) (map[string]interface{}, error)
+
+var preUnmarshalers map[string]PreUnmarshalerFunc
+
+func init() {
+	preUnmarshalers = make(map[string]PreUnmarshalerFunc)
+}
+
+// RegisterFunctionPreUnmarshaler registers a buildscript pre-unmarshaler for a buildexpression
+// function.
+// Pre-unmarshalers accept a JSON object of function arguments, transform those arguments as
+// necessary, and return a JSON object for final unmarshaling to buildscript.
+func RegisterFunctionPreUnmarshaler(name string, preUnmarshal PreUnmarshalerFunc) {
+	preUnmarshalers[name] = preUnmarshal
+}
+
 // UnmarshalBuildExpression returns a BuildScript constructed from the given build expression in
 // JSON format.
 // Build scripts and build expressions are almost identical, with the exception of the atTime field.
@@ -251,12 +267,21 @@ func unmarshalFuncCall(path []string, m map[string]interface{}) (*FuncCall, erro
 	var name string
 	var argsInterface interface{}
 	for key, value := range m {
-		_, ok := value.(map[string]interface{})
+		m, ok := value.(map[string]interface{})
 		if !ok {
 			return nil, errs.New("Incorrect argument format")
 		}
 
 		name = key
+
+		if preUnmarshal, exists := preUnmarshalers[name]; exists {
+			var err error
+			value, err = preUnmarshal(m)
+			if err != nil {
+				return nil, errs.Wrap(err, "Unable to pre-unmarshal function '%s'", name)
+			}
+		}
+
 		argsInterface = value
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3031" title="DX-3031" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3031</a>  Our buildscript package can mediate evaluation of client-side functions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This allows for outside packages to hook into:
- Unmarshaling from buildexpression to buildscript
- Marshaling from buildscript to buildexpression

Also: utilize this when marshaling `Req()` function to legacy object format. We cannot utilize the unmarshaling yet.