### PR TITLE
Fix `state commit --skip-validation` saying failed when it was a success

### DIFF
--- a/internal/runners/commit/commit.go
+++ b/internal/runners/commit/commit.go
@@ -141,11 +141,10 @@ func (c *Commit) Run(params *Params) (rerr error) {
 	if err != nil {
 		return errs.Wrap(err, "Could not update project to reflect build script changes.")
 	}
+	pg.Stop(locale.T("progress_success"))
+	pg = nil
 
 	if !params.SkipValidation {
-		pg.Stop(locale.T("progress_success"))
-		pg = nil
-
 		pgSolve := output.StartSpinner(out, locale.T("progress_solve"), constants.TerminalAnimationInterval)
 		defer func() {
 			if pgSolve != nil {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1053" title="CP-1053" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-1053</a>  state commit --skip-validation emits "failed" at cli
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
