### PR TITLE
Implement user-facing errors for environment setup commands.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -646,8 +646,6 @@ err_incompatible_move_file_dir:
   other: |
     Could not move [NOTICE]{{.V0}}[/RESET] to [NOTICE]{{.V1}}[/RESET].  One is a file, the other a directory.
     This indicates that the requested build may be corrupted.
-err_init_lang:
-  other: "Invalid language: {{.V0}}@{{.V1}}"
 initializing_project:
   other: |
     Initializing Project
@@ -1217,8 +1215,6 @@ err_findproject_notfound:
   other: "Could not load project [ACTIONABLE]{{.V0}}[/RESET] from path: [ACTIONABLE]{{.V1}}[/RESET]"
 arg_state_shell_namespace_description:
   other: The namespace of the project you wish to start a virtual environment shell/prompt for, or just the project name if previously used
-err_language_by_commit:
-  other: Could not get language from commit ID {{.V0}}
 err_parse_project:
   other: Could not parse project file at {{.V0}}
 err_uninstall_privilege_mismatch:

--- a/internal/runners/initialize/init.go
+++ b/internal/runners/initialize/init.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ActiveState/cli/internal/primer"
 	"github.com/ActiveState/cli/internal/runbits/buildscript"
 	"github.com/ActiveState/cli/internal/runbits/dependencies"
-	"github.com/ActiveState/cli/internal/runbits/errors"
 	"github.com/ActiveState/cli/internal/runbits/org"
 	"github.com/ActiveState/cli/internal/runbits/rationalize"
 	"github.com/ActiveState/cli/internal/runbits/runtime"
@@ -89,6 +88,8 @@ type errUnrecognizedLanguage struct {
 func (e errUnrecognizedLanguage) Error() string {
 	return fmt.Sprintf("unrecognized language: %s", e.Name)
 }
+
+var errDeleteProjectAfterError = errs.New("could not delete initialized project")
 
 // New returns a prepared ptr to Initialize instance.
 func New(prime primeable) *Initialize {
@@ -164,16 +165,15 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 
 	err := fileutils.MkdirUnlessExists(path)
 	if err != nil {
-		return locale.WrapError(err, "err_init_preparedir", "Could not create directory at [NOTICE]{{.V0}}[/RESET]. Error: {{.V1}}", params.Path, err.Error())
+		return errs.Wrap(err, "Could not create directory '%s'", params.Path)
 	}
 
 	path, err = filepath.Abs(params.Path)
 	if err != nil {
-		return locale.WrapExternalError(err, "err_init_abs_path", "Could not determine absolute path to [NOTICE]{{.V0}}[/RESET]. Error: {{.V1}}", path, err.Error())
+		return errs.Wrap(err, "Could not determine absolute path to '%s'", params.Path)
 	}
 
 	var languageName, languageVersion string
-	var inferred bool
 	if params.Language != "" {
 		langParts := strings.Split(params.Language, "@")
 		languageName = langParts[0]
@@ -181,7 +181,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 			languageVersion = langParts[1]
 		}
 	} else {
-		languageName, languageVersion, inferred = inferLanguage(r.config, r.auth)
+		languageName, languageVersion, _ = inferLanguage(r.config, r.auth)
 	}
 
 	if languageName == "" {
@@ -200,11 +200,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 
 	version, err := deriveVersion(lang, languageVersion, r.auth)
 	if err != nil {
-		if inferred || errors.IsReportableError(err) {
-			return locale.WrapError(err, "err_init_lang", "", languageName, languageVersion)
-		} else {
-			return locale.WrapExternalError(err, "err_init_lang", "", languageName, languageVersion)
-		}
+		return errs.Wrap(err, "Unable to get language version")
 	}
 
 	resolvedOwner, err = org.Get(paramOwner, r.auth, r.config)
@@ -226,7 +222,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 
 	pjfile, err := projectfile.Create(createParams)
 	if err != nil {
-		return locale.WrapError(err, "err_init_pjfile", "Could not create project file")
+		return errs.Wrap(err, "Could not create project file")
 	}
 
 	// If an error occurs, remove the created activestate.yaml file so the user can try again.
@@ -296,7 +292,7 @@ func (r *Initialize) Run(params *RunParams) (rerr error) {
 		err2 := model.DeleteProject(namespace.Owner, namespace.Project, r.auth)
 		if err2 != nil {
 			multilog.Error("Error deleting remotely created project after runtime setup error: %v", errs.JoinMessage(err2))
-			return locale.WrapError(err, "err_init_refresh_delete_project", "Could not setup runtime after init, and could not delete newly created Platform project. Please delete it manually before trying again")
+			return errDeleteProjectAfterError
 		}
 		return errs.Wrap(err, "Failed to fetch build result")
 	}

--- a/internal/runners/initialize/rationalize.go
+++ b/internal/runners/initialize/rationalize.go
@@ -83,5 +83,10 @@ func rationalizeError(owner, project string, rerr *error) {
 				errs.SetTips(locale.T("err_init_authenticated")))
 		}
 
+	case errors.Is(*rerr, errDeleteProjectAfterError):
+		*rerr = errs.WrapUserFacing(*rerr,
+			locale.Tl("err_init_refresh_delete_project", "Could not setup runtime after init, and could not delete newly created Platform project. Please delete it manually before trying again"),
+		)
+
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-2855" title="DX-2855" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-2855</a>  User facing errors for Environment Setup commands
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


For all `locale.WrapError()` calls in these runners, I navigated up the call chain to see what kinds of errors were being returned.
- For the cases where a locale or input error (e.g. projectfile package) was ultimately being produced, I replaced the runner error with `errs.Wrap()` since the extra localization was superfluous, and no user-facing error was needed.
- For the cases where there was no locale or input error, I replaced the error with an error struct, and ultimately a user facing error.