### PR TITLE
The only commands that should ignore async runtimes are `refresh`, `deploy`, and `activate`.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1448,6 +1448,9 @@ err_packages_update_runtime_init:
   other: Could not initialize runtime.
 pkg_already_uptodate:
   other: Dependencies for your project are already configured and installed.
+notice_async_runtime:
+  other: |
+    [WARNING]Warning:[/RESET] Skipping runtime sourcing since {{.V0}} is enabled. Please run '[ACTIONABLE]state refresh[/RESET]' to manually source the runtime.
 install_runtime:
   other: Sourcing Runtime
 install_runtime_info:
@@ -1541,7 +1544,7 @@ err_uninstall_platform_nomatch:
 err_uninstall_platform_multimatch:
   other: |
     The platform query you provided matches multiple platforms in your project.
-    Please specify the platform to uninstall by using its version and bit-width. 
+    Please specify the platform to uninstall by using its version and bit-width.
     To view the platforms your project uses run: [ACTIONABLE]state platforms[/RESET].
 progress_requirements:
   other: "• Updating requirements"

--- a/internal/runbits/reqop_runbit/update.go
+++ b/internal/runbits/reqop_runbit/update.go
@@ -108,6 +108,9 @@ func UpdateAndReload(prime primeable, script *buildscript.BuildScript, oldCommit
 			}
 			return errs.Wrap(err, "Failed to refresh runtime")
 		}
+	} else {
+		prime.Output().Notice("") // blank line
+		prime.Output().Notice(locale.Tr("notice_async_runtime", constants.AsyncRuntimeConfig))
 	}
 
 	// Update commit ID

--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -225,6 +225,8 @@ func Update(
 	// any errors regarding solves, buildscripts, etc.
 	if prime.Config().GetBool(constants.AsyncRuntimeConfig) && !opts.IgnoreAsync {
 		logging.Debug("Skipping runtime update due to async runtime")
+		prime.Output().Notice("") // blank line
+		prime.Output().Notice(locale.Tr("notice_async_runtime", constants.AsyncRuntimeConfig))
 		return rt, nil
 	}
 

--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -126,7 +126,7 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 
 	s.out.Notice(locale.Tr("operating_message", projectNamespace, projectDir))
 
-	rt, err := runtime_runbit.Update(s.prime, trigger, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
+	rt, err := runtime_runbit.Update(s.prime, trigger, runtime_runbit.WithoutHeaders())
 	if err != nil {
 		return errs.Wrap(err, "Could not initialize runtime")
 	}

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -93,7 +93,7 @@ func (u *Shell) Run(params *Params) error {
 		return locale.NewInputError("err_shell_commit_id_mismatch")
 	}
 
-	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerShell, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
+	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerShell, runtime_runbit.WithoutHeaders())
 	if err != nil {
 		return locale.WrapExternalError(err, "err_shell_runtime_new", "Could not start a shell/prompt for this project.")
 	}

--- a/internal/runners/use/use.go
+++ b/internal/runners/use/use.go
@@ -90,7 +90,7 @@ func (u *Use) Run(params *Params) error {
 		return locale.NewInputError("err_use_commit_id_mismatch")
 	}
 
-	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerUse, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
+	rti, err := runtime_runbit.Update(u.prime, trigger.TriggerUse, runtime_runbit.WithoutHeaders())
 	if err != nil {
 		return locale.WrapError(err, "err_use_runtime_new", "Cannot use this project.")
 	}

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -82,7 +82,7 @@ func (s *ScriptRun) NeedsActivation() bool {
 
 // PrepareVirtualEnv sets up the relevant runtime and prepares the environment.
 func (s *ScriptRun) PrepareVirtualEnv() (rerr error) {
-	rt, err := runtime_runbit.Update(s.prime, trigger.TriggerScript, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())
+	rt, err := runtime_runbit.Update(s.prime, trigger.TriggerScript, runtime_runbit.WithoutHeaders())
 	if err != nil {
 		return locale.WrapError(err, "err_activate_runtime", "Could not initialize a runtime for this project.")
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3071" title="DX-3071" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3071</a>  Limit async runtime to JUST `state refresh`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Show a warning to the user when async runtime cases update skips.