### PR TITLE
Fixed failing integration test.

### DIFF
--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -253,7 +253,7 @@ func Update(
 	if opts.Archive != nil {
 		rtOpts = append(rtOpts, runtime.WithArchive(opts.Archive.Dir, opts.Archive.PlatformID, checkout.ArtifactExt))
 	}
-	if commit.BuildPlan().IsBuildInProgress() {
+	if buildPlan.IsBuildInProgress() {
 		// Build progress URL is of the form
 		// https://<host>/<owner>/<project>/distributions?branch=<branch>&commitID=<commitID>
 		host := constants.DefaultAPIHost


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3169" title="DX-3169" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3169</a>  Nightly failure: TestCheckoutIntegrationTestSuite/TestCheckoutFromArchive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
When checking out from an archive, there is no commit. Instead, the archive contains a buildplan, so we should use that.