### PR TITLE
Initial ecosystem implementation for .NET/C#.

### DIFF
--- a/pkg/runtime/ecosystem.go
+++ b/pkg/runtime/ecosystem.go
@@ -20,6 +20,7 @@ func init() {
 		func() ecosystem { return &ecosys.Java{} },
 		func() ecosystem { return &ecosys.JavaScript{} },
 		func() ecosystem { return &ecosys.Rust{} },
+		func() ecosystem { return &ecosys.DotNet{} },
 	}
 }
 

--- a/pkg/runtime/ecosystem/dotnet.go
+++ b/pkg/runtime/ecosystem/dotnet.go
@@ -1,0 +1,114 @@
+package ecosystem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ActiveState/cli/internal/errs"
+	"github.com/ActiveState/cli/internal/fileutils"
+	"github.com/ActiveState/cli/internal/unarchiver"
+
+	"github.com/ActiveState/cli/pkg/buildplan"
+)
+
+type DotNet struct {
+	runtimePath string
+	nupkgDir    string
+}
+
+func (e *DotNet) Init(runtimePath string, buildplan *buildplan.BuildPlan) error {
+	e.runtimePath = runtimePath
+	e.nupkgDir = filepath.Join("usr", "nupkg")
+	err := fileutils.MkdirUnlessExists(filepath.Join(e.runtimePath, e.nupkgDir))
+	if err != nil {
+		return errs.Wrap(err, "Unable to create nupkg directory")
+	}
+	return nil
+}
+
+func (e *DotNet) Namespaces() []string {
+	return []string{"language/dotnet"}
+}
+
+// Note: it's okay to leave the last two values blank.
+const nupkgMetadata = `{
+"version": 2,
+"contentHash": "",
+"source": ""
+}`
+
+func (e *DotNet) Add(artifact *buildplan.Artifact, artifactSrcPath string) ([]string, error) {
+	installedFiles := []string{}
+
+	files, err := fileutils.ListDir(artifactSrcPath, false)
+	if err != nil {
+		return nil, errs.Wrap(err, "Unable to read artifact source directory")
+	}
+	for _, file := range files {
+		if file.Name() == "runtime.json" {
+			err = injectEnvVar(file.AbsolutePath(), "NUGET_PACKAGES", "${INSTALLDIR}/"+e.nupkgDir)
+			if err != nil {
+				return nil, errs.Wrap(err, "Unable to add NUGET_PACKAGES to runtime.json")
+			}
+			continue
+		}
+		if !strings.HasSuffix(file.Name(), ".nupkg") {
+			continue
+		}
+
+		// The .NET runtime's package tree looks like this:
+		// $NUGET_PACKAGES/
+		//   - name1/
+		//     - version1/
+		//     - version2/
+		//   - name2/
+		//     - version1/
+		//     - version2/
+		// ...
+		// Create the <name> folder so the nupkg can be unpacked into <name>/<version>.
+		relativeNupkgDir := filepath.Join(e.nupkgDir, artifact.Name(), artifact.Version())
+		absNupkgDir := filepath.Join(e.runtimePath, relativeNupkgDir)
+		err = fileutils.MkdirUnlessExists(filepath.Dir(absNupkgDir))
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to create nupkg dir")
+		}
+
+		// Delete any previously extracted package.
+		if fileutils.DirExists(absNupkgDir) {
+			err = os.RemoveAll(absNupkgDir)
+			if err != nil {
+				return nil, errs.Wrap(err, "Unable to remove previously unpacked nupkg")
+			}
+		}
+
+		// Unpack the nupkg into a <version> folder inside the <name> folder.
+		ua := unarchiver.NewZip()
+		f, size, err := ua.PrepareUnpacking(file.AbsolutePath(), absNupkgDir)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to prepare for unpacking downloaded nupkg")
+		}
+		err = ua.Unarchive(f, size, absNupkgDir)
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to unpack downloaded nupkg")
+		}
+
+		// Packages need a .nupkg.metadata file too.
+		err = fileutils.WriteFile(filepath.Join(absNupkgDir, ".nupkg.metadata"), []byte(nupkgMetadata))
+		if err != nil {
+			return nil, errs.Wrap(err, "Unable to write empty metadata")
+		}
+
+		installedFiles = append(installedFiles, relativeNupkgDir)
+	}
+
+	return installedFiles, nil
+}
+
+func (e *DotNet) Remove(artifact *buildplan.Artifact) error {
+	return nil // TODO: CP-956
+}
+
+func (e *DotNet) Apply() error {
+	return nil
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-980" title="CP-980" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />CP-980</a>  Implement C# ecosystem installer in State Tool
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The `dotnet` command, provided by the .NET runtime/SDK, functions like `npm` for JavaScript. It replaces nuget's functionality. (This means it is possible to use `dotnet` to pull down packages from the nuget online package registry.) We cannot use nuget in Linux because of it's dependency on Mono, which is a large framework we should absolutely **not** depend on.

However, `dotnet` requires a project to operate in, so we cannot install _*.nupkg_ artifacts directly like we can with npm. Instead, we unpack _*.nupkg_ artifacts into a directory structure `dotnet` recognizes. Then users can build their own projects using our packages.

<img width="1544" height="1218" alt="image" src="https://github.com/user-attachments/assets/277c177e-ccca-4c2e-884e-9f444b2dec85" />

The order of operations is:
- Checkout a .NET Platform project.
- Install a .NET package.
- Start a shell for the project, which sets the `$NUGET_PACKAGES` environment variable that points to our virtual environment's package listing.
- Go to your .NET project and run `dotnet restore`, which will read your .NET project's project file and verify you have all the required dependencies (which should be in our virtual environment).
- Build and run the .NET project.

After the `state install` command, I turned off my network to confirm that `dotnet` can detect and use packages in our virtual environment.

It's a bit unfortunate that `dotnet restore` needs the `--source $NUGET_PACKAGES` argument, but oh well. It's certainly possible that people building against a local package listing have to do something similar to prevent a reachout to the nuget registry, so it may not be so bad.