### PR TITLE
Installing in non-interactive mode on Windows with admin should bypass the prompt.

### DIFF
--- a/cmd/state-installer/installer.go
+++ b/cmd/state-installer/installer.go
@@ -61,7 +61,8 @@ func (i *Installer) Install() (rerr error) {
 		if i.Params.force {
 			prompter.SetForce(true)
 		}
-		confirm, err := prompter.Confirm("", locale.T("installer_prompt_is_admin"), ptr.To(false), ptr.To(true))
+		defaultChoice := i.Params.nonInteractive
+		confirm, err := prompter.Confirm("", locale.T("installer_prompt_is_admin"), &defaultChoice, ptr.To(true))
 		if err != nil {
 			return errs.Wrap(err, "Not confirmed")
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3174" title="DX-3174" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3174</a>  Nightly failure: TestInstallerIntegrationTestSuite/*
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
