### PR TITLE
Use ubuntu-latest for GitHub Actions runners.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,7 +441,7 @@ jobs:
     name: Deploy
     needs:
       - scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       ACTIVESTATE_CI: true
       SHELL: bash
@@ -522,7 +522,7 @@ jobs:
         uses: geekyeggo/delete-artifact@v5
         with:
           name: |
-            session-build-ubuntu-20.04
+            session-build-ubuntu-latest
             session-build-macos-11
             session-build-windows-2019
             session-build-ubuntu-24.04-arm

--- a/.github/workflows/propagate.yml
+++ b/.github/workflows/propagate.yml
@@ -12,7 +12,7 @@ jobs:
   # === Set target branch ===
   propagate:
     name: Propagate to affected version branches
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       ACTIVESTATE_CI: true
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,7 +15,7 @@ jobs:
   # === Target & Verify PR ===
   verifypr:
     name: Target & Verify PR
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JIRA_USERNAME: ${{ secrets.JIRA_EMAIL }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3246" title="DX-3246" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3246</a>  Update GitHub Actions runners to use ubuntu-22.04 or higher
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


All of the updated jobs can use latest since they're running non-build-related tasks.