### PR TITLE
Add `security.reporting` config to disable CVE reporting

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -400,6 +400,9 @@ const ReportAnalyticsConfig = "report.analytics"
 // PreferredGlibcVersionConfig is the config key used to determine the preferred glibc version
 const PreferredGlibcVersionConfig = "runtime.preferred.glibc"
 
+// SecurityReportingConfig is the config key used to determine if we will report security information (ie. CVEs)
+const SecurityReportingConfig = "security.reporting"
+
 // SecurityPromptConfig is the config key used to determine if we will prompt the user for security related actions
 const SecurityPromptConfig = "security.prompt.enabled"
 

--- a/internal/runbits/cves/cves.go
+++ b/internal/runbits/cves/cves.go
@@ -20,6 +20,7 @@ import (
 )
 
 func init() {
+	configMediator.RegisterOption(constants.SecurityReportingConfig, configMediator.Bool, true)
 	configMediator.RegisterOption(constants.SecurityPromptConfig, configMediator.Bool, true)
 	severities := configMediator.NewEnum([]string{
 		vulnModel.SeverityCritical,
@@ -120,6 +121,10 @@ func (c *CveReport) Report(newBuildPlan *buildplan.BuildPlan, oldBuildPlan *buil
 }
 
 func (c *CveReport) shouldSkipReporting(changeset buildplan.ArtifactChangeset) bool {
+	if !c.prime.Config().GetBool(constants.SecurityReportingConfig) {
+		return true
+	}
+	
 	if !c.prime.Auth().Authenticated() {
 		return true
 	}

--- a/internal/runners/manifest/manifest.go
+++ b/internal/runners/manifest/manifest.go
@@ -147,6 +147,10 @@ func (m *Manifest) fetchBuildplanRequirements() (buildplan.Ingredients, error) {
 func (m *Manifest) fetchVulnerabilities(reqs []buildscript.Requirement, bpReqs buildplan.Ingredients) (vulnerabilities, error) {
 	vulns := make(vulnerabilities)
 
+	if !m.cfg.GetBool(constants.SecurityReportingConfig) {
+		return vulns, nil
+	}
+
 	if !m.auth.Authenticated() {
 		for _, req := range reqs {
 			r, ok := req.(buildscript.DependencyRequirement)


### PR DESCRIPTION
I couldn't test on a PR deploy because the CVE service is unavailable.

This adds `state config set security.reporting true|false`.

It defaults to `true`, which means it will report on security related issue (ie. CVEs). Turning this to false will negate `security.prompt.enabled` and `security.prompt.level`.

The primary use-case for this is avoiding disruptions during test cycles where the CVE service may be unavailable.