### PR TITLE
Sort artifact changesets by name.

### DIFF
--- a/pkg/buildplan/buildplan.go
+++ b/pkg/buildplan/buildplan.go
@@ -2,6 +2,7 @@ package buildplan
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/go-openapi/strfmt"
 
@@ -130,6 +131,8 @@ func (b *BuildPlan) DiffArtifacts(oldBp *BuildPlan, requestedOnly bool) Artifact
 			Artifact:   artf,
 		})
 	}
+
+	sort.SliceStable(changeset, func(i, j int) bool { return changeset[i].Artifact.Name() < changeset[j].Artifact.Name() })
 
 	return changeset
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3028" title="DX-3028" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3028</a>  Requirement ordering is consistent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Unfortunately, it's not as simple as sorting buildplan artifacts once and you're done. For example, the `DiffArtifacts()` function creates a map of artifacts, which is inherently unsorted, so we have to sort it after the fact. (It doesn't matter whether or not the incoming artifacts are sorted.) Other functions throughout the codebase have the capability to do something similar (if they do not already). We could either:

1. Identify and rewrite all functions that utilize artifacts, ingredients, and requirements to be mindful of sort order, and keep this in mind for all future functions we write.
2. Sort as needed, attempting to capture the largest number of use cases at as high a level as possible.

This PR chooses option 2, which sorts the `DiffArtifacts()` output. This results in CVE lists, change summary lists, and `state upgrade` lists outputting sorted lists of artifacts.