### PR TITLE
Do not run remote installer test in non-interactive mode.

### DIFF
--- a/test/integration/remote_installer_int_test.go
+++ b/test/integration/remote_installer_int_test.go
@@ -74,7 +74,7 @@ func (suite *RemoteInstallIntegrationTestSuite) TestInstall() {
 			installPath := filepath.Join(ts.Dirs.Work, "install")
 			stateExePath := filepath.Join(installPath, "bin", constants.StateCmd+osutils.ExeExtension)
 
-			args := []string{"-n"}
+			args := []string{"--non-interactive"}
 			if tt.Version != "" {
 				args = append(args, "--version", tt.Version)
 			}
@@ -93,10 +93,15 @@ func (suite *RemoteInstallIntegrationTestSuite) TestInstall() {
 			)
 
 			cp.Expect("Terms of Service")
-			cp.SendLine("Y")
+			cp.Expect("Continuing because State Tool is running in non-interactive mode")
 			cp.Expect("Downloading")
 			cp.Expect("Running Installer...")
 			cp.Expect("Installing")
+			if runtime.GOOS == "windows" {
+				cp.Expect("You are installing the State Tool as an admin")
+				cp.Expect("Are you sure")
+				cp.Expect("Continuing because State Tool is running in non-interactive mode")
+			}
 			cp.Expect("Installation Complete")
 			cp.Expect("Press ENTER to exit")
 			cp.SendEnter()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3173" title="DX-3173" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3173</a>  Nightly failure: TestRemoteInstallIntegrationTestSuite/TestInstall/install-prbranch-and-channel_(@master) 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


It turns out we need to be running in non-interactive mode because the Windows installer detects installation as admin and prompts you to continue. I've updated the test to stop trying to send "Y" to the TOS prompt and instead assert it's continuing due to non-interactive mode. There's an extra assertion for Windows so we do not forget this use-case.