### PR TITLE
Do not report user-facing errors to Rollbar.

### DIFF
--- a/internal/runbits/errors/errors.go
+++ b/internal/runbits/errors/errors.go
@@ -225,5 +225,5 @@ func ReportError(err error, cmd *captain.Command, an analytics.Dispatcher) {
 }
 
 func IsReportableError(err error) bool {
-	return !locale.IsInputError(err) && !errs.IsExternalError(err) && !errs.IsSilent(err)
+	return !locale.IsInputError(err) && !errs.IsExternalError(err) && !errs.IsSilent(err) && !errs.IsUserFacing(err)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3133" title="DX-3133" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3133</a>  Rollbar: Could not activate project: 'User Facing Error: Your current platform ([ACTIONABLE]MacOS/amd64[/RESET]) does not appear to be configured in your project. 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
