### PR TITLE
Fixed interline diffs.

### DIFF
--- a/internal/runbits/buildscript/buildscript.go
+++ b/internal/runbits/buildscript/buildscript.go
@@ -33,7 +33,6 @@ func generateDiff(script *buildscript.BuildScript, otherScript *buildscript.Buil
 	scriptLines, newScriptLines, lines := diff.DiffLinesToChars(string(sb1), string(sb2))
 	hunks := diff.DiffMain(scriptLines, newScriptLines, false)
 	hunks = diff.DiffCharsToLines(hunks, lines)
-	hunks = diff.DiffCleanupSemantic(hunks)
 	for i := 0; i < len(hunks); i++ {
 		switch hunk := hunks[i]; hunk.Type {
 		case diffmatchpatch.DiffEqual:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3165" title="DX-3165" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3165</a>  Unproductive diff produced by buildscript conflicts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Do not try to clean up the line diff, as it may end up inadvertently combining lines.