### PR TITLE
Do not log JSON output pipe errors to rollbar.

### DIFF
--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -109,7 +109,7 @@ func (f *JSON) Error(value interface{}) {
 
 func isPipeClosedError(err error) bool {
 	pipeErr := errors.Is(err, syscall.EPIPE)
-	if runtime.GOOS == "windows" && errors.Is(err, syscall.Errno(242)) {
+	if runtime.GOOS == "windows" && errors.Is(err, syscall.Errno(232)) {
 		// Note: 232 is Windows error code ERROR_NO_DATA, "The pipe is being closed".
 		// See https://go.dev/src/os/pipe_test.go
 		pipeErr = true

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -2,8 +2,11 @@ package output
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"runtime"
+	"syscall"
 
 	"github.com/ActiveState/cli/internal/colorize"
 	"github.com/ActiveState/cli/internal/locale"
@@ -63,7 +66,11 @@ func (f *JSON) Fprint(writer io.Writer, value interface{}) {
 
 	_, err := writer.Write(b)
 	if err != nil {
-		multilog.Error("Could not write json output, error: %v", err)
+		if isPipeClosedError(err) {
+			logging.Error("Could not write json output, error: %v", err) // do not log to rollbar
+		} else {
+			multilog.Error("Could not write json output, error: %v", err)
+		}
 	}
 }
 
@@ -92,8 +99,22 @@ func (f *JSON) Error(value interface{}) {
 
 	_, err = f.cfg.OutWriter.Write(b)
 	if err != nil {
-		multilog.Error("Could not write json output, error: %v", err)
+		if isPipeClosedError(err) {
+			logging.Error("Could not write json output, error: %v", err) // do not log to rollbar
+		} else {
+			multilog.Error("Could not write json output, error: %v", err)
+		}
 	}
+}
+
+func isPipeClosedError(err error) bool {
+	pipeErr := errors.Is(err, syscall.EPIPE)
+	if runtime.GOOS == "windows" && errors.Is(err, syscall.Errno(242)) {
+		// Note: 232 is Windows error code ERROR_NO_DATA, "The pipe is being closed".
+		// See https://go.dev/src/os/pipe_test.go
+		pipeErr = true
+	}
+	return pipeErr
 }
 
 // Notice is ignored by JSON, as they are considered as non-critical output and there's currently no reliable way to


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3135" title="DX-3135" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3135</a>  Rollbar: projects [-o]: Could not write json output, error: 'write /dev/stdout: The pipe is being closed.': The pipe is being closed.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The system is hanging up on us and there is nothing we can do about it.