### PR TITLE
Build scripts can distinguish between solve nodes for different targets.

### DIFF
--- a/pkg/buildscript/unmarshal.go
+++ b/pkg/buildscript/unmarshal.go
@@ -50,5 +50,15 @@ func Unmarshal(data []byte) (*BuildScript, error) {
 		break
 	}
 
+	// Verify there are no duplicate key assignments.
+	// This is primarily to catch duplicate solve nodes for a given target.
+	seen := make(map[string]bool)
+	for _, assignment := range raw.Assignments {
+		if _, exists := seen[assignment.Key]; exists {
+			return nil, locale.NewInputError(locale.Tl("err_buildscript_duplicate_keys", "Build script has duplicate '{{.V0}}' assignments", assignment.Key))
+		}
+		seen[assignment.Key] = true
+	}
+
 	return &BuildScript{raw}, nil
 }

--- a/pkg/buildscript/unmarshal_buildexpression.go
+++ b/pkg/buildscript/unmarshal_buildexpression.go
@@ -81,18 +81,6 @@ func (b *BuildScript) UnmarshalBuildExpression(data []byte) error {
 		return errs.Wrap(err, "Could not get at_time node")
 	}
 
-	// If the requirements are in legacy object form, e.g.
-	//   requirements = [{"name": "<name>", "namespace": "<name>"}, {...}, ...]
-	// then transform them into function call form for the AScript format, e.g.
-	//   requirements = [Req(name = "<name>", namespace = "<name>"), Req(...), ...]
-	requirements, err := b.getRequirementsNode()
-	if err != nil {
-		return errs.Wrap(err, "Could not get requirements node")
-	}
-	if isLegacyRequirementsList(requirements) {
-		requirements.List = transformRequirements(requirements).List
-	}
-
 	return nil
 }
 
@@ -238,6 +226,13 @@ func unmarshalFuncCall(path []string, fc map[string]interface{}) (*funcCall, err
 			uv, err := unmarshalValue(path, valueInterface)
 			if err != nil {
 				return nil, errs.Wrap(err, "Could not parse '%s' function's argument '%s': %v", name, key, valueInterface)
+			}
+			if key == requirementsKey && isSolveFuncName(name) && isLegacyRequirementsList(uv) {
+				// If the requirements are in legacy object form, e.g.
+				//   requirements = [{"name": "<name>", "namespace": "<name>"}, {...}, ...]
+				// then transform them into function call form for the AScript format, e.g.
+				//   requirements = [Req(name = "<name>", namespace = "<name>"), Req(...), ...]
+				uv.List = transformRequirements(uv).List
 			}
 			args = append(args, &value{Assignment: &assignment{key, uv}})
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2960" title="DX-2960" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2960</a>  We can interpret a buildscript where the solve node is not top level
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This adds back #3531 but with the ability to search merge nodes for solve nodes.