### PR TITLE
Do not assume all depot artifacts are cached yet.

### DIFF
--- a/pkg/runtime/depot.go
+++ b/pkg/runtime/depot.go
@@ -422,6 +422,12 @@ func (d *depot) Save() error {
 	// Mark artifacts that are no longer used and remove the old ones.
 	for id := range d.artifacts {
 		if deployments, ok := d.config.Deployments[id]; !ok || len(deployments) == 0 {
+			if _, exists := d.config.Cache[id]; !exists {
+				err := d.recordUse(id)
+				if err != nil {
+					return errs.Wrap(err, "Could not update depot cache with previously used artifact")
+				}
+			}
 			d.config.Cache[id].InUse = false
 			logging.Debug("Artifact '%s' is no longer in use", id.String())
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3213" title="DX-3213" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3213</a>  Keep a cache of unused artifacts in the depot to speed up checkouts / branch switches
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Users upgrading State Tool will not have their artifacts cached in the depot yet.