### PR TITLE
`state pull` should use the already-merged commit's build script instead of attempting a merge.

### DIFF
--- a/internal/runners/pull/pull.go
+++ b/internal/runners/pull/pull.go
@@ -278,12 +278,10 @@ func (p *Pull) mergeBuildScript(remoteCommit, localCommit strfmt.UUID) error {
 	// Compute the merge strategy.
 	strategies, err := model.MergeCommit(remoteCommit, localCommit)
 	if err != nil {
-		switch {
-		case errors.Is(err, model.ErrMergeFastForward):
+		if errors.Is(err, model.ErrMergeFastForward) || errors.Is(err, model.ErrMergeCommitInHistory) {
 			return buildscript_runbit.Update(p.project, scriptB)
-		case !errors.Is(err, model.ErrMergeCommitInHistory):
-			return locale.WrapError(err, "err_mergecommit", "Could not detect if merge is necessary.")
 		}
+		return locale.WrapError(err, "err_mergecommit", "Could not detect if merge is necessary.")
 	}
 
 	// Attempt the merge.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3175" title="DX-3175" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3175</a>  `state pull` with merge in history causes buildscript panic
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
There will be no strategy, and lead to a nil-pointer exception.