### PR TITLE
Log a warning if a depot artifact to undeploy does not exist.

### DIFF
--- a/pkg/runtime/depot.go
+++ b/pkg/runtime/depot.go
@@ -331,7 +331,11 @@ func (d *depot) Undeploy(id strfmt.UUID, relativeSrc, path string) error {
 
 	// Perform uninstall based on deployment type
 	if err := smartlink.UnlinkContents(filepath.Join(d.Path(id), relativeSrc), path); err != nil {
-		return errs.Wrap(err, "failed to unlink artifact")
+		if os.IsNotExist(err) {
+			logging.Warning("artifact no longer exists: %s", filepath.Join(d.Path(id), relativeSrc))
+		} else {
+			return errs.Wrap(err, "failed to unlink artifact")
+		}
 	}
 
 	// Re-link or re-copy any files provided by other artifacts.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3243" title="DX-3243" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />DX-3243</a>  Runtime sourcing fails if it can't delete old entries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Do not error out.