### PR TITLE
Added dashboard build progress details URL.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -493,3 +493,6 @@ const OverrideShellEnvVarName = "ACTIVESTATE_CLI_SHELL_OVERRIDE"
 
 // IgnoreEnvEnvVarName is the environment variable to set for skipping specific environment variables during runtime setup.
 const IgnoreEnvEnvVarName = "ACTIVESTATE_CLI_IGNORE_ENV"
+
+// ProgressUrlPathName is the trailing path for a project's build progress.
+const BuildProgressUrlPathName = "distributions"

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1127,7 +1127,9 @@ progress_solve_preruntime:
 progress_pkg_nolang:
   other: "• Searching for [ACTIONABLE]{{.V0}}[/RESET] across all languages in the ActiveState Catalog"
 progress_build_log:
-  other: "Build Log [ACTIONABLE]{{.V0}}[/RESET]"
+  other: "Build Log: [ACTIONABLE]{{.V0}}[/RESET]"
+progress_build_url:
+  other: "Detailed Progress: [ACTIONABLE]{{.V0}}[/RESET]"
 progress_completed:
   other: "[SUCCESS]✔ All dependencies have been installed and verified[/RESET]"
 progress_failed:

--- a/internal/runbits/runtime/progress/progress.go
+++ b/internal/runbits/runtime/progress/progress.go
@@ -147,6 +147,7 @@ func (p *ProgressDigester) Handle(ev events.Event) error {
 		// already progressbars being displayed which won't play nice with newly printed output.
 		if v.RequiresBuild {
 			p.out.Notice(locale.Tr("progress_build_log", v.LogFilePath))
+			p.out.Notice(locale.Tr("progress_build_url", v.ProgressUrl))
 		}
 
 		p.recipeID = v.RecipeID

--- a/pkg/runtime/events/events.go
+++ b/pkg/runtime/events/events.go
@@ -37,6 +37,7 @@ type Start struct {
 
 	RequiresBuild bool
 	LogFilePath   string
+	ProgressUrl   string
 
 	ArtifactsToBuild    buildplan.ArtifactIDMap
 	ArtifactsToDownload buildplan.ArtifactIDMap

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -13,6 +13,10 @@ func WithBuildlogFilePath(path string) SetOpt {
 	return func(opts *Opts) { opts.BuildlogFilePath = path }
 }
 
+func WithBuildProgressUrl(url string) SetOpt {
+	return func(opts *Opts) { opts.BuildProgressUrl = url }
+}
+
 func WithPreferredLibcVersion(version string) SetOpt {
 	return func(opts *Opts) { opts.PreferredLibcVersion = version }
 }

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -46,6 +46,7 @@ type Opts struct {
 	PreferredLibcVersion string
 	EventHandlers        []events.HandlerFunc
 	BuildlogFilePath     string
+	BuildProgressUrl     string
 
 	FromArchive *fromArchive
 
@@ -200,6 +201,7 @@ func (s *setup) RunAndWait() (rerr error) {
 		RecipeID:            s.buildplan.LegacyRecipeID(),
 		RequiresBuild:       s.buildplan.IsBuildInProgress() && len(s.toDownload) > 0,
 		LogFilePath:         s.opts.BuildlogFilePath,
+		ProgressUrl:         s.opts.BuildProgressUrl,
 		ArtifactsToBuild:    s.toBuild,
 		ArtifactsToDownload: s.toDownload,
 		ArtifactsToUnpack:   s.toUnpack,

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -169,7 +169,8 @@ func (suite *RuntimeIntegrationTestSuite) TestBuildInProgress() {
 	ts.PrepareEmptyProject()
 
 	cp = ts.Spawn("install", "private/"+e2e.PersistentUsername+"/hello-world", "--ts", "now")
-	cp.Expect("Build Log")
+	cp.Expect("Build Log:")
+	cp.Expect("Detailed Progress:")
 	cp.Expect("Building")
 	cp.Expect("All dependencies have been installed and verified", e2e.RuntimeBuildSourcingTimeoutOpt)
 	cp.Expect("Added: private/" + e2e.PersistentUsername + "/hello-world")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3155" title="DX-3155" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3155</a>  Show dashboard progress URL during builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Sample:

```
% state install cmake@3.29.5.1
█ Installing Package

Operating on project ActiveState-CLI/small-python, located at 
/Users/me/small-python.

• Searching for packages in the ActiveState Catalog ✔ Found
• Resolving Dependencies ✔ Done
• Checking for vulnerabilities (CVEs) on cmake and its dependencies ✔ Safe
█ Sourcing Runtime

Build Log: 
/Users/me/Library/Caches/activestate/33fc907a/.activestate/build.log
Detailed Progress: https://platform.activestate.com/ActiveState-CLI/small-python
/distributions?branch=main&commitID=ff9978ba-1712-49ad-813f-664b2c939ec3
Building         /              0/2 [------------------------------------]   0 %
```

Copy-pasting the link sent me to the dashboard build progress page, where I confirmed that the package I was trying to install was being built.