### PR TITLE
Disable buildscript ingredient function integration test on Windows too.

### DIFF
--- a/test/integration/buildscript_int_test.go
+++ b/test/integration/buildscript_int_test.go
@@ -50,9 +50,7 @@ func (suite *BuildScriptIntegrationTestSuite) TestBuildScript_NeedsReset() {
 
 func (suite *BuildScriptIntegrationTestSuite) TestBuildScript_IngredientFunc() {
 	suite.OnlyRunForTags(tagsuite.BuildScripts)
-	if runtime.GOOS != "windows" {
-		suite.T().Skip("Buildplanner does not build the ingredient artifact") // re-enable this in DX-3220
-	}
+	suite.T().Skip("Buildplanner does not build the ingredient artifact") // re-enable this in DX-3220
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3232" title="DX-3232" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3232</a>  Nightly failure: TestBuildScriptIntegrationTestSuite/TestBuildScript_IngredientFunc
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

