### PR TITLE
Fix Publish Integration Test

### DIFF
--- a/internal/gqlclient/gqlclient.go
+++ b/internal/gqlclient/gqlclient.go
@@ -373,6 +373,8 @@ func (c *Client) runWithFiles(ctx context.Context, gqlReq RequestWithFiles, resp
 		return errors.Wrap(err, "decoding response")
 	}
 
+	// If the response is a single object, meaning we only have a single query in the request, we can unmarshal the
+	// response directly to the response type. Otherwise, we need to marshal the response as we normally would.
 	if len(intermediateResp) == 1 {
 		for _, val := range intermediateResp {
 			data, err := json.Marshal(val)

--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -40,7 +40,6 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 		constants.ServiceSockDir + "=" + dirs.SockRoot,
 		constants.HomeEnvVarName + "=" + dirs.HomeDir,
 		systemHomeEnvVarName + "=" + dirs.HomeDir,
-		constants.DebugServiceRequestsEnvVarName + "=true",
 		"NO_COLOR=true",
 		"CI=true",
 	}...)

--- a/internal/testhelpers/e2e/env.go
+++ b/internal/testhelpers/e2e/env.go
@@ -40,6 +40,7 @@ func sandboxedTestEnvironment(t *testing.T, dirs *Dirs, updatePath bool, extraEn
 		constants.ServiceSockDir + "=" + dirs.SockRoot,
 		constants.HomeEnvVarName + "=" + dirs.HomeDir,
 		systemHomeEnvVarName + "=" + dirs.HomeDir,
+		constants.DebugServiceRequestsEnvVarName + "=true",
 		"NO_COLOR=true",
 		"CI=true",
 	}...)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3160" title="DX-3160" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3160</a>  Nightly failure: TestPublishIntegrationTestSuite/TestPublish/*
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

We now have two graphQL client implementations. I've ported the changes from https://github.com/ActiveState/cli/pull/3580 into this PR but the real solution will be to unify the client code. I've filed a story for that here: https://activestatef.atlassian.net/browse/DX-3162