### PR TITLE
Add a bit of lag to the JWT renewal time.

### DIFF
--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -317,7 +317,7 @@ func (s *Auth) UpdateSession(accessToken *mono_models.JWT) {
 	s.bearerToken = accessToken.Token
 	clientAuth := httptransport.BearerToken(s.bearerToken)
 	s.clientAuth = &clientAuth
-	s.lastRenewal = ptr.To(time.Now())
+	s.lastRenewal = ptr.To(time.Now().Add(-1 * time.Minute)) // the renewal happened up to a few seconds ago, not now
 
 	persist = s
 }

--- a/pkg/platform/authentication/auth.go
+++ b/pkg/platform/authentication/auth.go
@@ -37,8 +37,8 @@ type ErrTokenRequired struct{ *locale.LocalizedError }
 var errNotYetGranted = locale.NewInputError("err_auth_device_noauth")
 
 // jwtLifetime is the lifetime of the JWT. This is defined by the API, but the API doesn't communicate this.
-// We drop a minute from this to avoid race conditions with the API.
-const jwtLifetime = (1 * time.Hour) - (1 * time.Minute)
+// We drop 10 minutes from this to be on the safe side and avoid race conditions with the API.
+const jwtLifetime = (1 * time.Hour) - (10 * time.Minute)
 
 // Auth is the base structure used to record the authenticated state
 type Auth struct {
@@ -317,7 +317,7 @@ func (s *Auth) UpdateSession(accessToken *mono_models.JWT) {
 	s.bearerToken = accessToken.Token
 	clientAuth := httptransport.BearerToken(s.bearerToken)
 	s.clientAuth = &clientAuth
-	s.lastRenewal = ptr.To(time.Now().Add(-1 * time.Minute)) // the renewal happened up to a few seconds ago, not now
+	s.lastRenewal = ptr.To(time.Now())
 
 	persist = s
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3151" title="DX-3151" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3151</a>  `state checkout` with expired JWT gives unhelpful error message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

It was possible to land within the interval between actual expired time and expected expired time.

I did my best to try and reproduce this, but I wasn't able to. I genuinely think I landed in the brief window of time where the JWT expired on the Platform, but state-svc or state tool thought it was still valid. Reducing the time state-svc or state tool think it's valid should avoid this. Either way, it's not something our users will run into on a regular basis (and waiting a minute or two for the state-svc poller to refresh would have silently fixed this error).