### PR TITLE
Ensure remote installer can run within restricted powershells.

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -181,9 +181,9 @@ scripts:
     value: |
       set -e
       $constants.SET_ENV
-      TARGET=$BUILD_REMOTE_INSTALLER_TARGET
+      TARGET=$constants.BUILD_REMOTE_INSTALLER_TARGET
       if [[ "$GOOS" == "windows" || "$OS" == "Windows_NT" ]]; then
-        TARGET="${BUILD_REMOTE_INSTALLER_TARGET}.exe"
+        TARGET="${constants.BUILD_REMOTE_INSTALLER_TARGET}.exe"
       fi
       GOFLAGS="" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
       cd cmd/state-remote-installer

--- a/test/integration/remote_installer_int_test.go
+++ b/test/integration/remote_installer_int_test.go
@@ -43,7 +43,10 @@ func (suite *RemoteInstallIntegrationTestSuite) TestInstall() {
 		}
 
 		policy := getPolicy()
-		defer setPolicy(policy)
+		defer func() {
+			setPolicy(policy)
+			suite.Assert().Equal(policy, getPolicy(), "execution policy was not reset to '"+policy+"'; subsequent test results may be invalid")
+		}()
 
 		setPolicy("Restricted")
 		suite.Assert().Equal("Restricted", getPolicy(), "should have set powershell policy to 'Restricted'")

--- a/test/integration/remote_installer_int_test.go
+++ b/test/integration/remote_installer_int_test.go
@@ -143,7 +143,7 @@ func (s *RemoteInstallIntegrationTestSuite) setupTest(ts *e2e.Session) {
 	buildDir := fileutils.Join(root, "build")
 	installerExe := filepath.Join(buildDir, constants.StateRemoteInstallerCmd+osutils.ExeExtension)
 	if !fileutils.FileExists(installerExe) {
-		s.T().Fatal("E2E tests require a state-remote-installer binary. Run `state run build-installer`.")
+		s.T().Fatal("E2E tests require a state-remote-installer binary. Run `state run build-remote-installer`.")
 	}
 	s.remoteInstallerExe = ts.CopyExeToDir(installerExe, filepath.Join(ts.Dirs.Base, "installer"))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2989" title="DX-2989" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-2989</a>  We integration test our remote-installer with restricted powershell permissions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
