### PR TITLE
Update windows runner to 2025

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,9 +249,8 @@ jobs:
         shell: bash
         #if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
         run: |
-          ls "/c/Program Files (x86)/Windows Kits/10/bin/"
-          find "/c/Program Files (x86)/Windows Kits/10/bin" -iname signtool.exe
-          export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.11/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.16299.0/x86/:$PATH
+          ls "/c/Program Files (x86)/"
+          export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.11/bin/:/c/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64:$PATH
 
           signtool.exe sign -d "ActiveState State Tool" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state.exe
           signtool.exe sign -d "ActiveState State Service" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-svc.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
       - # === Sign Binaries (Windows only) ===
         name: Sign Binaries (Windows only)
         shell: bash
-        #if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
+        if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
         run: |
           export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.14/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.26100.0/x64:$PATH
 
@@ -262,7 +262,7 @@ jobs:
       - # === Sign Install Scripts (Windows only) ===
         name: Sign Install Scripts (Windows only)
         shell: powershell
-        #if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
+        if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
         run: |
           $branchInfix = $Env:GITHUB_REF.Replace("refs/heads/", "").Replace("release", "")
           $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,8 +249,7 @@ jobs:
         shell: bash
         #if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
         run: |
-          ls "/c/Program Files (x86)/"
-          export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.11/bin/:/c/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64:$PATH
+          export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.14/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.26100.0/x64:$PATH
 
           signtool.exe sign -d "ActiveState State Tool" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state.exe
           signtool.exe sign -d "ActiveState State Service" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-svc.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,11 +251,11 @@ jobs:
         run: |
           export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.14/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.26100.0/x64:$PATH
 
-          signtool.exe sign -d "ActiveState State Tool" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state.exe
-          signtool.exe sign -d "ActiveState State Service" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-svc.exe
-          signtool.exe sign -d "ActiveState State Installer" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-installer.exe
-          signtool.exe sign -d "ActiveState State Tool Remote Installer" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-remote-installer.exe
-          signtool.exe sign -d "ActiveState State MCP" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-mcp.exe
+          signtool.exe sign -fd SHA1 -d "ActiveState State Tool" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state.exe
+          signtool.exe sign -fd SHA1 -d "ActiveState State Service" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-svc.exe
+          signtool.exe sign -fd SHA1 -d "ActiveState State Installer" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-installer.exe
+          signtool.exe sign -fd SHA1 -d "ActiveState State Tool Remote Installer" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-remote-installer.exe
+          signtool.exe sign -fd SHA1 -d "ActiveState State MCP" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state-mcp.exe
         env:
           CODE_SIGNING_PASSWD: ${{ secrets.CODE_SIGNING_PASSWD }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,7 @@ jobs:
         #if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
         run: |
           ls "/c/Program Files (x86)/Windows Kits/10/bin/"
+          find "/c/Program Files (x86)/Windows Kits/10/bin" -iname signtool.exe
           export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.11/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.16299.0/x86/:$PATH
 
           signtool.exe sign -d "ActiveState State Tool" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
       - # === Sign Binaries (Windows only) ===
         name: Sign Binaries (Windows only)
         shell: bash
-        if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
+        #if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
         run: |
           export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.11/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.16299.0/x86/:$PATH
 
@@ -262,7 +262,7 @@ jobs:
       - # === Sign Install Scripts (Windows only) ===
         name: Sign Install Scripts (Windows only)
         shell: powershell
-        if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
+        #if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
         run: |
           $branchInfix = $Env:GITHUB_REF.Replace("refs/heads/", "").Replace("release", "")
           $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,11 @@ jobs:
         go-version:
           - 1.23.8
         sys:
-          - {os: ubuntu-latest}
-          - {os: macos-13, shell: zsh}
-          - {os: macos-latest, shell: zsh}
-          - {os: windows-2019}
-          - {os: ubuntu-24.04-arm}
+          - { os: ubuntu-latest }
+          - { os: macos-13, shell: zsh }
+          - { os: macos-latest, shell: zsh }
+          - { os: windows-2025 }
+          - { os: ubuntu-24.04-arm }
       fail-fast: false
     runs-on: ${{ matrix.sys.os }}
     env:
@@ -536,5 +536,5 @@ jobs:
             session-build-ubuntu-latest
             session-build-macos-13
             session-build-macos-latest
-            session-build-windows-2019
+            session-build-windows-2025
             session-build-ubuntu-24.04-arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,6 +249,7 @@ jobs:
         shell: bash
         #if: runner.os == 'Windows' && contains(fromJSON('["refs/heads/beta", "refs/heads/release", "refs/heads/LTS"]'), github.ref)
         run: |
+          ls "/c/Program Files (x86)/Windows Kits/10/bin/"
           export PATH=/c/Program\ Files\ \(x86\)/WiX\ Toolset\ v3.11/bin/:/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.16299.0/x86/:$PATH
 
           signtool.exe sign -d "ActiveState State Tool" -f "Cert.p12" -p ${CODE_SIGNING_PASSWD} ./build/state.exe

--- a/internal/runners/clean/run_win.go
+++ b/internal/runners/clean/run_win.go
@@ -32,19 +32,19 @@ func (u *Uninstall) runUninstall(params *UninstallParams) error {
 	logFile, err := os.CreateTemp("", "state-clean-uninstall")
 	if err != nil {
 		logging.Error("Could not create temporary log file: %s", errs.JoinMessage(err))
-		aggErr = locale.WrapError(aggErr, "err_clean_logfile", "Could not create temporary log file")
+		aggErr = locale.WrapError(aggErr, "err_clean_logfile", "Could not create temporary log file: {{.V0}}", err.Error())
 	}
 
 	stateExec, err := installation.StateExec()
 	if err != nil {
 		logging.Debug("Could not get State Tool executable: %s", errs.JoinMessage(err))
-		aggErr = locale.WrapError(aggErr, "err_state_exec")
+		aggErr = locale.WrapError(aggErr, "err_state_exec_with_error", "Could not get State Tool executable: {{.V0}}", err.Error())
 	}
 
 	err = removeInstall(logFile.Name(), params, u.cfg)
 	if err != nil {
 		logging.Debug("Could not remove installation: %s", errs.JoinMessage(err))
-		aggErr = locale.WrapError(aggErr, "uninstall_remove_executables_err", "Failed to remove all State Tool files in installation directory {{.V0}}", filepath.Dir(stateExec))
+		aggErr = locale.WrapError(aggErr, "uninstall_remove_executables_err", "Failed to remove all State Tool files in installation directory {{.V0}}: {{.V1}}", filepath.Dir(stateExec), err.Error())
 	}
 
 	err = removeApp()

--- a/test/integration/errors_int_test.go
+++ b/test/integration/errors_int_test.go
@@ -17,35 +17,35 @@ func (suite *ErrorsIntegrationTestSuite) TestTips() {
 	suite.OnlyRunForTags(tagsuite.Errors, tagsuite.Critical)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
+	ts.IgnoreLogErrors()
 
 	cp := ts.Spawn("__test", "multierror")
 	cp.Expect("Need More Help?")
 	cp.Expect("Run →")
 	cp.Expect("Ask For Help →")
 	cp.ExpectExitCode(1)
-	ts.IgnoreLogErrors()
 }
 
 func (suite *ErrorsIntegrationTestSuite) TestMultiErrorWithInput() {
 	suite.OnlyRunForTags(tagsuite.Errors, tagsuite.Critical)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
+	ts.IgnoreLogErrors()
 
 	cp := ts.Spawn("__test", "multierror-input")
-	cp.ExpectRe(`\s+x error1.\s+\s+x error2.\s+x error3.\s+x error4.\s+█\s+Need More Help`)
+	cp.ExpectRe(`\s+x error1.\s+\s+x error2.\s+x error3.\s+x error4.\s+`)
 	cp.ExpectExitCode(1)
-	ts.IgnoreLogErrors()
 }
 
 func (suite *ErrorsIntegrationTestSuite) TestMultiErrorWithoutInput() {
 	suite.OnlyRunForTags(tagsuite.Errors, tagsuite.Critical)
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
+	ts.IgnoreLogErrors()
 
 	cp := ts.Spawn("__test", "multierror-noinput")
-	cp.ExpectRe(`\s+x error1.\s+\s+x error2.\s+x error3.\s+x error4.\s+█\s+Need More Help`)
+	cp.ExpectRe(`\s+x error1.\s+\s+x error2.\s+x error3.\s+x error4.\s+`)
 	cp.ExpectExitCode(1)
-	ts.IgnoreLogErrors()
 }
 
 func TestErrorsIntegrationTestSuite(t *testing.T) {

--- a/test/integration/shells_int_test.go
+++ b/test/integration/shells_int_test.go
@@ -66,7 +66,7 @@ func (suite *ShellsIntegrationTestSuite) TestShells() {
 				e2e.OptAppendEnv(constants.OverrideShellEnvVarName+"="),
 			)
 			cp.SendLine(e2e.QuoteCommand(shell, ts.ExecutablePath(), "checkout", "ActiveState-CLI/small-python", string(shell)))
-			cp.Expect("Checked out project")
+			cp.Expect("Checked out project", e2e.RuntimeSourcingTimeoutOpt)
 			cp.SendLine("exit")
 			if shell != e2e.Cmd {
 				cp.ExpectExitCode(0)

--- a/test/integration/uninstall_int_test.go
+++ b/test/integration/uninstall_int_test.go
@@ -106,23 +106,23 @@ func (suite *UninstallIntegrationTestSuite) testUninstall(all bool) {
 
 	if runtime.GOOS == "windows" {
 		// Allow time for spawned script to remove directories
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 
 	if all {
-		suite.NoDirExists(ts.Dirs.Cache, "Cache dir should not exist after full uninstall")
-		suite.NoDirExists(ts.Dirs.Config, "Config dir should not exist after full uninstall")
+		suite.NoDirExists(ts.Dirs.Cache, ts.DebugMessage("Cache dir should not exist after full uninstall"))
+		suite.NoDirExists(ts.Dirs.Config, ts.DebugMessage("Config dir should not exist after full uninstall"))
 	} else {
-		suite.DirExists(ts.Dirs.Cache, "Cache dir should still exist after partial uninstall")
-		suite.DirExists(ts.Dirs.Config, "Config dir should still exist after partial uninstall")
+		suite.DirExists(ts.Dirs.Cache, ts.DebugMessage("Cache dir should still exist after partial uninstall"))
+		suite.DirExists(ts.Dirs.Config, ts.DebugMessage("Config dir should still exist after partial uninstall"))
 	}
 
 	if fileutils.FileExists(stateExe) {
-		suite.Fail("State tool executable should not exist after uninstall")
+		suite.Fail(ts.DebugMessage("State tool executable should not exist after uninstall"))
 	}
 
 	if fileutils.FileExists(svcExe) {
-		suite.Fail("State service executable should not exist after uninstall")
+		suite.Fail(ts.DebugMessage("State service executable should not exist after uninstall"))
 	}
 
 	if runtime.GOOS == "linux" {
@@ -135,7 +135,7 @@ func (suite *UninstallIntegrationTestSuite) testUninstall(all bool) {
 
 	if runtime.GOOS == "darwin" {
 		if fileutils.DirExists(filepath.Join(binDir, "system")) {
-			suite.Fail("system directory should not exist after uninstall")
+			suite.Fail(ts.DebugMessage("system directory should not exist after uninstall"))
 		}
 	}
 
@@ -145,7 +145,7 @@ func (suite *UninstallIntegrationTestSuite) testUninstall(all bool) {
 	}
 
 	if fileutils.DirExists(binDir) {
-		suite.Fail("bin directory should not exist after uninstall")
+		suite.Fail(ts.DebugMessage("bin directory should not exist after uninstall"))
 	}
 }
 

--- a/test/integration/uninstall_int_test.go
+++ b/test/integration/uninstall_int_test.go
@@ -106,7 +106,7 @@ func (suite *UninstallIntegrationTestSuite) testUninstall(all bool) {
 
 	if runtime.GOOS == "windows" {
 		// Allow time for spawned script to remove directories
-		time.Sleep(2 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 
 	if all {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1034" title="CP-1034" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />CP-1034</a>  Update our Windows CI runner to latest
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I validated as much as I can without actually running this against a release branch, but it seems unlikely that release specific logic would be impacted by the host runner.

Integration tests are failing. I dug into the failures but they are all seemingly unrelated. It doesn't help that we have a number of failing integration tests already and the last windows run is not retained on github actions due to its age, so I can't compare. End of the day we'll have to treat fixing up our integration tests as a separate story.
