### PR TITLE
Try vendoring dependencies in Rust ecosystem.

### DIFF
--- a/pkg/runtime/ecosystem/rust.go
+++ b/pkg/runtime/ecosystem/rust.go
@@ -1,35 +1,28 @@
 package ecosystem
 
 import (
-	"fmt"
+	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/ActiveState/cli/internal/errs"
 	"github.com/ActiveState/cli/internal/fileutils"
-	"github.com/ActiveState/cli/internal/locale"
-	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/unarchiver"
 
 	"github.com/ActiveState/cli/pkg/buildplan"
 )
 
 type Rust struct {
-	runtimeDir     string
-	crateCacheName string // e.g. index.crates.io-6f16d22bbaa15001f
+	runtimeDir string
+	vendorDir  string
 }
 
 func (e *Rust) Init(runtimePath string, buildplan *buildplan.BuildPlan) error {
 	e.runtimeDir = runtimePath
-
-	var err error
-	e.crateCacheName, err = getCacheDirName(runtimePath)
-	switch {
-	case err != nil:
-		return errs.Wrap(err, "Unable to get cargo registry cache dir")
-	case e.crateCacheName == "":
-		return locale.NewError("rust_cache_not_found", "The Rust runtime does not have a cache directory for the crates.io index")
+	e.vendorDir = filepath.Join("usr", "cargo", "vendor")
+	err := fileutils.MkdirUnlessExists(filepath.Join(e.runtimeDir, e.vendorDir))
+	if err != nil {
+		return errs.Wrap(err, "Unable to create cargo vendor directory")
 	}
-
 	return nil
 }
 
@@ -37,10 +30,9 @@ func (e *Rust) Namespaces() []string {
 	return []string{"language/rust"}
 }
 
-// Add copies the "download" artifact to the Cargo cache directory, renaming it to
-// "<name>-<version>.crate" format.
-// We also inject the CARGO_HOME environment variable into runtime.json so cargo will look in the
-// right place for our artifacts instead of downloading its own.
+// Unpack the crate into the vendor directory.
+// We also inject the CARGO_HOME environment variable into runtime.json so cargo will look for our
+// vendored artifacts instead of downloading its own.
 func (e *Rust) Add(artifact *buildplan.Artifact, artifactSrcPath string) ([]string, error) {
 	installedFiles := []string{}
 
@@ -61,15 +53,40 @@ func (e *Rust) Add(artifact *buildplan.Artifact, artifactSrcPath string) ([]stri
 			continue
 		}
 
-		name := fmt.Sprintf("%s-%s.crate", artifact.Name(), artifact.Version())
-		relativeCrateCacheDir := filepath.Join("usr", "cargo", "registry", "cache", e.crateCacheName)
-		relativeInstalledFile := filepath.Join(relativeCrateCacheDir, name)
-		installedFile := filepath.Join(e.runtimeDir, relativeInstalledFile)
-		err = fileutils.CopyFile(file.AbsolutePath(), installedFile)
-		if err != nil {
-			return nil, errs.Wrap(err, "Unable to copy artifact crate into cache directory")
+		relativeVendored := filepath.Join(e.vendorDir, artifact.Name())
+		absVendored := filepath.Join(e.runtimeDir, relativeVendored)
+
+		// Delete any previously vendored crate.
+		if fileutils.DirExists(absVendored) {
+			err = os.RemoveAll(absVendored)
+			if err != nil {
+				return nil, errs.Wrap(err, "Unable to remove previously unpacked crate")
+			}
 		}
-		installedFiles = append(installedFiles, relativeInstalledFile)
+
+		// Unpacked crates contain a single <name>-<version> folder.
+		// That folder needs to be renamed to just <name> for Cargo to recognize it.
+		ua := unarchiver.NewTarGz()
+		unpackDir := filepath.Join(e.runtimeDir, e.vendorDir)
+		f, size, err := ua.PrepareUnpacking(file.AbsolutePath(), unpackDir)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to prepare for unpacking downloaded crate")
+		}
+		err = ua.Unarchive(f, size, unpackDir)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to unpack downloaded crate")
+		}
+		err = os.Rename(filepath.Join(unpackDir, artifact.Name()+"-"+artifact.Version()), absVendored)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to rename unpacked crate")
+		}
+		// Cargo needs a checksum file too. We cannot produce a real one, but it accepts an empty one.
+		err = fileutils.WriteFile(filepath.Join(absVendored, ".cargo-checksum.json"), []byte(`{"files":{}}`))
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to write empty checksum")
+		}
+
+		installedFiles = append(installedFiles, relativeVendored)
 	}
 
 	return installedFiles, nil
@@ -79,51 +96,25 @@ func (e *Rust) Remove(artifact *buildplan.Artifact) error {
 	return nil // TODO: CP-956
 }
 
+// configFileContents replaces the crates.io source with our vendored crates.
+// Note: the directory is relative to "e.runtimeDir/usr".
+const configFileContents = `
+[source.crates-io]
+replace-with = "vendor"
+
+[source.vendor]
+directory = "cargo/vendor"
+`
+
+// Create a Cargo config file that tells Cargo to use our vendored crates instead of downloading
+// its own.
 func (e *Rust) Apply() error {
+	configFile := filepath.Join(e.runtimeDir, "usr", "cargo", "config.toml")
+	if !fileutils.TargetExists(configFile) {
+		err := fileutils.WriteFile(configFile, []byte(configFileContents))
+		if err != nil {
+			return errs.Wrap(err, "Unable to write cargo config file")
+		}
+	}
 	return nil
-}
-
-// getCacheDirName returns Cargo's crates.io registry cache directory for this runtime.
-// Note: at the time of writing, the runtime has a usr/registry installed by the langauge core that
-// does not appear to be used, nor can it since Cargo's registry index directories have location-
-// dependent checksum suffixes, and the runtime's suffix was created at build-time.
-func getCacheDirName(runtimePath string) (string, error) {
-	cachePrefix := filepath.Join(runtimePath, "usr", "cargo", "registry", "cache")
-	if !fileutils.DirExists(cachePrefix) {
-		// Invoke cargo with a bogus "search" command that will fetch the crates.io registry index.
-		// We can use the registry index location to infer where the cache directory should be.
-		_, stderr, err := osutils.ExecSimple("cargo", []string{"search"}, []string{"CARGO_HOME=" + filepath.Join(runtimePath, "usr", "cargo")})
-		if err != nil {
-			return "", errs.Wrap(err, "Error running cargo: %s", stderr)
-		}
-		// Cargo's registry index directories have location-dependent checksum suffixes. Read it.
-		entries, err := fileutils.ListDirSimple(filepath.Join(runtimePath, "usr", "cargo", "registry", "index"), true)
-		if err != nil {
-			return "", errs.Wrap(err, "Unable to list contents of runtime usr/cargo/registry/index")
-		}
-		for _, entry := range entries {
-			if strings.Contains(entry, "index.crates.io-") {
-				name := filepath.Base(entry)
-				err = fileutils.Mkdir(filepath.Join(cachePrefix, name))
-				if err != nil {
-					return "", errs.Wrap(err, "Unable to make cache prefix")
-				}
-				return name, nil
-			}
-		}
-	}
-
-	// We already did the song and dance to create the location-specific cache directory, so just
-	// read it from the filesystem.
-	entries, err := fileutils.ListDirSimple(cachePrefix, true)
-	if err != nil {
-		return "", errs.Wrap(err, "Unable to list contents of runtime usr/cargo/registry/cache")
-	}
-	for _, entry := range entries {
-		if strings.Contains(entry, "index.crates.io-") {
-			return filepath.Base(entry), nil
-		}
-	}
-
-	return "", nil
 }


### PR DESCRIPTION
It looks like we can unpack our crates and trick Cargo into thinking they are vendored dependencies. Cargo does not reach out to crates.io at all. It only looks at what is vendored.

<img width="776" height="611" alt="Screenshot 2025-07-30 at 4 31 59 pm" src="https://github.com/user-attachments/assets/faf615b2-6f9c-4f1b-9346-a46bf96d7836" />
