### PR TITLE
Added "--portable" flag to `state checkout` for copying runtime files instead of linking them.

### DIFF
--- a/cmd/state/internal/cmdtree/checkout.go
+++ b/cmd/state/internal/cmdtree/checkout.go
@@ -27,6 +27,11 @@ func newCheckoutCommand(prime *primer.Values) *captain.Command {
 				Value:       &params.RuntimePath,
 			},
 			{
+				Name:        "portable",
+				Description: locale.Tl("flag_state_checkout_portable_description", "Copy files to their runtime path instead of linking to them"),
+				Value:       &params.Portable,
+			},
+			{
 				Name:        "no-clone",
 				Description: locale.Tl("flag_state_checkout_no_clone_description", "Do not clone the github repository associated with this project (if any)"),
 				Value:       &params.NoClone,

--- a/internal/assets/contents/activestate.yaml.cache.tpl
+++ b/internal/assets/contents/activestate.yaml.cache.tpl
@@ -1,2 +1,3 @@
 # It is recommended that you do not commit this file as it contains configuration that is specific to your machine
 cache: {{ .Cache }}
+portable: {{ .Portable }}

--- a/internal/runbits/checkout/checkout.go
+++ b/internal/runbits/checkout/checkout.go
@@ -52,7 +52,7 @@ func New(repo git.Repository, prime primeable) *Checkout {
 	return &Checkout{repo, prime}
 }
 
-func (r *Checkout) Run(ns *project.Namespaced, branchName, cachePath, targetPath string, noClone, bareCheckout bool) (_ string, rerr error) {
+func (r *Checkout) Run(ns *project.Namespaced, branchName, cachePath, targetPath string, noClone, bareCheckout, portable bool) (_ string, rerr error) {
 	defer r.rationalizeError(&rerr)
 
 	path, err := r.pathToUse(ns, targetPath)
@@ -94,7 +94,7 @@ func (r *Checkout) Run(ns *project.Namespaced, branchName, cachePath, targetPath
 		return "", errNoCommitID
 	}
 
-	if err := CreateProjectFiles(path, cachePath, owner, proj, branchName, commitID.String(), language); err != nil {
+	if err := CreateProjectFiles(path, cachePath, owner, proj, branchName, commitID.String(), language, portable); err != nil {
 		return "", errs.Wrap(err, "Could not create project files")
 	}
 
@@ -182,7 +182,7 @@ func (r *Checkout) fetchProject(
 	return owner, proj, commitID, branchName, language, pj.RepoURL, nil
 }
 
-func CreateProjectFiles(checkoutPath, cachePath, owner, name, branch, commitID, language string) error {
+func CreateProjectFiles(checkoutPath, cachePath, owner, name, branch, commitID, language string, portable bool) error {
 	configFile := filepath.Join(checkoutPath, constants.ConfigFileName)
 	if !fileutils.FileExists(configFile) {
 		_, err := projectfile.Create(&projectfile.CreateParams{
@@ -192,6 +192,7 @@ func CreateProjectFiles(checkoutPath, cachePath, owner, name, branch, commitID, 
 			Directory:  checkoutPath,
 			Language:   language,
 			Cache:      cachePath,
+			Portable:   portable,
 		})
 		if err != nil {
 			if osutils.IsAccessDeniedError(err) {

--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -252,6 +252,9 @@ func Update(
 	if opts.Archive != nil {
 		rtOpts = append(rtOpts, runtime.WithArchive(opts.Archive.Dir, opts.Archive.PlatformID, checkout.ArtifactExt))
 	}
+	if proj.IsPortable() {
+		rtOpts = append(rtOpts, runtime.WithPortable())
+	}
 
 	if err := rt.Update(buildPlan, rtHash, rtOpts...); err != nil {
 		return nil, locale.WrapError(err, "err_packages_update_runtime_install")

--- a/internal/runners/activate/activate.go
+++ b/internal/runners/activate/activate.go
@@ -95,7 +95,7 @@ func (r *Activate) Run(params *ActivateParams) (rerr error) {
 		}
 
 		// Perform fresh checkout
-		pathToUse, err := r.activateCheckout.Run(params.Namespace, params.Branch, "", params.PreferredPath, false, false)
+		pathToUse, err := r.activateCheckout.Run(params.Namespace, params.Branch, "", params.PreferredPath, false, false, false)
 		if err != nil {
 			return locale.WrapError(err, "err_activate_pathtouse", "Could not figure out what path to use.")
 		}

--- a/internal/runners/checkout/checkout.go
+++ b/internal/runners/checkout/checkout.go
@@ -38,6 +38,7 @@ type Params struct {
 	RuntimePath   string
 	NoClone       bool
 	Force         bool
+	Portable      bool
 }
 
 type primeable interface {
@@ -121,7 +122,7 @@ func (u *Checkout) Run(params *Params) (rerr error) {
 
 	u.out.Notice(locale.Tr("checking_out", ns.String()))
 
-	projectDir, err := u.checkout.Run(ns, params.Branch, params.RuntimePath, params.PreferredPath, params.NoClone, archive != nil)
+	projectDir, err := u.checkout.Run(ns, params.Branch, params.RuntimePath, params.PreferredPath, params.NoClone, archive != nil, params.Portable)
 	if err != nil {
 		return errs.Wrap(err, "Checkout failed")
 	}

--- a/internal/runners/deploy/deploy.go
+++ b/internal/runners/deploy/deploy.go
@@ -168,7 +168,7 @@ func (d *Deploy) install(params *Params, commitID strfmt.UUID) (rerr error) {
 
 	if err := checkout.CreateProjectFiles(
 		params.Path, params.Path, params.Namespace.Owner, params.Namespace.Project,
-		constants.DefaultBranchName, commitID.String(), "",
+		constants.DefaultBranchName, commitID.String(), "", true,
 	); err != nil {
 		return errs.Wrap(err, "Could not create project files")
 	}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -255,6 +255,8 @@ func (p *Project) Lock() string { return p.projectfile.Lock }
 // Cache returns the cache information for this project
 func (p *Project) Cache() string { return p.projectfile.Cache }
 
+func (p *Project) IsPortable() bool { return p.projectfile.Portable }
+
 // Namespace returns project namespace
 func (p *Project) Namespace() *Namespaced {
 	return &Namespaced{Owner: p.projectfile.Owner(), Project: p.projectfile.Name()}

--- a/pkg/projectfile/projectfile.go
+++ b/pkg/projectfile/projectfile.go
@@ -108,6 +108,7 @@ type Project struct {
 	Jobs          Jobs          `yaml:"jobs,omitempty"`
 	Private       bool          `yaml:"private,omitempty"`
 	Cache         string        `yaml:"cache,omitempty"`
+	Portable      bool          `yaml:"portable,omitempty"`
 	path          string        // "private"
 	parsedURL     projectURL    // parsed url data
 	parsedChannel string
@@ -920,6 +921,7 @@ type CreateParams struct {
 	path       string
 	ProjectURL string
 	Cache      string
+	Portable   bool
 }
 
 // Create will create a new activestate.yaml with a projectURL for the given details
@@ -1019,7 +1021,7 @@ func createCustom(params *CreateParams, lang language.Language) (*Project, error
 	}
 
 	if params.Cache != "" {
-		createErr := createHostFile(params.Directory, params.Cache)
+		createErr := createHostFile(params.Directory, params.Cache, params.Portable)
 		if createErr != nil {
 			return nil, errs.Wrap(createErr, "Could not create cache file")
 		}
@@ -1028,14 +1030,15 @@ func createCustom(params *CreateParams, lang language.Language) (*Project, error
 	return Parse(params.path)
 }
 
-func createHostFile(filePath, cachePath string) error {
+func createHostFile(filePath, cachePath string, portable bool) error {
 	user, err := user.Current()
 	if err != nil {
 		return errs.Wrap(err, "Could not get current user")
 	}
 
 	data := map[string]interface{}{
-		"Cache": cachePath,
+		"Cache":    cachePath,
+		"Portable": portable,
 	}
 
 	tplName := "activestate.yaml.cache.tpl"

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -17,6 +17,10 @@ func WithPreferredLibcVersion(version string) SetOpt {
 	return func(opts *Opts) { opts.PreferredLibcVersion = version }
 }
 
+func WithPortable() SetOpt {
+	return func(opts *Opts) { opts.Portable = true }
+}
+
 func WithArchive(dir string, platformID strfmt.UUID, ext string) SetOpt {
 	return func(opts *Opts) {
 		opts.FromArchive = &fromArchive{dir, platformID, ext}

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -46,6 +46,7 @@ type Opts struct {
 	PreferredLibcVersion string
 	EventHandlers        []events.HandlerFunc
 	BuildlogFilePath     string
+	Portable             bool
 
 	FromArchive *fromArchive
 
@@ -465,7 +466,7 @@ func (s *setup) install(id strfmt.UUID) (rerr error) {
 		return errs.Wrap(err, "Could not get env")
 	}
 
-	if envDef.NeedsTransforms() || !s.supportsHardLinks {
+	if envDef.NeedsTransforms() || !s.supportsHardLinks || s.opts.Portable {
 		if err := s.depot.DeployViaCopy(id, envDef.InstallDir, s.path); err != nil {
 			return errs.Wrap(err, "Could not deploy artifact via copy")
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3225" title="DX-3225" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3225</a>  Get portable depot into v0.47.1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


This is just a cherry-pick of #3602 with two resolved merge conflicts in runtime.go and setup.go.