### PR TITLE
Do not log invalid namespaces as errors and to rollbar.

### DIFF
--- a/cmd/state/internal/cmdtree/init.go
+++ b/cmd/state/internal/cmdtree/init.go
@@ -49,7 +49,7 @@ func newInitCommand(prime *primer.Values) *captain.Command {
 				if err != nil {
 					// If the namespace was invalid but an argument was passed, we
 					// assume it's a project name and not an owner.
-					logging.Error("Could not parse namespace: %v", err)
+					logging.Debug("Could not parse namespace: %v", err)
 					params.ProjectName = params.Namespace
 				} else {
 					params.ParsedNS = ns


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3178" title="DX-3178" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3178</a>  INIT: Wrong messages for invalid formatting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


The user is already being notified of this error when using invalid namespaces with `state init`.