### PR TITLE
Default to platform present if no timestamp input was provided

### DIFF
--- a/internal/runbits/commits_runbit/time.go
+++ b/internal/runbits/commits_runbit/time.go
@@ -36,7 +36,7 @@ func ExpandTime(ts *captain.TimeValue, auth *authentication.Auth) (time.Time, er
 		return latest, nil
 	}
 
-	if ts != nil && ts.IsPresent() {
+	if ts == nil || ts.IsPresent() {
 		latest, err := model.FetchLatestTimeStamp(auth)
 		if err != nil {
 			return time.Time{}, errs.Wrap(err, "Unable to fetch latest Platform timestamp")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1048" title="CP-1048" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-1048</a>  Nightly failure: TestPlatformsIntegrationTestSuite
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
