### PR TITLE
Return a commit even if there's a polling error.

### DIFF
--- a/pkg/platform/model/buildplanner/commit.go
+++ b/pkg/platform/model/buildplanner/commit.go
@@ -72,7 +72,7 @@ func (b *BuildPlanner) StageCommit(params StageCommitParams) (*Commit, error) {
 	if resp.Build.Status == raw.Planning {
 		resp.Build, err = b.pollBuildPlanned(resp.CommitID.String(), params.Owner, params.Project, nil)
 		if err != nil {
-			return nil, errs.Wrap(err, "failed to poll build plan")
+			return &Commit{resp, nil, nil}, errs.Wrap(err, "failed to poll build plan")
 		}
 	}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3205" title="DX-3205" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3205</a>  Nightly failure: CycloneDX and SPDX SBOM imports do not create commits
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Recent Platform changes have resulted in every stageCommit call responding with "build planning".

`state import` does not care if the plan ultimately fails due to requirements not being found. It should still make the commit.