### PR TITLE
Narrow detection of activated state.

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -128,5 +128,5 @@ func (a *Activation) Close() error {
 // IsActivated returns whether or not this process is being run in an activated
 // state. This can be this specific process, or one of it's parents.
 func IsActivated(cfg Configurable) bool {
-	return ActivationPID(cfg) != -1
+	return ActivationPID(cfg) != -1 && os.Getenv(constants.ActivatedStateEnvVarName) != ""
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3086" title="DX-3086" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3086</a>  `state shell` not working in VSCode/WSL, saying "already in a shell" with empty strings.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Do not rely on just config, which may be leftover from a previous activation.

Note: I do not have the means to reproduce this issue. My Windows VM cannot run WSL due to the lack of a hypervisor. However, after reading the code (https://github.com/ActiveState/cli/blob/af3779a135fa05b4b31e5dea19a8c8280b4b4403/internal/process/process.go#L130-L132 and https://github.com/ActiveState/cli/blob/af3779a135fa05b4b31e5dea19a8c8280b4b4403/internal/process/process.go#L24-L71), I see that we're relying on a config check, followed by a process ID running check. I think it's possible for a previous activation to be erroneously detected as still running under the right circumstances. The fact that Antoine could not immediately reproduce this issue when filing the initial bug report lends credence to my suspicion.

We may want to consider simplifying this detection to just look for environment variables. I was not present when this detection was initially written, so I don't know exactly why we need it or how accurate it needs to be; it just looks very convoluted to me.