### PR TITLE
When deleting cached depot artifacts, ensure ID is set.

### DIFF
--- a/pkg/runtime/depot.go
+++ b/pkg/runtime/depot.go
@@ -485,10 +485,12 @@ func (d *depot) removeStaleArtifacts() error {
 	var totalSize int64
 	unusedArtifacts := make([]*artifactInfo, 0)
 
-	for _, info := range d.config.Cache {
+	for id, info := range d.config.Cache {
 		if !info.InUse {
 			totalSize += info.Size
-			unusedArtifacts = append(unusedArtifacts, info)
+			unusedInfo := *info
+			unusedInfo.id = id // id is not set in cache since info is keyed by id
+			unusedArtifacts = append(unusedArtifacts, &unusedInfo)
 		}
 	}
 	logging.Debug("There are %d unused artifacts totaling %.1f MB in size", len(unusedArtifacts), float64(totalSize)/float64(MB))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3213" title="DX-3213" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />DX-3213</a>  Keep a cache of unused artifacts in the depot to speed up checkouts / branch switches
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Otherwise the entire depot will be accidentally deleted.