### PR TITLE
Warn when writing colored output fails.

### DIFF
--- a/internal/output/plain.go
+++ b/internal/output/plain.go
@@ -107,7 +107,7 @@ func (f *Plain) writeNow(writer io.Writer, value string) {
 	}
 	_, err := colorize.Colorize(value, writer, !f.cfg.Colored)
 	if err != nil {
-		logging.ErrorNoStacktrace("Writing colored output failed: %v", err)
+		logging.Warning("Writing colored output failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3179" title="DX-3179" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3179</a>  Log have an ERROR while executed on Linux
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Errors are sporadic and benign, but they affect automation tests, so drop the log level to warning.