### PR TITLE
Installers should not default to non-interactive.

### DIFF
--- a/cmd/state-installer/cmd.go
+++ b/cmd/state-installer/cmd.go
@@ -105,7 +105,7 @@ func main() {
 		OutWriter:   os.Stdout,
 		ErrWriter:   os.Stderr,
 		Colored:     true,
-		Interactive: false,
+		Interactive: term.IsTerminal(int(os.Stdin.Fd())),
 	})
 	if err != nil {
 		multilog.Critical("Could not set up output handler: " + errs.JoinMessage(err))

--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -173,9 +173,13 @@ func main() {
 }
 
 func execute(out output.Outputer, prompt prompt.Prompter, cfg *config.Instance, an analytics.Dispatcher, args []string, params *Params) error {
+	if params.nonInteractive {
+		prompt.SetInteractive(false)
+	}
+	defaultChoice := params.nonInteractive
 	msg := locale.Tr("tos_disclaimer", constants.TermsOfServiceURLLatest)
 	msg += locale.Tr("tos_disclaimer_prompt", constants.TermsOfServiceURLLatest)
-	cont, err := prompt.Confirm(locale.Tr("install_remote_title"), msg, ptr.To(true), nil)
+	cont, err := prompt.Confirm(locale.Tr("install_remote_title"), msg, &defaultChoice, nil)
 	if err != nil {
 		return errs.Wrap(err, "Not confirmed")
 	}

--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ActiveState/cli/internal/runbits/errors"
 	"github.com/ActiveState/cli/internal/runbits/panics"
 	"github.com/ActiveState/cli/internal/updater"
+	"golang.org/x/term"
 )
 
 type Params struct {
@@ -90,7 +91,7 @@ func main() {
 		OutWriter:   os.Stdout,
 		ErrWriter:   os.Stderr,
 		Colored:     true,
-		Interactive: false,
+		Interactive: term.IsTerminal(int(os.Stdin.Fd())),
 	})
 	if err != nil {
 		logging.Error("Could not set up output handler: " + errs.JoinMessage(err))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3193" title="DX-3193" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3193</a>  Windows ST install fail if install as Administrator
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


DX-3193 actually uncovered two problems:

1. `--non-interactive` was overriding `--force` (fixed in #3616 )
2. Installers were running in non-interactive mode by default (fixed here). Our automated tests didn't catch this case since they are always running in non-interactive mode. Only manual QA revealed it.