### PR TITLE
Fixed failing integration test.

### DIFF
--- a/test/integration/prepare_int_test.go
+++ b/test/integration/prepare_int_test.go
@@ -166,8 +166,9 @@ func (suite *PrepareIntegrationTestSuite) TestResetExecutors() {
 	cp = ts.Spawn("activate")
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("which python3")
-	cp.SendLine("python3 --version")
+	cp.SendLine("python3")
 	cp.Expect("ActiveState")
+	cp.SendLine("exit()") // exit from Python interpreter
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3067" title="DX-3067" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3067</a>  Nightly failure: TestPrepareIntegrationTestSuite/TestResetExecutors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Apparently we don't mention ActiveState in the Python --version anymore.