### PR TITLE
Increase test timeout.

### DIFF
--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -125,7 +125,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("import", "requirements.txt")
-		cp.ExpectExitCode(0, termtest.OptExpectTimeout(30*time.Second))
+		cp.ExpectExitCode(0, termtest.OptExpectTimeout(2*time.Minute)) // wait twice as long as a normal solve
 
 		cp = ts.Spawn("packages")
 		cp.Expect("coverage")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3062" title="DX-3062" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3062</a>  Nightly failure: TestImportIntegrationTestSuite/TestImport/complex_requirements.txt
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


It turns out the new timeout constant I mentioned in the ticket hasn't landed yet. I've filed https://activestatef.atlassian.net/browse/DX-3070 to revisit this and similar constants.