### PR TITLE
Runtime envdef handles case-insensitive environment variable names on Windows.

### DIFF
--- a/internal/runners/exec/exec.go
+++ b/internal/runners/exec/exec.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -155,9 +154,6 @@ func (s *Exec) Run(params *Params, args ...string) (rerr error) {
 			return !v
 		}
 		exesOnPath := osutils.FilterExesOnPATH(exeTarget, env["PATH"], filter)
-		if runtime.GOOS == "windows" {
-			exesOnPath = append(exesOnPath, osutils.FilterExesOnPATH(exeTarget, env["Path"], filter)...)
-		}
 
 		if len(exesOnPath) > 0 {
 			exeTarget = exesOnPath[0]

--- a/pkg/runtime/internal/envdef/collection.go
+++ b/pkg/runtime/internal/envdef/collection.go
@@ -1,9 +1,7 @@
 package envdef
 
 import (
-	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 
 	"github.com/ActiveState/cli/internal/errs"
@@ -65,29 +63,5 @@ func (c *Collection) Environment(installPath string, inherit bool) (map[string]s
 		}
 	}
 	constants := NewConstants(installPath)
-	env := result.ExpandVariables(constants).GetEnv(inherit)
-	promotePath(env)
-	return env, nil
-}
-
-// promotPath is a temporary fix to ensure that the PATH is interpreted correctly on Windows
-// Should be properly addressed by https://activestatef.atlassian.net/browse/DX-3030
-func promotePath(env map[string]string) {
-	if runtime.GOOS != "windows" {
-		return
-	}
-
-	PATH, exists := env["PATH"]
-	if !exists {
-		return
-	}
-
-	// If Path exists, prepend PATH values to it
-	Path, pathExists := env["Path"]
-	if !pathExists {
-		return
-	}
-
-	env["Path"] = PATH + string(os.PathListSeparator) + Path
-	delete(env, "PATH")
+	return result.ExpandVariables(constants).GetEnv(inherit), nil
 }

--- a/pkg/runtime/internal/envdef/environment.go
+++ b/pkg/runtime/internal/envdef/environment.go
@@ -395,8 +395,10 @@ func (ed *EnvironmentDefinition) getEnvBasedOn(envLookup map[string]string) (map
 		if len(ev.Values) > 0 {
 			res[pev.Name] = pev.ValueString()
 			if pev.Name != osName {
-				// On Windows, delete the case-insensitive version. Our case-sensitive version has already
-				// processed the value of the case-insensitive version.
+				// On Windows, delete the redundant (case-insensitive) version that our case-sensitive
+				// version could conflict with. (Our version has already processed the value of the
+				// redundant version.)
+				// For example, delete "Path" while preserving our "PATH".
 				delete(res, osName)
 			}
 		}

--- a/pkg/runtime/internal/envdef/environment.go
+++ b/pkg/runtime/internal/envdef/environment.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/ActiveState/cli/internal/constants"
@@ -344,19 +345,40 @@ func (ev *EnvironmentVariable) ValueString() string {
 		ev.Separator)
 }
 
-// GetEnvBasedOn returns the environment variable names and values defined by
+// getEnvBasedOn returns the environment variable names and values defined by
 // the EnvironmentDefinition.
 // If an environment variable is configured to inherit from the base
 // environment (`Inherit==true`), the base environment defined by the
 // `envLookup` method is joined with these environment variables.
 // This function is mostly used for testing. Use GetEnv() in production.
-func (ed *EnvironmentDefinition) GetEnvBasedOn(envLookup map[string]string) (map[string]string, error) {
+func (ed *EnvironmentDefinition) getEnvBasedOn(envLookup map[string]string) (map[string]string, error) {
 	res := maps.Clone(envLookup)
+
+	// On Windows, environment variable names are case-insensitive.
+	// For example, it uses "Path", but responds to "PATH" as well.
+	// This causes trouble with our environment merging, which will end up adding "PATH" (with the
+	// correct value) alongside "Path" (with the old value).
+	// In order to remedy this, track the OS-specific environment variable name and if it's
+	// modified/merged, replace it with our version (e.g. "Path" -> "PATH"). We do not use the OS name
+	// because we assume ours is the one that's used elsewhere in the codebase, and Windows will
+	// properly respond to a changed-case name anyway.
+	osEnvNames := map[string]string{}
+	if runtime.GOOS == "windows" {
+		for k := range envLookup {
+			osEnvNames[strings.ToLower(k)] = k
+		}
+	}
 
 	for _, ev := range ed.Env {
 		pev := &ev
+		osName := pev.Name
+		if runtime.GOOS == "windows" {
+			if name, ok := osEnvNames[strings.ToLower(osName)]; ok {
+				osName = name
+			}
+		}
+		osValue, hasOsValue := envLookup[osName]
 		if pev.Inherit {
-			osValue, hasOsValue := envLookup[pev.Name]
 			if hasOsValue {
 				osEv := ev
 				osEv.Values = []string{osValue}
@@ -364,15 +386,19 @@ func (ed *EnvironmentDefinition) GetEnvBasedOn(envLookup map[string]string) (map
 				pev, err = osEv.Merge(ev)
 				if err != nil {
 					return nil, err
-
 				}
 			}
-		} else if _, hasOsValue := envLookup[pev.Name]; hasOsValue {
+		} else if hasOsValue {
 			res[pev.Name] = "" // unset
 		}
 		// only add environment variable if at least one value is set (This allows us to remove variables from the environment.)
 		if len(ev.Values) > 0 {
 			res[pev.Name] = pev.ValueString()
+			if pev.Name != osName {
+				// On Windows, delete the case-insensitive version. Our case-sensitive version has already
+				// processed the value of the case-insensitive version.
+				delete(res, osName)
+			}
 		}
 	}
 	return res, nil
@@ -388,7 +414,7 @@ func (ed *EnvironmentDefinition) GetEnv(inherit bool) map[string]string {
 	if inherit {
 		lookupEnv = osutils.EnvSliceToMap(os.Environ())
 	}
-	res, err := ed.GetEnvBasedOn(lookupEnv)
+	res, err := ed.getEnvBasedOn(lookupEnv)
 	if err != nil {
 		panic(fmt.Sprintf("Could not inherit OS environment variable: %v", err))
 	}

--- a/test/integration/exec_int_test.go
+++ b/test/integration/exec_int_test.go
@@ -178,6 +178,33 @@ func (suite *ExecIntegrationTestSuite) TestExeBatArguments() {
 	cp.ExpectExitCode(0)
 }
 
+func (suite *ExecIntegrationTestSuite) TestExec_PATH_and_Path_on_Windows() {
+	suite.OnlyRunForTags(tagsuite.Exec)
+
+	if runtime.GOOS != "windows" {
+		suite.T().Skip("This test is only for windows")
+	}
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python", ".")
+	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("exec", "where", "python3")
+	cp.Expect(os.TempDir()) // from runtime's defined PATH
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("exec", "where", "notepad")
+	cp.Expect("notepad.exe") // from OS-defined default Path
+	cp.ExpectExitCode(0)
+
+	cp = ts.Spawn("exec", "does-not-exist")
+	cp.Expect("not found") // neither on PATH nor Path
+	cp.ExpectNotExitCode(0)
+}
+
 func TestExecIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(ExecIntegrationTestSuite))
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3030" title="DX-3030" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3030</a>  Handle/merge PATH case insensitively on Windows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
