### PR TITLE
Allow buildscript functions without arguments.

### DIFF
--- a/pkg/buildscript/marshal.go
+++ b/pkg/buildscript/marshal.go
@@ -136,11 +136,13 @@ func funcCallString(f *funcCall) string {
 	}
 
 	buf := bytes.Buffer{}
-	buf.WriteString(fmt.Sprintf("%s(%s", f.Name, newline))
-
-	buf.WriteString(argsToString(f.Arguments, newline, comma, indent))
-
-	buf.WriteString(")")
+	if len(f.Arguments) > 0 {
+		buf.WriteString(fmt.Sprintf("%s(%s", f.Name, newline))
+		buf.WriteString(argsToString(f.Arguments, newline, comma, indent))
+		buf.WriteString(")")
+	} else {
+		buf.WriteString(fmt.Sprintf("%s()", f.Name))
+	}
 	return buf.String()
 }
 

--- a/pkg/buildscript/raw.go
+++ b/pkg/buildscript/raw.go
@@ -71,5 +71,5 @@ type null struct {
 
 type funcCall struct {
 	Name      string   `parser:"@Ident"`
-	Arguments []*value `parser:"'(' @@ (',' @@)* ','? ')'"`
+	Arguments []*value `parser:"'(' (@@ (',' @@)* ','?)? ')'"`
 }

--- a/test/integration/buildscript_int_test.go
+++ b/test/integration/buildscript_int_test.go
@@ -168,9 +168,8 @@ func (suite *BuildScriptIntegrationTestSuite) TestBuildScriptRequirementVersionA
 	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	// Enable as part of DX-3230.
-	//cp = ts.Spawn("config", "set", constants.OptinBuildscriptsConfig, "true")
-	//cp.ExpectExitCode(0)
+	cp = ts.Spawn("config", "set", constants.OptinBuildscriptsConfig, "true")
+	cp.ExpectExitCode(0)
 
 	// This project's build expression has a requirement whose version is the "Any()" function.
 	// Make sure we can successfully checkout and modify this project.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3230" title="DX-3230" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3230</a>  Build script parser needs to recognize `Any()` function in `Req()` version requirements.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
