### PR TITLE
Remove no-op pops.

### DIFF
--- a/pkg/buildscript/unmarshal_buildexpression.go
+++ b/pkg/buildscript/unmarshal_buildexpression.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/logging"
-	"github.com/ActiveState/cli/internal/multilog"
 	"github.com/ActiveState/cli/internal/rtutils/ptr"
 	"github.com/ActiveState/cli/internal/sliceutils"
 )
@@ -128,12 +127,6 @@ const (
 
 func unmarshalAssignments(path []string, m map[string]interface{}) ([]*Assignment, error) {
 	path = append(path, ctxAssignments)
-	defer func() {
-		_, _, err := sliceutils.Pop(path)
-		if err != nil {
-			multilog.Error("Could not pop context: %v", err)
-		}
-	}()
 
 	assignments := []*Assignment{}
 	for key, valueInterface := range m {
@@ -160,12 +153,6 @@ func unmarshalAssignments(path []string, m map[string]interface{}) ([]*Assignmen
 
 func unmarshalValue(path []string, valueInterface interface{}) (*Value, error) {
 	path = append(path, ctxValue)
-	defer func() {
-		_, _, err := sliceutils.Pop(path)
-		if err != nil {
-			multilog.Error("Could not pop context: %v", err)
-		}
-	}()
 
 	value := &Value{}
 
@@ -236,12 +223,6 @@ func unmarshalValue(path []string, valueInterface interface{}) (*Value, error) {
 
 func isAp(path []string, value map[string]interface{}) bool {
 	path = append(path, ctxIsAp)
-	defer func() {
-		_, _, err := sliceutils.Pop(path)
-		if err != nil {
-			multilog.Error("Could not pop context: %v", err)
-		}
-	}()
 
 	_, hasIn := value[inKey]
 	return !hasIn || sliceutils.Contains(path, ctxAssignments)
@@ -249,12 +230,6 @@ func isAp(path []string, value map[string]interface{}) bool {
 
 func unmarshalFuncCall(path []string, m map[string]interface{}) (*FuncCall, error) {
 	path = append(path, ctxFuncCall)
-	defer func() {
-		_, _, err := sliceutils.Pop(path)
-		if err != nil {
-			multilog.Error("Could not pop context: %v", err)
-		}
-	}()
 
 	// m is a mapping of function name to arguments. There should only be one
 	// set of arguments. Since the arguments are key-value pairs, it should be
@@ -317,12 +292,6 @@ func unmarshalFuncCall(path []string, m map[string]interface{}) (*FuncCall, erro
 
 func unmarshalIn(path []string, inValue interface{}) (*Value, error) {
 	path = append(path, ctxIn)
-	defer func() {
-		_, _, err := sliceutils.Pop(path)
-		if err != nil {
-			multilog.Error("Could not pop context: %v", err)
-		}
-	}()
 
 	in := &Value{}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3087" title="DX-3087" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3087</a>  Buildexpression unmarshalling has potential pathing issues
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

We still want to keep context, but popping is not necessary since mutations are done locally (`path = append(path, ...)`), and do not affect the values passed by callers.