### PR TITLE
Remove unused events shorthand `-f` that's conflicting with `--force` shorthand.

### DIFF
--- a/cmd/state/internal/cmdtree/events.go
+++ b/cmd/state/internal/cmdtree/events.go
@@ -34,7 +34,6 @@ func newEventsLogCommand(prime *primer.Values) *captain.Command {
 		[]*captain.Flag{
 			{
 				Name:        "follow",
-				Shorthand:   "f",
 				Description: locale.Tl("tail_f_description", "Don't stop when end of file is reached. Wait for additional data."),
 				Value:       &params.Follow,
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3203" title="DX-3203" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3203</a>  Add `-f` to `--force` flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Nightly integration tests caught a clash between a global `-f` and a local `-f` for events that we don't use.