### PR TITLE
Add separate checkout info block to buildscripts.

### DIFF
--- a/internal/captain/rationalize.go
+++ b/internal/captain/rationalize.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
+	"github.com/ActiveState/cli/pkg/buildscript"
 	"github.com/ActiveState/cli/pkg/localcommit"
 )
 
@@ -30,6 +31,12 @@ func rationalizeError(err *error) {
 	case errors.As(*err, &errInvalidCommitID):
 		*err = errs.WrapUserFacing(*err,
 			locale.Tr("err_commit_id_invalid", errInvalidCommitID.CommitID),
+			errs.SetInput())
+
+	// Outdated build script.
+	case errors.Is(*err, buildscript.ErrOutdatedAtTime):
+		*err = errs.WrapUserFacing(*err,
+			locale.T("err_outdated_buildscript"),
 			errs.SetInput())
 	}
 }

--- a/internal/captain/rationalize.go
+++ b/internal/captain/rationalize.go
@@ -7,11 +7,11 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/pkg/buildscript"
-	"github.com/ActiveState/cli/pkg/localcommit"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 )
 
 func rationalizeError(err *error) {
-	var errInvalidCommitID *localcommit.ErrInvalidCommitID
+	var errInvalidCommitID *checkoutinfo.ErrInvalidCommitID
 
 	switch {
 	case err == nil:

--- a/internal/events/cmdcall/cmdcall.go
+++ b/internal/events/cmdcall/cmdcall.go
@@ -21,6 +21,7 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 // CmdCall manages dependencies for the handling of events triggered by command

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1371,6 +1371,8 @@ err_commit_id_invalid_given:
   other: "Invalid commit ID: '{{.V0}}'."
 err_commit_id_not_in_history:
   other: "The project '[ACTIONABLE]{{.V0}}[/RESET]' does not contain the provided commit: '[ACTIONABLE]{{.V1}}[/RESET]'."
+err_outdated_buildscript:
+  other: "[WARNING]Warning:[/RESET] You are using an outdated version of the buildscript. Please run '[ACTIONABLE]state reset LOCAL[/RESET]' in order to reinitialize your buildscript file."
 err_shortcutdir_writable:
   other: Could not continue as we don't have permission to create [ACTIONABLE]{{.V0}}[/RESET].
 move_prompt:

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/runbits/buildscript"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/projectfile"
@@ -29,7 +30,8 @@ func NewMigrator(auth *authentication.Auth, cfg *config.Instance, svcm *model.Sv
 			case 0:
 				if cfg.GetBool(constants.OptinBuildscriptsConfig) {
 					logging.Debug("Creating buildscript")
-					if err := buildscript_runbit.Initialize(filepath.Dir(project.Path()), auth, svcm); err != nil {
+					info := checkoutinfo.New(project)
+					if err := buildscript_runbit.Initialize(filepath.Dir(project.Path()), auth, svcm, info); err != nil {
 						return v, errs.Wrap(err, "Failed to initialize buildscript")
 					}
 				}

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -30,7 +30,7 @@ func NewMigrator(auth *authentication.Auth, cfg *config.Instance, svcm *model.Sv
 			case 0:
 				if cfg.GetBool(constants.OptinBuildscriptsConfig) {
 					logging.Debug("Creating buildscript")
-					info := checkoutinfo.New(project)
+					info := checkoutinfo.New(project, cfg)
 					if err := buildscript_runbit.Initialize(filepath.Dir(project.Path()), auth, svcm, info); err != nil {
 						return v, errs.Wrap(err, "Failed to initialize buildscript")
 					}

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -30,7 +30,7 @@ func NewMigrator(auth *authentication.Auth, cfg *config.Instance, svcm *model.Sv
 			case 0:
 				if cfg.GetBool(constants.OptinBuildscriptsConfig) {
 					logging.Debug("Creating buildscript")
-					info := checkoutinfo.New(project, cfg)
+					info := checkoutinfo.New(project, cfg.GetBool(constants.OptinBuildscriptsConfig))
 					if err := buildscript_runbit.Initialize(filepath.Dir(project.Path()), auth, svcm, info); err != nil {
 						return v, errs.Wrap(err, "Failed to initialize buildscript")
 					}

--- a/internal/primer/primer.go
+++ b/internal/primer/primer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ActiveState/cli/internal/analytics"
 	"github.com/ActiveState/cli/internal/condition"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/constraints"
 	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/output"
@@ -67,14 +68,14 @@ func New(values ...any) *Values {
 			}
 		}
 	}
-	result.checkoutinfo = checkoutinfo.New(result.projectfile, result.config)
+	result.checkoutinfo = checkoutinfo.New(result.projectfile, result.config.GetBool(constants.OptinBuildscriptsConfig))
 	return result
 }
 
 func (v *Values) SetProject(p *project.Project) {
 	v.project = p
 	v.projectfile = p.Source()
-	v.checkoutinfo = checkoutinfo.New(v.projectfile, v.config)
+	v.checkoutinfo = checkoutinfo.New(v.projectfile, v.config.GetBool(constants.OptinBuildscriptsConfig))
 }
 
 type Projecter interface {

--- a/internal/primer/primer.go
+++ b/internal/primer/primer.go
@@ -67,14 +67,14 @@ func New(values ...any) *Values {
 			}
 		}
 	}
-	result.checkoutinfo = checkoutinfo.New(result.projectfile)
+	result.checkoutinfo = checkoutinfo.New(result.projectfile, result.config)
 	return result
 }
 
 func (v *Values) SetProject(p *project.Project) {
 	v.project = p
 	v.projectfile = p.Source()
-	v.checkoutinfo = checkoutinfo.New(v.projectfile)
+	v.checkoutinfo = checkoutinfo.New(v.projectfile, v.config)
 }
 
 type Projecter interface {

--- a/internal/primer/primer.go
+++ b/internal/primer/primer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/svcctl"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
@@ -19,17 +20,18 @@ import (
 )
 
 type Values struct {
-	project     *project.Project
-	projectfile *projectfile.Project
-	output      output.Outputer
-	auth        *authentication.Auth
-	prompt      prompt.Prompter
-	subshell    subshell.SubShell
-	conditional *constraints.Conditional
-	config      *config.Instance
-	ipComm      svcctl.IPCommunicator
-	svcModel    *model.SvcModel
-	analytics   analytics.Dispatcher
+	project      *project.Project
+	projectfile  *projectfile.Project
+	output       output.Outputer
+	auth         *authentication.Auth
+	prompt       prompt.Prompter
+	subshell     subshell.SubShell
+	conditional  *constraints.Conditional
+	config       *config.Instance
+	ipComm       svcctl.IPCommunicator
+	svcModel     *model.SvcModel
+	analytics    analytics.Dispatcher
+	checkoutinfo *checkoutinfo.CheckoutInfo
 }
 
 func New(values ...any) *Values {
@@ -65,12 +67,14 @@ func New(values ...any) *Values {
 			}
 		}
 	}
+	result.checkoutinfo = checkoutinfo.New(result.projectfile)
 	return result
 }
 
 func (v *Values) SetProject(p *project.Project) {
 	v.project = p
 	v.projectfile = p.Source()
+	v.checkoutinfo = checkoutinfo.New(v.projectfile)
 }
 
 type Projecter interface {
@@ -118,6 +122,10 @@ type Conditioner interface {
 	Conditional() *constraints.Conditional
 }
 
+type CheckoutInfoer interface {
+	CheckoutInfo() *checkoutinfo.CheckoutInfo
+}
+
 func (v *Values) Project() *project.Project {
 	return v.project
 }
@@ -160,4 +168,8 @@ func (v *Values) Config() *config.Instance {
 
 func (v *Values) Analytics() analytics.Dispatcher {
 	return v.analytics
+}
+
+func (v *Values) CheckoutInfo() *checkoutinfo.CheckoutInfo {
+	return v.checkoutinfo
 }

--- a/internal/runbits/buildplanner/buildplanner.go
+++ b/internal/runbits/buildplanner/buildplanner.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/pkg/buildplan"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/request"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	bpModel "github.com/ActiveState/cli/pkg/platform/model/buildplanner"
@@ -39,6 +38,7 @@ type primeable interface {
 	primer.Auther
 	primer.Outputer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 // GetCommit returns a commit from the given arguments. By default, the local commit for the
@@ -54,6 +54,7 @@ func GetCommit(
 	out := prime.Output()
 	auth := prime.Auth()
 	svcm := prime.SvcModel()
+	info := prime.CheckoutInfo()
 
 	if pj == nil && !namespace.IsValid() {
 		return nil, rationalize.ErrNoProject
@@ -87,9 +88,9 @@ func GetCommit(
 	switch {
 	// Return the buildplan from this runtime.
 	case !namespaceProvided && !commitIdProvided:
-		localCommitID, err := localcommit.Get(pj.Path())
+		localCommitID, err := info.CommitID()
 		if err != nil {
-			return nil, errs.Wrap(err, "Could not get local commit")
+			return nil, errs.Wrap(err, "Could not get commit ID")
 		}
 
 		bp := bpModel.NewBuildPlannerModel(auth, svcm)
@@ -154,9 +155,9 @@ func GetCommit(
 		owner = pj.Owner()
 		name = pj.Name()
 		nsString = pj.NamespaceString()
-		commitID, err := localcommit.Get(pj.Path())
+		commitID, err := info.CommitID()
 		if err != nil {
-			return nil, errs.Wrap(err, "Could not get local commit")
+			return nil, errs.Wrap(err, "Could not get commit ID")
 		}
 		localCommitID = &commitID
 	}

--- a/internal/runbits/buildplanner/buildplanner.go
+++ b/internal/runbits/buildplanner/buildplanner.go
@@ -133,18 +133,8 @@ func GetCommit(
 
 	// Return the buildplan for the given commitID of the given project.
 	case namespaceProvided && commitIdProvided:
-		pj, err := model.FetchProjectByName(namespace.Owner, namespace.Project, auth)
-		if err != nil {
-			return nil, locale.WrapExternalError(err, "err_fetch_project", "", namespace.String())
-		}
-
-		branch, err := model.DefaultBranchForProject(pj)
-		if err != nil {
-			return nil, errs.Wrap(err, "Could not grab branch for project")
-		}
-
 		bp := bpModel.NewBuildPlannerModel(auth, svcm)
-		commit, err = bp.FetchCommit(commitUUID, namespace.Owner, namespace.Project, branch.Label, targetPtr)
+		commit, err = bp.FetchCommit(commitUUID, namespace.Owner, namespace.Project, "", targetPtr)
 		if err != nil {
 			return nil, errs.Wrap(err, "Failed to fetch commit")
 		}

--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -25,7 +25,7 @@ func TestDiff(t *testing.T) {
 	script, err := buildscript.Unmarshal([]byte(
 		checkoutInfo(testProject, testTime) + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"
@@ -50,7 +50,7 @@ main = runtime`))
 	require.NoError(t, err)
 	assert.Equal(t, checkoutInfo(testProject, testTime)+`
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 <<<<<<< local
 		"77777",
@@ -99,7 +99,7 @@ runtime = state_tool_artifacts_v1(
 	src = sources
 )
 sources = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"78977bc8-0f32-519d-80f3-9043f059398c",
 		"7c998ec2-7491-4e75-be4d-8885800ef5f2",

--- a/internal/runbits/buildscript/buildscript_test.go
+++ b/internal/runbits/buildscript/buildscript_test.go
@@ -11,9 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testProject = "https://platform.activestate.com/org/project?branch=main&commitID=00000000-0000-0000-0000-000000000000"
+const testTime = "2000-01-01T00:00:00.000Z"
+
+func checkoutInfo(project, time string) string {
+	return "```\n" +
+		"Project: " + project + "\n" +
+		"Time: " + time + "\n" +
+		"```\n"
+}
+
 func TestDiff(t *testing.T) {
 	script, err := buildscript.Unmarshal([]byte(
-		`at_time = "2000-01-01T00:00:00.000Z"
+		checkoutInfo(testProject, testTime) + `
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -38,7 +48,7 @@ main = runtime`))
 	// Generate the difference between the modified script and the original expression.
 	result, err := generateDiff(modifiedScript, script)
 	require.NoError(t, err)
-	assert.Equal(t, `at_time = "2000-01-01T00:00:00.000Z"
+	assert.Equal(t, checkoutInfo(testProject, testTime)+`
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -71,11 +81,16 @@ func TestRealWorld(t *testing.T) {
 	require.NoError(t, err)
 	result, err := generateDiff(script1, script2)
 	require.NoError(t, err)
-	assert.Equal(t, `<<<<<<< local
-at_time = "2023-10-16T22:20:29.000Z"
-=======
-at_time = "2023-08-01T16:20:11.985Z"
->>>>>>> remote
+	assert.Equal(t,
+		"```\n"+
+			"<<<<<<< local\n"+
+			"Project: https://platform.activestate.com/ActiveState-CLI/Merge?branch=main&commitID=d908a758-6a81-40d4-b0eb-87069cd7f07d\n"+
+			"Time: 2024-05-10T00:00:13.138Z\n"+
+			"=======\n"+
+			"Project: https://platform.activestate.com/ActiveState-CLI/Merge?branch=main&commitID=f3263ee4-ac4c-41ee-b778-2585333f49f7\n"+
+			"Time: 2023-08-01T16:20:11.985Z\n"+
+			">>>>>>> remote\n"+
+			"```\n"+`
 runtime = state_tool_artifacts_v1(
 	build_flags = [
 	],

--- a/internal/runbits/buildscript/file.go
+++ b/internal/runbits/buildscript/file.go
@@ -58,7 +58,7 @@ func Initialize(path string, auth *authentication.Auth, svcm *model.SvcModel, in
 	}
 
 	buildplanner := buildplanner.NewBuildPlannerModel(auth, svcm)
-	script, err = buildplanner.GetBuildScript(commitId.String())
+	script, err = buildplanner.GetBuildScript(info.Owner(), info.Name(), info.Branch(), commitId.String())
 	if err != nil {
 		return errs.Wrap(err, "Unable to get the remote build expression and time")
 	}

--- a/internal/runbits/buildscript/file.go
+++ b/internal/runbits/buildscript/file.go
@@ -9,9 +9,8 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/pkg/buildscript"
-	"github.com/ActiveState/cli/pkg/localcommit"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/platform/model/buildplanner"
@@ -42,12 +41,7 @@ func ScriptFromFile(path string) (*buildscript.BuildScript, error) {
 	return buildscript.Unmarshal(data)
 }
 
-type primeable interface {
-	primer.Auther
-	primer.SvcModeler
-}
-
-func Initialize(path string, auth *authentication.Auth, svcm *model.SvcModel) error {
+func Initialize(path string, auth *authentication.Auth, svcm *model.SvcModel, info *checkoutinfo.CheckoutInfo) error {
 	scriptPath := filepath.Join(path, constants.BuildScriptFileName)
 	script, err := ScriptFromFile(scriptPath)
 	if err == nil {
@@ -58,7 +52,7 @@ func Initialize(path string, auth *authentication.Auth, svcm *model.SvcModel) er
 	}
 
 	logging.Debug("Build script does not exist. Creating one.")
-	commitId, err := localcommit.Get(path)
+	commitId, err := info.CommitID()
 	if err != nil {
 		return errs.Wrap(err, "Unable to get the local commit ID")
 	}

--- a/internal/runbits/buildscript/file.go
+++ b/internal/runbits/buildscript/file.go
@@ -23,7 +23,7 @@ type projecter interface {
 	Name() string
 }
 
-var ErrBuildscriptNotExist = errors.New("Build script does not exist")
+var ErrBuildscriptNotExist = checkoutinfo.ErrBuildscriptNotExist
 
 func ScriptFromProject(proj projecter) (*buildscript.BuildScript, error) {
 	path := filepath.Join(proj.ProjectDir(), constants.BuildScriptFileName)
@@ -47,11 +47,11 @@ func Initialize(path string, auth *authentication.Auth, svcm *model.SvcModel, in
 	if err == nil {
 		return nil // nothing to do, buildscript already exists
 	}
-	if !errors.Is(err, os.ErrNotExist) {
+	if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, buildscript.ErrOutdatedAtTime) {
 		return errs.Wrap(err, "Could not read build script from file")
 	}
 
-	logging.Debug("Build script does not exist. Creating one.")
+	logging.Debug("Build script does not exist or is outdated. Creating one.")
 	commitId, err := info.CommitID()
 	if err != nil {
 		return errs.Wrap(err, "Unable to get the local commit ID")

--- a/internal/runbits/buildscript/testdata/buildscript1.as
+++ b/internal/runbits/buildscript/testdata/buildscript1.as
@@ -1,4 +1,8 @@
-at_time = "2023-10-16T22:20:29.000000Z"
+```
+Project: https://platform.activestate.com/ActiveState-CLI/Merge?branch=main&commitID=d908a758-6a81-40d4-b0eb-87069cd7f07d
+Time: 2024-05-10T00:00:13.138Z
+```
+
 runtime = state_tool_artifacts_v1(
 	build_flags = [
 	],

--- a/internal/runbits/buildscript/testdata/buildscript1.as
+++ b/internal/runbits/buildscript/testdata/buildscript1.as
@@ -11,7 +11,7 @@ runtime = state_tool_artifacts_v1(
 	src = sources
 )
 sources = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"78977bc8-0f32-519d-80f3-9043f059398c",
 		"7c998ec2-7491-4e75-be4d-8885800ef5f2",

--- a/internal/runbits/buildscript/testdata/buildscript2.as
+++ b/internal/runbits/buildscript/testdata/buildscript2.as
@@ -1,4 +1,8 @@
-at_time = "2023-08-01T16:20:11.985000Z"
+```
+Project: https://platform.activestate.com/ActiveState-CLI/Merge?branch=main&commitID=f3263ee4-ac4c-41ee-b778-2585333f49f7
+Time: 2023-08-01T16:20:11.985000Z
+```
+
 runtime = state_tool_artifacts_v1(
 	build_flags = [
 	],

--- a/internal/runbits/buildscript/testdata/buildscript2.as
+++ b/internal/runbits/buildscript/testdata/buildscript2.as
@@ -11,7 +11,7 @@ runtime = state_tool_artifacts_v1(
 	src = sources
 )
 sources = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"78977bc8-0f32-519d-80f3-9043f059398c",
 		"7c998ec2-7491-4e75-be4d-8885800ef5f2",

--- a/internal/runbits/checker/checker.go
+++ b/internal/runbits/checker/checker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
-	"github.com/ActiveState/cli/pkg/localcommit"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
@@ -16,8 +16,8 @@ import (
 
 // RunCommitsBehindNotifier checks for the commits behind count based on the
 // provided project and displays the results to the user in a helpful manner.
-func RunCommitsBehindNotifier(p *project.Project, out output.Outputer, auth *authentication.Auth) {
-	count, err := CommitsBehind(p, auth)
+func RunCommitsBehindNotifier(p *project.Project, out output.Outputer, auth *authentication.Auth, info *checkoutinfo.CheckoutInfo) {
+	count, err := CommitsBehind(p, auth, info)
 	if err != nil {
 		if errors.Is(err, model.ErrCommitCountUnknowable) {
 			out.Notice(output.Title(locale.Tr("runtime_update_notice_unknown_count")))
@@ -35,7 +35,7 @@ func RunCommitsBehindNotifier(p *project.Project, out output.Outputer, auth *aut
 	}
 }
 
-func CommitsBehind(p *project.Project, auth *authentication.Auth) (int, error) {
+func CommitsBehind(p *project.Project, auth *authentication.Auth, info *checkoutinfo.CheckoutInfo) (int, error) {
 	if p.IsHeadless() {
 		return 0, nil
 	}
@@ -49,9 +49,9 @@ func CommitsBehind(p *project.Project, auth *authentication.Auth) (int, error) {
 		return 0, locale.NewError("err_latest_commit", "Latest commit ID is nil")
 	}
 
-	commitID, err := localcommit.Get(p.Dir())
+	commitID, err := info.CommitID()
 	if err != nil {
-		return 0, errs.Wrap(err, "Unable to get local commit")
+		return 0, errs.Wrap(err, "Unable to get commit ID")
 	}
 
 	return model.CommitsBehind(*latestCommitID, commitID, auth)

--- a/internal/runbits/checkout/checkout.go
+++ b/internal/runbits/checkout/checkout.go
@@ -86,7 +86,7 @@ func (r *Checkout) Run(ns *project.Namespaced, branchName, cachePath, targetPath
 
 		// Clone the related repo, if it is defined
 		if !noClone && repoURL != nil && *repoURL != "" {
-			err := r.repo.CloneProject(ns.Owner, ns.Project, path, r.prime.Output(), r.prime.Analytics())
+			err := r.repo.CloneProject(ns.Owner, ns.Project, path, r.prime.Output(), r.prime.Analytics(), r.prime.Config())
 			if err != nil {
 				return "", locale.WrapError(err, "err_clone_project", "Could not clone associated git repository")
 			}

--- a/internal/runbits/commits_runbit/time.go
+++ b/internal/runbits/commits_runbit/time.go
@@ -75,7 +75,7 @@ func ExpandTimeForBuildScript(ts *captain.TimeValue, auth *authentication.Auth, 
 
 	atTime := script.AtTime()
 	if atTime.After(timestamp) {
-		return *atTime, nil
+		return atTime, nil
 	}
 
 	return timestamp, nil

--- a/internal/runbits/commits_runbit/time.go
+++ b/internal/runbits/commits_runbit/time.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ActiveState/cli/internal/captain"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/pkg/buildscript"
-	"github.com/ActiveState/cli/pkg/localcommit"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
@@ -40,14 +40,14 @@ func ExpandTime(ts *captain.TimeValue, auth *authentication.Auth) (time.Time, er
 
 // ExpandTimeForProject is the same as ExpandTime except that it ensures the returned time is either the same or
 // later than that of the most recent commit.
-func ExpandTimeForProject(ts *captain.TimeValue, auth *authentication.Auth, proj *project.Project) (time.Time, error) {
+func ExpandTimeForProject(ts *captain.TimeValue, auth *authentication.Auth, proj *project.Project, info *checkoutinfo.CheckoutInfo) (time.Time, error) {
 	timestamp, err := ExpandTime(ts, auth)
 	if err != nil {
 		return time.Time{}, errs.Wrap(err, "Unable to expand time")
 	}
 
 	if proj != nil {
-		commitID, err := localcommit.Get(proj.Dir())
+		commitID, err := info.CommitID()
 		if err != nil {
 			return time.Time{}, errs.Wrap(err, "Unable to get commit ID")
 		}

--- a/internal/runbits/commits_runbit/time.go
+++ b/internal/runbits/commits_runbit/time.go
@@ -74,8 +74,8 @@ func ExpandTimeForBuildScript(ts *captain.TimeValue, auth *authentication.Auth, 
 	}
 
 	atTime := script.AtTime()
-	if atTime.After(timestamp) {
-		return atTime, nil
+	if atTime != nil && atTime.After(timestamp) {
+		return *atTime, nil
 	}
 
 	return timestamp, nil

--- a/internal/runbits/git/git.go
+++ b/internal/runbits/git/git.go
@@ -98,7 +98,7 @@ func EnsureCorrectProject(owner, name, projectFilePath, repoURL string, out outp
 
 	if !(strings.EqualFold(proj.Owner(), owner)) || !(strings.EqualFold(proj.Name(), name)) {
 		out.Notice(locale.Tr("warning_git_project_mismatch", repoURL, project.NewNamespace(owner, name, "").String(), constants.DocumentationURLMismatch))
-		info := checkoutinfo.New(projectFile, cfg)
+		info := checkoutinfo.New(projectFile, cfg.GetBool(constants.OptinBuildscriptsConfig))
 		err = info.SetNamespace(owner, name)
 		if err != nil {
 			return locale.WrapError(err, "err_git_update_mismatch", "Could not update projectfile namespace")

--- a/internal/runbits/git/git.go
+++ b/internal/runbits/git/git.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/ActiveState/cli/pkg/projectfile"
@@ -96,7 +97,8 @@ func EnsureCorrectProject(owner, name, projectFilePath, repoURL string, out outp
 
 	if !(strings.EqualFold(proj.Owner(), owner)) || !(strings.EqualFold(proj.Name(), name)) {
 		out.Notice(locale.Tr("warning_git_project_mismatch", repoURL, project.NewNamespace(owner, name, "").String(), constants.DocumentationURLMismatch))
-		err = proj.Source().SetNamespace(owner, name)
+		info := checkoutinfo.New(projectFile)
+		err = info.SetNamespace(owner, name)
 		if err != nil {
 			return locale.WrapError(err, "err_git_update_mismatch", "Could not update projectfile namespace")
 		}

--- a/internal/runbits/git/test/integration/git_test.go
+++ b/internal/runbits/git/test/integration/git_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
+	"github.com/ActiveState/cli/internal/config"
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/rtutils/singlethread"
 	runbitsGit "github.com/ActiveState/cli/internal/runbits/git"
 	"github.com/ActiveState/cli/internal/testhelpers/outputhelper"
 	"github.com/ActiveState/cli/pkg/project"
@@ -80,7 +82,9 @@ func (suite *GitTestSuite) AfterTest(suiteName, testName string) {
 }
 
 func (suite *GitTestSuite) TestEnsureCorrectProject() {
-	err := runbitsGit.EnsureCorrectProject("test-owner", "test-project", filepath.Join(suite.dir, constants.ConfigFileName), "test-repo", outputhelper.NewCatcher(), blackhole.New())
+	cfg, err := config.NewCustom(suite.dir, singlethread.New(), true)
+	suite.NoError(err, "could not create config")
+	err = runbitsGit.EnsureCorrectProject("test-owner", "test-project", filepath.Join(suite.dir, constants.ConfigFileName), "test-repo", outputhelper.NewCatcher(), blackhole.New(), cfg)
 	suite.NoError(err, "projectfile URL should contain owner and name")
 }
 
@@ -89,7 +93,9 @@ func (suite *GitTestSuite) TestEnsureCorrectProject_Missmatch() {
 	name := "bad-project"
 	projectPath := filepath.Join(suite.dir, constants.ConfigFileName)
 	actualCatcher := outputhelper.NewCatcher()
-	err := runbitsGit.EnsureCorrectProject(owner, name, projectPath, "test-repo", actualCatcher, blackhole.New())
+	cfg, err := config.NewCustom(suite.dir, singlethread.New(), true)
+	suite.NoError(err, "could not create config")
+	err = runbitsGit.EnsureCorrectProject(owner, name, projectPath, "test-repo", actualCatcher, blackhole.New(), cfg)
 	suite.NoError(err)
 
 	proj, err := project.Parse(projectPath)

--- a/internal/runbits/reqop_runbit/update.go
+++ b/internal/runbits/reqop_runbit/update.go
@@ -33,6 +33,7 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 type requirements []*Requirement

--- a/internal/runbits/reqop_runbit/update.go
+++ b/internal/runbits/reqop_runbit/update.go
@@ -69,6 +69,7 @@ func UpdateAndReload(prime primeable, script *buildscript.BuildScript, oldCommit
 	commitParams := buildplanner.StageCommitParams{
 		Owner:        pj.Owner(),
 		Project:      pj.Name(),
+		Branch:       pj.BranchName(),
 		ParentCommit: string(oldCommit.CommitID),
 		Description:  commitMsg,
 		Script:       script,
@@ -128,7 +129,7 @@ func updateCommitID(prime primeable, commitID strfmt.UUID) error {
 
 	if prime.Config().GetBool(constants.OptinBuildscriptsConfig) {
 		bp := buildplanner.NewBuildPlannerModel(prime.Auth(), prime.SvcModel())
-		script, err := bp.GetBuildScript(commitID.String())
+		script, err := bp.GetBuildScript(prime.Project().Owner(), prime.Project().Name(), prime.Project().BranchName(), commitID.String())
 		if err != nil {
 			return errs.Wrap(err, "Could not get remote build expr and time")
 		}

--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -196,7 +196,7 @@ func Update(
 		solveSpinner := output.StartSpinner(prime.Output(), locale.T("progress_solve"), constants.TerminalAnimationInterval)
 
 		bpm := bpModel.NewBuildPlannerModel(prime.Auth(), prime.SvcModel())
-		commit, err = bpm.FetchCommit(commitID, proj.Owner(), proj.Name(), nil)
+		commit, err = bpm.FetchCommit(commitID, proj.Owner(), proj.Name(), proj.BranchName(), nil)
 		if err != nil {
 			solveSpinner.Stop(locale.T("progress_fail"))
 			return nil, errs.Wrap(err, "Failed to fetch build result")

--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/runtime/progress"
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/pkg/buildplan"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	bpModel "github.com/ActiveState/cli/pkg/platform/model/buildplanner"
 	"github.com/ActiveState/cli/pkg/project"
@@ -105,6 +104,7 @@ type primeable interface {
 	primer.Configurer
 	primer.SvcModeler
 	primer.Analyticer
+	primer.CheckoutInfoer
 }
 
 func Update(
@@ -147,7 +147,7 @@ func Update(
 		commitID = opts.Commit.CommitID
 	}
 	if commitID == "" {
-		commitID, err = localcommit.Get(proj.Dir())
+		commitID, err = prime.CheckoutInfo().CommitID()
 		if err != nil {
 			return nil, errs.Wrap(err, "Failed to get local commit")
 		}
@@ -169,7 +169,7 @@ func Update(
 		}
 	}()
 
-	rtHash, err := runtime_helpers.Hash(proj, &commitID)
+	rtHash, err := runtime_helpers.Hash(prime, &commitID)
 	if err != nil {
 		ah.fire(anaConsts.CatRuntimeDebug, anaConsts.ActRuntimeCache, nil)
 		return nil, errs.Wrap(err, "Failed to get runtime hash")

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/virtualenvironment"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
@@ -66,6 +65,7 @@ type primeable interface {
 	primer.Configurer
 	primer.SvcModeler
 	primer.Analyticer
+	primer.CheckoutInfoer
 }
 
 func NewActivate(prime primeable) *Activate {
@@ -146,9 +146,9 @@ func (r *Activate) Run(params *ActivateParams) (rerr error) {
 	}
 
 	if proj != nil {
-		commitID, err := localcommit.Get(proj.Dir())
+		commitID, err := r.prime.CheckoutInfo().CommitID()
 		if err != nil {
-			return errs.Wrap(err, "Unable to get local commit")
+			return errs.Wrap(err, "Unable to get commit ID")
 		}
 		if cid := params.Namespace.CommitID; cid != nil && *cid != commitID {
 			return locale.NewInputError("err_activate_commit_id_mismatch")
@@ -196,9 +196,9 @@ func (r *Activate) Run(params *ActivateParams) (rerr error) {
 		}
 	}
 
-	commitID, err := localcommit.Get(proj.Dir())
+	commitID, err := r.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 	if commitID == "" {
 		err := locale.NewInputError("err_project_no_commit", "Your project does not have a commit ID. Please run [ACTIONIABLE]'state push'[/RESET] first.", model.ProjectURL(proj.Owner(), proj.Name(), ""))

--- a/internal/runners/artifacts/artifacts.go
+++ b/internal/runners/artifacts/artifacts.go
@@ -31,6 +31,7 @@ type primeable interface {
 	primer.SvcModeler
 	primer.Configurer
 	primer.Analyticer
+	primer.CheckoutInfoer
 }
 
 type Params struct {

--- a/internal/runners/branch/add.go
+++ b/internal/runners/branch/add.go
@@ -6,13 +6,13 @@ import (
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
 )
 
 type Add struct {
+	prime   primeable
 	out     output.Outputer
 	project *project.Project
 	auth    *authentication.Auth
@@ -24,6 +24,7 @@ type AddParams struct {
 
 func NewAdd(prime primeable) *Add {
 	return &Add{
+		prime:   prime,
 		out:     prime.Output(),
 		project: prime.Project(),
 		auth:    prime.Auth(),
@@ -53,9 +54,9 @@ func (a *Add) Run(params AddParams) error {
 		return locale.WrapError(err, "err_fetch_branch", "", localBranch)
 	}
 
-	commitID, err := localcommit.Get(a.project.Dir())
+	commitID, err := a.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 
 	err = model.UpdateBranchTracking(branchID, commitID, branch.BranchID, model.TrackingIgnore, a.auth)

--- a/internal/runners/branch/list.go
+++ b/internal/runners/branch/list.go
@@ -17,6 +17,7 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 type List struct {

--- a/internal/runners/checkout/checkout.go
+++ b/internal/runners/checkout/checkout.go
@@ -150,7 +150,7 @@ func (u *Checkout) Run(params *Params) (rerr error) {
 		// Solve runtime
 		solveSpinner := output.StartSpinner(u.out, locale.T("progress_solve"), constants.TerminalAnimationInterval)
 		bpm := bpModel.NewBuildPlannerModel(u.auth, u.svcModel)
-		commit, err := bpm.FetchCommit(commitID, proj.Owner(), proj.Name(), nil)
+		commit, err := bpm.FetchCommit(commitID, proj.Owner(), proj.Name(), proj.BranchName(), nil)
 		if err != nil {
 			solveSpinner.Stop(locale.T("progress_fail"))
 			return errs.Wrap(err, "Failed to fetch build result")

--- a/internal/runners/checkout/checkout.go
+++ b/internal/runners/checkout/checkout.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/pkg/buildplan"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	bpModel "github.com/ActiveState/cli/pkg/platform/model/buildplanner"
@@ -48,6 +47,7 @@ type primeable interface {
 	primer.SvcModeler
 	primer.Analyticer
 	primer.Projecter
+	primer.CheckoutInfoer
 }
 
 type Checkout struct {
@@ -142,7 +142,7 @@ func (u *Checkout) Run(params *Params) (rerr error) {
 	var buildPlan *buildplan.BuildPlan
 	rtOpts := []runtime_runbit.SetOpt{}
 	if archive == nil {
-		commitID, err := localcommit.Get(proj.Path())
+		commitID, err := u.prime.CheckoutInfo().CommitID()
 		if err != nil {
 			return errs.Wrap(err, "Could not get local commit")
 		}

--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -84,7 +84,7 @@ func (c *Commit) Run() (rerr error) {
 		return errs.Wrap(err, "Unable to get commit ID")
 	}
 	bp := buildplanner.NewBuildPlannerModel(c.prime.Auth(), c.prime.SvcModel())
-	remoteScript, err := bp.GetBuildScript(localCommitID.String())
+	remoteScript, err := bp.GetBuildScript(proj.Owner(), proj.Name(), proj.BranchName(), localCommitID.String())
 	if err != nil {
 		return errs.Wrap(err, "Could not get remote build expr and time for provided commit")
 	}
@@ -109,6 +109,7 @@ func (c *Commit) Run() (rerr error) {
 	stagedCommit, err := bp.StageCommit(buildplanner.StageCommitParams{
 		Owner:        proj.Owner(),
 		Project:      proj.Name(),
+		Branch:       proj.BranchName(),
 		ParentCommit: localCommitID.String(),
 		Script:       script,
 	})
@@ -122,7 +123,7 @@ func (c *Commit) Run() (rerr error) {
 	}
 
 	// Update our local build expression to match the committed one. This allows our API a way to ensure forward compatibility.
-	newScript, err := bp.GetBuildScript(stagedCommit.CommitID.String())
+	newScript, err := bp.GetBuildScript(proj.Owner(), proj.Name(), proj.BranchName(), stagedCommit.CommitID.String())
 	if err != nil {
 		return errs.Wrap(err, "Unable to get the remote build script")
 	}
@@ -141,13 +142,13 @@ func (c *Commit) Run() (rerr error) {
 	}()
 
 	// Solve runtime
-	rtCommit, err := bp.FetchCommit(stagedCommit.CommitID, proj.Owner(), proj.Name(), nil)
+	rtCommit, err := bp.FetchCommit(stagedCommit.CommitID, proj.Owner(), proj.Name(), proj.BranchName(), nil)
 	if err != nil {
 		return errs.Wrap(err, "Could not fetch staged commit")
 	}
 
 	// Get old buildplan.
-	oldCommit, err := bp.FetchCommit(localCommitID, proj.Owner(), proj.Name(), nil)
+	oldCommit, err := bp.FetchCommit(localCommitID, proj.Owner(), proj.Name(), proj.BranchName(), nil)
 	if err != nil {
 		return errs.Wrap(err, "Failed to fetch old commit")
 	}

--- a/internal/runners/deploy/deploy.go
+++ b/internal/runners/deploy/deploy.go
@@ -71,6 +71,7 @@ type primeable interface {
 	primer.Analyticer
 	primer.SvcModeler
 	primer.Projecter
+	primer.CheckoutInfoer
 }
 
 func NewDeploy(step Step, prime primeable) *Deploy {

--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -85,7 +85,7 @@ func (u *Uninstall) Run(params *Params) error {
 		return locale.WrapError(err, "err_deploy_uninstall_cannot_read_project", "Cannot read project at '{{.V0}}'", path)
 	}
 
-	commitID, err := checkoutinfo.New(proj.Source()).CommitID()
+	commitID, err := checkoutinfo.New(proj.Source(), u.cfg).CommitID()
 	if err != nil {
 		return locale.WrapError(err, "err_deploy_uninstall_cannot_read_commit", "Cannot read commit ID from project at '{{.V0}}'", path)
 	}

--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -6,9 +6,10 @@ import (
 	"runtime"
 
 	"github.com/ActiveState/cli/internal/analytics"
-	"github.com/ActiveState/cli/internal/analytics/constants"
+	anaConst "github.com/ActiveState/cli/internal/analytics/constants"
 	"github.com/ActiveState/cli/internal/analytics/dimensions"
 	"github.com/ActiveState/cli/internal/config"
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/instanceid"
 	"github.com/ActiveState/cli/internal/locale"
@@ -85,7 +86,7 @@ func (u *Uninstall) Run(params *Params) error {
 		return locale.WrapError(err, "err_deploy_uninstall_cannot_read_project", "Cannot read project at '{{.V0}}'", path)
 	}
 
-	commitID, err := checkoutinfo.New(proj.Source(), u.cfg).CommitID()
+	commitID, err := checkoutinfo.New(proj.Source(), u.cfg.GetBool(constants.OptinBuildscriptsConfig)).CommitID()
 	if err != nil {
 		return locale.WrapError(err, "err_deploy_uninstall_cannot_read_commit", "Cannot read commit ID from project at '{{.V0}}'", path)
 	}
@@ -106,7 +107,7 @@ func (u *Uninstall) Run(params *Params) error {
 		return locale.WrapError(err, "err_deploy_uninstall", "Unable to remove deployed runtime at '{{.V0}}'", path)
 	}
 
-	u.analytics.Event(constants.CatRuntimeUsage, constants.ActRuntimeDelete, &dimensions.Values{
+	u.analytics.Event(anaConst.CatRuntimeUsage, anaConst.ActRuntimeDelete, &dimensions.Values{
 		Trigger:          ptr.To(trigger.TriggerDeploy.String()),
 		CommitID:         ptr.To(commitID.String()),
 		ProjectNameSpace: ptr.To(proj.Namespace().String()),

--- a/internal/runners/deploy/uninstall/uninstall.go
+++ b/internal/runners/deploy/uninstall/uninstall.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/subshell/sscommon"
-	"github.com/ActiveState/cli/pkg/localcommit"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/ActiveState/cli/pkg/projectfile"
 )
@@ -85,7 +85,7 @@ func (u *Uninstall) Run(params *Params) error {
 		return locale.WrapError(err, "err_deploy_uninstall_cannot_read_project", "Cannot read project at '{{.V0}}'", path)
 	}
 
-	commitID, err := localcommit.Get(path)
+	commitID, err := checkoutinfo.New(proj.Source()).CommitID()
 	if err != nil {
 		return locale.WrapError(err, "err_deploy_uninstall_cannot_read_commit", "Cannot read commit ID from project at '{{.V0}}'", path)
 	}

--- a/internal/runners/eval/eval.go
+++ b/internal/runners/eval/eval.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/model/buildplanner"
 )
 
@@ -16,6 +15,7 @@ type primeable interface {
 	primer.Auther
 	primer.Projecter
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 type Params struct {
@@ -49,7 +49,7 @@ func (e *Eval) Run(params *Params) (rerr error) {
 		return rationalize.ErrNoProject
 	}
 
-	commitID, err := localcommit.Get(proj.Dir())
+	commitID, err := e.prime.CheckoutInfo().CommitID()
 	if err != nil {
 		return errs.Wrap(err, "Unable to get commit ID")
 	}

--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -62,6 +62,7 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 type Params struct {

--- a/internal/runners/export/deptree/artifacts.go
+++ b/internal/runners/export/deptree/artifacts.go
@@ -24,6 +24,7 @@ type primeable interface {
 	primer.Projecter
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 type ArtifactParams struct {

--- a/internal/runners/export/deptree/artifacts.go
+++ b/internal/runners/export/deptree/artifacts.go
@@ -60,7 +60,7 @@ func (d *DeptreeByArtifacts) Run(params ArtifactParams) error {
 	}
 
 	bpm := buildplanner.NewBuildPlannerModel(d.prime.Auth(), d.prime.SvcModel())
-	commit, err := bpm.FetchCommit(*ns.CommitID, ns.Owner, ns.Project, nil)
+	commit, err := bpm.FetchCommit(*ns.CommitID, ns.Owner, ns.Project, "", nil)
 	if err != nil {
 		return errs.Wrap(err, "Could not get remote build expr and time for provided commit")
 	}

--- a/internal/runners/export/deptree/common.go
+++ b/internal/runners/export/deptree/common.go
@@ -5,7 +5,6 @@ import (
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
 	"github.com/go-openapi/strfmt"
@@ -42,9 +41,9 @@ func resolveNamespace(inputNs *project.Namespaced, inputCommitID string, prime p
 			ns.CommitID = branch.CommitID
 		} else {
 			var err error
-			commitID, err = localcommit.Get(proj.Dir())
+			commitID, err = prime.CheckoutInfo().CommitID()
 			if err != nil {
-				return nil, errs.Wrap(err, "Unable to get local commit ID")
+				return nil, errs.Wrap(err, "Unable to get commit ID ID")
 			}
 			ns.CommitID = &commitID
 		}

--- a/internal/runners/export/deptree/ingredients.go
+++ b/internal/runners/export/deptree/ingredients.go
@@ -47,7 +47,7 @@ func (d *DeptreeByIngredients) Run(params IngredientParams) error {
 	}
 
 	bpm := buildplanner.NewBuildPlannerModel(d.prime.Auth(), d.prime.SvcModel())
-	commit, err := bpm.FetchCommit(*ns.CommitID, ns.Owner, ns.Project, nil)
+	commit, err := bpm.FetchCommit(*ns.CommitID, ns.Owner, ns.Project, "", nil)
 	if err != nil {
 		return errs.Wrap(err, "Could not get remote build expr and time for provided commit")
 	}

--- a/internal/runners/export/export.go
+++ b/internal/runners/export/export.go
@@ -13,6 +13,7 @@ type primeable interface {
 	primer.Projecter
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 type Export struct{}

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -109,7 +109,7 @@ func inferLanguage(config projectfile.ConfigGetter, auth *authentication.Auth) (
 	if err != nil {
 		return "", "", false
 	}
-	commitID, err := checkoutinfo.New(defaultProj.Source()).CommitID()
+	commitID, err := checkoutinfo.New(defaultProj.Source(), config).CommitID()
 	if err != nil {
 		multilog.Error("Unable to get commit ID: %v", errs.JoinMessage(err))
 		return "", "", false

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -109,7 +109,7 @@ func inferLanguage(config projectfile.ConfigGetter, auth *authentication.Auth) (
 	if err != nil {
 		return "", "", false
 	}
-	commitID, err := checkoutinfo.New(defaultProj.Source(), config).CommitID()
+	commitID, err := checkoutinfo.New(defaultProj.Source(), config.GetBool(constants.OptinBuildscriptsConfig)).CommitID()
 	if err != nil {
 		multilog.Error("Unable to get commit ID: %v", errs.JoinMessage(err))
 		return "", "", false

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -290,7 +290,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 	// Solve runtime
 	solveSpinner := output.StartSpinner(r.out, locale.T("progress_solve"), constants.TerminalAnimationInterval)
 	bpm := bpModel.NewBuildPlannerModel(r.auth, r.svcModel)
-	commit, err := bpm.FetchCommit(commitID, r.prime.Project().Owner(), r.prime.Project().Name(), nil)
+	commit, err := bpm.FetchCommit(commitID, r.prime.Project().Owner(), r.prime.Project().Name(), r.prime.Project().BranchName(), nil)
 	if err != nil {
 		solveSpinner.Stop(locale.T("progress_fail"))
 		logging.Debug("Deleting remotely created project due to runtime setup error")

--- a/internal/runners/install/install.go
+++ b/internal/runners/install/install.go
@@ -122,7 +122,7 @@ func (i *Install) Run(params Params) (rerr error) {
 		if err != nil {
 			return errs.Wrap(err, "Unable to get commit ID")
 		}
-		oldCommit, err = bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), nil)
+		oldCommit, err = bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), pj.BranchName(), nil)
 		if err != nil {
 			return errs.Wrap(err, "Failed to fetch old build result")
 		}

--- a/internal/runners/install/install.go
+++ b/internal/runners/install/install.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/internal/sliceutils"
 	"github.com/ActiveState/cli/pkg/buildscript"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/types"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	bpModel "github.com/ActiveState/cli/pkg/platform/model/buildplanner"
@@ -35,6 +34,7 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 // Params tracks the info required for running Install.
@@ -118,9 +118,9 @@ func (i *Install) Run(params Params) (rerr error) {
 		pg = output.StartSpinner(out, locale.T("progress_search"), constants.TerminalAnimationInterval)
 
 		// Grab local commit info
-		localCommitID, err := localcommit.Get(i.prime.Project().Dir())
+		localCommitID, err := i.prime.CheckoutInfo().CommitID()
 		if err != nil {
-			return errs.Wrap(err, "Unable to get local commit")
+			return errs.Wrap(err, "Unable to get commit ID")
 		}
 		oldCommit, err = bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), nil)
 		if err != nil {

--- a/internal/runners/languages/languages.go
+++ b/internal/runners/languages/languages.go
@@ -92,7 +92,7 @@ func (l *Languages) Run() error {
 
 	// Fetch commit and buildplan, which will give us access to ingredients, and ingredients can be languages..
 	bpm := bpModel.NewBuildPlannerModel(l.auth, l.svcModel)
-	commit, err := bpm.FetchCommit(commitID, l.project.Owner(), l.project.Name(), nil)
+	commit, err := bpm.FetchCommit(commitID, l.project.Owner(), l.project.Name(), l.project.BranchName(), nil)
 	if err != nil {
 		return errs.Wrap(err, "could not fetch commit")
 	}

--- a/internal/runners/manifest/manifest.go
+++ b/internal/runners/manifest/manifest.go
@@ -111,7 +111,7 @@ func (m *Manifest) fetchRequirements() ([]buildscript.Requirement, error) {
 		}
 
 		bp := bpModel.NewBuildPlannerModel(m.auth, m.svcModel)
-		script, err = bp.GetBuildScript(commitID.String())
+		script, err = bp.GetBuildScript(m.prime.Project().Owner(), m.prime.Project().Name(), m.prime.Project().BranchName(), commitID.String())
 		if err != nil {
 			return nil, errs.Wrap(err, "Could not get remote build expr and time")
 		}
@@ -134,7 +134,7 @@ func (m *Manifest) fetchBuildplanRequirements() (buildplan.Ingredients, error) {
 	// Solve runtime
 	solveSpinner := output.StartSpinner(m.out, locale.T("progress_solve"), constants.TerminalAnimationInterval)
 	bpm := bpModel.NewBuildPlannerModel(m.auth, m.svcModel)
-	commit, err := bpm.FetchCommit(commitID, m.project.Owner(), m.project.Name(), nil)
+	commit, err := bpm.FetchCommit(commitID, m.project.Owner(), m.project.Name(), m.project.BranchName(), nil)
 	if err != nil {
 		solveSpinner.Stop(locale.T("progress_fail"))
 		return nil, errs.Wrap(err, "Failed to fetch build result")

--- a/internal/runners/manifest/manifest.go
+++ b/internal/runners/manifest/manifest.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/pkg/buildplan"
 	"github.com/ActiveState/cli/pkg/buildscript"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api/vulnerabilities/request"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
@@ -27,6 +26,7 @@ type primeable interface {
 	primer.Analyticer
 	primer.SvcModeler
 	primer.Configurer
+	primer.CheckoutInfoer
 }
 
 type Params struct {
@@ -105,7 +105,7 @@ func (m *Manifest) fetchRequirements() ([]buildscript.Requirement, error) {
 			return nil, errs.Wrap(err, "Could not get buildscript")
 		}
 	} else {
-		commitID, err := localcommit.Get(m.project.Dir())
+		commitID, err := m.prime.CheckoutInfo().CommitID()
 		if err != nil {
 			return nil, errs.Wrap(err, "Could not get commit ID")
 		}
@@ -126,7 +126,7 @@ func (m *Manifest) fetchRequirements() ([]buildscript.Requirement, error) {
 }
 
 func (m *Manifest) fetchBuildplanRequirements() (buildplan.Ingredients, error) {
-	commitID, err := localcommit.Get(m.project.Dir())
+	commitID, err := m.prime.CheckoutInfo().CommitID()
 	if err != nil {
 		return nil, errs.Wrap(err, "Failed to get local commit")
 	}

--- a/internal/runners/packages/import.go
+++ b/internal/runners/packages/import.go
@@ -116,7 +116,7 @@ func (i *Import) Run(params *ImportRunParams) (rerr error) {
 	}
 
 	bp := buildplanner.NewBuildPlannerModel(auth, i.prime.SvcModel())
-	bs, err := bp.GetBuildScript(localCommitId.String())
+	bs, err := bp.GetBuildScript(proj.Owner(), proj.Name(), proj.BranchName(), localCommitId.String())
 	if err != nil {
 		return locale.WrapError(err, "err_cannot_get_build_expression", "Could not get build expression")
 	}
@@ -129,6 +129,7 @@ func (i *Import) Run(params *ImportRunParams) (rerr error) {
 	stagedCommit, err := bp.StageCommit(buildplanner.StageCommitParams{
 		Owner:        proj.Owner(),
 		Project:      proj.Name(),
+		Branch:       proj.BranchName(),
 		ParentCommit: localCommitId.String(),
 		Description:  msg,
 		Script:       bs,
@@ -144,7 +145,7 @@ func (i *Import) Run(params *ImportRunParams) (rerr error) {
 	}
 
 	// Output change summary.
-	previousCommit, err := bp.FetchCommit(localCommitId, proj.Owner(), proj.Name(), nil)
+	previousCommit, err := bp.FetchCommit(localCommitId, proj.Owner(), proj.Name(), proj.BranchName(), nil)
 	if err != nil {
 		return errs.Wrap(err, "Failed to fetch build result for previous commit")
 	}

--- a/internal/runners/packages/info.go
+++ b/internal/runners/packages/info.go
@@ -30,17 +30,19 @@ type InfoRunParams struct {
 
 // Info manages the information execution context.
 type Info struct {
-	out  output.Outputer
-	proj *project.Project
-	auth *authentication.Auth
+	prime primeable
+	out   output.Outputer
+	proj  *project.Project
+	auth  *authentication.Auth
 }
 
 // NewInfo prepares an information execution context for use.
 func NewInfo(prime primeable) *Info {
 	return &Info{
-		out:  prime.Output(),
-		proj: prime.Project(),
-		auth: prime.Auth(),
+		prime: prime,
+		out:   prime.Output(),
+		proj:  prime.Project(),
+		auth:  prime.Auth(),
 	}
 }
 
@@ -58,7 +60,7 @@ func (i *Info) Run(params InfoRunParams, nstype model.NamespaceType) error {
 	}
 
 	if nsTypeV != nil {
-		language, err := targetedLanguage(params.Language, i.proj, i.auth)
+		language, err := targetedLanguage(params.Language, i.prime)
 		if err != nil {
 			return locale.WrapError(err, fmt.Sprintf("%s_err_cannot_obtain_language", *nsTypeV))
 		}
@@ -71,7 +73,7 @@ func (i *Info) Run(params InfoRunParams, nstype model.NamespaceType) error {
 		normalized = params.Package.Name
 	}
 
-	ts, err := commits_runbit.ExpandTimeForProject(&params.Timestamp, i.auth, i.proj)
+	ts, err := commits_runbit.ExpandTimeForProject(&params.Timestamp, i.auth, i.proj, i.prime.CheckoutInfo())
 	if err != nil {
 		return errs.Wrap(err, "Unable to get timestamp from params")
 	}

--- a/internal/runners/packages/list.go
+++ b/internal/runners/packages/list.go
@@ -114,7 +114,7 @@ func (l *List) Run(params ListRunParams, nstype model.NamespaceType) error {
 	var artifacts buildplan.Artifacts
 	if l.project != nil && params.Project == "" {
 		bpm := bpModel.NewBuildPlannerModel(l.auth, l.svcModel)
-		commit, err := bpm.FetchCommit(*commitID, l.project.Owner(), l.project.Name(), nil)
+		commit, err := bpm.FetchCommit(*commitID, l.project.Owner(), l.project.Name(), l.project.BranchName(), nil)
 		if err != nil {
 			return errs.Wrap(err, "could not fetch commit")
 		}

--- a/internal/runners/platforms/add.go
+++ b/internal/runners/platforms/add.go
@@ -76,7 +76,7 @@ func (a *Add) Run(params AddRunParams) (rerr error) {
 	if err != nil {
 		return errs.Wrap(err, "Unable to get commit ID")
 	}
-	oldCommit, err := bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), nil)
+	oldCommit, err := bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), pj.BranchName(), nil)
 	if err != nil {
 		return errs.Wrap(err, "Failed to fetch old build result")
 	}

--- a/internal/runners/platforms/list.go
+++ b/internal/runners/platforms/list.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ActiveState/cli/internal/logging"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
@@ -15,17 +14,19 @@ import (
 
 // List manages the listing execution context.
 type List struct {
-	out  output.Outputer
-	proj *project.Project
-	auth *authentication.Auth
+	prime primeable
+	out   output.Outputer
+	proj  *project.Project
+	auth  *authentication.Auth
 }
 
 // NewList prepares a list execution context for use.
 func NewList(prime primeable) *List {
 	return &List{
-		out:  prime.Output(),
-		proj: prime.Project(),
-		auth: prime.Auth(),
+		prime: prime,
+		out:   prime.Output(),
+		proj:  prime.Project(),
+		auth:  prime.Auth(),
 	}
 }
 
@@ -37,9 +38,9 @@ func (l *List) Run() error {
 		return rationalize.ErrNoProject
 	}
 
-	commitID, err := localcommit.Get(l.proj.Dir())
+	commitID, err := l.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 
 	targetCommitID, err := targetedCommitID(commitID.String(), l.proj.Name(), l.proj.Owner(), l.proj.BranchName())

--- a/internal/runners/platforms/remove.go
+++ b/internal/runners/platforms/remove.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/rationalizers"
 	"github.com/ActiveState/cli/internal/runbits/reqop_runbit"
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	bpResp "github.com/ActiveState/cli/pkg/platform/api/buildplanner/response"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	bpModel "github.com/ActiveState/cli/pkg/platform/model/buildplanner"
@@ -59,9 +58,9 @@ func (a *Remove) Run(params RemoveRunParams) (rerr error) {
 	pg = output.StartSpinner(out, locale.T("progress_platforms"), constants.TerminalAnimationInterval)
 
 	// Grab local commit info
-	localCommitID, err := localcommit.Get(pj.Dir())
+	localCommitID, err := a.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 	oldCommit, err := bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), nil)
 	if err != nil {

--- a/internal/runners/platforms/remove.go
+++ b/internal/runners/platforms/remove.go
@@ -62,7 +62,7 @@ func (a *Remove) Run(params RemoveRunParams) (rerr error) {
 	if err != nil {
 		return errs.Wrap(err, "Unable to get commit ID")
 	}
-	oldCommit, err := bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), nil)
+	oldCommit, err := bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), pj.BranchName(), nil)
 	if err != nil {
 		return errs.Wrap(err, "Failed to fetch old build result")
 	}

--- a/internal/runners/prepare/prepare.go
+++ b/internal/runners/prepare/prepare.go
@@ -37,10 +37,13 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.Projecter
+	primer.CheckoutInfoer
 }
 
 // Prepare manages the prepare execution context.
 type Prepare struct {
+	prime     primeable
 	out       output.Outputer
 	subshell  subshell.SubShell
 	cfg       *config.Instance
@@ -51,6 +54,7 @@ type Prepare struct {
 // New prepares a prepare execution context for use.
 func New(prime primeable) *Prepare {
 	return &Prepare{
+		prime:     prime,
 		out:       prime.Output(),
 		subshell:  prime.Subshell(),
 		cfg:       prime.Config(),
@@ -71,13 +75,14 @@ func (r *Prepare) resetExecutors() error {
 	if err != nil {
 		return errs.Wrap(err, "Could not get project from its directory")
 	}
+	r.prime.SetProject(proj)
 
 	rt, err := runtime_helpers.FromProject(proj)
 	if err != nil {
 		return errs.Wrap(err, "Could not initialize runtime for project.")
 	}
 
-	rtHash, err := runtime_helpers.Hash(proj, nil)
+	rtHash, err := runtime_helpers.Hash(r.prime, nil)
 	if err != nil {
 		return errs.Wrap(err, "Could not get runtime hash")
 	}

--- a/internal/runners/projects/edit.go
+++ b/internal/runners/projects/edit.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"strings"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
@@ -149,7 +150,7 @@ func (e *Edit) editLocalCheckout(owner, checkout string, params *EditParams) err
 		return errs.Wrap(err, "Could not get projectfile at %s", checkout)
 	}
 
-	info := checkoutinfo.New(pjFile, e.config)
+	info := checkoutinfo.New(pjFile, e.config.GetBool(constants.OptinBuildscriptsConfig))
 	err = info.SetNamespace(owner, params.ProjectName)
 	if err != nil {
 		return errs.Wrap(err, "Could not set project namespace at %s", checkout)

--- a/internal/runners/projects/edit.go
+++ b/internal/runners/projects/edit.go
@@ -149,7 +149,7 @@ func (e *Edit) editLocalCheckout(owner, checkout string, params *EditParams) err
 		return errs.Wrap(err, "Could not get projectfile at %s", checkout)
 	}
 
-	info := checkoutinfo.New(pjFile)
+	info := checkoutinfo.New(pjFile, e.config)
 	err = info.SetNamespace(owner, params.ProjectName)
 	if err != nil {
 		return errs.Wrap(err, "Could not set project namespace at %s", checkout)

--- a/internal/runners/projects/edit.go
+++ b/internal/runners/projects/edit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
@@ -148,7 +149,8 @@ func (e *Edit) editLocalCheckout(owner, checkout string, params *EditParams) err
 		return errs.Wrap(err, "Could not get projectfile at %s", checkout)
 	}
 
-	err = pjFile.SetNamespace(owner, params.ProjectName)
+	info := checkoutinfo.New(pjFile)
+	err = info.SetNamespace(owner, params.ProjectName)
 	if err != nil {
 		return errs.Wrap(err, "Could not set project namespace at %s", checkout)
 	}

--- a/internal/runners/projects/move.go
+++ b/internal/runners/projects/move.go
@@ -1,6 +1,7 @@
 package projects
 
 import (
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
@@ -98,7 +99,7 @@ func (m *Move) updateLocalCheckout(checkout string, params *MoveParams) error {
 		return errs.Wrap(err, "Could not get projectfile at %s", checkout)
 	}
 
-	info := checkoutinfo.New(pjFile, m.config)
+	info := checkoutinfo.New(pjFile, m.config.GetBool(constants.OptinBuildscriptsConfig))
 	err = info.SetNamespace(params.NewOwner, params.Namespace.Project)
 	if err != nil {
 		return errs.Wrap(err, "Could not set project namespace at %s", checkout)

--- a/internal/runners/projects/move.go
+++ b/internal/runners/projects/move.go
@@ -98,7 +98,7 @@ func (m *Move) updateLocalCheckout(checkout string, params *MoveParams) error {
 		return errs.Wrap(err, "Could not get projectfile at %s", checkout)
 	}
 
-	info := checkoutinfo.New(pjFile)
+	info := checkoutinfo.New(pjFile, m.config)
 	err = info.SetNamespace(params.NewOwner, params.Namespace.Project)
 	if err != nil {
 		return errs.Wrap(err, "Could not set project namespace at %s", checkout)

--- a/internal/runners/projects/move.go
+++ b/internal/runners/projects/move.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
 	"github.com/ActiveState/cli/internal/prompt"
+	"github.com/ActiveState/cli/pkg/checkoutinfo"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
@@ -97,7 +98,8 @@ func (m *Move) updateLocalCheckout(checkout string, params *MoveParams) error {
 		return errs.Wrap(err, "Could not get projectfile at %s", checkout)
 	}
 
-	err = pjFile.SetNamespace(params.NewOwner, params.Namespace.Project)
+	info := checkoutinfo.New(pjFile)
+	err = info.SetNamespace(params.NewOwner, params.Namespace.Project)
 	if err != nil {
 		return errs.Wrap(err, "Could not set project namespace at %s", checkout)
 	}

--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -270,7 +270,7 @@ func (p *Pull) mergeBuildScript(remoteCommit, localCommit strfmt.UUID) error {
 
 	// Get the local and remote build expressions to merge.
 	bp := buildplanner.NewBuildPlannerModel(p.auth, p.svcModel)
-	scriptB, err := bp.GetBuildScript(remoteCommit.String())
+	scriptB, err := bp.GetBuildScript(p.prime.Project().Owner(), p.prime.Project().Name(), p.prime.Project().BranchName(), remoteCommit.String())
 	if err != nil {
 		return errs.Wrap(err, "Unable to get buildexpression and time for remote commit")
 	}

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -252,14 +252,14 @@ func (r *Push) Run(params PushParams) (rerr error) {
 
 	// Write the project namespace to the as.yaml, if it changed
 	if r.project.Owner() != targetNamespace.Owner || r.project.Name() != targetNamespace.Project {
-		if err := r.project.Source().SetNamespace(targetNamespace.Owner, targetNamespace.Project); err != nil {
+		if err := r.prime.CheckoutInfo().SetNamespace(targetNamespace.Owner, targetNamespace.Project); err != nil {
 			return errs.Wrap(err, "Could not set project namespace in project file")
 		}
 	}
 
 	// Write the branch to the as.yaml, if it changed
 	if branch.Label != r.project.BranchName() {
-		if err := r.project.Source().SetBranch(branch.Label); err != nil {
+		if err := r.prime.CheckoutInfo().SetBranch(branch.Label); err != nil {
 			return errs.Wrap(err, "Could not set branch")
 		}
 	}

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ActiveState/cli/internal/prompt"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/types"
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
@@ -48,6 +47,7 @@ type primeable interface {
 	primer.Prompter
 	primer.Auther
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 func NewPush(prime primeable) *Push {
@@ -93,10 +93,10 @@ func (r *Push) Run(params PushParams) (rerr error) {
 	}
 	r.out.Notice(locale.Tr("operating_message", r.project.NamespaceString(), r.project.Dir()))
 
-	commitID, err := localcommit.Get(r.project.Dir()) // The commit we want to push
+	commitID, err := r.prime.CheckoutInfo().CommitID() // The commit we want to push
 	if err != nil {
 		// Note: should not get here, as verifyInput() ensures there is a local commit
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 
 	// Detect target namespace if possible
@@ -198,7 +198,7 @@ func (r *Push) Run(params PushParams) (rerr error) {
 		}
 
 		// Update the project's commitID with the create project or push result.
-		if err := localcommit.Set(r.project.Dir(), commitID.String()); err != nil {
+		if err := r.prime.CheckoutInfo().SetCommitID(commitID); err != nil {
 			return errs.Wrap(err, "Unable to create local commit file")
 		}
 
@@ -285,9 +285,9 @@ func (r *Push) verifyInput() error {
 		return rationalize.ErrNoProject
 	}
 
-	commitID, err := localcommit.Get(r.project.Dir())
+	commitID, err := r.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 	if commitID == "" {
 		return errNoCommit
@@ -323,9 +323,9 @@ func (r *Push) promptNamespace() (*project.Namespaced, error) {
 	}
 
 	var name string
-	commitID, err := localcommit.Get(r.project.Dir())
+	commitID, err := r.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return nil, errs.Wrap(err, "Unable to get local commit")
+		return nil, errs.Wrap(err, "Unable to get commit ID")
 	}
 	if lang, err := model.FetchLanguageForCommit(commitID, r.auth); err == nil {
 		name = lang.Name

--- a/internal/runners/push/push.go
+++ b/internal/runners/push/push.go
@@ -182,7 +182,7 @@ func (r *Push) Run(params PushParams) (rerr error) {
 		r.out.Notice(locale.Tl("push_creating_project", "Creating project [NOTICE]{{.V1}}[/RESET] under [NOTICE]{{.V0}}[/RESET] on the ActiveState Platform", targetNamespace.Owner, targetNamespace.Project))
 
 		// Create a new project with the current project's buildscript.
-		script, err := bp.GetBuildScript(commitID.String())
+		script, err := bp.GetBuildScript(r.prime.Project().Owner(), r.prime.Project().Name(), r.prime.Project().BranchName(), commitID.String())
 		if err != nil {
 			return errs.Wrap(err, "Could not get buildscript")
 		}

--- a/internal/runners/refresh/refresh.go
+++ b/internal/runners/refresh/refresh.go
@@ -36,6 +36,7 @@ type primeable interface {
 	primer.SvcModeler
 	primer.Analyticer
 	primer.Projecter
+	primer.CheckoutInfoer
 }
 
 type Refresh struct {
@@ -79,7 +80,7 @@ func (r *Refresh) Run(params *Params) error {
 
 	r.out.Notice(locale.Tr("operating_message", proj.NamespaceString(), proj.Dir()))
 
-	needsUpdate, err := runtime_helpers.NeedsUpdate(proj, nil)
+	needsUpdate, err := runtime_helpers.NeedsUpdate(r.prime, nil)
 	if err != nil {
 		return errs.Wrap(err, "could not determine if runtime needs update")
 	}

--- a/internal/runners/reset/reset.go
+++ b/internal/runners/reset/reset.go
@@ -127,17 +127,17 @@ func (r *Reset) Run(params *Params) error {
 		}
 	}
 
-	err = r.prime.CheckoutInfo().SetCommitID(commitID)
-	if err != nil {
-		return errs.Wrap(err, "Unable to set local commit")
-	}
-
 	// Ensure the buildscript exists. Normally we should never do this, but reset is used for resetting from a corrupted
 	// state, so it is appropriate.
 	if r.cfg.GetBool(constants.OptinBuildscriptsConfig) {
 		if err := buildscript_runbit.Initialize(r.project.Dir(), r.auth, r.svcModel, r.prime.CheckoutInfo()); err != nil {
 			return errs.Wrap(err, "Unable to initialize buildscript")
 		}
+	}
+
+	err = r.prime.CheckoutInfo().SetCommitID(commitID)
+	if err != nil {
+		return errs.Wrap(err, "Unable to set local commit")
 	}
 
 	_, err = runtime_runbit.Update(r.prime, trigger.TriggerReset, runtime_runbit.WithoutBuildscriptValidation())

--- a/internal/runners/revert/revert.go
+++ b/internal/runners/revert/revert.go
@@ -102,6 +102,7 @@ func (r *Revert) Run(params *Params) (rerr error) {
 	revertParams := revertParams{
 		organization:   r.project.Owner(),
 		project:        r.project.Name(),
+		branch:         r.project.BranchName(),
 		parentCommitID: latestCommit.String(),
 		revertCommitID: commitID,
 	}
@@ -181,6 +182,7 @@ func (r *Revert) Run(params *Params) (rerr error) {
 type revertParams struct {
 	organization   string
 	project        string
+	branch         string
 	parentCommitID string
 	revertCommitID string
 }
@@ -195,7 +197,7 @@ func (r *Revert) revertCommit(params revertParams, bp *buildplanner.BuildPlanner
 }
 
 func (r *Revert) revertToCommit(params revertParams, bp *buildplanner.BuildPlanner) (strfmt.UUID, error) {
-	bs, err := bp.GetBuildScript(params.revertCommitID)
+	bs, err := bp.GetBuildScript(r.prime.Project().Owner(), r.prime.Project().Name(), r.prime.Project().BranchName(), params.revertCommitID)
 	if err != nil {
 		return "", errs.Wrap(err, "Could not get build expression")
 	}
@@ -203,6 +205,7 @@ func (r *Revert) revertToCommit(params revertParams, bp *buildplanner.BuildPlann
 	stageCommitParams := buildplanner.StageCommitParams{
 		Owner:        params.organization,
 		Project:      params.project,
+		Branch:       params.branch,
 		ParentCommit: params.parentCommitID,
 		Description:  locale.Tl("revert_commit_description", "Revert to commit {{.V0}}", params.revertCommitID),
 		Script:       bs,

--- a/internal/runners/run/run.go
+++ b/internal/runners/run/run.go
@@ -43,6 +43,7 @@ type primeable interface {
 	primer.Configurer
 	primer.SvcModeler
 	primer.Analyticer
+	primer.CheckoutInfoer
 }
 
 // New constructs a new instance of Run.
@@ -76,7 +77,7 @@ func (r *Run) Run(name string, args []string) error {
 	r.out.Notice(output.Title(locale.Tl("run_script_title", "Running Script: [ACTIONABLE]{{.V0}}[/RESET]", name)))
 
 	if r.auth.Authenticated() {
-		checker.RunCommitsBehindNotifier(r.proj, r.out, r.auth)
+		checker.RunCommitsBehindNotifier(r.proj, r.out, r.auth, r.prime.CheckoutInfo())
 	}
 
 	script, err := r.proj.ScriptByName(name)

--- a/internal/runners/shell/shell.go
+++ b/internal/runners/shell/shell.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/internal/subshell"
 	"github.com/ActiveState/cli/internal/virtualenvironment"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
@@ -41,6 +40,7 @@ type primeable interface {
 	primer.SvcModeler
 	primer.Analyticer
 	primer.Projecter
+	primer.CheckoutInfoer
 }
 
 type Shell struct {
@@ -84,9 +84,9 @@ func (u *Shell) Run(params *Params) error {
 
 	u.prime.SetProject(proj)
 
-	commitID, err := localcommit.Get(proj.Dir())
+	commitID, err := u.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 
 	if cid := params.Namespace.CommitID; cid != nil && *cid != commitID {

--- a/internal/runners/swtch/switch.go
+++ b/internal/runners/swtch/switch.go
@@ -105,7 +105,7 @@ func (s *Switch) Run(params SwitchParams) error {
 	}
 
 	if id, ok := identifier.(branchIdentifier); ok {
-		err = s.project.Source().SetBranch(id.branch.Label)
+		err = s.prime.CheckoutInfo().SetBranch(id.branch.Label)
 		if err != nil {
 			return locale.WrapError(err, "err_switch_set_branch", "Could not update branch")
 		}

--- a/internal/runners/swtch/switch.go
+++ b/internal/runners/swtch/switch.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api/mono/mono_models"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
@@ -43,6 +42,7 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 type identifier interface {
@@ -119,7 +119,7 @@ func (s *Switch) Run(params SwitchParams) error {
 		return locale.NewInputError("err_identifier_branch_not_on_branch", "Commit does not belong to history for branch [ACTIONABLE]{{.V0}}[/RESET]", s.project.BranchName())
 	}
 
-	err = localcommit.Set(s.project.Dir(), identifier.CommitID().String())
+	err = s.prime.CheckoutInfo().SetCommitID(identifier.CommitID())
 	if err != nil {
 		return errs.Wrap(err, "Unable to set local commit")
 	}

--- a/internal/runners/uninstall/uninstall.go
+++ b/internal/runners/uninstall/uninstall.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/internal/sliceutils"
 	"github.com/ActiveState/cli/pkg/buildscript"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/types"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	bpModel "github.com/ActiveState/cli/pkg/platform/model/buildplanner"
@@ -30,6 +29,7 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 // Params tracks the info required for running Uninstall.
@@ -111,9 +111,9 @@ func (u *Uninstall) Run(params Params) (rerr error) {
 	pg = output.StartSpinner(out, locale.T("progress_requirements"), constants.TerminalAnimationInterval)
 
 	// Grab local commit info
-	localCommitID, err := localcommit.Get(u.prime.Project().Dir())
+	localCommitID, err := u.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 	oldCommit, err := bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), nil)
 	if err != nil {

--- a/internal/runners/uninstall/uninstall.go
+++ b/internal/runners/uninstall/uninstall.go
@@ -115,7 +115,7 @@ func (u *Uninstall) Run(params Params) (rerr error) {
 	if err != nil {
 		return errs.Wrap(err, "Unable to get commit ID")
 	}
-	oldCommit, err := bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), nil)
+	oldCommit, err := bp.FetchCommit(localCommitID, pj.Owner(), pj.Name(), pj.BranchName(), nil)
 	if err != nil {
 		return errs.Wrap(err, "Failed to fetch old build result")
 	}

--- a/internal/runners/upgrade/upgrade.go
+++ b/internal/runners/upgrade/upgrade.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ActiveState/cli/internal/sliceutils"
 	"github.com/ActiveState/cli/internal/table"
 	"github.com/ActiveState/cli/pkg/buildplan"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/response"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/types"
 	"github.com/ActiveState/cli/pkg/platform/model"
@@ -32,6 +31,7 @@ type primeable interface {
 	primer.Projecter
 	primer.Prompter
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 type Params struct {
@@ -91,7 +91,7 @@ func (u *Upgrade) Run(params *Params) (rerr error) {
 	}()
 
 	// Collect "before" buildplan
-	localCommitID, err := localcommit.Get(proj.Dir())
+	localCommitID, err := u.prime.CheckoutInfo().CommitID()
 	if err != nil {
 		return errs.Wrap(err, "Failed to get local commit")
 	}
@@ -157,7 +157,7 @@ func (u *Upgrade) Run(params *Params) (rerr error) {
 		}
 	}
 
-	if err := localcommit.Set(u.prime.Project().Dir(), bumpedCommit.CommitID.String()); err != nil {
+	if err := u.prime.CheckoutInfo().SetCommitID(bumpedCommit.CommitID); err != nil {
 		return errs.Wrap(err, "Failed to set local commit")
 	}
 

--- a/internal/runners/upgrade/upgrade.go
+++ b/internal/runners/upgrade/upgrade.go
@@ -97,7 +97,7 @@ func (u *Upgrade) Run(params *Params) (rerr error) {
 	}
 
 	bpm := bpModel.NewBuildPlannerModel(u.prime.Auth(), u.prime.SvcModel())
-	localCommit, err := bpm.FetchCommit(localCommitID, proj.Owner(), proj.Name(), nil)
+	localCommit, err := bpm.FetchCommit(localCommitID, proj.Owner(), proj.Name(), proj.BranchName(), nil)
 	if err != nil {
 		return errs.Wrap(err, "Failed to fetch build result")
 	}
@@ -118,6 +118,7 @@ func (u *Upgrade) Run(params *Params) (rerr error) {
 	bumpedCommit, err := bpm.StageCommit(bpModel.StageCommitParams{
 		Owner:        proj.Owner(),
 		Project:      proj.Name(),
+		Branch:       proj.BranchName(),
 		ParentCommit: localCommitID.String(),
 		Script:       bumpedBS,
 	})

--- a/internal/runners/use/use.go
+++ b/internal/runners/use/use.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/runtime"
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/internal/subshell"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/authentication"
 	"github.com/ActiveState/cli/pkg/platform/model"
 	"github.com/ActiveState/cli/pkg/project"
@@ -37,6 +36,7 @@ type primeable interface {
 	primer.SvcModeler
 	primer.Analyticer
 	primer.Projecter
+	primer.CheckoutInfoer
 }
 
 type Use struct {
@@ -81,9 +81,9 @@ func (u *Use) Run(params *Params) error {
 
 	u.prime.SetProject(proj)
 
-	commitID, err := localcommit.Get(proj.Dir())
+	commitID, err := u.prime.CheckoutInfo().CommitID()
 	if err != nil {
-		return errs.Wrap(err, "Unable to get local commit")
+		return errs.Wrap(err, "Unable to get commit ID")
 	}
 
 	if cid := params.Namespace.CommitID; cid != nil && *cid != commitID {

--- a/internal/scriptrun/scriptrun.go
+++ b/internal/scriptrun/scriptrun.go
@@ -33,6 +33,7 @@ type primeable interface {
 	primer.Configurer
 	primer.Analyticer
 	primer.SvcModeler
+	primer.CheckoutInfoer
 }
 
 // ScriptRun manages the context required to run a script.

--- a/internal/testhelpers/e2e/session.go
+++ b/internal/testhelpers/e2e/session.go
@@ -401,10 +401,10 @@ func (s *Session) PrepareProject(namespace, commitID string) {
 	}
 }
 
-func (s *Session) PrepareProjectAndBuildScript(namespace, commitID string) {
-	s.PrepareProject(namespace, commitID)
+func (s *Session) PrepareProjectAndBuildScript(owner, project, branch, commitID string) {
+	s.PrepareProject(owner+"/"+project, commitID)
 	bp := buildplanner.NewBuildPlannerModel(nil, s.cache)
-	script, err := bp.GetBuildScript(commitID)
+	script, err := bp.GetBuildScript(owner, project, branch, commitID)
 	require.NoError(s.T, err)
 	b, err := script.Marshal()
 	require.NoError(s.T, err)

--- a/pkg/buildscript/buildscript.go
+++ b/pkg/buildscript/buildscript.go
@@ -18,6 +18,14 @@ func New() (*BuildScript, error) {
 	return UnmarshalBuildExpression([]byte(emptyBuildExpression), nil)
 }
 
+func (b *BuildScript) Project() string {
+	return b.raw.CheckoutInfo.Project
+}
+
+func (b *BuildScript) SetProject(url string) {
+	b.raw.CheckoutInfo.Project = url
+}
+
 func (b *BuildScript) AtTime() time.Time {
 	return b.raw.CheckoutInfo.AtTime
 }

--- a/pkg/buildscript/buildscript.go
+++ b/pkg/buildscript/buildscript.go
@@ -11,27 +11,29 @@ import (
 // Instead this package should facilitate the use-case of the consuming code through convenience
 // methods that are easy to understand and work with.
 type BuildScript struct {
-	raw *rawBuildScript
+	raw     *rawBuildScript
+	project string
+	atTime  *time.Time
 }
 
 func New() (*BuildScript, error) {
-	return UnmarshalBuildExpression([]byte(emptyBuildExpression), nil)
+	return UnmarshalBuildExpression([]byte(emptyBuildExpression), "", nil)
 }
 
 func (b *BuildScript) Project() string {
-	return b.raw.CheckoutInfo.Project
+	return b.project
 }
 
 func (b *BuildScript) SetProject(url string) {
-	b.raw.CheckoutInfo.Project = url
+	b.project = url
 }
 
-func (b *BuildScript) AtTime() time.Time {
-	return b.raw.CheckoutInfo.AtTime
+func (b *BuildScript) AtTime() *time.Time {
+	return b.atTime
 }
 
 func (b *BuildScript) SetAtTime(t time.Time) {
-	b.raw.CheckoutInfo.AtTime = t
+	b.atTime = &t
 }
 
 func (b *BuildScript) Equals(other *BuildScript) (bool, error) {

--- a/pkg/buildscript/buildscript.go
+++ b/pkg/buildscript/buildscript.go
@@ -18,12 +18,12 @@ func New() (*BuildScript, error) {
 	return UnmarshalBuildExpression([]byte(emptyBuildExpression), nil)
 }
 
-func (b *BuildScript) AtTime() *time.Time {
-	return b.raw.AtTime
+func (b *BuildScript) AtTime() time.Time {
+	return b.raw.CheckoutInfo.AtTime
 }
 
 func (b *BuildScript) SetAtTime(t time.Time) {
-	b.raw.AtTime = &t
+	b.raw.CheckoutInfo.AtTime = t
 }
 
 func (b *BuildScript) Equals(other *BuildScript) (bool, error) {

--- a/pkg/buildscript/buildscript_test.go
+++ b/pkg/buildscript/buildscript_test.go
@@ -84,7 +84,7 @@ func TestRoundTripFromBuildScript(t *testing.T) {
 // expression and then immediately construct another build expression from that build script, the
 // build expressions are identical.
 func TestRoundTripFromBuildExpression(t *testing.T) {
-	script, err := UnmarshalBuildExpression(basicBuildExpression, nil)
+	script, err := UnmarshalBuildExpression(basicBuildExpression, "", nil)
 	require.NoError(t, err)
 
 	data, err := script.MarshalBuildExpression()
@@ -99,7 +99,7 @@ func TestExpressionToScript(t *testing.T) {
 	ts, err := time.Parse(strfmt.RFC3339Millis, testTime)
 	require.NoError(t, err)
 
-	script, err := UnmarshalBuildExpression(basicBuildExpression, &CheckoutInfo{testProject, ts})
+	script, err := UnmarshalBuildExpression(basicBuildExpression, testProject, &ts)
 	require.NoError(t, err)
 
 	data, err := script.Marshal()

--- a/pkg/buildscript/buildscript_test.go
+++ b/pkg/buildscript/buildscript_test.go
@@ -1,7 +1,6 @@
 package buildscript
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -10,10 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var atTime = "2000-01-01T00:00:00.000Z"
-
-var basicBuildScript = []byte(fmt.Sprintf(
-	`at_time = "%s"
+var basicBuildScript = []byte(
+	checkoutInfoString(testProject, testTime) + `
 runtime = state_tool_artifacts(
 	src = sources
 )
@@ -29,7 +26,7 @@ sources = solve(
 	solver_version = null
 )
 
-main = runtime`, atTime))
+main = runtime`)
 
 var basicBuildExpression = []byte(`{
   "let": {
@@ -99,10 +96,10 @@ func TestRoundTripFromBuildExpression(t *testing.T) {
 // TestExpressionToScript tests that creating a build script from a given Platform build expression
 // and at time produces the expected result.
 func TestExpressionToScript(t *testing.T) {
-	ts, err := time.Parse(strfmt.RFC3339Millis, atTime)
+	ts, err := time.Parse(strfmt.RFC3339Millis, testTime)
 	require.NoError(t, err)
 
-	script, err := UnmarshalBuildExpression(basicBuildExpression, &ts)
+	script, err := UnmarshalBuildExpression(basicBuildExpression, &CheckoutInfo{testProject, ts})
 	require.NoError(t, err)
 
 	data, err := script.Marshal()
@@ -121,4 +118,13 @@ func TestScriptToExpression(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, string(basicBuildExpression), string(data))
+}
+
+func TestOutdatedScript(t *testing.T) {
+	_, err := Unmarshal([]byte(
+		`at_time = "2000-01-01T00:00:00.000Z"
+	main = runtime
+	`))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrOutdatedAtTime)
 }

--- a/pkg/buildscript/buildscript_test.go
+++ b/pkg/buildscript/buildscript_test.go
@@ -15,7 +15,7 @@ runtime = state_tool_artifacts(
 	src = sources
 )
 sources = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"

--- a/pkg/buildscript/marshal.go
+++ b/pkg/buildscript/marshal.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/thoas/go-funk"
-
-	"github.com/ActiveState/cli/internal/rtutils/ptr"
 )
 
 const (
@@ -30,11 +28,10 @@ const (
 func (b *BuildScript) Marshal() ([]byte, error) {
 	buf := strings.Builder{}
 
-	if b.raw.AtTime != nil {
-		buf.WriteString(assignmentString(
-			&Assignment{atTimeKey, &Value{Str: ptr.To(b.raw.AtTime.Format(strfmt.RFC3339Millis))}}))
-		buf.WriteString("\n")
-	}
+	buf.WriteString("```\n")
+	buf.WriteString("Project: " + b.raw.CheckoutInfo.Project + "\n")
+	buf.WriteString("Time: " + b.raw.CheckoutInfo.AtTime.Format(strfmt.RFC3339Millis) + "\n")
+	buf.WriteString("```\n\n")
 
 	var main *Assignment
 	for _, assignment := range b.raw.Assignments {

--- a/pkg/buildscript/marshal.go
+++ b/pkg/buildscript/marshal.go
@@ -29,8 +29,8 @@ func (b *BuildScript) Marshal() ([]byte, error) {
 	buf := strings.Builder{}
 
 	buf.WriteString("```\n")
-	buf.WriteString("Project: " + b.raw.CheckoutInfo.Project + "\n")
-	buf.WriteString("Time: " + b.raw.CheckoutInfo.AtTime.Format(strfmt.RFC3339Millis) + "\n")
+	buf.WriteString("Project: " + b.Project() + "\n")
+	buf.WriteString("Time: " + b.AtTime().Format(strfmt.RFC3339Millis) + "\n")
 	buf.WriteString("```\n\n")
 
 	var main *Assignment

--- a/pkg/buildscript/marshal.go
+++ b/pkg/buildscript/marshal.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/thoas/go-funk"
+
+	"github.com/ActiveState/cli/internal/rtutils/ptr"
 )
 
 const (
@@ -30,7 +32,7 @@ func (b *BuildScript) Marshal() ([]byte, error) {
 
 	if b.raw.AtTime != nil {
 		buf.WriteString(assignmentString(
-			&Assignment{atTimeKey, newString(b.raw.AtTime.Format(strfmt.RFC3339Millis))}))
+			&Assignment{atTimeKey, &Value{Str: ptr.To(b.raw.AtTime.Format(strfmt.RFC3339Millis))}}))
 		buf.WriteString("\n")
 	}
 
@@ -77,7 +79,7 @@ func valueString(v *Value) string {
 		return buf.String()
 
 	case v.Str != nil:
-		return *v.Str // keep quoted
+		return strconv.Quote(*v.Str)
 
 	case v.Number != nil:
 		return strconv.FormatFloat(*v.Number, 'G', -1, 64) // 64-bit float with minimum digits on display

--- a/pkg/buildscript/marshal_buildexpression.go
+++ b/pkg/buildscript/marshal_buildexpression.go
@@ -58,9 +58,9 @@ func (b *BuildScript) MarshalJSON() ([]byte, error) {
 			if value.Str == nil {
 				return nil, errs.New("String timestamp expected for '%s'", key)
 			}
-			atTime, err := strfmt.ParseDateTime(strValue(value))
+			atTime, err := strfmt.ParseDateTime(*value.Str)
 			if err != nil {
-				return nil, errs.Wrap(err, "Invalid timestamp: %s", strValue(value))
+				return nil, errs.Wrap(err, "Invalid timestamp: %s", *value.Str)
 			}
 			b.raw.AtTime = ptr.To(time.Time(atTime))
 			continue // do not include this custom assignment in the let block
@@ -86,7 +86,7 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 	case v.List != nil:
 		return json.Marshal(v.List)
 	case v.Str != nil:
-		return json.Marshal(strValue(v))
+		return json.Marshal(*v.Str)
 	case v.Number != nil:
 		return json.Marshal(*v.Number)
 	case v.Null != nil:
@@ -142,12 +142,12 @@ func marshalReq(args []*Value) ([]byte, error) {
 		switch {
 		// Marshal the name argument (e.g. name = "<name>") into {"name": "<name>"}
 		case assignment.Key == requirementNameKey && assignment.Value.Str != nil:
-			requirement[requirementNameKey] = strValue(assignment.Value)
+			requirement[requirementNameKey] = *assignment.Value.Str
 
 		// Marshal the namespace argument (e.g. namespace = "<namespace>") into
 		// {"namespace": "<namespace>"}
 		case assignment.Key == requirementNamespaceKey && assignment.Value.Str != nil:
-			requirement[requirementNamespaceKey] = strValue(assignment.Value)
+			requirement[requirementNamespaceKey] = *assignment.Value.Str
 
 		// Marshal the version argument (e.g. version = <op>(value = "<version>")) into
 		// {"version_requirements": [{"comparator": "<op>", "version": "<version>"}]}
@@ -160,10 +160,10 @@ func marshalReq(args []*Value) ([]byte, error) {
 					req := make(map[string]string)
 					req[requirementComparatorKey] = strings.ToLower(name)
 					if len(funcCall.Arguments) == 0 || funcCall.Arguments[0].Assignment == nil ||
-						funcCall.Arguments[0].Assignment.Value.Str == nil || strValue(funcCall.Arguments[0].Assignment.Value) == "value" {
+						funcCall.Arguments[0].Assignment.Value.Str == nil || *funcCall.Arguments[0].Assignment.Value.Str == "value" {
 						return errs.New(`Illegal argument for version comparator '%s': 'value = "<version>"' expected`, name)
 					}
-					req[requirementVersionKey] = strValue(funcCall.Arguments[0].Assignment.Value)
+					req[requirementVersionKey] = *funcCall.Arguments[0].Assignment.Value.Str
 					requirements = append(requirements, req)
 				case andFuncName:
 					if len(funcCall.Arguments) != 2 {

--- a/pkg/buildscript/marshal_buildexpression.go
+++ b/pkg/buildscript/marshal_buildexpression.go
@@ -3,13 +3,9 @@ package buildscript
 import (
 	"encoding/json"
 	"strings"
-	"time"
-
-	"github.com/go-openapi/strfmt"
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/rtutils/ptr"
 )
 
 const (
@@ -54,16 +50,6 @@ func (b *BuildScript) MarshalJSON() ([]byte, error) {
 		key := assignment.Key
 		value := assignment.Value
 		switch key {
-		case atTimeKey:
-			if value.Str == nil {
-				return nil, errs.New("String timestamp expected for '%s'", key)
-			}
-			atTime, err := strfmt.ParseDateTime(*value.Str)
-			if err != nil {
-				return nil, errs.Wrap(err, "Invalid timestamp: %s", *value.Str)
-			}
-			b.raw.AtTime = ptr.To(time.Time(atTime))
-			continue // do not include this custom assignment in the let block
 		case mainKey:
 			key = inKey // rename
 		}

--- a/pkg/buildscript/marshal_buildexpression.go
+++ b/pkg/buildscript/marshal_buildexpression.go
@@ -86,7 +86,12 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 		}
 		return json.Marshal(m)
 	case v.Ident != nil:
-		return json.Marshal("$" + *v.Ident)
+		name := *v.Ident
+		switch name {
+		case "TIME":
+			name = "at_time" // build expression uses this variable name
+		}
+		return json.Marshal("$" + name)
 	}
 	return json.Marshal([]*Value{}) // participle does not create v.List if it's empty
 }

--- a/pkg/buildscript/merge.go
+++ b/pkg/buildscript/merge.go
@@ -85,7 +85,7 @@ func isAutoMergePossible(scriptA *BuildScript, scriptB *BuildScript) bool {
 }
 
 // getComparableJson returns a comparable JSON map[string]interface{} structure for the given build
-// script. The map will not have a "requirements" field, nor will it have an "at_time" field.
+// script. The map will not have a "requirements" field.
 func getComparableJson(script *BuildScript) (map[string]interface{}, error) {
 	data, err := script.MarshalBuildExpression()
 	if err != nil {
@@ -103,7 +103,6 @@ func getComparableJson(script *BuildScript) (map[string]interface{}, error) {
 		return nil, errs.New("'let' key is not a JSON object")
 	}
 	deleteKey(&letMap, "requirements")
-	deleteKey(&letMap, "at_time")
 
 	return m, nil
 }

--- a/pkg/buildscript/merge.go
+++ b/pkg/buildscript/merge.go
@@ -57,8 +57,8 @@ func (b *BuildScript) Merge(other *BuildScript, strategies *mono_models.MergeStr
 
 	// When merging build scripts we want to use the most recent timestamp
 	atTime := other.AtTime()
-	if atTime.After(b.AtTime()) {
-		b.SetAtTime(atTime)
+	if atTime != nil && atTime.After(*b.AtTime()) {
+		b.SetAtTime(*atTime)
 	}
 
 	return nil

--- a/pkg/buildscript/merge.go
+++ b/pkg/buildscript/merge.go
@@ -57,8 +57,8 @@ func (b *BuildScript) Merge(other *BuildScript, strategies *mono_models.MergeStr
 
 	// When merging build scripts we want to use the most recent timestamp
 	atTime := other.AtTime()
-	if atTime != nil && atTime.After(*b.AtTime()) {
-		b.SetAtTime(*atTime)
+	if atTime.After(b.AtTime()) {
+		b.SetAtTime(atTime)
 	}
 
 	return nil

--- a/pkg/buildscript/merge_test.go
+++ b/pkg/buildscript/merge_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const mergeATime = "2000-01-01T00:00:00.000Z"
+const mergeBTime = "2000-01-02T00:00:00.000Z"
+
 func TestMergeAdd(t *testing.T) {
-	scriptA, err := Unmarshal([]byte(`
-at_time = "2000-01-01T00:00:00.000Z"
+	scriptA, err := Unmarshal([]byte(
+		checkoutInfoString(testProject, mergeATime) + `
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -27,8 +30,8 @@ main = runtime
 `))
 	require.NoError(t, err)
 
-	scriptB, err := Unmarshal([]byte(`
-at_time = "2000-01-02T00:00:00.000Z"
+	scriptB, err := Unmarshal([]byte(
+		checkoutInfoString(testProject, mergeBTime) + `
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -60,7 +63,7 @@ main = runtime
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		`at_time = "2000-01-02T00:00:00.000Z"
+		checkoutInfoString(testProject, mergeBTime)+`
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -78,8 +81,8 @@ main = runtime`, string(v))
 }
 
 func TestMergeRemove(t *testing.T) {
-	scriptA, err := Unmarshal([]byte(`
-at_time = "2000-01-02T00:00:00.000Z"
+	scriptA, err := Unmarshal([]byte(
+		checkoutInfoString(testProject, mergeBTime) + `
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -97,8 +100,8 @@ main = runtime
 `))
 	require.NoError(t, err)
 
-	scriptB, err := Unmarshal([]byte(`
-at_time = "2000-01-01T00:00:00.000Z"
+	scriptB, err := Unmarshal([]byte(
+		checkoutInfoString(testProject, mergeATime) + `
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -129,7 +132,7 @@ main = runtime
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		`at_time = "2000-01-02T00:00:00.000Z"
+		checkoutInfoString(testProject, mergeBTime)+`
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -146,8 +149,8 @@ main = runtime`, string(v))
 }
 
 func TestMergeConflict(t *testing.T) {
-	scriptA, err := Unmarshal([]byte(`
-at_time = "2000-01-01T00:00:00.000Z"
+	scriptA, err := Unmarshal([]byte(
+		checkoutInfoString(testProject, mergeATime) + `
 runtime = solve(
 	at_time = at_time,
 	platforms = [
@@ -163,8 +166,8 @@ main = runtime
 `))
 	require.NoError(t, err)
 
-	scriptB, err := Unmarshal([]byte(`
-at_time = "2000-01-01T00:00:00.000Z"
+	scriptB, err := Unmarshal([]byte(
+		checkoutInfoString(testProject, mergeATime) + `
 runtime = solve(
 	at_time = at_time,
 	platforms = [

--- a/pkg/buildscript/merge_test.go
+++ b/pkg/buildscript/merge_test.go
@@ -15,7 +15,7 @@ func TestMergeAdd(t *testing.T) {
 	scriptA, err := Unmarshal([]byte(
 		checkoutInfoString(testProject, mergeATime) + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"
@@ -33,7 +33,7 @@ main = runtime
 	scriptB, err := Unmarshal([]byte(
 		checkoutInfoString(testProject, mergeBTime) + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"
@@ -65,7 +65,7 @@ main = runtime
 	assert.Equal(t,
 		checkoutInfoString(testProject, mergeBTime)+`
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"
@@ -84,7 +84,7 @@ func TestMergeRemove(t *testing.T) {
 	scriptA, err := Unmarshal([]byte(
 		checkoutInfoString(testProject, mergeBTime) + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"
@@ -103,7 +103,7 @@ main = runtime
 	scriptB, err := Unmarshal([]byte(
 		checkoutInfoString(testProject, mergeATime) + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"
@@ -134,7 +134,7 @@ main = runtime
 	assert.Equal(t,
 		checkoutInfoString(testProject, mergeBTime)+`
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"
@@ -152,7 +152,7 @@ func TestMergeConflict(t *testing.T) {
 	scriptA, err := Unmarshal([]byte(
 		checkoutInfoString(testProject, mergeATime) + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345",
 		"67890"
@@ -169,7 +169,7 @@ main = runtime
 	scriptB, err := Unmarshal([]byte(
 		checkoutInfoString(testProject, mergeATime) + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = [
 		"12345"
 	],

--- a/pkg/buildscript/mutations.go
+++ b/pkg/buildscript/mutations.go
@@ -42,8 +42,8 @@ func (b *BuildScript) AddRequirement(requirement types.Requirement) error {
 
 	// Use object form for now, and then transform it into function form later.
 	obj := []*Assignment{
-		{requirementNameKey, newString(requirement.Name)},
-		{requirementNamespaceKey, newString(requirement.Namespace)},
+		{requirementNameKey, &Value{Str: &requirement.Name}},
+		{requirementNamespaceKey, &Value{Str: &requirement.Namespace}},
 	}
 
 	if requirement.Revision != nil {
@@ -54,8 +54,8 @@ func (b *BuildScript) AddRequirement(requirement types.Requirement) error {
 		values := []*Value{}
 		for _, req := range requirement.VersionRequirement {
 			values = append(values, &Value{Object: &[]*Assignment{
-				{requirementComparatorKey, newString(req[requirementComparatorKey])},
-				{requirementVersionKey, newString(req[requirementVersionKey])},
+				{requirementComparatorKey, &Value{Str: ptr.To(req[requirementComparatorKey])}},
+				{requirementVersionKey, &Value{Str: ptr.To(req[requirementVersionKey])}},
 			}})
 		}
 		obj = append(obj, &Assignment{requirementVersionRequirementsKey, &Value{List: &values}})
@@ -94,13 +94,13 @@ func (b *BuildScript) RemoveRequirement(requirement types.Requirement) error {
 
 		for _, arg := range req.FuncCall.Arguments {
 			if arg.Assignment.Key == requirementNameKey {
-				match = strValue(arg.Assignment.Value) == requirement.Name
+				match = *arg.Assignment.Value.Str == requirement.Name
 				if !match || requirement.Namespace == "" {
 					break
 				}
 			}
 			if requirement.Namespace != "" && arg.Assignment.Key == requirementNamespaceKey {
-				match = strValue(arg.Assignment.Value) == requirement.Namespace
+				match = *arg.Assignment.Value.Str == requirement.Namespace
 				if !match {
 					break
 				}
@@ -132,7 +132,7 @@ func (b *BuildScript) AddPlatform(platformID strfmt.UUID) error {
 	}
 
 	list := *platformsNode.List
-	list = append(list, newString(platformID.String()))
+	list = append(list, &Value{Str: ptr.To(platformID.String())})
 	platformsNode.List = &list
 
 	return nil
@@ -151,7 +151,7 @@ func (b *BuildScript) RemovePlatform(platformID strfmt.UUID) error {
 
 	var found bool
 	for i, value := range *platformsNode.List {
-		if value.Str != nil && strValue(value) == platformID.String() {
+		if value.Str != nil && *value.Str == platformID.String() {
 			list := *platformsNode.List
 			list = append(list[:i], list[i+1:]...)
 			platformsNode.List = &list

--- a/pkg/buildscript/mutations_test.go
+++ b/pkg/buildscript/mutations_test.go
@@ -264,7 +264,7 @@ func TestUpdateRequirements(t *testing.T) {
 			data, err := fileutils.ReadFile(filepath.Join(wd, "pkg", "buildscript", "testdata", tt.args.filename))
 			assert.NoError(t, err)
 
-			script, err := UnmarshalBuildExpression(data, nil)
+			script, err := UnmarshalBuildExpression(data, "", nil)
 			assert.NoError(t, err)
 
 			err = script.UpdateRequirement(tt.args.operation, tt.args.requirement.Requirement)
@@ -344,7 +344,7 @@ func TestUpdatePlatform(t *testing.T) {
 			data, err := fileutils.ReadFile(filepath.Join(wd, "pkg", "buildscript", "testdata", tt.args.filename))
 			assert.NoError(t, err)
 
-			script, err := UnmarshalBuildExpression(data, nil)
+			script, err := UnmarshalBuildExpression(data, "", nil)
 			assert.NoError(t, err)
 
 			if tt.args.operation == types.OperationAdded {

--- a/pkg/buildscript/queries.go
+++ b/pkg/buildscript/queries.go
@@ -61,9 +61,9 @@ func (b *BuildScript) Requirements() ([]Requirement, error) {
 			for _, arg := range req.FuncCall.Arguments {
 				switch arg.Assignment.Key {
 				case requirementNameKey:
-					r.Name = strValue(arg.Assignment.Value)
+					r.Name = *arg.Assignment.Value.Str
 				case requirementNamespaceKey:
-					r.Namespace = strValue(arg.Assignment.Value)
+					r.Namespace = *arg.Assignment.Value.Str
 				case requirementVersionKey:
 					r.VersionRequirement = getVersionRequirements(arg.Assignment.Value)
 				}
@@ -74,9 +74,9 @@ func (b *BuildScript) Requirements() ([]Requirement, error) {
 			for _, arg := range req.FuncCall.Arguments {
 				switch arg.Assignment.Key {
 				case requirementNameKey:
-					r.Name = strValue(arg.Assignment.Value)
+					r.Name = *arg.Assignment.Value.Str
 				case requirementRevisionIDKey:
-					r.RevisionID = strfmt.UUID(strValue(arg.Assignment.Value))
+					r.RevisionID = strfmt.UUID(*arg.Assignment.Value.Str)
 				}
 			}
 			requirements = append(requirements, r)
@@ -132,7 +132,7 @@ func getVersionRequirements(v *Value) []types.VersionRequirement {
 	case eqFuncName, neFuncName, gtFuncName, gteFuncName, ltFuncName, lteFuncName:
 		reqs = append(reqs, types.VersionRequirement{
 			requirementComparatorKey: strings.ToLower(v.FuncCall.Name),
-			requirementVersionKey:    strValue(v.FuncCall.Arguments[0].Assignment.Value),
+			requirementVersionKey:    *v.FuncCall.Arguments[0].Assignment.Value.Str,
 		})
 
 	// e.g. And(left = Gte(value = "1.0"), right = Lt(value = "2.0"))
@@ -199,7 +199,7 @@ func (b *BuildScript) Platforms() ([]strfmt.UUID, error) {
 
 	list := []strfmt.UUID{}
 	for _, value := range *node.List {
-		list = append(list, strfmt.UUID(strValue(value)))
+		list = append(list, strfmt.UUID(*value.Str))
 	}
 	return list, nil
 }

--- a/pkg/buildscript/queries_test.go
+++ b/pkg/buildscript/queries_test.go
@@ -110,7 +110,7 @@ func TestRequirements(t *testing.T) {
 			data, err := fileutils.ReadFile(filepath.Join(wd, "pkg", "buildscript", "testdata", tt.args.filename))
 			assert.NoError(t, err)
 
-			script, err := UnmarshalBuildExpression(data, nil)
+			script, err := UnmarshalBuildExpression(data, "", nil)
 			assert.NoError(t, err)
 
 			got, err := script.Requirements()
@@ -164,7 +164,7 @@ func TestRevision(t *testing.T) {
 			data, err := fileutils.ReadFile(filepath.Join(wd, "pkg", "buildscript", "testdata", tt.args.filename))
 			assert.NoError(t, err)
 
-			script, err := UnmarshalBuildExpression(data, nil)
+			script, err := UnmarshalBuildExpression(data, "", nil)
 			assert.NoError(t, err)
 
 			got, err := script.Requirements()

--- a/pkg/buildscript/raw.go
+++ b/pkg/buildscript/raw.go
@@ -1,15 +1,9 @@
 package buildscript
 
-import (
-	"time"
-)
-
 // Tagged fields will be filled in by Participle.
 type rawBuildScript struct {
 	Info        *string       `parser:"(RawString @RawString RawString)?"`
 	Assignments []*Assignment `parser:"@@+"`
-
-	CheckoutInfo CheckoutInfo // set after initial read
 }
 
 type Assignment struct {
@@ -36,9 +30,4 @@ type Null struct {
 type FuncCall struct {
 	Name      string   `parser:"@Ident"`
 	Arguments []*Value `parser:"'(' @@ (',' @@)* ','? ')'"`
-}
-
-type CheckoutInfo struct {
-	Project string
-	AtTime  time.Time
 }

--- a/pkg/buildscript/raw.go
+++ b/pkg/buildscript/raw.go
@@ -6,9 +6,10 @@ import (
 
 // Tagged fields will be filled in by Participle.
 type rawBuildScript struct {
+	Info        *string       `parser:"(RawString @RawString RawString)?"`
 	Assignments []*Assignment `parser:"@@+"`
 
-	AtTime *time.Time // set after initial read
+	CheckoutInfo CheckoutInfo // set after initial read
 }
 
 type Assignment struct {
@@ -35,4 +36,9 @@ type Null struct {
 type FuncCall struct {
 	Name      string   `parser:"@Ident"`
 	Arguments []*Value `parser:"'(' @@ (',' @@)* ','? ')'"`
+}
+
+type CheckoutInfo struct {
+	Project string
+	AtTime  time.Time
 }

--- a/pkg/buildscript/raw.go
+++ b/pkg/buildscript/raw.go
@@ -1,11 +1,7 @@
 package buildscript
 
 import (
-	"strconv"
-	"strings"
 	"time"
-
-	"github.com/ActiveState/cli/internal/rtutils/ptr"
 )
 
 // Tagged fields will be filled in by Participle.
@@ -23,7 +19,7 @@ type Assignment struct {
 type Value struct {
 	FuncCall *FuncCall `parser:"@@"`
 	List     *[]*Value `parser:"| '[' (@@ (',' @@)* ','?)? ']'"`
-	Str      *string   `parser:"| @String"` // note: this value is ALWAYS quoted
+	Str      *string   `parser:"| @String"`
 	Number   *float64  `parser:"| (@Float | @Int)"`
 	Null     *Null     `parser:"| @@"`
 
@@ -39,16 +35,4 @@ type Null struct {
 type FuncCall struct {
 	Name      string   `parser:"@Ident"`
 	Arguments []*Value `parser:"'(' @@ (',' @@)* ','? ')'"`
-}
-
-// newString is a convenience function for constructing a string Value from an unquoted string.
-// Use this instead of &Value{Str: ptr.To(strconv.Quote(s))}
-func newString(s string) *Value {
-	return &Value{Str: ptr.To(strconv.Quote(s))}
-}
-
-// strValue is a convenience function for retrieving an unquoted string from Value.
-// Use this instead of strings.Trim(*v.Str, `"`)
-func strValue(v *Value) string {
-	return strings.Trim(*v.Str, `"`)
 }

--- a/pkg/buildscript/raw_test.go
+++ b/pkg/buildscript/raw_test.go
@@ -2,10 +2,8 @@ package buildscript
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
-	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,9 +41,7 @@ main = runtime
 `))
 	require.NoError(t, err)
 
-	atTimeStrfmt, err := strfmt.ParseDateTime("2000-01-01T00:00:00.000Z")
-	require.NoError(t, err)
-	atTime := time.Time(atTimeStrfmt)
+	assert.Contains(t, *script.raw.Info, "2000-01-01T00:00:00.000Z")
 
 	assert.Equal(t, &rawBuildScript{
 		Info: ptr.To(testCheckoutInfo[2 : len(testCheckoutInfo)-3]),
@@ -89,7 +85,6 @@ main = runtime
 			}},
 			{"main", &Value{Ident: ptr.To("runtime")}},
 		},
-		CheckoutInfo: CheckoutInfo{testProject, atTime},
 	}, script.raw)
 }
 
@@ -119,9 +114,7 @@ main = merge(
 `))
 	require.NoError(t, err)
 
-	atTimeStrfmt, err := strfmt.ParseDateTime("2000-01-01T00:00:00.000Z")
-	require.NoError(t, err)
-	atTime := time.Time(atTimeStrfmt)
+	assert.Contains(t, *script.raw.Info, "2000-01-01T00:00:00.000Z")
 
 	assert.Equal(t, &rawBuildScript{
 		Info: ptr.To(testCheckoutInfo[2 : len(testCheckoutInfo)-3]),
@@ -170,7 +163,6 @@ main = merge(
 					{FuncCall: &FuncCall{"tar_installer", []*Value{{Ident: ptr.To("linux_runtime")}}}},
 				}}}},
 		},
-		CheckoutInfo: CheckoutInfo{testProject, atTime},
 	}, script.raw)
 }
 
@@ -193,9 +185,7 @@ main = runtime
 `))
 	require.NoError(t, err)
 
-	atTimeStrfmt, err := strfmt.ParseDateTime("2023-04-27T17:30:05.999Z")
-	require.NoError(t, err)
-	atTime := time.Time(atTimeStrfmt)
+	assert.Contains(t, *script.raw.Info, "2023-04-27T17:30:05.999Z")
 
 	assert.Equal(t, &rawBuildScript{
 		Info: ptr.To(checkoutInfo[2 : len(checkoutInfo)-3]),
@@ -266,6 +256,5 @@ main = runtime
 			}},
 			{"main", &Value{Ident: ptr.To("runtime")}},
 		},
-		CheckoutInfo: CheckoutInfo{testProject, atTime},
 	}, script.raw)
 }

--- a/pkg/buildscript/raw_test.go
+++ b/pkg/buildscript/raw_test.go
@@ -30,7 +30,7 @@ func TestRawRepresentation(t *testing.T) {
 	script, err := Unmarshal([]byte(
 		testCheckoutInfo + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = ["linux", "windows"],
 	requirements = [
 		Req(name = "python", namespace = "language"),
@@ -52,7 +52,7 @@ main = runtime
 		Assignments: []*Assignment{
 			{"runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
-					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
+					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`TIME`)}}},
 					{Assignment: &Assignment{
 						"platforms", &Value{List: &[]*Value{
 							{Str: ptr.To(`linux`)},
@@ -97,7 +97,7 @@ func TestComplex(t *testing.T) {
 	script, err := Unmarshal([]byte(
 		testCheckoutInfo + `
 linux_runtime = solve(
-		at_time = at_time,
+		at_time = TIME,
 		requirements=[
 			Req(name = "python", namespace = "language")
 		],
@@ -105,7 +105,7 @@ linux_runtime = solve(
 )
 
 win_runtime = solve(
-		at_time = at_time,
+		at_time = TIME,
 		requirements=[
 			Req(name = "perl", namespace = "language")
 		],
@@ -128,7 +128,7 @@ main = merge(
 		Assignments: []*Assignment{
 			{"linux_runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
-					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
+					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`TIME`)}}},
 					{Assignment: &Assignment{
 						"requirements", &Value{List: &[]*Value{
 							{FuncCall: &FuncCall{
@@ -147,7 +147,7 @@ main = merge(
 			}},
 			{"win_runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
-					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
+					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`TIME`)}}},
 					{Assignment: &Assignment{
 						"requirements", &Value{List: &[]*Value{
 							{FuncCall: &FuncCall{
@@ -179,7 +179,7 @@ func TestComplexVersions(t *testing.T) {
 	script, err := Unmarshal([]byte(
 		checkoutInfo + `
 runtime = solve(
-	at_time = at_time,
+	at_time = TIME,
 	platforms = ["96b7e6f2-bebf-564c-bc1c-f04482398f38", "96b7e6f2-bebf-564c-bc1c-f04482398f38"],
 	requirements = [
 		Req(name = "python", namespace = "language"),
@@ -202,7 +202,7 @@ main = runtime
 		Assignments: []*Assignment{
 			{"runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
-					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
+					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`TIME`)}}},
 					{Assignment: &Assignment{
 						"platforms", &Value{List: &[]*Value{
 							{Str: ptr.To(`96b7e6f2-bebf-564c-bc1c-f04482398f38`)},

--- a/pkg/buildscript/raw_test.go
+++ b/pkg/buildscript/raw_test.go
@@ -32,14 +32,14 @@ main = runtime
 	atTime := time.Time(atTimeStrfmt)
 
 	assert.Equal(t, &rawBuildScript{
-		[]*Assignment{
+		Assignments: []*Assignment{
 			{"runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
 					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
 					{Assignment: &Assignment{
 						"platforms", &Value{List: &[]*Value{
-							{Str: ptr.To(`"linux"`)},
-							{Str: ptr.To(`"windows"`)},
+							{Str: ptr.To(`linux`)},
+							{Str: ptr.To(`windows`)},
 						}},
 					}},
 					{Assignment: &Assignment{
@@ -47,19 +47,19 @@ main = runtime
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
-									{Assignment: &Assignment{"name", newString("python")}},
-									{Assignment: &Assignment{"namespace", newString("language")}},
+									{Assignment: &Assignment{"name", &Value{Str: ptr.To("python")}}},
+									{Assignment: &Assignment{"namespace", &Value{Str: ptr.To("language")}}},
 								}}},
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
-									{Assignment: &Assignment{"name", newString("requests")}},
-									{Assignment: &Assignment{"namespace", newString("language/python")}},
+									{Assignment: &Assignment{"name", &Value{Str: ptr.To("requests")}}},
+									{Assignment: &Assignment{"namespace", &Value{Str: ptr.To("language/python")}}},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
 											Name: "Eq",
 											Arguments: []*Value{
-												{Assignment: &Assignment{"value", newString("3.10.10")}},
+												{Assignment: &Assignment{"value", &Value{Str: ptr.To("3.10.10")}}},
 											},
 										}},
 									}},
@@ -72,7 +72,7 @@ main = runtime
 			}},
 			{"main", &Value{Ident: ptr.To("runtime")}},
 		},
-		&atTime,
+		AtTime: &atTime,
 	}, script.raw)
 }
 
@@ -107,7 +107,7 @@ main = merge(
 	atTime := time.Time(atTimeStrfmt)
 
 	assert.Equal(t, &rawBuildScript{
-		[]*Assignment{
+		Assignments: []*Assignment{
 			{"linux_runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
 					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
@@ -116,14 +116,14 @@ main = merge(
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
-									{Assignment: &Assignment{"name", newString("python")}},
-									{Assignment: &Assignment{"namespace", newString("language")}},
+									{Assignment: &Assignment{"name", &Value{Str: ptr.To("python")}}},
+									{Assignment: &Assignment{"namespace", &Value{Str: ptr.To("language")}}},
 								},
 							}},
 						}},
 					}},
 					{Assignment: &Assignment{
-						"platforms", &Value{List: &[]*Value{{Str: ptr.To(`"67890"`)}}},
+						"platforms", &Value{List: &[]*Value{{Str: ptr.To(`67890`)}}},
 					}},
 				}},
 			}},
@@ -135,14 +135,14 @@ main = merge(
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
-									{Assignment: &Assignment{"name", newString("perl")}},
-									{Assignment: &Assignment{"namespace", newString("language")}},
+									{Assignment: &Assignment{"name", &Value{Str: ptr.To("perl")}}},
+									{Assignment: &Assignment{"namespace", &Value{Str: ptr.To("language")}}},
 								},
 							}},
 						}},
 					}},
 					{Assignment: &Assignment{
-						"platforms", &Value{List: &[]*Value{{Str: ptr.To(`"12345"`)}}},
+						"platforms", &Value{List: &[]*Value{{Str: ptr.To(`12345`)}}},
 					}},
 				}},
 			}},
@@ -152,7 +152,7 @@ main = merge(
 					{FuncCall: &FuncCall{"tar_installer", []*Value{{Ident: ptr.To("linux_runtime")}}}},
 				}}}},
 		},
-		&atTime,
+		AtTime: &atTime,
 	}, script.raw)
 }
 
@@ -179,14 +179,14 @@ func TestComplexVersions(t *testing.T) {
 	atTime := time.Time(atTimeStrfmt)
 
 	assert.Equal(t, &rawBuildScript{
-		[]*Assignment{
+		Assignments: []*Assignment{
 			{"runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
 					{Assignment: &Assignment{"at_time", &Value{Ident: ptr.To(`at_time`)}}},
 					{Assignment: &Assignment{
 						"platforms", &Value{List: &[]*Value{
-							{Str: ptr.To(`"96b7e6f2-bebf-564c-bc1c-f04482398f38"`)},
-							{Str: ptr.To(`"96b7e6f2-bebf-564c-bc1c-f04482398f38"`)},
+							{Str: ptr.To(`96b7e6f2-bebf-564c-bc1c-f04482398f38`)},
+							{Str: ptr.To(`96b7e6f2-bebf-564c-bc1c-f04482398f38`)},
 						}},
 					}},
 					{Assignment: &Assignment{
@@ -194,20 +194,20 @@ func TestComplexVersions(t *testing.T) {
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
-									{Assignment: &Assignment{"name", newString("python")}},
-									{Assignment: &Assignment{"namespace", newString("language")}},
+									{Assignment: &Assignment{"name", &Value{Str: ptr.To("python")}}},
+									{Assignment: &Assignment{"namespace", &Value{Str: ptr.To("language")}}},
 								},
 							}},
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
-									{Assignment: &Assignment{"name", newString("requests")}},
-									{Assignment: &Assignment{"namespace", newString("language/python")}},
+									{Assignment: &Assignment{"name", &Value{Str: ptr.To("requests")}}},
+									{Assignment: &Assignment{"namespace", &Value{Str: ptr.To("language/python")}}},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
 											Name: "Eq",
 											Arguments: []*Value{
-												{Assignment: &Assignment{Key: "value", Value: newString("3.10.10")}},
+												{Assignment: &Assignment{Key: "value", Value: &Value{Str: ptr.To("3.10.10")}}},
 											},
 										}},
 									}},
@@ -216,8 +216,8 @@ func TestComplexVersions(t *testing.T) {
 							{FuncCall: &FuncCall{
 								Name: "Req",
 								Arguments: []*Value{
-									{Assignment: &Assignment{"name", newString("argparse")}},
-									{Assignment: &Assignment{"namespace", newString("language/python")}},
+									{Assignment: &Assignment{"name", &Value{Str: ptr.To("argparse")}}},
+									{Assignment: &Assignment{"namespace", &Value{Str: ptr.To("language/python")}}},
 									{Assignment: &Assignment{
 										"version", &Value{FuncCall: &FuncCall{
 											Name: "And",
@@ -225,13 +225,13 @@ func TestComplexVersions(t *testing.T) {
 												{Assignment: &Assignment{Key: "left", Value: &Value{FuncCall: &FuncCall{
 													Name: "Gt",
 													Arguments: []*Value{
-														{Assignment: &Assignment{Key: "value", Value: newString("1.0")}},
+														{Assignment: &Assignment{Key: "value", Value: &Value{Str: ptr.To("1.0")}}},
 													},
 												}}}},
 												{Assignment: &Assignment{Key: "right", Value: &Value{FuncCall: &FuncCall{
 													Name: "Lt",
 													Arguments: []*Value{
-														{Assignment: &Assignment{Key: "value", Value: newString("2.0")}},
+														{Assignment: &Assignment{Key: "value", Value: &Value{Str: ptr.To("2.0")}}},
 													},
 												}}}},
 											},
@@ -246,6 +246,6 @@ func TestComplexVersions(t *testing.T) {
 			}},
 			{"main", &Value{Ident: ptr.To("runtime")}},
 		},
-		&atTime,
+		AtTime: &atTime,
 	}, script.raw)
 }

--- a/pkg/buildscript/raw_test.go
+++ b/pkg/buildscript/raw_test.go
@@ -10,9 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testProject = "https://platform.activestate.com/org/project?branch=main&commitID=00000000-0000-0000-0000-000000000000"
+const testTime = "2000-01-01T00:00:00.000Z"
+
+func checkoutInfoString(project, time string) string {
+	return "```\n" +
+		"Project: " + project + "\n" +
+		"Time: " + time + "\n" +
+		"```\n"
+}
+
+var testCheckoutInfo string
+
+func init() {
+	testCheckoutInfo = checkoutInfoString(testProject, testTime)
+}
+
 func TestRawRepresentation(t *testing.T) {
 	script, err := Unmarshal([]byte(
-		`at_time = "2000-01-01T00:00:00.000Z"
+		testCheckoutInfo + `
 runtime = solve(
 	at_time = at_time,
 	platforms = ["linux", "windows"],
@@ -32,6 +48,7 @@ main = runtime
 	atTime := time.Time(atTimeStrfmt)
 
 	assert.Equal(t, &rawBuildScript{
+		Info: ptr.To(testCheckoutInfo[2 : len(testCheckoutInfo)-3]),
 		Assignments: []*Assignment{
 			{"runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
@@ -72,13 +89,13 @@ main = runtime
 			}},
 			{"main", &Value{Ident: ptr.To("runtime")}},
 		},
-		AtTime: &atTime,
+		CheckoutInfo: CheckoutInfo{testProject, atTime},
 	}, script.raw)
 }
 
 func TestComplex(t *testing.T) {
 	script, err := Unmarshal([]byte(
-		`at_time = "2000-01-01T00:00:00.000Z"
+		testCheckoutInfo + `
 linux_runtime = solve(
 		at_time = at_time,
 		requirements=[
@@ -107,6 +124,7 @@ main = merge(
 	atTime := time.Time(atTimeStrfmt)
 
 	assert.Equal(t, &rawBuildScript{
+		Info: ptr.To(testCheckoutInfo[2 : len(testCheckoutInfo)-3]),
 		Assignments: []*Assignment{
 			{"linux_runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
@@ -152,11 +170,14 @@ main = merge(
 					{FuncCall: &FuncCall{"tar_installer", []*Value{{Ident: ptr.To("linux_runtime")}}}},
 				}}}},
 		},
-		AtTime: &atTime,
+		CheckoutInfo: CheckoutInfo{testProject, atTime},
 	}, script.raw)
 }
 
-const buildscriptWithComplexVersions = `at_time = "2023-04-27T17:30:05.999Z"
+func TestComplexVersions(t *testing.T) {
+	checkoutInfo := checkoutInfoString(testProject, "2023-04-27T17:30:05.999Z")
+	script, err := Unmarshal([]byte(
+		checkoutInfo + `
 runtime = solve(
 	at_time = at_time,
 	platforms = ["96b7e6f2-bebf-564c-bc1c-f04482398f38", "96b7e6f2-bebf-564c-bc1c-f04482398f38"],
@@ -168,10 +189,8 @@ runtime = solve(
 	solver_version = 0
 )
 
-main = runtime`
-
-func TestComplexVersions(t *testing.T) {
-	script, err := Unmarshal([]byte(buildscriptWithComplexVersions))
+main = runtime
+`))
 	require.NoError(t, err)
 
 	atTimeStrfmt, err := strfmt.ParseDateTime("2023-04-27T17:30:05.999Z")
@@ -179,6 +198,7 @@ func TestComplexVersions(t *testing.T) {
 	atTime := time.Time(atTimeStrfmt)
 
 	assert.Equal(t, &rawBuildScript{
+		Info: ptr.To(checkoutInfo[2 : len(checkoutInfo)-3]),
 		Assignments: []*Assignment{
 			{"runtime", &Value{
 				FuncCall: &FuncCall{"solve", []*Value{
@@ -246,6 +266,6 @@ func TestComplexVersions(t *testing.T) {
 			}},
 			{"main", &Value{Ident: ptr.To("runtime")}},
 		},
-		AtTime: &atTime,
+		CheckoutInfo: CheckoutInfo{testProject, atTime},
 	}, script.raw)
 }

--- a/pkg/buildscript/unmarshal.go
+++ b/pkg/buildscript/unmarshal.go
@@ -2,18 +2,26 @@ package buildscript
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/go-openapi/strfmt"
+	"gopkg.in/yaml.v2"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
-	"github.com/ActiveState/cli/internal/rtutils/ptr"
 )
 
 const atTimeKey = "at_time"
+
+var ErrOutdatedAtTime = errs.New("outdated at_time on top")
+
+type checkoutInfo struct {
+	Project string `yaml:"Project"`
+	Time    string `yaml:"Time"`
+}
 
 // Unmarshal returns a structured form of the given AScript (on-disk format).
 func Unmarshal(data []byte) (*BuildScript, error) {
@@ -31,23 +39,31 @@ func Unmarshal(data []byte) (*BuildScript, error) {
 		return nil, locale.WrapError(err, "err_parse_buildscript_bytes", "Could not parse build script: {{.V0}}", err.Error())
 	}
 
-	// Extract 'at_time' value from the list of assignments, if it exists.
-	for i, assignment := range raw.Assignments {
-		key := assignment.Key
-		value := assignment.Value
-		if key != atTimeKey {
+	// If 'at_time' is among the list of assignments, this is an outdated build script, so error out.
+	for _, assignment := range raw.Assignments {
+		if assignment.Key != atTimeKey {
 			continue
 		}
-		raw.Assignments = append(raw.Assignments[:i], raw.Assignments[i+1:]...)
-		if value.Str == nil {
-			break
-		}
-		atTime, err := strfmt.ParseDateTime(*value.Str)
+		return nil, ErrOutdatedAtTime
+	}
+
+	if raw.Info != nil {
+		info := checkoutInfo{}
+
+		err := yaml.Unmarshal([]byte(strings.Trim(*raw.Info, "`\n")), &info)
 		if err != nil {
-			return nil, errs.Wrap(err, "Invalid timestamp: %s", *value.Str)
+			return nil, locale.NewExternalError(
+				"err_buildscript_checkoutinfo",
+				"Could not parse checkout information in the buildscript. The parser produced the following error: {{.V0}}", err.Error())
 		}
-		raw.AtTime = ptr.To(time.Time(atTime))
-		break
+
+		raw.CheckoutInfo.Project = info.Project
+
+		atTime, err := strfmt.ParseDateTime(info.Time)
+		if err != nil {
+			return nil, errs.Wrap(err, "Invalid timestamp: %s", info.Time)
+		}
+		raw.CheckoutInfo.AtTime = time.Time(atTime)
 	}
 
 	return &BuildScript{raw}, nil

--- a/pkg/buildscript/unmarshal.go
+++ b/pkg/buildscript/unmarshal.go
@@ -17,7 +17,7 @@ const atTimeKey = "at_time"
 
 // Unmarshal returns a structured form of the given AScript (on-disk format).
 func Unmarshal(data []byte) (*BuildScript, error) {
-	parser, err := participle.Build[rawBuildScript]()
+	parser, err := participle.Build[rawBuildScript](participle.Unquote())
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not create parser for build script")
 	}
@@ -42,9 +42,9 @@ func Unmarshal(data []byte) (*BuildScript, error) {
 		if value.Str == nil {
 			break
 		}
-		atTime, err := strfmt.ParseDateTime(strValue(value))
+		atTime, err := strfmt.ParseDateTime(*value.Str)
 		if err != nil {
-			return nil, errs.Wrap(err, "Invalid timestamp: %s", strValue(value))
+			return nil, errs.Wrap(err, "Invalid timestamp: %s", *value.Str)
 		}
 		raw.AtTime = ptr.To(time.Time(atTime))
 		break

--- a/pkg/buildscript/unmarshal.go
+++ b/pkg/buildscript/unmarshal.go
@@ -55,7 +55,7 @@ func Unmarshal(data []byte) (*BuildScript, error) {
 
 		err := yaml.Unmarshal([]byte(strings.Trim(*raw.Info, "`\n")), &info)
 		if err != nil {
-			return nil, locale.NewExternalError(
+			return nil, locale.NewInputError(
 				"err_buildscript_checkoutinfo",
 				"Could not parse checkout information in the buildscript. The parser produced the following error: {{.V0}}", err.Error())
 		}

--- a/pkg/buildscript/unmarshal.go
+++ b/pkg/buildscript/unmarshal.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/rtutils/ptr"
 )
 
 const atTimeKey = "at_time"
@@ -47,6 +48,8 @@ func Unmarshal(data []byte) (*BuildScript, error) {
 		return nil, ErrOutdatedAtTime
 	}
 
+	var project string
+	var atTimePtr *time.Time
 	if raw.Info != nil {
 		info := checkoutInfo{}
 
@@ -57,14 +60,14 @@ func Unmarshal(data []byte) (*BuildScript, error) {
 				"Could not parse checkout information in the buildscript. The parser produced the following error: {{.V0}}", err.Error())
 		}
 
-		raw.CheckoutInfo.Project = info.Project
+		project = info.Project
 
 		atTime, err := strfmt.ParseDateTime(info.Time)
 		if err != nil {
 			return nil, errs.Wrap(err, "Invalid timestamp: %s", info.Time)
 		}
-		raw.CheckoutInfo.AtTime = time.Time(atTime)
+		atTimePtr = ptr.To(time.Time(atTime))
 	}
 
-	return &BuildScript{raw}, nil
+	return &BuildScript{raw, project, atTimePtr}, nil
 }

--- a/pkg/buildscript/unmarshal_buildexpression.go
+++ b/pkg/buildscript/unmarshal_buildexpression.go
@@ -63,7 +63,7 @@ func RegisterFunctionPreUnmarshaler(name string, preUnmarshal PreUnmarshalerFunc
 // Build scripts and build expressions are almost identical, with the exception of the atTime field.
 // Build expressions ALWAYS set at_time to `$at_time`, which refers to the timestamp on the commit,
 // while buildscripts encode this timestamp as part of their definition. For this reason we have
-// to supply the timestamp as a separate argument.
+// to supply the timestamp as a separate argument (as part of checkoutinfo).
 func UnmarshalBuildExpression(data []byte, checkoutInfo *CheckoutInfo) (*BuildScript, error) {
 	expr := make(map[string]interface{})
 	err := json.Unmarshal(data, &expr)
@@ -85,15 +85,19 @@ func UnmarshalBuildExpression(data []byte, checkoutInfo *CheckoutInfo) (*BuildSc
 	script := &BuildScript{&rawBuildScript{Assignments: assignments}}
 
 	// Extract the 'at_time' from the solve node, if it exists, and change its value to be a
-	// reference to "$at_time", which is how we want to show it in AScript format.
-	if atTimeNode, err := script.getSolveAtTimeValue(); err == nil && atTimeNode.Str != nil && !strings.HasPrefix(*atTimeNode.Str, `$`) {
-		atTime, err := strfmt.ParseDateTime(*atTimeNode.Str)
-		if err != nil {
-			return nil, errs.Wrap(err, "Invalid timestamp: %s", *atTimeNode.Str)
+	// reference to "TIME", which is how we want to show it in AScript format.
+	if atTimeNode, err := script.getSolveAtTimeValue(); err == nil {
+		if atTimeNode.Str != nil && !strings.HasPrefix(*atTimeNode.Str, `$`) {
+			atTime, err := strfmt.ParseDateTime(*atTimeNode.Str)
+			if err != nil {
+				return nil, errs.Wrap(err, "Invalid timestamp: %s", *atTimeNode.Str)
+			}
+			atTimeNode.Str = nil
+			atTimeNode.Ident = ptr.To("TIME")
+			script.raw.CheckoutInfo.AtTime = time.Time(atTime)
+		} else if atTimeNode.Ident != nil && *atTimeNode.Ident == "at_time" {
+			atTimeNode.Ident = ptr.To("TIME")
 		}
-		atTimeNode.Str = nil
-		atTimeNode.Ident = ptr.To("at_time")
-		script.raw.CheckoutInfo.AtTime = time.Time(atTime)
 	} else if err != nil {
 		return nil, errs.Wrap(err, "Could not get at_time node")
 	}

--- a/pkg/buildscript/unmarshal_buildexpression.go
+++ b/pkg/buildscript/unmarshal_buildexpression.go
@@ -3,7 +3,6 @@ package buildscript
 import (
 	"encoding/json"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -87,10 +86,10 @@ func UnmarshalBuildExpression(data []byte, atTime *time.Time) (*BuildScript, err
 
 	// Extract the 'at_time' from the solve node, if it exists, and change its value to be a
 	// reference to "$at_time", which is how we want to show it in AScript format.
-	if atTimeNode, err := script.getSolveAtTimeValue(); err == nil && atTimeNode.Str != nil && !strings.HasPrefix(strValue(atTimeNode), `$`) {
-		atTime, err := strfmt.ParseDateTime(strValue(atTimeNode))
+	if atTimeNode, err := script.getSolveAtTimeValue(); err == nil && atTimeNode.Str != nil && !strings.HasPrefix(*atTimeNode.Str, `$`) {
+		atTime, err := strfmt.ParseDateTime(*atTimeNode.Str)
 		if err != nil {
-			return nil, errs.Wrap(err, "Invalid timestamp: %s", strValue(atTimeNode))
+			return nil, errs.Wrap(err, "Invalid timestamp: %s", *atTimeNode.Str)
 		}
 		atTimeNode.Str = nil
 		atTimeNode.Ident = ptr.To("at_time")
@@ -217,7 +216,7 @@ func unmarshalValue(path []string, valueInterface interface{}) (*Value, error) {
 		if sliceutils.Contains(path, ctxIn) || strings.HasPrefix(v, "$") {
 			value.Ident = ptr.To(strings.TrimPrefix(v, "$"))
 		} else {
-			value.Str = ptr.To(strconv.Quote(v)) // quoting is mandatory
+			value.Str = ptr.To(v)
 		}
 
 	case float64:
@@ -415,7 +414,7 @@ func transformVersion(requirements *Assignment) *FuncCall {
 					{Assignment: &Assignment{"value", o.Value}},
 				}
 			case requirementComparatorKey:
-				f.Name = cases.Title(language.English).String(strValue(o.Value))
+				f.Name = cases.Title(language.English).String(*o.Value.Str)
 			}
 		}
 		funcs = append(funcs, f)

--- a/pkg/buildscript/unmarshal_buildexpression.go
+++ b/pkg/buildscript/unmarshal_buildexpression.go
@@ -64,7 +64,7 @@ func RegisterFunctionPreUnmarshaler(name string, preUnmarshal PreUnmarshalerFunc
 // Build expressions ALWAYS set at_time to `$at_time`, which refers to the timestamp on the commit,
 // while buildscripts encode this timestamp as part of their definition. For this reason we have
 // to supply the timestamp as a separate argument.
-func UnmarshalBuildExpression(data []byte, atTime *time.Time) (*BuildScript, error) {
+func UnmarshalBuildExpression(data []byte, checkoutInfo *CheckoutInfo) (*BuildScript, error) {
 	expr := make(map[string]interface{})
 	err := json.Unmarshal(data, &expr)
 	if err != nil {
@@ -93,13 +93,13 @@ func UnmarshalBuildExpression(data []byte, atTime *time.Time) (*BuildScript, err
 		}
 		atTimeNode.Str = nil
 		atTimeNode.Ident = ptr.To("at_time")
-		script.raw.AtTime = ptr.To(time.Time(atTime))
+		script.raw.CheckoutInfo.AtTime = time.Time(atTime)
 	} else if err != nil {
 		return nil, errs.Wrap(err, "Could not get at_time node")
 	}
 
-	if atTime != nil {
-		script.raw.AtTime = atTime
+	if checkoutInfo != nil {
+		script.raw.CheckoutInfo = *checkoutInfo
 	}
 
 	// If the requirements are in legacy object form, e.g.

--- a/pkg/buildscript/unmarshal_buildexpression_test.go
+++ b/pkg/buildscript/unmarshal_buildexpression_test.go
@@ -86,7 +86,7 @@ func TestUnmarshalBuildExpression(t *testing.T) {
 			data, err := fileutils.ReadFile(filepath.Join(wd, "pkg", "buildscript", "testdata", tt.args.filename))
 			assert.NoError(t, err)
 
-			_, err = UnmarshalBuildExpression(data, nil)
+			_, err = UnmarshalBuildExpression(data, "", nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/checkoutinfo/checkoutinfo.go
+++ b/pkg/checkoutinfo/checkoutinfo.go
@@ -13,6 +13,9 @@ func (e ErrInvalidCommitID) Error() string {
 }
 
 type projectfiler interface {
+	Owner() string
+	Name() string
+	BranchName() string
 	LegacyCommitID() string
 	SetLegacyCommit(string) error
 }
@@ -23,6 +26,24 @@ type CheckoutInfo struct {
 
 func New(project projectfiler) *CheckoutInfo {
 	return &CheckoutInfo{project}
+}
+
+// Owner returns the project owner from activestate.yaml.
+// Note: cannot read this from buildscript because it may not exist yet.
+func (c *CheckoutInfo) Owner() string {
+	return c.project.Owner()
+}
+
+// Name returns the project name from activestate.yaml.
+// Note: cannot read this from buildscript because it may not exist yet.
+func (c *CheckoutInfo) Name() string {
+	return c.project.Name()
+}
+
+// Branch returns the project branch from activestate.yaml.
+// Note: cannot read this from buildscript because it may not exist yet.
+func (c *CheckoutInfo) Branch() string {
+	return c.project.BranchName()
 }
 
 func (c *CheckoutInfo) CommitID() (strfmt.UUID, error) {

--- a/pkg/checkoutinfo/checkoutinfo.go
+++ b/pkg/checkoutinfo/checkoutinfo.go
@@ -1,0 +1,38 @@
+package checkoutinfo
+
+import (
+	"github.com/go-openapi/strfmt"
+)
+
+type ErrInvalidCommitID struct {
+	CommitID string
+}
+
+func (e ErrInvalidCommitID) Error() string {
+	return "invalid commit ID"
+}
+
+type projectfiler interface {
+	LegacyCommitID() string
+	SetLegacyCommit(string) error
+}
+
+type CheckoutInfo struct {
+	project projectfiler
+}
+
+func New(project projectfiler) *CheckoutInfo {
+	return &CheckoutInfo{project}
+}
+
+func (c *CheckoutInfo) CommitID() (strfmt.UUID, error) {
+	commitID := c.project.LegacyCommitID()
+	if !strfmt.IsUUID(commitID) {
+		return "", &ErrInvalidCommitID{commitID}
+	}
+	return strfmt.UUID(commitID), nil
+}
+
+func (c *CheckoutInfo) SetCommitID(commitID strfmt.UUID) error {
+	return c.project.SetLegacyCommit(commitID.String())
+}

--- a/pkg/checkoutinfo/checkoutinfo.go
+++ b/pkg/checkoutinfo/checkoutinfo.go
@@ -17,6 +17,8 @@ type projectfiler interface {
 	Name() string
 	BranchName() string
 	LegacyCommitID() string
+	SetNamespace(string, string) error
+	SetBranch(string) error
 	SetLegacyCommit(string) error
 }
 
@@ -52,6 +54,14 @@ func (c *CheckoutInfo) CommitID() (strfmt.UUID, error) {
 		return "", &ErrInvalidCommitID{commitID}
 	}
 	return strfmt.UUID(commitID), nil
+}
+
+func (c *CheckoutInfo) SetNamespace(owner, project string) error {
+	return c.project.SetNamespace(owner, project)
+}
+
+func (c *CheckoutInfo) SetBranch(branch string) error {
+	return c.project.SetBranch(branch)
 }
 
 func (c *CheckoutInfo) SetCommitID(commitID strfmt.UUID) error {

--- a/pkg/checkoutinfo/checkoutinfo.go
+++ b/pkg/checkoutinfo/checkoutinfo.go
@@ -33,19 +33,15 @@ type projectfiler interface {
 	URL() string
 }
 
-type configurer interface {
-	GetBool(string) bool
-}
-
 type CheckoutInfo struct {
-	project projectfiler
-	config  configurer
+	project           projectfiler
+	optinBuildScripts bool
 }
 
 var ErrBuildscriptNotExist = errors.New("Build script does not exist")
 
-func New(project projectfiler, config configurer) *CheckoutInfo {
-	return &CheckoutInfo{project, config}
+func New(project projectfiler, optinBuildScripts bool) *CheckoutInfo {
+	return &CheckoutInfo{project, optinBuildScripts}
 }
 
 // Owner returns the project owner from activestate.yaml.
@@ -99,11 +95,10 @@ func (c *CheckoutInfo) SetCommitID(commitID strfmt.UUID) error {
 }
 
 func (c *CheckoutInfo) updateBuildScriptProject() error {
-	if !c.config.GetBool(constants.OptinBuildscriptsConfig) {
+	if !c.optinBuildScripts {
 		return nil
 	}
 
-	// Note: cannot use functions from buildscript_runbit due to import cycle.
 	scriptPath := filepath.Join(c.project.Dir(), constants.BuildScriptFileName)
 	data, err := fileutils.ReadFile(scriptPath)
 	if err != nil {

--- a/pkg/platform/model/buildplanner/build.go
+++ b/pkg/platform/model/buildplanner/build.go
@@ -104,7 +104,7 @@ func (b *BuildPlanner) FetchCommit(commitID strfmt.UUID, owner, project string, 
 		return nil, errs.Wrap(err, "failed to unmarshal build plan")
 	}
 
-	script, err := buildscript.UnmarshalBuildExpression(commit.Expression, ptr.To(time.Time(commit.AtTime)))
+	script, err := buildscript.UnmarshalBuildExpression(commit.Expression, buildScriptCheckoutInfo(owner, project, commitID.String(), time.Time(commit.AtTime)))
 	if err != nil {
 		return nil, errs.Wrap(err, "failed to parse build expression")
 	}

--- a/pkg/platform/model/buildplanner/build.go
+++ b/pkg/platform/model/buildplanner/build.go
@@ -56,7 +56,7 @@ func (c *client) Run(req gqlclient.Request, resp interface{}) error {
 
 const fetchCommitCacheExpiry = time.Hour * 12
 
-func (b *BuildPlanner) FetchCommit(commitID strfmt.UUID, owner, project string, target *string) (*Commit, error) {
+func (b *BuildPlanner) FetchCommit(commitID strfmt.UUID, owner, project, branch string, target *string) (*Commit, error) {
 	logging.Debug("FetchCommit, commitID: %s, owner: %s, project: %s", commitID, owner, project)
 	resp := &response.ProjectCommitResponse{}
 
@@ -104,7 +104,7 @@ func (b *BuildPlanner) FetchCommit(commitID strfmt.UUID, owner, project string, 
 		return nil, errs.Wrap(err, "failed to unmarshal build plan")
 	}
 
-	script, err := buildscript.UnmarshalBuildExpression(commit.Expression, buildScriptCheckoutInfo(owner, project, commitID.String(), time.Time(commit.AtTime)))
+	script, err := buildscript.UnmarshalBuildExpression(commit.Expression, buildScriptCheckoutInfo(owner, project, branch, commitID.String(), time.Time(commit.AtTime)))
 	if err != nil {
 		return nil, errs.Wrap(err, "failed to parse build expression")
 	}

--- a/pkg/platform/model/buildplanner/build.go
+++ b/pkg/platform/model/buildplanner/build.go
@@ -104,7 +104,7 @@ func (b *BuildPlanner) FetchCommit(commitID strfmt.UUID, owner, project, branch 
 		return nil, errs.Wrap(err, "failed to unmarshal build plan")
 	}
 
-	script, err := buildscript.UnmarshalBuildExpression(commit.Expression, buildScriptCheckoutInfo(owner, project, branch, commitID.String(), time.Time(commit.AtTime)))
+	script, err := buildscript.UnmarshalBuildExpression(commit.Expression, projectField(owner, project, branch, commitID.String()), ptr.To(time.Time(commit.AtTime)))
 	if err != nil {
 		return nil, errs.Wrap(err, "failed to parse build expression")
 	}

--- a/pkg/platform/model/buildplanner/buildscript.go
+++ b/pkg/platform/model/buildplanner/buildscript.go
@@ -2,16 +2,39 @@ package buildplanner
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/rtutils/ptr"
+	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/pkg/buildscript"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/request"
 	bpResp "github.com/ActiveState/cli/pkg/platform/api/buildplanner/response"
 )
+
+func buildScriptCheckoutInfo(owner, project, commitID string, atTime time.Time) *buildscript.CheckoutInfo {
+	// Note: cannot use api.GetPlatformURL() due to import cycle.
+	host := constants.DefaultAPIHost
+	if hostOverride := os.Getenv(constants.APIHostEnvVarName); hostOverride != "" {
+		host = hostOverride
+	}
+	u, err := url.Parse(fmt.Sprintf("https://%s/%s/%s", host, owner, project))
+	if err != nil {
+		multilog.Error("url parse for project URL failed: %w", err)
+		return nil
+	}
+	q := u.Query()
+	q.Set("commitID", commitID)
+	u.RawQuery = q.Encode()
+	projectURL := u.String()
+
+	return &buildscript.CheckoutInfo{projectURL, atTime}
+}
 
 func (b *BuildPlanner) GetBuildScript(commitID string) (*buildscript.BuildScript, error) {
 	logging.Debug("GetBuildScript, commitID: %s", commitID)
@@ -52,7 +75,7 @@ func (b *BuildPlanner) GetBuildScript(commitID string) (*buildscript.BuildScript
 		return nil, errs.New("Commit does not contain expression")
 	}
 
-	script, err := buildscript.UnmarshalBuildExpression(resp.Commit.Expression, ptr.To(time.Time(resp.Commit.AtTime)))
+	script, err := buildscript.UnmarshalBuildExpression(resp.Commit.Expression, buildScriptCheckoutInfo("", "", "", time.Time(resp.Commit.AtTime)))
 	if err != nil {
 		return nil, errs.Wrap(err, "failed to parse build expression")
 	}

--- a/pkg/platform/model/buildplanner/commit.go
+++ b/pkg/platform/model/buildplanner/commit.go
@@ -46,7 +46,7 @@ func (b *BuildPlanner) StageCommit(params StageCommitParams) (*Commit, error) {
 	}
 
 	// With the updated build expression call the stage commit mutation
-	request := request.StageCommit(params.Owner, params.Project, params.ParentCommit, params.Description, ptr.To(script.AtTime()), expression)
+	request := request.StageCommit(params.Owner, params.Project, params.ParentCommit, params.Description, script.AtTime(), expression)
 	resp := &response.StageCommitResult{}
 	if err := b.client.Run(request, resp); err != nil {
 		return nil, processBuildPlannerError(err, "failed to stage commit")
@@ -83,7 +83,7 @@ func (b *BuildPlanner) StageCommit(params StageCommitParams) (*Commit, error) {
 		return nil, errs.Wrap(err, "failed to unmarshal build plan")
 	}
 
-	stagedScript, err := buildscript.UnmarshalBuildExpression(resp.Commit.Expression, buildScriptCheckoutInfo(params.Owner, params.Project, params.Branch, resp.Commit.CommitID.String(), time.Time(resp.Commit.AtTime)))
+	stagedScript, err := buildscript.UnmarshalBuildExpression(resp.Commit.Expression, projectField(params.Owner, params.Project, params.Branch, resp.Commit.CommitID.String()), ptr.To(time.Time(resp.Commit.AtTime)))
 	if err != nil {
 		return nil, errs.Wrap(err, "failed to parse build expression")
 	}

--- a/pkg/platform/model/buildplanner/commit.go
+++ b/pkg/platform/model/buildplanner/commit.go
@@ -45,7 +45,7 @@ func (b *BuildPlanner) StageCommit(params StageCommitParams) (*Commit, error) {
 	}
 
 	// With the updated build expression call the stage commit mutation
-	request := request.StageCommit(params.Owner, params.Project, params.ParentCommit, params.Description, script.AtTime(), expression)
+	request := request.StageCommit(params.Owner, params.Project, params.ParentCommit, params.Description, ptr.To(script.AtTime()), expression)
 	resp := &response.StageCommitResult{}
 	if err := b.client.Run(request, resp); err != nil {
 		return nil, processBuildPlannerError(err, "failed to stage commit")
@@ -82,7 +82,7 @@ func (b *BuildPlanner) StageCommit(params StageCommitParams) (*Commit, error) {
 		return nil, errs.Wrap(err, "failed to unmarshal build plan")
 	}
 
-	stagedScript, err := buildscript.UnmarshalBuildExpression(resp.Commit.Expression, ptr.To(time.Time(resp.Commit.AtTime)))
+	stagedScript, err := buildscript.UnmarshalBuildExpression(resp.Commit.Expression, buildScriptCheckoutInfo(params.Owner, params.Project, resp.Commit.CommitID.String(), time.Time(resp.Commit.AtTime)))
 	if err != nil {
 		return nil, errs.Wrap(err, "failed to parse build expression")
 	}

--- a/pkg/platform/model/buildplanner/commit.go
+++ b/pkg/platform/model/buildplanner/commit.go
@@ -26,6 +26,7 @@ type StageCommitRequirement struct {
 type StageCommitParams struct {
 	Owner        string
 	Project      string
+	Branch       string
 	ParentCommit string
 	Description  string
 	Script       *buildscript.BuildScript
@@ -82,7 +83,7 @@ func (b *BuildPlanner) StageCommit(params StageCommitParams) (*Commit, error) {
 		return nil, errs.Wrap(err, "failed to unmarshal build plan")
 	}
 
-	stagedScript, err := buildscript.UnmarshalBuildExpression(resp.Commit.Expression, buildScriptCheckoutInfo(params.Owner, params.Project, resp.Commit.CommitID.String(), time.Time(resp.Commit.AtTime)))
+	stagedScript, err := buildscript.UnmarshalBuildExpression(resp.Commit.Expression, buildScriptCheckoutInfo(params.Owner, params.Project, params.Branch, resp.Commit.CommitID.String(), time.Time(resp.Commit.AtTime)))
 	if err != nil {
 		return nil, errs.Wrap(err, "failed to parse build expression")
 	}

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -913,6 +913,7 @@ type CreateParams struct {
 	Owner      string
 	Project    string
 	BranchName string
+	CommitID   string
 	Directory  string
 	Content    string
 	Language   string
@@ -953,6 +954,10 @@ func createCustom(params *CreateParams, lang language.Language) (*Project, error
 
 		if params.BranchName != "" {
 			q.Set("branch", params.BranchName)
+		}
+
+		if params.CommitID != "" {
+			q.Set("commitID", params.CommitID)
 		}
 
 		u.RawQuery = q.Encode()

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -1185,6 +1185,7 @@ type ConfigGetter interface {
 	AllKeys() []string
 	GetStringSlice(string) []string
 	GetString(string) string
+	GetBool(string) bool
 	Set(string, interface{}) error
 	GetThenSet(string, func(interface{}) (interface{}, error)) error
 	Close() error

--- a/scripts/to-buildscript/main.go
+++ b/scripts/to-buildscript/main.go
@@ -35,16 +35,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	var atTime *time.Time
+	var checkoutInfo *buildscript.CheckoutInfo
 	if len(os.Args) == 2 {
 		t, err := time.Parse(strfmt.RFC3339Millis, os.Args[1])
 		if err != nil {
 			panic(errs.JoinMessage(err))
 		}
-		atTime = &t
+		checkoutInfo = &buildscript.CheckoutInfo{"https://platform.activestate.com/org/project?commitID=00000000-0000-0000-0000-000000000000", t}
 	}
 
-	bs, err := buildscript.UnmarshalBuildExpression([]byte(input), atTime)
+	bs, err := buildscript.UnmarshalBuildExpression([]byte(input), checkoutInfo)
 	if err != nil {
 		panic(errs.JoinMessage(err))
 	}

--- a/scripts/to-buildscript/main.go
+++ b/scripts/to-buildscript/main.go
@@ -35,16 +35,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	var checkoutInfo *buildscript.CheckoutInfo
+	var atTime *time.Time
 	if len(os.Args) == 2 {
 		t, err := time.Parse(strfmt.RFC3339Millis, os.Args[1])
 		if err != nil {
 			panic(errs.JoinMessage(err))
 		}
-		checkoutInfo = &buildscript.CheckoutInfo{"https://platform.activestate.com/org/project?commitID=00000000-0000-0000-0000-000000000000", t}
+		atTime = &t
 	}
 
-	bs, err := buildscript.UnmarshalBuildExpression([]byte(input), checkoutInfo)
+	bs, err := buildscript.UnmarshalBuildExpression([]byte(input), "https://platform.activestate.com/org/project?commitID=00000000-0000-0000-0000-000000000000", atTime)
 	if err != nil {
 		panic(errs.JoinMessage(err))
 	}

--- a/test/integration/commit_int_test.go
+++ b/test/integration/commit_int_test.go
@@ -25,7 +25,7 @@ func (suite *CommitIntegrationTestSuite) TestCommitManualBuildScriptMod() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.PrepareProjectAndBuildScript("ActiveState-CLI/Commit-Test-A", "7a1b416e-c17f-4d4a-9e27-cbad9e8f5655")
+	ts.PrepareProjectAndBuildScript("ActiveState-CLI", "Commit-Test-A", "main", "7a1b416e-c17f-4d4a-9e27-cbad9e8f5655")
 
 	proj, err := project.FromPath(ts.Dirs.Work)
 	suite.NoError(err, "Error loading project")
@@ -66,7 +66,7 @@ func (suite *CommitIntegrationTestSuite) TestCommitAtTimeChange() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.PrepareProjectAndBuildScript("ActiveState-CLI/Commit-Test-A", "7a1b416e-c17f-4d4a-9e27-cbad9e8f5655")
+	ts.PrepareProjectAndBuildScript("ActiveState-CLI", "Commit-Test-A", "main", "7a1b416e-c17f-4d4a-9e27-cbad9e8f5655")
 
 	proj, err := project.FromPath(ts.Dirs.Work)
 	suite.NoError(err, "Error loading project")

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
-	"github.com/ActiveState/cli/pkg/localcommit"
 	"github.com/ActiveState/cli/pkg/platform/api/buildplanner/types"
 	"github.com/ActiveState/cli/pkg/project"
 )
@@ -118,9 +117,8 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	// ignore it). After resolving buildscript conflicts, `state commit` should always have something
 	// new to commit.
 	remoteHeadCommit := "2c461e7c-43d2-4e43-b169-a255c305becd"
-	commit, err := localcommit.Get(ts.Dirs.Work)
-	suite.Require().NoError(err)
-	suite.Assert().Equal(remoteHeadCommit, commit.String(), "localcommit should have been updated to remote commit")
+	commit := ts.CommitID()
+	suite.Assert().Equal(remoteHeadCommit, commit, "commitID should have been updated to remote commit")
 }
 
 func (suite *PullIntegrationTestSuite) assertMergeStrategyNotification(ts *e2e.Session, strategy string) {

--- a/test/integration/reset_int_test.go
+++ b/test/integration/reset_int_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
 	"github.com/ActiveState/cli/internal/testhelpers/tagsuite"
-	"github.com/ActiveState/cli/pkg/localcommit"
 )
 
 type ResetIntegrationTestSuite struct {
@@ -23,8 +22,7 @@ func (suite *ResetIntegrationTestSuite) TestReset() {
 	defer ts.Close()
 
 	ts.PrepareEmptyProject()
-	commitID, err := localcommit.Get(ts.Dirs.Work)
-	suite.Require().NoError(err)
+	commitID := ts.CommitID()
 
 	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
@@ -38,11 +36,11 @@ func (suite *ResetIntegrationTestSuite) TestReset() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("reset")
-	cp.Expect("Your project will be reset to " + commitID.String())
+	cp.Expect("Your project will be reset to " + commitID)
 	cp.Expect("Are you sure")
 	cp.Expect("(y/N)")
 	cp.SendLine("y")
-	cp.Expect("Successfully reset to commit: " + commitID.String())
+	cp.Expect("Successfully reset to commit: " + commitID)
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("history")
@@ -76,12 +74,11 @@ func (suite *ResetIntegrationTestSuite) TestRevertInvalidURL() {
 	defer ts.Close()
 
 	ts.PrepareEmptyProject()
-	commitID, err := localcommit.Get(ts.Dirs.Work)
-	suite.Require().NoError(err)
+	commitID := ts.CommitID()
 
 	contents := fileutils.ReadFileUnsafe(filepath.Join(ts.Dirs.Work, constants.ConfigFileName))
-	contents = bytes.Replace(contents, []byte(commitID.String()), []byte(""), 1)
-	err = fileutils.WriteFile(filepath.Join(ts.Dirs.Work, constants.ConfigFileName), contents)
+	contents = bytes.Replace(contents, []byte(commitID), []byte(""), 1)
+	err := fileutils.WriteFile(filepath.Join(ts.Dirs.Work, constants.ConfigFileName), contents)
 	suite.Require().NoError(err)
 
 	cp := ts.Spawn("install", "language/python/requests")
@@ -90,7 +87,7 @@ func (suite *ResetIntegrationTestSuite) TestRevertInvalidURL() {
 	cp.ExpectNotExitCode(0)
 
 	cp = ts.Spawn("reset", "-n")
-	cp.Expect("Successfully reset to commit: " + commitID.String())
+	cp.Expect("Successfully reset to commit: " + commitID)
 	cp.ExpectExitCode(0)
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3024" title="DX-3024" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3024</a>  Non-versioned buildscript information is clearly denoted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


- Use triple-backticks to separate checkout info from buildscript. Using triple-quotes will require a new parser and/or lexer. Since we're experimenting, let's use what we have.
- Buildscripts always have an AtTime (it's no longer optional). I believe we had it optional for compatiblity with build expressions that didn't have a separate commit time, but all build expressions now have an associated commit time from what I can tell.
- Renamed `localcommit` package to `checkoutinfo`
  - `checkoutinfo` is a primer property and all runners go through it to get commit IDs and set commit info like owner, name, and branch.
- Changed `buildplanner.GetBuildScript()` to additionally accept an owner, project, branch, and commitID. It uses these fields to construct the "Project" field in the commit info section of buildscripts.
- `state reset LOCAL` will always re-initialize a build script.
- Internal change in the raw buildscript format to not store strings with quotes. (Unmarshaling strips quotes, and marshaling adds them back.)
- Users are shown a warning if they attempt to use an outdate build script (`state install`, etc.).