### PR TITLE
Use `e2e.Runtime*TimeoutOpt` where reasonable.

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -182,7 +182,7 @@ func (suite *ActivateIntegrationTestSuite) TestActivatePythonByHostOnly() {
 	if runtime.GOOS == "linux" {
 		cp.Expect("Creating a Virtual Environment")
 		cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-		cp.ExpectInput(termtest.OptExpectTimeout(40 * time.Second))
+		cp.ExpectInput()
 		cp.SendLine("exit")
 		cp.ExpectExitCode(0)
 	} else {
@@ -248,7 +248,7 @@ func (suite *ActivateIntegrationTestSuite) activatePython(version string, extraE
 
 	cp.SendLine("state activate --default")
 	cp.Expect("Creating a Virtual Environment")
-	cp.ExpectInput(termtest.OptExpectTimeout(40 * time.Second))
+	cp.ExpectInput(e2e.RuntimeSourcingTimeoutOpt)
 	pythonShim := pythonExe + osutils.ExeExtension
 
 	// test that existing environment variables are inherited by the activated shell

--- a/test/integration/analytics_int_test.go
+++ b/test/integration/analytics_int_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ActiveState/cli/internal/runbits/runtime/trigger"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
-	"github.com/ActiveState/termtest"
 	"github.com/thoas/go-funk"
 
 	"github.com/ActiveState/cli/internal/analytics/client/sync/reporters"
@@ -77,7 +76,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestHeartbeats() {
 
 	cp.Expect("Creating a Virtual Environment")
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectInput(termtest.OptExpectTimeout(120 * time.Second))
+	cp.ExpectInput()
 
 	time.Sleep(time.Second) // Ensure state-svc has time to report events
 
@@ -479,7 +478,7 @@ func (suite *AnalyticsIntegrationTestSuite) TestAttempts() {
 
 	cp.Expect("Creating a Virtual Environment")
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectInput(termtest.OptExpectTimeout(120 * time.Second))
+	cp.ExpectInput()
 
 	cp.SendLine("python3 --version")
 	cp.Expect("Python 3.")
@@ -522,8 +521,8 @@ func (suite *AnalyticsIntegrationTestSuite) TestHeapEvents() {
 	)
 
 	cp.Expect("Creating a Virtual Environment")
-	cp.Expect("Activated")
-	cp.ExpectInput(termtest.OptExpectTimeout(120 * time.Second))
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
+	cp.ExpectInput()
 
 	time.Sleep(time.Second) // Ensure state-svc has time to report events
 

--- a/test/integration/languages_int_test.go
+++ b/test/integration/languages_int_test.go
@@ -3,11 +3,9 @@ package integration
 import (
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/testhelpers/suite"
-	"github.com/ActiveState/termtest"
 	goversion "github.com/hashicorp/go-version"
 
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
@@ -52,7 +50,7 @@ func (suite *LanguagesIntegrationTestSuite) TestLanguages_install() {
 	ts.PrepareProject("ActiveState-CLI/Languages", "1eb82b25-a564-42ee-a7d4-d51d2ea73cd5")
 
 	cp := ts.Spawn("languages")
-	cp.Expect("Name", termtest.OptExpectTimeout(60*time.Second)) // Cached solves are often slow too
+	cp.Expect("Name", e2e.RuntimeSolvingTimeoutOpt) // Cached solves are often slow too
 	cp.Expect("python")
 	cp.ExpectExitCode(0)
 
@@ -62,7 +60,7 @@ func (suite *LanguagesIntegrationTestSuite) TestLanguages_install() {
 	cp = ts.Spawn("languages", "install", "python@3.9.16")
 	cp.Expect("project has been updated")
 	// This can take a little while
-	cp.ExpectExitCode(0, termtest.OptExpectTimeout(60*time.Second))
+	cp.ExpectExitCode(0, e2e.RuntimeSolvingTimeoutOpt)
 
 	cp = ts.Spawn("languages")
 	cp.Expect("Name")

--- a/test/integration/push_int_test.go
+++ b/test/integration/push_int_test.go
@@ -87,10 +87,10 @@ func (suite *PushIntegrationTestSuite) TestInitAndPush() {
 	cp = ts.Spawn("install", suite.extraPackage)
 	switch runtime.GOOS {
 	case "darwin":
-		cp.ExpectRe("Added|being built", termtest.OptExpectTimeout(60*time.Second)) // while cold storage is off
+		cp.ExpectRe("Added|being built", e2e.RuntimeSolvingTimeoutOpt) // while cold storage is off
 		cp.Wait()
 	default:
-		cp.Expect("Added", termtest.OptExpectTimeout(60*time.Second))
+		cp.Expect("Added", e2e.RuntimeSolvingTimeoutOpt)
 		cp.ExpectExitCode(0)
 	}
 
@@ -129,10 +129,10 @@ func (suite *PushIntegrationTestSuite) TestPush_NoPermission_NewProject() {
 	cp = ts.Spawn("install", suite.extraPackage)
 	switch runtime.GOOS {
 	case "darwin":
-		cp.ExpectRe("Added|being built", termtest.OptExpectTimeout(60*time.Second)) // while cold storage is off
+		cp.ExpectRe("Added|being built", e2e.RuntimeSolvingTimeoutOpt) // while cold storage is off
 		cp.Wait()
 	default:
-		cp.Expect("Added", termtest.OptExpectTimeout(60*time.Second))
+		cp.Expect("Added", e2e.RuntimeSolvingTimeoutOpt)
 		cp.ExpectExitCode(0)
 	}
 

--- a/test/integration/run_int_test.go
+++ b/test/integration/run_int_test.go
@@ -230,7 +230,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Unauthenticated() {
 
 	cp := ts.Spawn("activate")
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
+	cp.ExpectInput()
 
 	cp.SendLine(fmt.Sprintf("%s run testMultipleLanguages", cp.Executable()))
 	cp.Expect("2")
@@ -291,7 +291,7 @@ func (suite *RunIntegrationTestSuite) TestRun_Perl_Variable() {
 		e2e.OptAppendEnv("PERL_VERSION=does_not_exist"),
 	)
 	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectInput(termtest.OptExpectTimeout(10 * time.Second))
+	cp.ExpectInput()
 
 	cp.SendLine("perl -MEnglish -e 'print $PERL_VERSION'")
 	cp.Expect("v5.32.0")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3070" title="DX-3070" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3070</a>  Audit integration test usage of `termtest.OptExpectTimeout()` and use constants where possible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
