### PR TITLE
Added installable githook for creating a platform commit with the buildscript changes.

### DIFF
--- a/scripts/git-hooks/buildscript-commit
+++ b/scripts/git-hooks/buildscript-commit
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Git pre-commit hook to run `state commit` prior to committing any build script changes.
+# Usage: call this script from your git pre-commit hook or use it as your pre-commit hook.
 
 if git diff --name-only --cached | grep -q buildscript.as; then
 	echo "Running 'state commit', as buildscript.as is being committed."

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if git diff --name-only --cached | grep -q buildscript.as; then
+	echo "Running 'state commit', as buildscript.as is being committed."
+	tmpfile=`mktemp -t activestate.XXXX`
+	state commit --non-interactive 2> >(tee "$tmpfile" >&2)
+	if [[ $? -ne 0 ]] && ! grep -q 'no new changes' "$tmpfile"; then
+		rm $tmpfile
+		echo "Attempting to abort git commit process."
+		exit 1
+	fi
+	rm $tmpfile
+	# Update the buildscript.as being committed.
+	git add buildscript.as
+	echo "Continuing git commit process."
+fi


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3092" title="DX-3092" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3092</a>  We have a git hook that runs `state commit` automatically on `git commit`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The hook also auto-updates the buildscript with any resulting changes prior to commit.

The end result is that the committed buildscript will be the latest one, but it may NOT be what the user intended to commit. For example, if the ordering of requirements in the platform commit's buildscript is different, the buildscript committed locally will have the new order, not the order the user originally intended to commit.