### PR TITLE
Added ceremonial break.

### DIFF
--- a/pkg/buildscript/unmarshal_buildexpression.go
+++ b/pkg/buildscript/unmarshal_buildexpression.go
@@ -283,6 +283,7 @@ func unmarshalFuncCall(path []string, m map[string]interface{}) (*FuncCall, erro
 		}
 
 		argsInterface = value
+		break // technically this is not needed since there's only one element in m
 	}
 
 	args := []*Value{}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3088" title="DX-3088" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3088</a>  Buildexpression unmarshalling may be dropping args
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Function calls in JSON have a single argument object with a list of values. We already assert that the object is of length 1 (the list of args; https://github.com/ActiveState/cli/blob/2deb60816da0be22d8f7aeef6a5fcead2274cc86/pkg/buildscript/unmarshal_buildexpression.go#L259-L264), but a cursory glance at a later loop in the code may lead one to believe there is more than one object. I've added a ceremonial break with a comment for clarity.

We're not dropping any args; the interface contains a list of all arguments.