### PR TITLE
Added runtime sourcing timeout for failing integration test.

### DIFF
--- a/test/integration/checkout_int_test.go
+++ b/test/integration/checkout_int_test.go
@@ -402,7 +402,7 @@ func (suite *CheckoutIntegrationTestSuite) TestCheckoutPortable() {
 
 	// Checkout a working runtime.
 	cp := ts.Spawn("checkout", "ActiveState-CLI/small-python#fb513fe6-b9f4-4c54-adf3-8a7833b290f3", ".", "--portable")
-	cp.Expect("Checked out project")
+	cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 
 	// Remove the artifact depot.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3234" title="DX-3234" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3234</a>  Nightly failure: TestCheckoutIntegrationTestSuite/TestCheckoutPortable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
