### PR TITLE
Fixed detection of JavaScript modules installed in a runtime.

### DIFF
--- a/pkg/runtime/ecosystem/javascript.go
+++ b/pkg/runtime/ecosystem/javascript.go
@@ -48,7 +48,10 @@ func (e *JavaScript) Add(artifact *buildplan.Artifact, artifactSrcPath string) (
 		if ext != ".tar.gz" && ext != ".tgz" {
 			continue
 		}
-		if !strings.HasPrefix(file.Name(), artifact.Name()) {
+		if !strings.HasPrefix(file.Name(), packageName) {
+			// A vast majority of the time, the installed package name is the artifact name.
+			// When this is not the case, extract the package name from the file name. The file name is
+			// of the form <name>-<version>.tar.gz, so extract the <name> part.
 			if i := strings.LastIndex(file.Name(), "-"); i != -1 {
 				packageName = file.Name()[:i]
 			}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1018" title="CP-1018" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-1018</a>  npm detecting wrong root
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

The version number is not part of the directory name.

```
$ state shell
$ env | grep NPM
NPM_CONFIG_PREFIX=/home/me/.cache/activestate/54ce7b20
$ npm root -g
/home/me/.cache/activestate/54ce7b20/usr/lib/node_modules
```