### PR TITLE
`state refresh` should not error if the runtime is up to date.

### DIFF
--- a/internal/runners/refresh/refresh.go
+++ b/internal/runners/refresh/refresh.go
@@ -92,7 +92,8 @@ func (r *Refresh) Run(params *Params) error {
 	}
 
 	if !needsUpdate {
-		return locale.NewInputError("refresh_runtime_uptodate")
+		r.out.Notice(locale.T("refresh_runtime_uptodate"))
+		return nil
 	}
 
 	rti, err := runtime_runbit.Update(r.prime, trigger.TriggerRefresh, runtime_runbit.WithoutHeaders(), runtime_runbit.WithIgnoreAsync())

--- a/test/integration/refresh_int_test.go
+++ b/test/integration/refresh_int_test.go
@@ -39,7 +39,7 @@ func (suite *RefreshIntegrationTestSuite) TestRefresh() {
 
 	cp = ts.Spawn("refresh")
 	cp.Expect("already up to date")
-	cp.ExpectExitCode(1)
+	cp.ExpectExitCode(0)
 }
 
 func (suite *RefreshIntegrationTestSuite) TestJSON() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3142" title="DX-3142" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3142</a>  [Forsta]- State Tool does not exit with error code 1 on a refresh that is a no-op
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
