### PR TITLE
Do not report config initialization input errors to rollbar.

### DIFF
--- a/cmd/state/main.go
+++ b/cmd/state/main.go
@@ -79,8 +79,14 @@ func main() {
 	var err error
 	cfg, err = config.New()
 	if err != nil {
-		multilog.Critical("Could not initialize config: %v", errs.JoinMessage(err))
-		fmt.Fprintf(os.Stderr, "Could not load config, if this problem persists please reinstall the State Tool. Error: %s\n", errs.JoinMessage(err))
+		if !locale.IsInputError(err) {
+			multilog.Critical("Could not initialize config: %v", errs.JoinMessage(err))
+			fmt.Fprintf(os.Stderr, "Could not load config, if this problem persists please reinstall the State Tool. Error: %s\n", errs.JoinMessage(err))
+		} else {
+			for _, err2 := range locale.UnpackError(err) {
+				fmt.Fprintf(os.Stderr, err2.Error())
+			}
+		}
 		exitCode = 1
 		return
 	}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -128,6 +128,7 @@ type LoggingHandler interface {
 
 type standardHandler struct {
 	formatter Formatter
+	verbose   bool
 }
 
 func (l *standardHandler) SetFormatter(f Formatter) {
@@ -135,6 +136,7 @@ func (l *standardHandler) SetFormatter(f Formatter) {
 }
 
 func (l *standardHandler) SetVerbose(v bool) {
+	l.verbose = v
 }
 
 func (l *standardHandler) Output() io.Writer {
@@ -143,7 +145,9 @@ func (l *standardHandler) Output() io.Writer {
 
 // default handling interface - just
 func (l *standardHandler) Emit(ctx *MessageContext, message string, args ...interface{}) error {
-	fmt.Fprintln(os.Stderr, l.formatter.Format(ctx, message, args...))
+	if l.verbose {
+		fmt.Fprintln(os.Stderr, l.formatter.Format(ctx, message, args...))
+	}
 	return nil
 }
 
@@ -158,6 +162,7 @@ func (l *standardHandler) Close() {}
 
 var currentHandler LoggingHandler = &standardHandler{
 	DefaultFormatter,
+	os.Getenv("VERBOSE") != "",
 }
 
 // Set the current handler of the library. We currently support one handler, but it might be nice to have more

--- a/internal/osutils/user/user.go
+++ b/internal/osutils/user/user.go
@@ -23,7 +23,7 @@ func (e *HomeDirNotFoundError) Error() string {
 	return homeDirNotFoundErrorMessage
 }
 
-func (e *HomeDirNotFoundError) LocalizedError() string {
+func (e *HomeDirNotFoundError) LocaleError() string {
 	return homeDirNotFoundErrorMessage
 }
 


### PR DESCRIPTION
Also, the default logger should not log verbosely by default. This cleans up error output.

Now the output looks like this:

```
% state
Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
```

Previously, it looked like this:

```
% state
[ERR 12:02:20.380 defaults.go:90] Could not detect AppData dir: ? |-
    Could not get user home directory: Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

    This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
:   ? |-
        Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

        This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
    : $HOME is not defined

Stacktrace: ./internal/logging/logging.go:287:logging.Error
./internal/logging/defaults.go:90:logging.init.0
<go>/src/runtime/proc.go:7176:runtime.doInit1
<go>/src/runtime/proc.go:7143:
<go>/src/runtime/proc.go:253:runtime.main
<go>/src/runtime/asm_amd64.s:1695:runtime.goexit

[DBG 12:02:20.381 listeners.go:18] Adding listener for config key: report.errors
[DBG 12:02:20.382 locale.go:41] Init
[ERR 12:02:20.382 multilog.go:19] Could not load  config to check locale, error: Could not detect appdata dir:
    ? |-
        Could not get user home directory: Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

        This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
    :   ? |-
            Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

            This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
        : $HOME is not defined

Stacktrace: ./internal/logging/logging.go:287:logging.Error
./internal/multilog/multilog.go:19:multilog.Error
./internal/locale/locale.go:57:locale.init.0
<go>/src/runtime/proc.go:7176:runtime.doInit1
<go>/src/runtime/proc.go:7143:
<go>/src/runtime/proc.go:253:runtime.main
<go>/src/runtime/asm_amd64.s:1695:runtime.goexit

Rollbar error: empty token
[ERR 12:02:20.393 multilog.go:19] Could not set locale: Could not get configuration to store updated locale:
    Could not detect appdata dir:
        ? |-
            Could not get user home directory: Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

            This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
        :   ? |-
                Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

                This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
            : $HOME is not defined

Stacktrace: ./internal/logging/logging.go:287:logging.Error
./internal/multilog/multilog.go:19:multilog.Error
./internal/locale/locale.go:78:locale.init.0
<go>/src/runtime/proc.go:7176:runtime.doInit1
<go>/src/runtime/proc.go:7143:
<go>/src/runtime/proc.go:253:runtime.main
<go>/src/runtime/asm_amd64.s:1695:runtime.goexit

Rollbar error: empty token
[CRT 12:02:20.395 multilog.go:24] Could not initialize config: Could not detect appdata dir:
    ? |-
        Could not get user home directory: Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

        This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
    :   ? |-
            Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

            This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
        : $HOME is not defined
goroutine 1 [running, locked to thread]:
runtime/debug.Stack()
	/Users/runner/hostedtoolcache/go/1.22.5/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/ActiveState/cli/internal/logging.Critical({0xd6eeaa5?, 0xc0006c7de8?}, {0xc00061ce10?, 0x10?, 0xd9d0b60?})
	/Users/runner/work/cli/cli/internal/logging/logging.go:310 +0x5e
github.com/ActiveState/cli/internal/multilog.Critical({0xd6eeaa5, 0x1f}, {0xc00061ce10, 0x1, 0x1})
	/Users/runner/work/cli/cli/internal/multilog/multilog.go:24 +0x2c
main.main()
	/Users/runner/work/cli/cli/cmd/state/main.go:81 +0x1ca

Could not load config, if this problem persists please reinstall the State Tool. Error: Could not detect appdata dir:
    ? |-
        Could not get user home directory: Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

        This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
    :   ? |-
            Could not proceed because your HOME environment variable is unset. Please ensure that your HOME environment variable is set. Alternatively if you do not or cannot set this variable you can instead use the ACTIVESTATE_HOME variable.

            This variable is used by the State Tool to determine things like the installation directory, config directory and cache directory.
        : $HOME is not defined
```