### PR TITLE
First attempt building for Apple Silicon.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         sys:
           - {os: ubuntu-latest}
           - {os: macos-13, shell: zsh}
+          - {os: macos-latest, shell: zsh}
           - {os: windows-2019}
           - {os: ubuntu-24.04-arm}
       fail-fast: false
@@ -523,6 +524,7 @@ jobs:
         with:
           name: |
             session-build-ubuntu-latest
-            session-build-macos-11
+            session-build-macos-13
+            session-build-macos-latest
             session-build-windows-2019
             session-build-ubuntu-24.04-arm

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -39,9 +39,7 @@ constants:
       export CGO_ENABLED=0
       PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
       BUILD_EXEC_TARGET=$constants.BUILD_EXEC_TARGET
-
-      # add the GOARCH as infix to BUILD_TARGET_DIR if not amd64
-      BUILD_TARGET_DIR=$constants.BUILD_TARGET_PREFIX_DIR/${GOARCH#amd64}
+      BUILD_TARGET_DIR=$constants.BUILD_TARGET_PREFIX_DIR/
   - name: SCRIPT_EXT
     if: ne .OS.Name "Windows"
     value: .sh
@@ -245,7 +243,7 @@ scripts:
       GOOS=windows go build -o .github/deps/Windows/amd64/bin/parallelize.exe github.com/ActiveState/cli/scripts/ci/parallelize/
       GOOS=linux go build -o .github/deps/Linux/amd64/bin/parallelize github.com/ActiveState/cli/scripts/ci/parallelize/
       GOOS=linux GOARCH=arm64 go build -o .github/deps/Linux/arm64/bin/parallelize github.com/ActiveState/cli/scripts/ci/parallelize/
-      GOOS=darwin go build -o .github/deps/macOS/amd64/bin/parallelize github.com/ActiveState/cli/scripts/ci/parallelize/
+      GOOS=darwin GOARCH=amd64 go build -o .github/deps/macOS/amd64/bin/parallelize github.com/ActiveState/cli/scripts/ci/parallelize/
   - name: test
     language: bash
     standalone: true

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -82,6 +82,8 @@ Linux)
 Darwin)
   OS="darwin"
   ARCH="amd64"
+  arch="`uname -m`"
+  if [ $arch = "arm64" ]; then ARCH="arm64"; fi
   DOWNLOADEXT=".tar.gz"
   SHA256SUM="shasum -a 256"
   ;;

--- a/test/integration/upgen_int_test.go
+++ b/test/integration/upgen_int_test.go
@@ -30,9 +30,6 @@ func (suite *UpdateGenIntegrationTestSuite) TestUpdateBits() {
 		ext = ".zip"
 	}
 	hostArch := runtime.GOARCH
-	if runtime.GOOS == "darwin" && hostArch == "arm64" {
-		hostArch = "amd64"
-	}
 	platform := runtime.GOOS + "-" + hostArch
 
 	archivePath := filepath.Join(root, "build/update", constants.ChannelName, constants.VersionNumber, platform, fmt.Sprintf("state-%s-%s%s", platform, constants.Version, ext))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/DX-3247" title="DX-3247" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />DX-3247</a>  Support ARM on Mac; New Macs can't install State Tool as they no longer ship with Rosetta
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


Most of the plumbing was already in place from the Linux ARM PR. This is just adding a new arch for macOS.

Note that macOS runtimes are still amd64, so they will run with Rosetta, just like ARM Macs are doing now. (It's just State Tool that's ARM-native.)