### PR TITLE
Add ability for runners to ignore async runtimes.

### DIFF
--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -49,6 +49,7 @@ type Opts struct {
 	Archive  *checkout.Archive
 
 	ValidateBuildscript bool
+	IgnoreAsync         bool
 }
 
 type SetOpt func(*Opts)
@@ -88,6 +89,12 @@ func WithoutBuildscriptValidation() SetOpt {
 func WithArchive(archive *checkout.Archive) SetOpt {
 	return func(opts *Opts) {
 		opts.Archive = archive
+	}
+}
+
+func WithIgnoreAsync() SetOpt {
+	return func(opts *Opts) {
+		opts.IgnoreAsync = true
 	}
 }
 
@@ -216,7 +223,7 @@ func Update(
 
 	// Async runtimes should still do everything up to the actual update itself, because we still want to raise
 	// any errors regarding solves, buildscripts, etc.
-	if prime.Config().GetBool(constants.AsyncRuntimeConfig) {
+	if prime.Config().GetBool(constants.AsyncRuntimeConfig) && !opts.IgnoreAsync {
 		logging.Debug("Skipping runtime update due to async runtime")
 		return rt, nil
 	}

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -176,7 +176,7 @@ func (r *Activate) Run(params *ActivateParams) (rerr error) {
 		}
 	}
 
-	rt, err := runtime_runbit.Update(r.prime, trigger.TriggerActivate, runtime_runbit.WithoutHeaders())
+	rt, err := runtime_runbit.Update(r.prime, trigger.TriggerActivate, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_could_not_activate_venv", "Could not activate project")
 	}

--- a/internal/runners/deploy/deploy.go
+++ b/internal/runners/deploy/deploy.go
@@ -182,7 +182,7 @@ func (d *Deploy) install(params *Params, commitID strfmt.UUID) (rerr error) {
 	pg := progress.NewRuntimeProgressIndicator(d.output)
 	defer rtutils.Closer(pg.Close, &rerr)
 
-	if _, err := runtime_runbit.Update(d.prime, trigger.TriggerDeploy, runtime_runbit.WithTargetDir(params.Path)); err != nil {
+	if _, err := runtime_runbit.Update(d.prime, trigger.TriggerDeploy, runtime_runbit.WithTargetDir(params.Path), runtime_runbit.WithIgnoreAsync()); err != nil {
 		return locale.WrapError(err, "err_deploy_runtime_err", "Could not initialize runtime")
 	}
 

--- a/internal/runners/export/env.go
+++ b/internal/runners/export/env.go
@@ -47,7 +47,7 @@ func (e *Env) Run() error {
 		e.project.Dir()),
 	)
 
-	rt, err := runtime_runbit.Update(e.prime, trigger.TriggerActivate, runtime_runbit.WithoutHeaders())
+	rt, err := runtime_runbit.Update(e.prime, trigger.TriggerActivate, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_export_new_runtime", "Could not initialize runtime")
 	}

--- a/internal/runners/refresh/refresh.go
+++ b/internal/runners/refresh/refresh.go
@@ -86,7 +86,7 @@ func (r *Refresh) Run(params *Params) error {
 		return locale.NewInputError("refresh_runtime_uptodate")
 	}
 
-	rti, err := runtime_runbit.Update(r.prime, trigger.TriggerRefresh, runtime_runbit.WithoutHeaders())
+	rti, err := runtime_runbit.Update(r.prime, trigger.TriggerRefresh, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_refresh_runtime_new", "Could not update runtime for this project.")
 	}

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -93,7 +93,7 @@ func (u *Shell) Run(params *Params) error {
 		return locale.NewInputError("err_shell_commit_id_mismatch")
 	}
 
-	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerShell, runtime_runbit.WithoutHeaders())
+	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerShell, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
 	if err != nil {
 		return locale.WrapExternalError(err, "err_shell_runtime_new", "Could not start a shell/prompt for this project.")
 	}

--- a/internal/runners/use/use.go
+++ b/internal/runners/use/use.go
@@ -90,7 +90,7 @@ func (u *Use) Run(params *Params) error {
 		return locale.NewInputError("err_use_commit_id_mismatch")
 	}
 
-	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerUse, runtime_runbit.WithoutHeaders())
+	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerUse, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_use_runtime_new", "Cannot use this project.")
 	}

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -82,7 +82,7 @@ func (s *ScriptRun) NeedsActivation() bool {
 
 // PrepareVirtualEnv sets up the relevant runtime and prepares the environment.
 func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
-	rt, err := runtime_runbit.Update(s.prime, trigger.TriggerScript, runtime_runbit.WithoutHeaders())
+	rt, err := runtime_runbit.Update(s.prime, trigger.TriggerScript, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
 	if err != nil {
 		return locale.WrapError(err, "err_activate_runtime", "Could not initialize a runtime for this project.")
 	}

--- a/test/integration/shell_int_test.go
+++ b/test/integration/shell_int_test.go
@@ -441,7 +441,7 @@ func (suite *ShellIntegrationTestSuite) TestScriptAlias() {
 	defer ts.Close()
 
 	cp := ts.Spawn("checkout", "ActiveState-CLI/Perl-5.32", ".")
-	cp.Expect("Checked out project")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	suite.NoError(fileutils.WriteFile(filepath.Join(ts.Dirs.Work, "testargs.pl"), []byte(`


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3054" title="DX-3054" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3054</a>  Once `optin.unstable.async_runtime` is true no commands sourcing the runtime
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is needed for `state refresh` and `state shell`.