### PR TITLE
Do not list dependencies being checked for CVEs.

### DIFF
--- a/internal/config/instance.go
+++ b/internal/config/instance.go
@@ -185,7 +185,11 @@ func (i *Instance) Get(key string) interface{} {
 		return result
 	}
 	if opt := mediator.GetOption(key); mediator.KnownOption(opt) {
-		return opt.Default
+		default_ := opt.Default
+		if enum, ok := default_.(*mediator.Enums); ok {
+			return enum.Default
+		}
+		return default_
 	}
 	return nil
 }

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1103,7 +1103,7 @@ progress_search:
 progress_platform_search:
   other: "• Searching for platform in the ActiveState Catalog"
 progress_cve_search:
-  other: "• Checking for vulnerabilities (CVEs) on [ACTIONABLE]{{.V0}}[/RESET] and its dependencies"
+  other: "• Checking for vulnerabilities (CVEs) in your project and its dependencies"
 setup_runtime:
   other: "Setting Up Runtime"
 progress_solve:
@@ -1140,13 +1140,13 @@ unstable_feature_banner:
   other: "[NOTICE]Beta Feature: This feature is still in beta and may be unstable.[/RESET]\n"
 warning_vulnerable:
   other: |
-    [ERROR]Warning: Dependency has {{.V0}} direct and {{.V1}} indirect known vulnerabilities (CVEs)[/RESET]
+    [ERROR]Warning: Found {{.V0}} new vulnerabilities (CVEs): {{.V1}} direct and {{.V2}} indirect[/RESET]
 warning_vulnerable_indirectonly:
   other: |
-    [ERROR]Warning: Dependency has {{.V0}} indirect known vulnerabilities (CVEs)[/RESET]
+    [ERROR]Warning: Found {{.V0}} new, indirect vulnerabilities (CVEs)[/RESET]
 warning_vulnerable_directonly:
   other: |
-    [ERROR]Warning: Dependency has {{.V0}} known vulnerabilities (CVEs)[/RESET]
+    [ERROR]Warning: Found {{.V0}} new vulnerabilities (CVEs)[/RESET]
 cve_critical:
   other: Critical
 cve_high:
@@ -1161,7 +1161,7 @@ disable_prompting_vulnerabilities:
   other: To disable prompting for vulnerabilities run '[ACTIONABLE]state config set security.prompt.enabled false[/RESET]'.
 warning_vulnerable_short:
   other: |
-    [ERROR]Warning:[/RESET] Dependency has [ERROR]{{.V0}} known vulnerabilities (CVEs)[/RESET]. Severity: {{.V1}}. Run '[ACTIONABLE]state security[/RESET]' for more info.
+    [ERROR]Warning:[/RESET] Found [ERROR]{{.V0}} new vulnerabilities (CVEs)[/RESET]. Severity: {{.V1}}. Run '[ACTIONABLE]state security[/RESET]' for more info.
 prompt_continue_pkg_operation:
   other: |
     Do you want to continue installing this dependency despite its vulnerabilities?
@@ -1541,7 +1541,7 @@ err_uninstall_platform_nomatch:
 err_uninstall_platform_multimatch:
   other: |
     The platform query you provided matches multiple platforms in your project.
-    Please specify the platform to uninstall by using its version and bit-width. 
+    Please specify the platform to uninstall by using its version and bit-width.
     To view the platforms your project uses run: [ACTIONABLE]state platforms[/RESET].
 progress_requirements:
   other: "• Updating requirements"

--- a/internal/runbits/cves/cves.go
+++ b/internal/runbits/cves/cves.go
@@ -77,8 +77,7 @@ func (c *CveReport) Report(newBuildPlan *buildplan.BuildPlan, oldBuildPlan *buil
 		}
 	}
 
-	names := addedRequirements(oldBuildPlan, newBuildPlan)
-	pg := output.StartSpinner(c.prime.Output(), locale.Tr("progress_cve_search", strings.Join(names, ", ")), constants.TerminalAnimationInterval)
+	pg := output.StartSpinner(c.prime.Output(), locale.T("progress_cve_search"), constants.TerminalAnimationInterval)
 
 	ingredientVulnerabilities, err := model.FetchVulnerabilitiesForIngredients(c.prime.Auth(), ingredients)
 	if err != nil {
@@ -96,6 +95,7 @@ func (c *CveReport) Report(newBuildPlan *buildplan.BuildPlan, oldBuildPlan *buil
 	pg.Stop(locale.T("progress_unsafe"))
 	pg = nil
 
+	names := addedRequirements(oldBuildPlan, newBuildPlan)
 	vulnerabilities := model.CombineVulnerabilities(ingredientVulnerabilities, names...)
 
 	if c.prime.Prompt() == nil || !c.shouldPromptForSecurity(vulnerabilities) {
@@ -197,7 +197,7 @@ func (c *CveReport) summarizeCVEs(vulnerabilities model.VulnerableIngredientsByL
 	case vulnerabilities.CountPrimary == vulnerabilities.Count:
 		out.Print("  " + locale.Tr("warning_vulnerable_directonly", strconv.Itoa(vulnerabilities.Count)))
 	default:
-		out.Print("  " + locale.Tr("warning_vulnerable", strconv.Itoa(vulnerabilities.CountPrimary), strconv.Itoa(vulnerabilities.Count-vulnerabilities.CountPrimary)))
+		out.Print("  " + locale.Tr("warning_vulnerable", strconv.Itoa(vulnerabilities.Count), strconv.Itoa(vulnerabilities.CountPrimary), strconv.Itoa(vulnerabilities.Count-vulnerabilities.CountPrimary)))
 	}
 
 	printVulnerabilities := func(vulnerableIngredients model.VulnerableIngredientsByLevel, name, color string) {

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -571,7 +571,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_NoPrompt() {
 	// Note: this version has 2 direct vulnerabilities, and 3 indirect vulnerabilities, but since
 	// we're not prompting, we're only showing a single count.
 	cp = ts.Spawn("install", "urllib3@2.0.2")
-	cp.ExpectRe(`Warning: Dependency has .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
+	cp.ExpectRe(`Warning: Found \d+ new vulnerabilities \(CVEs\).`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }
 
@@ -587,14 +587,14 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Prompt() {
 	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("config", "set", "security.prompt.level", "high")
+	cp = ts.Spawn("config", "set", constants.SecurityPromptLevelConfig, "high")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "true")
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "urllib3@2.0.2", "--ts=2024-09-10T16:36:34.393Z")
-	cp.ExpectRe(`Warning: Dependency has .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
+	cp.ExpectRe(`Warning: Found \d+ new vulnerabilities \(CVEs\): \d+ direct and \d+ indirect`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.Expect("Do you want to continue")
 	cp.SendLine("y")
 	cp.ExpectExitCode(0)
@@ -616,7 +616,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Indirect() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "private/ActiveState-CLI-Testing/language/python/django_dep", "--ts=2024-09-10T16:36:34.393Z")
-	cp.ExpectRe(`Warning: Dependency has \d+ indirect known vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
+	cp.ExpectRe(`Warning: Found \d+ new, indirect vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.Expect("Do you want to continue")
 	cp.SendLine("n")
 	cp.ExpectExitCode(1)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3045" title="DX-3045" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3045</a>  CVE report doesn't address updated package
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Similar to how we're no longer listing which packages are being installed.

I changed some of the messaging because originally it assumed only one package at a time could be installed (and added, not updated).

Samples:

```
% state install urllib3@2.0.2
█ Installing Package

Operating on project qam/newpub, located at /path/to/newpub.

• Searching for packages in the ActiveState Catalog ✔ Found
• Resolving Dependencies ✔ Done
• Checking for vulnerabilities (CVEs) in your project and its dependencies x Unsafe

  Warning: Found 2 new vulnerabilities (CVEs). Severity: 1 High, 1 Medium. Run 'state security' for more info.

Added: language/python/urllib3@2.0.2

Your local project has been updated.
Run state push to save changes to the platform.
```

```
% state install language/python@3.11.9 pytest
█ Installing Package

Operating on project qam/newpub, located at /path/to/newpub.

• Searching for packages in the ActiveState Catalog ✔ Found
• Resolving Dependencies ✔ Done
• Checking for vulnerabilities (CVEs) in your project and its dependencies x Unsafe

  Warning: Found 2 new vulnerabilities (CVEs). Severity: 2 High. Run 'state security' for more info.

Updated: language/python@3.11.9
Updated: language/python/pytest@Auto

Your local project has been updated.
Run state push to save changes to the platform.
```

```
% state install private/ActiveState-CLI-Testing/language/python/django_dep --ts=2024-09-10T16:36:34.393Z
█ Installing Package

Operating on project qam/newpub, located at /path/to/newpub.

• Searching for packages in the ActiveState Catalog ✔ Found
• Resolving Dependencies ✔ Done

  Installing django_dep@1.0.0 includes 1 direct dependencies, and 3 indirect dependencies.
  └─ django@4.2 (3 dependencies)

• Checking for vulnerabilities (CVEs) in your project and its dependencies x Unsafe

  Warning: Found 9 new, indirect vulnerabilities (CVEs)

  • 2 Critical: django@4.2: CVE-2023-31047, CVE-2024-42005
  • 7 High: django@4.2: CVE-2023-36053, CVE-2023-41164, CVE-2023-43665, CVE-2024-24680, CVE-2024-41989, 
    CVE-2024-41990, CVE-2024-41991

  For more information on these vulnerabilities run 'state security open <ID>'.
  To disable prompting for vulnerabilities run 'state config set security.prompt.enabled false'.

Do you want to continue installing this dependency despite its vulnerabilities? (y/N)
```