### PR TITLE
Added test that verifies a bare `state` is not making any API calls.

### DIFF
--- a/test/integration/api_int_test.go
+++ b/test/integration/api_int_test.go
@@ -1,9 +1,12 @@
 package integration
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
@@ -27,6 +30,30 @@ func (suite *ApiIntegrationTestSuite) TestRequestHeaders() {
 	cp.ExpectRe(`User-Agent: state/(\d+\.?)+-SHA[[:xdigit:]]+; \S+ \([^;]+; [^;]+; [^)]+\)`)
 	cp.ExpectRe(`X-Requestor: [[:xdigit:]-]+`) // UUID
 	cp.ExpectExitCode(0)
+}
+
+// TestNoApiCallsForPlainInvocation asserts that a bare `state` does not make any API calls.
+func (suite *ApiIntegrationTestSuite) TestNoApiCallsForPlainInvocation() {
+	suite.OnlyRunForTags(tagsuite.Critical)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.SpawnWithOpts(
+		e2e.OptAppendEnv(constants.DebugServiceRequestsEnvVarName + "=true"),
+	)
+	cp.ExpectExitCode(0)
+
+	readLogFile := false
+	for _, path := range ts.LogFiles() {
+		if !strings.HasPrefix(filepath.Base(path), "state-") {
+			continue
+		}
+		contents := string(fileutils.ReadFileUnsafe(path))
+		suite.Assert().NotContains(contents, "URL: ") // pkg/platform/api logs URL, User-Agent, and X-Requestor for API calls
+		readLogFile = true
+	}
+	suite.Assert().True(readLogFile, "did not read log file")
 }
 
 func TestApiIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2897" title="DX-2897" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2897</a>  We have an integration test that checks for API requests on plain state tool invocations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
