### PR TITLE
Use fixed timestamp when asserting package versions.

### DIFF
--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -656,13 +656,15 @@ func (suite *PackageIntegrationTestSuite) TestChangeSummaryShowsAddedForUpdate()
 
 	ts.PrepareProject("ActiveState-CLI/small-python", "5a1e49e5-8ceb-4a09-b605-ed334474855b")
 
-	cp = ts.Spawn("install", "jinja2@2.0")
+	timestamp := "--ts=2024-08-15T20:07:00.000Z"
+
+	cp = ts.Spawn("install", "jinja2@2.0", timestamp)
 	cp.Expect("Added: language/python/jinja2")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("install", "jinja2@3.1.4")
+	cp = ts.Spawn("install", "jinja2@3.1.4", timestamp)
 	cp.Expect("Installing jinja2@3.1.4 includes 1 direct dep")
-	cp.Expect("└─ markupsafe@3.0.1")
+	cp.Expect("└─ markupsafe@2.1.5")
 	cp.Expect("Updated: language/python/jinja2")
 	cp.ExpectExitCode(0)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3128" title="DX-3128" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3128</a>  Nightly failure: TestPackageIntegrationTestSuite/TestChangeSummaryShowsAddedForUpdate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

