### PR TITLE
Map to ingredient when its source can be identified as a single straight path

### DIFF
--- a/internal/maputils/maputils.go
+++ b/internal/maputils/maputils.go
@@ -1,0 +1,7 @@
+package maputils
+
+// Contains is a shortcut to `_, ok := map[key]`. This allows for evaluating
+func Contains[T comparable, V any](m map[T]V, value T) bool {
+	_, ok := m[value]
+	return ok
+}

--- a/internal/maputils/maputils.go
+++ b/internal/maputils/maputils.go
@@ -1,7 +1,0 @@
-package maputils
-
-// Contains is a shortcut to `_, ok := map[key]`. This allows for evaluating
-func Contains[T comparable, V any](m map[T]V, value T) bool {
-	_, ok := m[value]
-	return ok
-}

--- a/pkg/buildplan/buildplan.go
+++ b/pkg/buildplan/buildplan.go
@@ -37,9 +37,10 @@ func Unmarshal(data []byte) (*BuildPlan, error) {
 		return nil, errs.Wrap(err, "error hydrating build plan")
 	}
 
-	if len(b.artifacts) == 0 || len(b.ingredients) == 0 || len(b.platforms) == 0 {
-		return nil, errs.New("Buildplan unmarshalling failed as it got zero artifacts (%d), ingredients (%d) and or platforms (%d).",
-			len(b.artifacts), len(b.ingredients), len(b.platforms))
+	if len(b.artifacts) == 0 || len(b.platforms) == 0 {
+		// Ingredients are not considered here because certain builds (eg. camel) won't be able to relate to a single ingredient
+		return nil, errs.New("Buildplan unmarshalling failed as it got zero artifacts (%d) and/or platforms (%d).",
+			len(b.artifacts), len(b.platforms))
 	}
 
 	return b, nil

--- a/pkg/buildplan/filters.go
+++ b/pkg/buildplan/filters.go
@@ -47,7 +47,7 @@ func FilterStateArtifacts() FilterArtifact {
 		internalIngredients := sliceutils.Filter(a.Ingredients, func(i *Ingredient) bool {
 			return i.Namespace == NamespaceInternal
 		})
-		if len(a.Ingredients) == len(internalIngredients) {
+		if len(a.Ingredients) > 0 && len(a.Ingredients) == len(internalIngredients) {
 			return false
 		}
 		if strings.Contains(a.URL, "as-builds/noop") {

--- a/pkg/buildplan/hydrate.go
+++ b/pkg/buildplan/hydrate.go
@@ -211,14 +211,6 @@ func (b *BuildPlan) hydrateWithIngredients(artifact *Artifact, platformID *strfm
 // If there are duplicates we're likely to see failures down the chain if live, though that's by no means guaranteed.
 // Surfacing it here will make it easier to reason about the failure.
 func (b *BuildPlan) sanityCheck() error {
-	// Ensure all artifacts have an associated ingredient
-	// If this fails either the API is bugged or the hydrate logic is bugged
-	for _, a := range b.Artifacts() {
-		if raw.IsStateToolMimeType(a.MimeType) && len(a.Ingredients) == 0 {
-			return errs.New("artifact '%s (%s)' does not have an ingredient", a.ArtifactID, a.DisplayName)
-		}
-	}
-
 	// The remainder of sanity checks aren't checking for error conditions so much as they are checking for smoking guns
 	// If these fail then it's likely the API has changed in a backward incompatible way, or we broke something.
 	// In any case it does not necessarily mean runtime sourcing is broken.

--- a/pkg/buildplan/hydrate.go
+++ b/pkg/buildplan/hydrate.go
@@ -55,7 +55,7 @@ func (b *BuildPlan) hydrate() error {
 		}
 		ingredient, ok := ingredientLookup[source.IngredientID]
 		if !ok {
-			return errs.New("missing ingredient for source ID: %s", req.Source)
+			continue
 		}
 		b.requirements = append(b.requirements, &Requirement{
 			Requirement: req.Requirement,

--- a/pkg/buildplan/hydrate.go
+++ b/pkg/buildplan/hydrate.go
@@ -55,6 +55,8 @@ func (b *BuildPlan) hydrate() error {
 		}
 		ingredient, ok := ingredientLookup[source.IngredientID]
 		if !ok {
+			// It's possible that we haven't associated a source to an artifact if that source links to multiple artifacts.
+			// In this case we cannot determine which artifact relates to which source.
 			continue
 		}
 		b.requirements = append(b.requirements, &Requirement{

--- a/pkg/buildplan/mock/mock.go
+++ b/pkg/buildplan/mock/mock.go
@@ -153,7 +153,8 @@ var BuildWithRuntimeDeps = &raw.Build{
 	},
 }
 
-var BuildWithRuntimeDepsViaSrc = &raw.Build{
+// BuildWithInstallerDepsViaSrc is a build that includes an installer which has two artifacts as its dependencies.
+var BuildWithInstallerDepsViaSrc = &raw.Build{
 	Terminals: []*raw.NamedTarget{
 		{
 			Tag:     "platform:00000000-0000-0000-0000-000000000001",
@@ -165,7 +166,12 @@ var BuildWithRuntimeDepsViaSrc = &raw.Build{
 			StepID:  "00000000-0000-0000-0000-000000000003",
 			Outputs: []string{"00000000-0000-0000-0000-000000000002"},
 			Inputs: []*raw.NamedTarget{
-				{Tag: "src", NodeIDs: []strfmt.UUID{"00000000-0000-0000-0000-000000000007"}},
+				{
+					Tag: "src", NodeIDs: []strfmt.UUID{
+						"00000000-0000-0000-0000-000000000007",
+						"00000000-0000-0000-0000-000000000010",
+					},
+				},
 			},
 		},
 		{
@@ -173,6 +179,13 @@ var BuildWithRuntimeDepsViaSrc = &raw.Build{
 			Outputs: []string{"00000000-0000-0000-0000-000000000007"},
 			Inputs: []*raw.NamedTarget{
 				{Tag: "src", NodeIDs: []strfmt.UUID{"00000000-0000-0000-0000-000000000009"}},
+			},
+		},
+		{
+			StepID:  "00000000-0000-0000-0000-000000000011",
+			Outputs: []string{"00000000-0000-0000-0000-000000000010"},
+			Inputs: []*raw.NamedTarget{
+				{Tag: "src", NodeIDs: []strfmt.UUID{"00000000-0000-0000-0000-000000000012"}},
 			},
 		},
 	},
@@ -187,7 +200,65 @@ var BuildWithRuntimeDepsViaSrc = &raw.Build{
 		{
 			NodeID:      "00000000-0000-0000-0000-000000000007",
 			DisplayName: "pkgOne",
-			MimeType:    types.XActiveStateArtifactMimeType,
+			GeneratedBy: "00000000-0000-0000-0000-000000000008",
+		},
+		{
+			NodeID:      "00000000-0000-0000-0000-000000000010",
+			DisplayName: "pkgTwo",
+			GeneratedBy: "00000000-0000-0000-0000-000000000011",
+		},
+	},
+	Sources: []*raw.Source{
+		{
+			"00000000-0000-0000-0000-000000000009",
+			raw.IngredientSource{
+				IngredientID: "00000000-0000-0000-0000-000000000009",
+			},
+		},
+		{
+			"00000000-0000-0000-0000-000000000012",
+			raw.IngredientSource{
+				IngredientID: "00000000-0000-0000-0000-000000000012",
+			},
+		},
+	},
+}
+
+// BuildWithStateArtifactThroughPyWheel is a build with a state tool artifact that has a python wheel as its dependency
+var BuildWithStateArtifactThroughPyWheel = &raw.Build{
+	Terminals: []*raw.NamedTarget{
+		{
+			Tag:     "platform:00000000-0000-0000-0000-000000000001",
+			NodeIDs: []strfmt.UUID{"00000000-0000-0000-0000-000000000002"},
+		},
+	},
+	Steps: []*raw.Step{
+		{
+			StepID:  "00000000-0000-0000-0000-000000000003",
+			Outputs: []string{"00000000-0000-0000-0000-000000000002"},
+			Inputs: []*raw.NamedTarget{
+				{
+					Tag: "src", NodeIDs: []strfmt.UUID{"00000000-0000-0000-0000-000000000007"},
+				},
+			},
+		},
+		{
+			StepID:  "00000000-0000-0000-0000-000000000008",
+			Outputs: []string{"00000000-0000-0000-0000-000000000007"},
+			Inputs: []*raw.NamedTarget{
+				{Tag: "src", NodeIDs: []strfmt.UUID{"00000000-0000-0000-0000-000000000009"}},
+			},
+		},
+	},
+	Artifacts: []*raw.Artifact{
+		{
+			NodeID:      "00000000-0000-0000-0000-000000000002",
+			DisplayName: "pkgStateArtifact",
+			GeneratedBy: "00000000-0000-0000-0000-000000000003",
+		},
+		{
+			NodeID:      "00000000-0000-0000-0000-000000000007",
+			DisplayName: "pkgPyWheel",
 			GeneratedBy: "00000000-0000-0000-0000-000000000008",
 		},
 	},

--- a/pkg/buildplan/mock/mock.go
+++ b/pkg/buildplan/mock/mock.go
@@ -200,11 +200,13 @@ var BuildWithInstallerDepsViaSrc = &raw.Build{
 		{
 			NodeID:      "00000000-0000-0000-0000-000000000007",
 			DisplayName: "pkgOne",
+			MimeType:    types.XActiveStateArtifactMimeType,
 			GeneratedBy: "00000000-0000-0000-0000-000000000008",
 		},
 		{
 			NodeID:      "00000000-0000-0000-0000-000000000010",
 			DisplayName: "pkgTwo",
+			MimeType:    types.XActiveStateArtifactMimeType,
 			GeneratedBy: "00000000-0000-0000-0000-000000000011",
 		},
 	},

--- a/pkg/buildplan/raw/walk_test.go
+++ b/pkg/buildplan/raw/walk_test.go
@@ -158,6 +158,7 @@ func TestRawBuild_walkNodesViaRuntimeDeps(t *testing.T) {
 			mock.BuildWithInstallerDepsViaSrc,
 			[]walkCall{
 				{"00000000-0000-0000-0000-000000000007", "Artifact", "00000000-0000-0000-0000-000000000002"},
+				{"00000000-0000-0000-0000-000000000010", "Artifact", "00000000-0000-0000-0000-000000000002"},
 			},
 			false,
 		},

--- a/pkg/runtime/depot.go
+++ b/pkg/runtime/depot.go
@@ -137,6 +137,9 @@ func (d *depot) Path(id strfmt.UUID) string {
 // necessary information. Writing externally is preferred because otherwise the depot would need a lot of specialized
 // logic that ultimately don't really need to be a concern of the depot.
 func (d *depot) Put(id strfmt.UUID) error {
+	d.fsMutex.Lock()
+	defer d.fsMutex.Unlock()
+
 	if !fileutils.TargetExists(d.Path(id)) {
 		return errs.New("could not put %s, as dir does not exist: %s", id, d.Path(id))
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3066" title="DX-3066" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3066</a>  Nightly failure: TestPackageIntegrationTestSuite/TestPackage_operation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The problem I found was that some artifacts (in this case urllib3) seem to be generated from python wheels, which means that in the buildplan you have a state tool artifact that has a python wheel artifact as its source, which then in turn has the actual ingredient as its source.

I've addressed this by still associating artifacts to ingredients so long as each step it iterates over to get to the source only has a single input node.