### PR TITLE
Show warning for runtime in use instead of erroring out.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -187,9 +187,10 @@ run_description:
   other: Run your project scripts
 scripts_description:
   other: Show project scripts
-runtime_setup_in_use_err:
+runtime_setup_in_use_warning:
   other: |
-    Could not update your runtime as it is currently in use. Please stop any active runtime processes and try again. State Tool found the following processes to be using the runtime:
+    [WARNING]Warning:[/RESET] the runtime for this project is in use, it is recommended you restart any active processes to avoid conflicts.
+    The following processes are currently using this runtime:
     {{.V0}}
 runtime_alternative_file_transforms_err:
   other: "Could not apply necessary file transformations after unpacking."

--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -1,8 +1,10 @@
 package runtime_runbit
 
 import (
+	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	anaConsts "github.com/ActiveState/cli/internal/analytics/constants"
 	"github.com/ActiveState/cli/internal/analytics/dimensions"
@@ -236,7 +238,11 @@ func Update(
 	defer cancel()
 	if procs, err := prime.SvcModel().GetProcessesInUse(ctx, rt.Env(false).ExecutorsPath); err == nil {
 		if len(procs) > 0 {
-			return nil, &RuntimeInUseError{procs}
+			list := []string{}
+			for _, proc := range procs {
+				list = append(list, fmt.Sprintf("   - %s (process: %d)", proc.Exe, proc.Pid))
+			}
+			prime.Output().Notice(locale.Tr("runtime_setup_in_use_warning", strings.Join(list, "\n")))
 		}
 	} else {
 		multilog.Error("Unable to determine if runtime is in use: %v", errs.JoinMessage(err))

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -128,10 +128,9 @@ func (suite *RuntimeIntegrationTestSuite) TestInUse() {
 	time.Sleep(1 * time.Second) // allow time for perl to start up
 
 	cp2 := ts.Spawn("install", "DateTime")
-	cp2.Expect("currently in use", e2e.RuntimeSourcingTimeoutOpt)
+	cp2.Expect("the runtime for this project is in use", e2e.RuntimeSourcingTimeoutOpt)
 	cp2.Expect("perl")
-	cp2.ExpectNotExitCode(0)
-	ts.IgnoreLogErrors()
+	cp2.ExpectExitCode(0)
 
 	cp.SendCtrlC()
 	cp.SendLine("exit")

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -113,6 +113,10 @@ func (suite *RuntimeIntegrationTestSuite) TestInterruptSetup() {
 }
 
 func (suite *RuntimeIntegrationTestSuite) TestInUse() {
+	if runtime.GOOS == "windows" {
+		// https://activestatef.atlassian.net/browse/DX-2926
+		suite.T().Skip("interrupting on windows is currently broken when ran via CI")
+	}
 	if runtime.GOOS == "darwin" {
 		return // gopsutil errors on later versions of macOS (DX-2723)
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3209" title="DX-3209" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3209</a>  Don't block runtime updates if runtime is in use
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
