### PR TITLE
Implement an artifact cache in the depot.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -493,3 +493,6 @@ const IgnoreEnvEnvVarName = "ACTIVESTATE_CLI_IGNORE_ENV"
 
 // ProgressUrlPathName is the trailing path for a project's build progress.
 const BuildProgressUrlPathName = "distributions"
+
+// RuntimeCacheSizeConfigKey is the config key for the runtime cache size.
+const RuntimeCacheSizeConfigKey = "runtime.cache_size"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -495,4 +495,4 @@ const IgnoreEnvEnvVarName = "ACTIVESTATE_CLI_IGNORE_ENV"
 const BuildProgressUrlPathName = "distributions"
 
 // RuntimeCacheSizeConfigKey is the config key for the runtime cache size.
-const RuntimeCacheSizeConfigKey = "runtime.cache_size"
+const RuntimeCacheSizeConfigKey = "runtime.cache.size"

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -1299,3 +1299,22 @@ func windowsPathToPosixPath(path string) string {
 func posixPathToWindowsPath(path string) string {
 	return strings.ReplaceAll(path, "/", "\\")
 }
+
+// GetDirSize returns the on-disk size of the given directory and all of its contents.
+// Does not follow symlinks.
+func GetDirSize(dir string) (int64, error) {
+	var size int64
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		return size, errs.Wrap(err, "Unable to compute size")
+	}
+	return size, nil
+}

--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -281,6 +281,7 @@ func Update(
 	if proj.IsPortable() {
 		rtOpts = append(rtOpts, runtime.WithPortable())
 	}
+	rtOpts = append(rtOpts, runtime.WithCacheSize(prime.Config().GetInt(constants.RuntimeCacheSizeConfigKey)))
 
 	if isArmPlatform(buildPlan) {
 		prime.Output().Notice(locale.Tl("warning_arm_unstable", "[WARNING]Warning:[/RESET] You are using an ARM64 architecture, which is currently unstable. While it may work, you might encounter issues."))

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -25,6 +25,10 @@ func WithPortable() SetOpt {
 	return func(opts *Opts) { opts.Portable = true }
 }
 
+func WithCacheSize(mb int) SetOpt {
+	return func(opts *Opts) { opts.CacheSize = mb }
+}
+
 func WithArchive(dir string, platformID strfmt.UUID, ext string) SetOpt {
 	return func(opts *Opts) {
 		opts.FromArchive = &fromArchive{dir, platformID, ext}

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -48,6 +48,7 @@ type Opts struct {
 	BuildlogFilePath     string
 	BuildProgressUrl     string
 	Portable             bool
+	CacheSize            int
 
 	FromArchive *fromArchive
 
@@ -93,6 +94,7 @@ type setup struct {
 }
 
 func newSetup(path string, bp *buildplan.BuildPlan, env *envdef.Collection, depot *depot, opts *Opts) (*setup, error) {
+	depot.SetCacheSize(opts.CacheSize)
 	installedArtifacts := depot.List(path)
 
 	var platformID strfmt.UUID

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ActiveState/cli/internal/constants"
+	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/osutils"
 	"github.com/ActiveState/cli/internal/testhelpers/e2e"
 	"github.com/ActiveState/cli/internal/testhelpers/osutil"
@@ -223,13 +224,16 @@ func (suite *RuntimeIntegrationTestSuite) TestRuntimeCache() {
 	cp.Expect("Downloading")
 	cp.ExpectExitCode(0)
 
+	depot := filepath.Join(ts.Dirs.Cache, "depot")
+	artifacts, err := fileutils.ListDirSimple(depot, true)
+	suite.Require().NoError(err)
+
 	cp = ts.Spawn("switch", "mingw") // should not remove cached shared/zlib artifact
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("install", "shared/zlib")
-	cp.Expect("Installing")
-	cp.ExpectExitCode(0)
-	suite.Assert().NotContains(cp.Snapshot(), "Downloading", "shared/zlib should have been cached")
+	artifacts2, err := fileutils.ListDirSimple(depot, true)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(artifacts, artifacts2, "shared/zlib should have remained in the cache")
 
 	cp = ts.Spawn("config", "set", constants.RuntimeCacheSizeConfigKey, "0")
 	cp.ExpectExitCode(0)
@@ -237,9 +241,9 @@ func (suite *RuntimeIntegrationTestSuite) TestRuntimeCache() {
 	cp = ts.Spawn("switch", "main") // should remove cached shared/zlib artifact
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("install", "shared/zlib")
-	cp.Expect("Downloading")
-	cp.ExpectExitCode(0)
+	artifacts3, err := fileutils.ListDirSimple(depot, true)
+	suite.Require().NoError(err)
+	suite.Assert().NotEqual(artifacts, artifacts3, "shared/zlib should have been removed from the cache")
 }
 
 func TestRuntimeIntegrationTestSuite(t *testing.T) {

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -217,23 +217,24 @@ func (suite *RuntimeIntegrationTestSuite) TestRuntimeCache() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.PrepareProject("ActiveState-CLI/Empty", "b55d0e63-db48-43c4-8341-e2b7a1cc134c")
+	ts.PrepareEmptyProject()
 
 	cp := ts.Spawn("install", "shared/zlib")
 	cp.Expect("Downloading")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("reset", "-n") // should not remove cached shared/zlib artifact
+	cp = ts.Spawn("switch", "mingw") // should not remove cached shared/zlib artifact
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "shared/zlib")
+	cp.Expect("Installing")
 	cp.ExpectExitCode(0)
 	suite.Assert().NotContains(cp.Snapshot(), "Downloading", "shared/zlib should have been cached")
 
 	cp = ts.Spawn("config", "set", constants.RuntimeCacheSizeConfigKey, "0")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("reset", "-n") // should remove cached shared/zlib artifact
+	cp = ts.Spawn("switch", "main") // should remove cached shared/zlib artifact
 	cp.ExpectExitCode(0)
 
 	cp = ts.Spawn("install", "shared/zlib")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3213" title="DX-3213" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3213</a>  Keep a cache of unused artifacts in the depot to speed up checkouts / branch switches
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
We cache up to 500MB of unused artifacts by default, but this size is configurable.