### PR TITLE
Update check-format script

### DIFF
--- a/activestate.yaml
+++ b/activestate.yaml
@@ -389,28 +389,19 @@ scripts:
     standalone: true
     description: "Checks if the code is formatted correctly"
     value: |
-      set -e
-
-      if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-        echo "Detected shallow clone, fetching complete history..."
-        git fetch --unshallow origin master
+      TARGET_BRANCH=$GITHUB_BASE_REF
+      if [ "$GITHUB_BASE_REF" == "" ]; then
+        TARGET_BRANCH="master"
       fi
 
-      git fetch origin master:refs/remotes/origin/master
-
-      MERGE_BASE=$(git merge-base HEAD origin/master)
-      CHANGED=$(git diff --name-only $MERGE_BASE...HEAD | grep -v testdata | grep -v vendor) || true
-      if [ -z "$CHANGED" ]; then
-        echo "No relevant changed files found"
+      if [ "$TARGET_BRANCH" == "master" ]; then
+        echo "Target branch is master, not checking for newlines"
         exit 0
       fi
-      echo "Changed files: $CHANGED"
 
+      CHANGED=$(git diff --name-only origin/$TARGET_BRANCH | grep -v testdata | grep -v vendor)
       NO_NEWLINE=0
       for FILE in $CHANGED; do
-          if [ ! -f "$FILE" ]; then
-              continue
-          fi
           if file "$FILE" | grep -q -E 'text|ASCII'; then
               if [ $(tail -c 1 "$FILE" | wc -l) -eq 0 ]; then
                   echo "Missing newline at end of file: $FILE"
@@ -418,6 +409,13 @@ scripts:
               fi
           fi
       done
+
+      if [ "$NO_NEWLINE" -ne 0 ]; then
+          echo "Error: Some text files are missing a newline at the end."
+          exit 1
+      else
+          echo "Success: All modified text files end with a newline."
+      fi
   - name: grab-mergecommits
     language: bash
     standalone: true

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -401,6 +401,8 @@ scripts:
         exit 0
       fi
 
+      git fetch --quiet origin $TARGET_BRANCH:refs/remotes/origin/$TARGET_BRANCH
+
       CHANGED=$(git diff --name-only origin/$TARGET_BRANCH | grep -v testdata | grep -v vendor)
       NO_NEWLINE=0
       for FILE in $CHANGED; do

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -430,7 +430,7 @@ scripts:
       if [ -z "$CHANGED" ]; then
         echo "No relevant changed files found"
         exit 0
-      }
+      fi
       echo "Changed files: $CHANGED"
 
       NO_NEWLINE=0
@@ -439,7 +439,7 @@ scripts:
           if [ ! -f "$FILE" ]; then
               echo "Warning: File no longer exists: $FILE"
               continue
-          }
+          fi
           if file "$FILE" | grep -q -E 'text|ASCII'; then
               echo "File is text: $FILE"
               if [ $(tail -c 1 "$FILE" | wc -l) -eq 0 ]; then

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -391,14 +391,10 @@ scripts:
     value: |
       set -e
 
-      TARGET_BRANCH=$GITHUB_BASE_REF
-      if [ "$GITHUB_BASE_REF" == "" ]; then
-        TARGET_BRANCH="master"
-      fi
+      git fetch --quiet origin master
 
-      git fetch --quiet origin $TARGET_BRANCH:refs/remotes/origin/$TARGET_BRANCH
-
-      CHANGED=$(git diff --name-only origin/$TARGET_BRANCH | grep -v testdata | grep -v vendor)
+      MERGE_BASE=$(git merge-base HEAD origin/master)
+      CHANGED=$(git diff --name-only $MERGE_BASE...HEAD | grep -v testdata | grep -v vendor)
       NO_NEWLINE=0
       for FILE in $CHANGED; do
           if file "$FILE" | grep -q -E 'text|ASCII'; then

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -390,30 +390,46 @@ scripts:
     description: "Checks if the code is formatted correctly"
     value: |
       set -e
+      set -x
 
-      git fetch --quiet origin master
+      echo "Starting check-format script"
+
+      if ! git fetch --quiet origin master; then
+        echo "Error: Failed to fetch from origin"
+        exit 1
+      fi
       echo "Checking format for changes since master"
 
-      MERGE_BASE=$(git merge-base HEAD origin/master)
+      MERGE_BASE=$(git merge-base HEAD origin/master) || {
+        echo "Error: Could not find merge base with origin/master"
+        exit 1
+      }
       echo "Merge base: $MERGE_BASE"
-      CHANGED=$(git diff --name-only $MERGE_BASE...HEAD | grep -v testdata | grep -v vendor)
+
+      CHANGED=$(git diff --name-only $MERGE_BASE...HEAD | grep -v testdata | grep -v vendor) || true
+      if [ -z "$CHANGED" ]; then
+        echo "No relevant changed files found"
+        exit 0
+      }
       echo "Changed files: $CHANGED"
+
       NO_NEWLINE=0
       for FILE in $CHANGED; do
+          echo "Checking file: $FILE"
+          if [ ! -f "$FILE" ]; then
+              echo "Warning: File no longer exists: $FILE"
+              continue
+          }
           if file "$FILE" | grep -q -E 'text|ASCII'; then
+              echo "File is text: $FILE"
               if [ $(tail -c 1 "$FILE" | wc -l) -eq 0 ]; then
                   echo "Missing newline at end of file: $FILE"
                   NO_NEWLINE=1
               fi
+          else
+              echo "Skipping non-text file: $FILE"
           fi
       done
-
-      if [ "$NO_NEWLINE" -ne 0 ]; then
-          echo "Error: Some text files are missing a newline at the end."
-          exit 1
-      else
-          echo "Success: All modified text files end with a newline."
-      fi
   - name: grab-mergecommits
     language: bash
     standalone: true

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -392,9 +392,12 @@ scripts:
       set -e
 
       git fetch --quiet origin master
+      echo "Checking format for changes since master"
 
       MERGE_BASE=$(git merge-base HEAD origin/master)
+      echo "Merge base: $MERGE_BASE"
       CHANGED=$(git diff --name-only $MERGE_BASE...HEAD | grep -v testdata | grep -v vendor)
+      echo "Changed files: $CHANGED"
       NO_NEWLINE=0
       for FILE in $CHANGED; do
           if file "$FILE" | grep -q -E 'text|ASCII'; then

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -394,42 +394,38 @@ scripts:
 
       echo "Starting check-format script"
       
-      # Check if origin exists
-      if ! git remote get-url origin; then
-        echo "Error: 'origin' remote is not configured"
-        exit 1
+      if git rev-parse --is-shallow-repository; then
+        echo "Detected shallow clone, fetching complete history..."
+        git fetch --unshallow origin master || {
+          echo "Failed to unshallow repository"
+          exit 1
+        }
       fi
 
-      # Show current git status
-      echo "Current branch: $(git branch --show-current)"
-      echo "Git remotes:"
-      git remote -v
-
-      # Fetch with more verbose output
-      echo "Fetching from origin..."
-      if ! git fetch --verbose origin master; then
-        echo "Error: Failed to fetch from origin"
+      echo "Fetching master branch..."
+      git fetch origin master:refs/remotes/origin/master || {
+        echo "Failed to fetch master branch"
         exit 1
-      fi
+      }
 
-      # Verify master branch exists
-      if ! git show-ref --verify --quiet refs/remotes/origin/master; then
-        echo "Error: origin/master branch does not exist"
-        echo "Current HEAD: $(git rev-parse HEAD)"
-        echo "Origin master: $(git rev-parse origin/master)"
-        exit 1
+      # If we're in detached HEAD state, create a temporary branch
+      if [ -z "$(git branch --show-current)" ]; then
+        echo "Detected detached HEAD state, creating temporary branch..."
+        git branch temp_format_check HEAD || {
+          echo "Failed to create temporary branch"
+          exit 1
+        }
+        git checkout temp_format_check
       fi
 
       echo "Checking format for changes since master"
-
       MERGE_BASE=$(git merge-base HEAD origin/master) || {
         echo "Error: Could not find merge base with origin/master"
         echo "Current HEAD: $(git rev-parse HEAD)"
         echo "Origin master: $(git rev-parse origin/master)"
         exit 1
       }
-      echo "Merge base: $MERGE_BASE"
-
+      
       CHANGED=$(git diff --name-only $MERGE_BASE...HEAD | grep -v testdata | grep -v vendor) || true
       if [ -z "$CHANGED" ]; then
         echo "No relevant changed files found"

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -390,10 +390,7 @@ scripts:
     description: "Checks if the code is formatted correctly"
     value: |
       set -e
-      set -x
 
-      echo "Starting check-format script"
-      
       if git rev-parse --is-shallow-repository; then
         echo "Detected shallow clone, fetching complete history..."
         git fetch --unshallow origin master || {
@@ -402,27 +399,13 @@ scripts:
         }
       fi
 
-      echo "Fetching master branch..."
       git fetch origin master:refs/remotes/origin/master || {
         echo "Failed to fetch master branch"
         exit 1
       }
 
-      # If we're in detached HEAD state, create a temporary branch
-      if [ -z "$(git branch --show-current)" ]; then
-        echo "Detected detached HEAD state, creating temporary branch..."
-        git branch temp_format_check HEAD || {
-          echo "Failed to create temporary branch"
-          exit 1
-        }
-        git checkout temp_format_check
-      fi
-
-      echo "Checking format for changes since master"
       MERGE_BASE=$(git merge-base HEAD origin/master) || {
         echo "Error: Could not find merge base with origin/master"
-        echo "Current HEAD: $(git rev-parse HEAD)"
-        echo "Origin master: $(git rev-parse origin/master)"
         exit 1
       }
       

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -393,15 +393,39 @@ scripts:
       set -x
 
       echo "Starting check-format script"
+      
+      # Check if origin exists
+      if ! git remote get-url origin; then
+        echo "Error: 'origin' remote is not configured"
+        exit 1
+      fi
 
-      if ! git fetch --quiet origin master; then
+      # Show current git status
+      echo "Current branch: $(git branch --show-current)"
+      echo "Git remotes:"
+      git remote -v
+
+      # Fetch with more verbose output
+      echo "Fetching from origin..."
+      if ! git fetch --verbose origin master; then
         echo "Error: Failed to fetch from origin"
         exit 1
       fi
+
+      # Verify master branch exists
+      if ! git show-ref --verify --quiet refs/remotes/origin/master; then
+        echo "Error: origin/master branch does not exist"
+        echo "Current HEAD: $(git rev-parse HEAD)"
+        echo "Origin master: $(git rev-parse origin/master)"
+        exit 1
+      fi
+
       echo "Checking format for changes since master"
 
       MERGE_BASE=$(git merge-base HEAD origin/master) || {
         echo "Error: Could not find merge base with origin/master"
+        echo "Current HEAD: $(git rev-parse HEAD)"
+        echo "Origin master: $(git rev-parse origin/master)"
         exit 1
       }
       echo "Merge base: $MERGE_BASE"

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -389,6 +389,8 @@ scripts:
     standalone: true
     description: "Checks if the code is formatted correctly"
     value: |
+      set -e
+
       TARGET_BRANCH=$GITHUB_BASE_REF
       if [ "$GITHUB_BASE_REF" == "" ]; then
         TARGET_BRANCH="master"

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -391,24 +391,14 @@ scripts:
     value: |
       set -e
 
-      if git rev-parse --is-shallow-repository; then
+      if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
         echo "Detected shallow clone, fetching complete history..."
-        git fetch --unshallow origin master || {
-          echo "Failed to unshallow repository"
-          exit 1
-        }
+        git fetch --unshallow origin master
       fi
 
-      git fetch origin master:refs/remotes/origin/master || {
-        echo "Failed to fetch master branch"
-        exit 1
-      }
+      git fetch origin master:refs/remotes/origin/master
 
-      MERGE_BASE=$(git merge-base HEAD origin/master) || {
-        echo "Error: Could not find merge base with origin/master"
-        exit 1
-      }
-      
+      MERGE_BASE=$(git merge-base HEAD origin/master)
       CHANGED=$(git diff --name-only $MERGE_BASE...HEAD | grep -v testdata | grep -v vendor) || true
       if [ -z "$CHANGED" ]; then
         echo "No relevant changed files found"
@@ -418,19 +408,14 @@ scripts:
 
       NO_NEWLINE=0
       for FILE in $CHANGED; do
-          echo "Checking file: $FILE"
           if [ ! -f "$FILE" ]; then
-              echo "Warning: File no longer exists: $FILE"
               continue
           fi
           if file "$FILE" | grep -q -E 'text|ASCII'; then
-              echo "File is text: $FILE"
               if [ $(tail -c 1 "$FILE" | wc -l) -eq 0 ]; then
                   echo "Missing newline at end of file: $FILE"
                   NO_NEWLINE=1
               fi
-          else
-              echo "Skipping non-text file: $FILE"
           fi
       done
   - name: grab-mergecommits


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3077" title="DX-3077" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3077</a>  check_format raising files that were not touched
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The reason the script raised an issue in this PR: https://github.com/ActiveState/cli/pull/3504 is because it was run when the target branch was `master` and not the RC branch that it should have been. We rely on `GITHUB_BASE_REF` to identify the target branch. I looked into some ways to work around this but there doesn't seem to be a clear solution so rather than try I've just opted to skip the check if the target branch is master.