### PR TITLE
Localize an access denied error when attempting to migrate an activestate.yaml.

### DIFF
--- a/pkg/projectfile/yamlfield.go
+++ b/pkg/projectfile/yamlfield.go
@@ -59,7 +59,7 @@ func (y *yamlField) Save(path string) error {
 
 	if err := os.WriteFile(path, out, 0664); err != nil {
 		if osutils.IsAccessDeniedError(err) {
-			return locale.WrapError(err, "err_migrate_projectfile_access_denied",
+			return locale.WrapInputError(err, "err_migrate_projectfile_access_denied",
 				"Your project file at '{{.V0}}' is out of date, but State Tool does not have permission to update it. Please make it writeable or re-checkout the project to a writeable location.",
 				path)
 		}

--- a/pkg/projectfile/yamlfield.go
+++ b/pkg/projectfile/yamlfield.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 
 	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/locale"
+	"github.com/ActiveState/cli/internal/osutils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -56,6 +58,11 @@ func (y *yamlField) Save(path string) error {
 	}
 
 	if err := os.WriteFile(path, out, 0664); err != nil {
+		if osutils.IsAccessDeniedError(err) {
+			return locale.WrapError(err, "err_migrate_projectfile_access_denied",
+				"Your project file at '{{.V0}}' is out of date, but State Tool does not have permission to update it. Please make it writeable or re-checkout the project to a writeable location.",
+				path)
+		}
 		return errs.Wrap(err, "ioutil.WriteFile %s failed", path)
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3137" title="DX-3137" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3137</a>  Rollbar: MUST ADDRESS: Error does not have localization: Could not parse projectfile
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
