### PR TITLE
Added runtime sourcing timeout opt to fix occasionally failing test.

### DIFF
--- a/cmd/state-installer/test/integration/installer_int_test.go
+++ b/cmd/state-installer/test/integration/installer_int_test.go
@@ -242,7 +242,7 @@ func (suite *InstallerIntegrationTestSuite) TestInstallWhileInUse() {
 	cp.Expect("successfully installed", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectInput()
 	cp.SendLine("state checkout ActiveState/Perl-5.32")
-	cp.Expect("Checked out")
+	cp.Expect("Checked out", e2e.RuntimeSourcingTimeoutOpt)
 	cp.SendLine("state shell Perl-5.32")
 	cp.Expect("Activated") // state.exe remains active
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3130" title="DX-3130" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3130</a>  Nightly failure: TestInstallerIntegrationTestSuite/TestInstallWhileInUse
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
