### PR TITLE
Fix exec should bypass async; not export env

### DIFF
--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -126,7 +126,7 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 
 	s.out.Notice(locale.Tr("operating_message", projectNamespace, projectDir))
 
-	rt, err := runtime_runbit.Update(s.prime, trigger, runtime_runbit.WithoutHeaders())
+	rt, err := runtime_runbit.Update(s.prime, trigger, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
 	if err != nil {
 		return errs.Wrap(err, "Could not initialize runtime")
 	}

--- a/internal/runners/export/env.go
+++ b/internal/runners/export/env.go
@@ -47,7 +47,7 @@ func (e *Env) Run() error {
 		e.project.Dir()),
 	)
 
-	rt, err := runtime_runbit.Update(e.prime, trigger.TriggerActivate, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
+	rt, err := runtime_runbit.Update(e.prime, trigger.TriggerActivate, runtime_runbit.WithoutHeaders())
 	if err != nil {
 		return locale.WrapError(err, "err_export_new_runtime", "Could not initialize runtime")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3054" title="DX-3054" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3054</a>  Once `optin.unstable.async_runtime` is true no commands sourcing the runtime
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
