### PR TITLE
Generalized `state install` CVE report.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1099,7 +1099,7 @@ progress_search:
 progress_platform_search:
   other: "• Searching for platform in the ActiveState Catalog"
 progress_cve_search:
-  other: "• Checking for vulnerabilities (CVEs) on [ACTIONABLE]{{.V0}}[/RESET] and its dependencies"
+  other: "• Checking for vulnerabilities (CVEs)"
 setup_runtime:
   other: "Setting Up Runtime"
 progress_solve:
@@ -1138,13 +1138,13 @@ unstable_feature_banner:
   other: "[NOTICE]Beta Feature: This feature is still in beta and may be unstable.[/RESET]\n"
 warning_vulnerable:
   other: |
-    [ERROR]Warning: Dependency has {{.V0}} direct and {{.V1}} indirect known vulnerabilities (CVEs)[/RESET]
+    [ERROR]Warning: Found {{.V0}} direct and {{.V1}} indirect known vulnerabilities (CVEs)[/RESET]
 warning_vulnerable_indirectonly:
   other: |
-    [ERROR]Warning: Dependency has {{.V0}} indirect known vulnerabilities (CVEs)[/RESET]
+    [ERROR]Warning: Found {{.V0}} indirect known vulnerabilities (CVEs)[/RESET]
 warning_vulnerable_directonly:
   other: |
-    [ERROR]Warning: Dependency has {{.V0}} known vulnerabilities (CVEs)[/RESET]
+    [ERROR]Warning: Found {{.V0}} known vulnerabilities (CVEs)[/RESET]
 cve_critical:
   other: Critical
 cve_high:
@@ -1159,7 +1159,7 @@ disable_prompting_vulnerabilities:
   other: To disable prompting for vulnerabilities run '[ACTIONABLE]state config set security.prompt.enabled false[/RESET]'.
 warning_vulnerable_short:
   other: |
-    [ERROR]Warning:[/RESET] Dependency has [ERROR]{{.V0}} known vulnerabilities (CVEs)[/RESET]. Severity: {{.V1}}. Run '[ACTIONABLE]state security[/RESET]' for more info.
+    [ERROR]Warning:[/RESET] Found [ERROR]{{.V0}} known vulnerabilities (CVEs)[/RESET]. Severity: {{.V1}}. Run '[ACTIONABLE]state security[/RESET]' for more info.
 prompt_continue_pkg_operation:
   other: |
     Do you want to continue installing this dependency despite its vulnerabilities?

--- a/internal/runbits/cves/cves.go
+++ b/internal/runbits/cves/cves.go
@@ -77,8 +77,7 @@ func (c *CveReport) Report(newBuildPlan *buildplan.BuildPlan, oldBuildPlan *buil
 		}
 	}
 
-	names := changedRequirements(oldBuildPlan, newBuildPlan)
-	pg := output.StartSpinner(c.prime.Output(), locale.Tr("progress_cve_search", strings.Join(names, ", ")), constants.TerminalAnimationInterval)
+	pg := output.StartSpinner(c.prime.Output(), locale.T("progress_cve_search"), constants.TerminalAnimationInterval)
 
 	ingredientVulnerabilities, err := model.FetchVulnerabilitiesForIngredients(c.prime.Auth(), ingredients)
 	if err != nil {
@@ -96,6 +95,7 @@ func (c *CveReport) Report(newBuildPlan *buildplan.BuildPlan, oldBuildPlan *buil
 	pg.Stop(locale.T("progress_unsafe"))
 	pg = nil
 
+	names := changedRequirements(oldBuildPlan, newBuildPlan)
 	vulnerabilities := model.CombineVulnerabilities(ingredientVulnerabilities, names...)
 
 	if c.prime.Prompt() == nil || !c.shouldPromptForSecurity(vulnerabilities) {

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -571,7 +571,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_NoPrompt() {
 	// Note: this version has 2 direct vulnerabilities, and 3 indirect vulnerabilities, but since
 	// we're not prompting, we're only showing a single count.
 	cp = ts.Spawn("install", "urllib3@2.0.2")
-	cp.ExpectRe(`Warning: Dependency has .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
+	cp.ExpectRe(`Warning: Found .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.ExpectExitCode(0)
 }
 
@@ -594,7 +594,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Prompt() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "urllib3@2.0.2", "--ts=2024-09-10T16:36:34.393Z")
-	cp.ExpectRe(`Warning: Dependency has .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
+	cp.ExpectRe(`Warning: Found .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.Expect("Do you want to continue")
 	cp.SendLine("y")
 	cp.ExpectExitCode(0)
@@ -619,7 +619,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_NonInteractive() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "urllib3@2.0.2", "--ts=2024-09-10T16:36:34.393Z", "--non-interactive")
-	cp.ExpectRe(`Warning: Dependency has .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
+	cp.ExpectRe(`Warning: Found .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.Expect("Aborting because State Tool is running in non-interactive mode")
 	cp.ExpectNotExitCode(0)
 }
@@ -643,7 +643,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Force() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "urllib3@2.0.2", "--ts=2024-09-10T16:36:34.393Z", "--force")
-	cp.ExpectRe(`Warning: Dependency has .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
+	cp.ExpectRe(`Warning: Found .* vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.Expect("Continuing because the '--force' flag is set")
 	cp.ExpectExitCode(0)
 }
@@ -664,7 +664,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Indirect() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "private/ActiveState-CLI-Testing/language/python/django_dep", "--ts=2024-09-10T16:36:34.393Z")
-	cp.ExpectRe(`Warning: Dependency has \d+ indirect known vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
+	cp.ExpectRe(`Warning: Found \d+ indirect known vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.Expect("Do you want to continue")
 	cp.SendLine("n")
 	cp.ExpectExitCode(1)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3186" title="DX-3186" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3186</a>  When installing one package CVEs tested for one more package
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Accurately listing all package names being checked would often result in a horrendously long notice.

Also, now that `state install` allows multiple arguments, singular "Dependency" is not good grammar.

Sample:

```
% state checkout qam/newpub#56a04c65-3279-43af-987a-54f371a8302d
Checking out project: qam/newpub

• Resolving Dependencies ✔ Done

  Setting up the following dependencies:
  ├─ flask@3.0.0 (7 sub-dependencies)
  ├─ pytest@8.3.2 (5 sub-dependencies)
  └─ python@3.10.13 (27 sub-dependencies)

• Checking for vulnerabilities (CVEs) x Unsafe

  Warning: Found 4 known vulnerabilities (CVEs)

  • 3 High: CVE-2024-6232, CVE-2024-7592, CVE-2023-36632
  • 1 Medium: CVE-2023-27043

  For more information on these vulnerabilities run 'state security open <ID>'.
  To disable prompting for vulnerabilities run 'state config set 
  security.prompt.enabled false'.
```

```
% state install django
█ Installing Package

Operating on project qam/newpub, located at /path/to/newpub.

• Searching for packages in the ActiveState Catalog ✔ Found
• Resolving Dependencies ✔ Done

  Installing django@5.1.4 includes 2 direct dependencies, and 1 indirect 
  dependencies.
  ├─ asgiref@3.8.1 (1 dependencies)
  └─ sqlparse@0.5.3

• Checking for vulnerabilities (CVEs) ✔ Safe

Warning: Skipping runtime sourcing since optin.unstable.async_runtime is 
enabled. Please run 'state refresh' to manually source the runtime.

Added: language/python/django@Auto

Your local project has been updated.
Run state push to save changes to the platform.
```