### PR TITLE
Add "arch" param to install script's state-update URLs.

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -69,6 +69,9 @@ error () {
 case `uname -s` in
 Linux)
   OS="linux"
+  ARCH="amd64"
+  arch="`uname -m`"
+  if [ $arch = "arm64" -o $arch = "aarch64"  ]; then ARCH="arm64"; fi
   DOWNLOADEXT=".tar.gz"
   ;;
 *BSD)
@@ -78,11 +81,13 @@ Linux)
   ;;
 Darwin)
   OS="darwin"
+  ARCH="amd64"
   DOWNLOADEXT=".tar.gz"
   SHA256SUM="shasum -a 256"
   ;;
 MINGW*|MSYS*)
   OS="windows"
+  ARCH="amd64"
   DOWNLOADEXT=".zip"
   BINARYEXT=".exe"
   ;;
@@ -113,18 +118,18 @@ mkdir -p "$INSTALLERTMPDIR"
 if [ -z "$VERSION" ]; then
   # If the user did not specify a version, formulate a query to fetch the JSON info of the latest
   # version, including where it is.
-  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS"
+  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS&arch=$ARCH"
 elif [ -z "`echo $VERSION | grep -o '\-SHA'`" ]; then
   # If the user specified a partial version (i.e. no SHA), formulate a query to fetch the JSON info
   # of that version's latest SHA, including where it is.
   VERSIONNOSHA="$VERSION"
   VERSION=""
-  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS&target-version=$VERSIONNOSHA"
+  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS&arch=$ARCH&target-version=$VERSIONNOSHA"
 else
   # If the user specified a full version with SHA, formulate a query to fetch the JSON info of that
   # version.
   VERSIONNOSHA="`echo $VERSION | sed 's/-SHA.*$//'`"
-  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS&target-version=$VERSIONNOSHA"
+  JSONURL="$BASE_INFO_URL?channel=$CHANNEL&source=install&platform=$OS&arch=$ARCH&target-version=$VERSIONNOSHA"
 fi
 
 # Fetch version info.
@@ -157,13 +162,13 @@ else
     error "Unknown version: $VERSION"
     exit 1
   fi
-  RELURL="$CHANNEL/$VERSIONNOSHA/$OS-amd64/state-$OS-amd64-$VERSION$DOWNLOADEXT"
+  RELURL="$CHANNEL/$VERSIONNOSHA/$OS-$ARCH/state-$OS-$ARCH-$VERSION$DOWNLOADEXT"
 fi
 
 # Fetch the requested or latest version.
 progress "Preparing Installer for State Tool Package Manager version $VERSION"
 STATEURL="$BASE_FILE_URL/$RELURL"
-ARCHIVE="$OS-amd64$DOWNLOADEXT"
+ARCHIVE="$OS-$ARCH$DOWNLOADEXT"
 $FETCH $INSTALLERTMPDIR/$ARCHIVE $STATEURL
 # wget and curl differ on how to handle AWS' "Forbidden" result for unknown versions.
 # wget will exit with nonzero status. curl simply creates an XML file with the forbidden error.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3211" title="DX-3211" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3211</a>  [Vectra] We produce and automate ARM64 Linux builds for State Tool 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


There is currently a chicken-and-egg problem. State Tool needs itself to build on CI, but no State Tool builds for ARM have been released (via CI). I've bootstrapped an ARM build that can be installed, but the install scripts cannot find it yet since the existing install script assumes the arch is amd64.

This PR only changes the install script to allow for detecting and passing the architecture to the state-update service in order to retrieve ARM builds.

Once this PR is resolved, #3632 can start building on CI.