### PR TITLE
Make new storage dirs behave the same way as the old

### DIFF
--- a/internal/config/instance.go
+++ b/internal/config/instance.go
@@ -42,7 +42,7 @@ func NewCustom(localPath string, thread *singlethread.Thread, closeThread bool) 
 	i.closeThread = closeThread
 
 	if localPath != "" {
-		i.appDataDir = storage.AppDataPathWithParent(localPath)
+		i.appDataDir = localPath
 	} else {
 		i.appDataDir = storage.AppDataPath()
 	}

--- a/internal/installation/storage/storage.go
+++ b/internal/installation/storage/storage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 )
 
-
 var homeDir string
 
 func init() {
@@ -23,7 +22,6 @@ func init() {
 		panic(fmt.Sprintf("Could not get home dir, you can fix this by ensuring the $HOME environment variable is set. Error: %v", err))
 	}
 }
-
 
 func relativeAppDataPath() string {
 	return filepath.Join(constants.InternalConfigNamespace, fmt.Sprintf("%s-%s", constants.LibraryName, constants.ChannelName))
@@ -36,7 +34,7 @@ func relativeCachePath() string {
 func AppDataPath() string {
 	localPath, envSet := os.LookupEnv(constants.ConfigEnvVarName)
 	if envSet {
-		return AppDataPathWithParent(localPath)
+		return localPath
 	} else if condition.InUnitTest() {
 		var err error
 		localPath, err = appDataPathInTest()
@@ -47,7 +45,7 @@ func AppDataPath() string {
 		return localPath
 	}
 
-	return AppDataPathWithParent(BaseAppDataPath())
+	return filepath.Join(BaseAppDataPath(), relativeAppDataPath())
 }
 
 var _appDataPathInTest string


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-967" title="CP-967" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-967</a>  Nightly failure: TestManifestIntegrationTestSuite/TestManifest
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

ie. don't add branch info if the appdata path is overridden

Github confused itself, test results are here:

https://github.com/ActiveState/cli/actions/runs/16357596409

Remaining failure is unrelated.