### PR TITLE
If `ACTIVESTATE_API_KEY` is set, try to authenticate with it, or explicitly error out.

### DIFF
--- a/internal/runners/auth/auth.go
+++ b/internal/runners/auth/auth.go
@@ -1,6 +1,9 @@
 package auth
 
 import (
+	"os"
+
+	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/keypairs"
 	"github.com/ActiveState/cli/internal/locale"
 	"github.com/ActiveState/cli/internal/output"
@@ -89,6 +92,14 @@ func (a *Auth) authenticate(params *AuthParams) error {
 
 	if params.Token != "" {
 		return auth.AuthenticateWithToken(params.Token, a.Auth)
+	}
+
+	if apiKey := os.Getenv(constants.APIKeyEnvVarName); apiKey != "" {
+		err := auth.AuthenticateWithToken(apiKey, a.Auth)
+		if err != nil {
+			return locale.WrapError(err, "err_auth_api_key", "Failed to authenticate with [ACTIONABLE]{{.V0}}[/RESET] environment variable", constants.APIKeyEnvVarName)
+		}
+		return nil
 	}
 
 	if params.NonInteractive {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3080" title="DX-3080" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3080</a>  We error out if the stored API key is invalid
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
