### PR TITLE
Remove `state init` language inference.

### DIFF
--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -876,7 +876,7 @@ deploy_uninstall_success:
 err_arg_required:
   other: "The following argument is required:\n  Name: [NOTICE]{{.V0}}[/RESET]\n  Description: [NOTICE]{{.V1}}[/RESET]"
 err_init_no_language:
-  other: "A project has not been set using 'state use'. You must include the [NOTICE]language[/RESET] argument. For more help, run '[ACTIONABLE]state init --help[/RESET]'."
+  other: "You must include the [NOTICE]language[/RESET] argument. For more help, run '[ACTIONABLE]state init --help[/RESET]'."
 platform_added:
   other: "[NOTICE]{{.V0}}[/RESET] has been added."
 platform_removed:

--- a/test/integration/init_int_test.go
+++ b/test/integration/init_int_test.go
@@ -114,33 +114,6 @@ func (suite *InitIntegrationTestSuite) TestInit_NoLanguage() {
 	ts.IgnoreLogErrors()
 }
 
-func (suite *InitIntegrationTestSuite) TestInit_InferLanguageFromUse() {
-	suite.OnlyRunForTags(tagsuite.Init)
-	ts := e2e.New(suite.T(), false)
-	defer ts.Close()
-	ts.LoginAsPersistentUser()
-
-	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("checkout", "ActiveState-CLI/small-python")
-	cp.Expect("Checked out project")
-	cp.ExpectExitCode(0)
-
-	cp = ts.Spawn("use", "small-python")
-	cp.Expect("Switched to project", e2e.RuntimeSourcingTimeoutOpt)
-	cp.ExpectExitCode(0)
-
-	pname := strutils.UUID()
-	namespace := fmt.Sprintf("%s/%s", e2e.PersistentUsername, pname)
-	cp = ts.Spawn("init", namespace)
-	cp.Expect("successfully initialized")
-	cp.ExpectExitCode(0)
-	ts.NotifyProjectCreated(e2e.PersistentUsername, pname.String())
-
-	suite.Contains(string(fileutils.ReadFileUnsafe(filepath.Join(ts.Dirs.Work, constants.ConfigFileName))), "language: python3")
-}
-
 func (suite *InitIntegrationTestSuite) TestInit_NotAuthenticated() {
 	suite.OnlyRunForTags(tagsuite.Init)
 	ts := e2e.New(suite.T(), false)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3229" title="DX-3229" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3229</a>  Remove default language mechanic from `state init`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
It was too confusing. Just go back to requiring the `--language` argument.