### PR TITLE
Fixed failing integration test.

### DIFF
--- a/test/integration/import_int_test.go
+++ b/test/integration/import_int_test.go
@@ -113,7 +113,7 @@ func (suite *ImportIntegrationTestSuite) TestImport() {
 		cp.ExpectExitCode(0)
 
 		cp = ts.Spawn("import", "requirements.txt")
-		cp.Expect("already installed")
+		cp.Expect("no changes")
 		cp.ExpectNotExitCode(0)
 	})
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3096" title="DX-3096" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3096</a>  Nightly failure: TestImportIntegrationTestSuite/TestImport/valid_requirements.txt
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I think the test failure was caused by a bad merge. Both v46 and v47 have the same message if you try to run `state import requirements.txt` twice. I've updated the expectation in the test. I don't think it's a regression in functionality.