### PR TITLE
Use a dummy port for integration test.

### DIFF
--- a/internal/scriptrun/test/integration/scriptrun_test.go
+++ b/internal/scriptrun/test/integration/scriptrun_test.go
@@ -120,7 +120,8 @@ func (suite *ScriptRunSuite) TestEnvIsSet() {
 	cfg.Set(constants.AsyncRuntimeConfig, true)
 
 	out := capturer.CaptureOutput(func() {
-		scriptRun := scriptrun.New(primer.New(auth, outputhelper.NewCatcher(), subshell.New(cfg), proj, cfg, blackhole.New(), model.NewSvcModel("")))
+		port := ":12345" // pick a high number that doesn't require admin privileges
+		scriptRun := scriptrun.New(primer.New(auth, outputhelper.NewCatcher(), subshell.New(cfg), proj, cfg, blackhole.New(), model.NewSvcModel(port)))
 		script, err := proj.ScriptByName("run")
 		require.NoError(t, err, "Error: "+errs.JoinMessage(err))
 		err = scriptRun.Run(script, nil)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3094" title="DX-3094" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3094</a>  Nightly failure: TestScriptRunSuite/TestEnvIsSet
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
An empty port uses :80 by default, which requires admin privileges or something.