### PR TITLE
Initial implementation for installing packages from ecosystems.

### DIFF
--- a/pkg/runtime/ecosystem.go
+++ b/pkg/runtime/ecosystem.go
@@ -1,0 +1,60 @@
+package runtime
+
+import "github.com/ActiveState/cli/pkg/buildplan"
+
+// eg.
+// availableEcosystems = []func() (ecosystem, error){
+// 	func() (ecosystem, error) {
+// 		return &python.Ecosystem{}, nil
+// 	},
+// }
+var availableEcosystems []func() ecosystem
+
+type ecosystem interface {
+	Init(runtimePath string, buildplan *buildplan.BuildPlan) error
+	Namespaces() []string
+	Add(artifact *buildplan.Artifact, artifactSrcPath string) ([]string, error)
+	Remove(artifact *buildplan.Artifact) error
+	Apply() error
+}
+
+func artifactMatchesEcosystem(a *buildplan.Artifact, e ecosystem) bool {
+	for _, namespace := range e.Namespaces() {
+		for _, i := range a.Ingredients {
+			if i.Namespace == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func namespacesMatchesEcosystem(namespaces []string, e ecosystem) bool {
+	for _, namespace := range e.Namespaces() {
+		for _, n := range namespaces {
+			if n == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func filterEcosystemMatchingArtifact(artifact *buildplan.Artifact, ecosystems []ecosystem) ecosystem {
+	for _, ecosystem := range ecosystems {
+		if artifactMatchesEcosystem(artifact, ecosystem) {
+			return ecosystem
+		}
+	}
+	return nil
+}
+
+func filterEcosystemsMatchingNamespaces(ecosystems []ecosystem, namespaces []string) []ecosystem {
+	result := []ecosystem{}
+	for _, ecosystem := range ecosystems {
+		if namespacesMatchesEcosystem(namespaces, ecosystem) {
+			result = append(result, ecosystem)
+		}
+	}
+	return result
+}

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -281,13 +281,6 @@ func (s *setup) update() error {
 		}
 	}
 
-	// Tell applicable ecosystems to perform any final uninstall actions.
-	for _, e := range s.ecosystems {
-		if err := e.Apply(); err != nil {
-			return errs.Wrap(err, "Could not apply ecosystem changes")
-		}
-	}
-
 	// Install artifacts
 	wp = workerpool.New(maxConcurrency)
 	for _, a := range s.toInstall {
@@ -302,13 +295,6 @@ func (s *setup) update() error {
 	// Wait for workerpool handling artifact installs to finish
 	if err := wp.Wait(); err != nil {
 		return errs.Wrap(err, "errors occurred during install")
-	}
-
-	// Tell applicable ecosystems to perform any final install actions.
-	for _, e := range s.ecosystems {
-		if err := e.Apply(); err != nil {
-			return errs.Wrap(err, "Could not apply ecosystem changes")
-		}
 	}
 
 	if err := s.postProcess(); err != nil {
@@ -590,6 +576,13 @@ func (s *setup) postProcess() (rerr error) {
 			}
 		}
 	}()
+
+	// Tell applicable ecosystems to apply changes.
+	for _, e := range s.ecosystems {
+		if err := e.Apply(); err != nil {
+			return errs.Wrap(err, "Could not apply ecosystem changes")
+		}
+	}
 
 	// Update executors
 	if err := s.updateExecutors(); err != nil {

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -548,6 +548,7 @@ func (s *setup) uninstall(id strfmt.UUID) (rerr error) {
 
 	artifactDepotPath := s.depot.Path(id)
 
+	// TODO: CP-956
 	//if ecosys := filterEcosystemMatchingArtifact(artifact, s.ecosystems); ecosys != nil {
 	//	err := ecosys.Remove(artifact)
 	//	if err != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-933" title="CP-933" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />CP-933</a>  Introduce ecosystem mechanic into State Tool
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
- This PR omits implementation of `Remove()` and `Untrack()` function, which is to be done in CP-956.
- The artifact install and uninstall routines are very enmeshed in the depot and lifting them out and into *setup.go* would be a pretty significant refactor, so I have those features call `Track()` and `Untrack()` as necessary.
- The ecosystem `Add()` and `Remove()` functions do not call the depot's existing artifact install and uninstall routines, just `Track()` and `Untrack()`.