### PR TITLE
Use runtime sourcing timeout opt to fix failing test.

### DIFF
--- a/test/integration/activate_int_test.go
+++ b/test/integration/activate_int_test.go
@@ -582,11 +582,8 @@ func (suite *ActivateIntegrationTestSuite) TestActivateBranch() {
 
 	namespace := "ActiveState-CLI/Branches"
 
-	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("activate", namespace, "--branch", "firstbranch")
-	cp.Expect("Activated")
+	cp := ts.Spawn("activate", namespace, "--branch", "firstbranch")
+	cp.Expect("Activated", e2e.RuntimeSourcingTimeoutOpt) // note: activate always sources the runtime
 	cp.SendLine("exit")
 	cp.ExpectExitCode(0)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3131" title="DX-3131" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3131</a>  Nightly failure: TestActivateIntegrationTestSuite/TestActivateBranch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
