### PR TITLE
Do not validate commit ID from within projectfile.

### DIFF
--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ActiveState/cli/internal/sliceutils"
 	"github.com/ActiveState/cli/internal/strutils"
 	"github.com/ActiveState/cli/pkg/sysinfo"
-	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/imdario/mergo"
 	"github.com/spf13/cast"
@@ -660,19 +659,6 @@ func (p *Project) parseURL() (projectURL, error) {
 	return parseURL(p.Project)
 }
 
-func validateUUID(uuidStr string) error {
-	if ok := strfmt.Default.Validates("uuid", uuidStr); !ok {
-		return locale.NewError("err_commit_id_invalid", "", uuidStr)
-	}
-
-	var uuid strfmt.UUID
-	if err := uuid.UnmarshalText([]byte(uuidStr)); err != nil {
-		return locale.WrapError(err, "err_commit_id_unmarshal", "Failed to unmarshal the commit id {{.V0}} read from activestate.yaml.", uuidStr)
-	}
-
-	return nil
-}
-
 func parseURL(rawURL string) (projectURL, error) {
 	p := projectURL{}
 
@@ -699,12 +685,6 @@ func parseURL(rawURL string) (projectURL, error) {
 	q := u.Query()
 	if c := q.Get("commitID"); c != "" {
 		p.LegacyCommitID = c
-	}
-
-	if p.LegacyCommitID != "" {
-		if err := validateUUID(p.LegacyCommitID); err != nil {
-			return p, err
-		}
 	}
 
 	if b := q.Get("branch"); b != "" {

--- a/pkg/projectfile/projectfile_test.go
+++ b/pkg/projectfile/projectfile_test.go
@@ -377,13 +377,12 @@ func TestValidateProjectURL(t *testing.T) {
 
 func Test_parseURL(t *testing.T) {
 	tests := []struct {
-		name    string
-		rawURL  string
-		want    projectURL
-		wantErr bool
+		name   string
+		rawURL string
+		want   projectURL
 	}{
 		{
-			"Valid full legacy URL",
+			"Full URL",
 			"https://platform.activestate.com/Owner/Name?commitID=7BA74758-8665-4D3F-921C-757CD271A0C1&branch=main",
 			projectURL{
 				Owner:          "Owner",
@@ -391,10 +390,9 @@ func Test_parseURL(t *testing.T) {
 				LegacyCommitID: "7BA74758-8665-4D3F-921C-757CD271A0C1",
 				BranchName:     "main",
 			},
-			false,
 		},
 		{
-			"Valid commit URL",
+			"Legacy commit URL",
 			"https://platform.activestate.com/commit/7BA74758-8665-4D3F-921C-757CD271A0C1",
 			projectURL{
 				Owner:          "",
@@ -402,23 +400,16 @@ func Test_parseURL(t *testing.T) {
 				LegacyCommitID: "7BA74758-8665-4D3F-921C-757CD271A0C1",
 				BranchName:     "",
 			},
-			false,
-		},
-		{
-			"Invalid commit",
-			"https://platform.activestate.com/commit/nope",
-			projectURL{},
-			true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseURL(tt.rawURL)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseURL() error = %v, wantErr %v", err, tt.wantErr)
+			if err != nil {
+				t.Errorf("parseURL() error = %v", err)
 				return
 			}
-			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseURL() got = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3050" title="DX-3050" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3050</a>  The attempt to fix invalid URL by `state reset` fail
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Doing so prevents `state reset` from fixing a bad ID.

Any runners that need a commit ID get it from localcommit, which raises an invalid commit ID error, so this validation is superfluous.