### PR TITLE
Set shell override on Windows

### DIFF
--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -147,6 +147,14 @@ function error([string] $msg)
     Write-Host $msg -ForegroundColor Red
 }
 
+function setShellOverride {
+    $parentProcess = Get-WmiObject Win32_Process | Where-Object { $_.ProcessId -eq $PID }
+    $parentProcessDetails = Get-WmiObject Win32_Process | Where-Object { $_.ProcessId -eq $parentProcess.ParentProcessId }
+    if ($parentProcessDetails.Name -eq "cmd" -or $parentProcessDetails.Name -eq "cmd.exe") {
+        [System.Environment]::SetEnvironmentVariable("ACTIVESTATE_CLI_SHELL_OVERRIDE", $parentProcessDetails.Name, "Process")
+    }
+}
+
 $version = $script:VERSION
 if (!$version) {
     # If the user did not specify a version, formulate a query to fetch the JSON info of the latest
@@ -248,6 +256,7 @@ $PSDefaultParameterValues['*:Encoding'] = 'utf8'
 
 # Run the installer.
 $env:ACTIVESTATE_SESSION_TOKEN = $script:SESSION_TOKEN_VALUE
+setShellOverride
 & $exePath $args --source-installer="install.ps1"
 $success = $?
 if (Test-Path env:ACTIVESTATE_SESSION_TOKEN)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3000" title="DX-3000" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3000</a>  Windows one-liner install command executed in CMD dropped to PS at the end.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Tested on my Windows machine. After installation we are still in `cmd`.