### PR TITLE
Show prompts, even if running in non-interactive or force mode.

### DIFF
--- a/internal/prompt/overrides.go
+++ b/internal/prompt/overrides.go
@@ -6,6 +6,34 @@ import (
 
 type Select struct {
 	*survey.Select
+	nonInteractiveChoice *string
+}
+
+func (s *Select) Prompt() (interface{}, error) {
+	if s.nonInteractiveChoice == nil {
+		return s.Select.Prompt()
+	}
+
+	idx := 0
+	for i, choice := range s.Select.Options {
+		if choice == *s.nonInteractiveChoice {
+			idx = i
+			break
+		}
+	}
+
+	err := s.Select.Render(
+		survey.SelectQuestionTemplate,
+		survey.SelectTemplateData{
+			Select:        *s.Select,
+			PageEntries:   s.Select.Options,
+			SelectedIndex: idx,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return *s.nonInteractiveChoice, nil
 }
 
 func (s *Select) Cleanup(interface{}) error {
@@ -15,6 +43,22 @@ func (s *Select) Cleanup(interface{}) error {
 
 type Input struct {
 	*survey.Input
+	nonInteractiveResponse *string
+}
+
+func (i *Input) Prompt() (interface{}, error) {
+	if i.nonInteractiveResponse == nil {
+		return i.Input.Prompt()
+	}
+
+	err := i.Input.Render(
+		survey.InputQuestionTemplate,
+		survey.InputTemplateData{Input: *i.Input})
+	if err != nil {
+		return nil, err
+	}
+
+	return *i.nonInteractiveResponse, nil
 }
 
 func (i *Input) Cleanup(val interface{}) error {
@@ -33,6 +77,22 @@ func (i *Password) Cleanup(val interface{}) error {
 
 type Confirm struct {
 	*survey.Confirm
+	nonInteractiveChoice *bool
+}
+
+func (s *Confirm) Prompt() (interface{}, error) {
+	if s.nonInteractiveChoice == nil {
+		return s.Confirm.Prompt()
+	}
+
+	err := s.Confirm.Render(
+		survey.ConfirmQuestionTemplate,
+		survey.ConfirmTemplateData{Confirm: *s.Confirm})
+	if err != nil {
+		return nil, err
+	}
+
+	return *s.nonInteractiveChoice, nil
 }
 
 func (s *Confirm) Cleanup(interface{}) error {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3166" title="DX-3166" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3166</a>  Bring back the `--force` flag to allow running an action regardless of prompts OR defaults
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Prompts were never shown in non-interactive mode, and the previous PR for this ticket didn't change that. This PR changes the prompt library to also show prompts in non-interactive and force mode before the "continuing because non-interactive/--force" notices.

```
% state reset --force      
█ Reset to a Commit

Operating on project org/project, located at 
/path/to/project.

Your project will be reset to 6d79f2ae-f8b5-46bd-917a-d4b2558ec7b8

Resetting is destructive. You will lose any changes that were not pushed. Are 
you sure you want to do this? (y/N)
Continuing because the '--force' flag is set.
█ Sourcing Runtime

• Resolving Dependencies ✔ Done
```

```
% state install datetime -n     
█ Installing Package

Operating on project org/project, located at /path/to/project.

• Searching for packages in the ActiveState Catalog ............
Multiple Matches
Your query for datetime has multiple matches. Which one would you like to use?

> DateTime (language/perl)
  DateTime (language/python)
Using 'DateTime (language/perl)' because State Tool is running in non-interactive mode.
 ✔ Found
```