### PR TITLE
Log retries

### DIFF
--- a/internal/retryhttp/client.go
+++ b/internal/retryhttp/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/logging"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/thoas/go-funk"
@@ -139,6 +140,7 @@ func normalizeResponse(res *http.Response, err error) (*http.Response, error) {
 }
 
 func normalizeRetryResponse(res *http.Response, err error, numTries int) (*http.Response, error) {
+	logging.Debug("Retry failed with error: %v, after %d tries", err, numTries)
 	if err2, ok := err.(net.Error); ok && err2.Timeout() {
 		return res, locale.WrapExternalError(&UserNetworkError{-1}, "err_user_network_timeout", "", locale.Tr("err_user_network_solution", constants.ForumsURL))
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3156" title="DX-3156" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3156</a>  Ensure timeouts during polling are retried
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I am fairly confident that our buildplanner polling is retrying. The [`pollBuildPlanned`](https://github.com/ActiveState/cli/blob/master/pkg/platform/model/buildplanner/build.go#L240) function uses the same underlying client that all buildplanner requests use. This client uses the [`HTTPTransport`](https://github.com/ActiveState/cli/blob/master/pkg/platform/api/api.go#L33) from the retry library.

The error message in the story description is also from the retry library: https://github.com/ActiveState/cli/blob/master/internal/retryhttp/client.go#L143. The `pollBuildPlanned` function has its own a timeout, but produces a different error.

For this PR I've added logging of the number of retries so we can ensure that they did happen when we check the log. We could also add the number of retries to the error message if that would be more helpful.

I've also verified that we retry server-side timeouts. We have a list of status codes that we check in the response to determine if we are going to retry the request and a server timeout is one of them: https://github.com/ActiveState/cli/blob/master/internal/retryhttp/client.go#L59