### PR TITLE
Support namespace:name syntax for packages.

### DIFF
--- a/internal/captain/values.go
+++ b/internal/captain/values.go
@@ -123,6 +123,8 @@ func (u *UsersValue) Type() string {
 // - <name>
 // - <namespace>/<name>
 // - <namespace>/<name>@<version>
+// - <namespace>:<name>
+// - <namespace>:<name>@<version>
 type PackageValue struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
@@ -137,7 +139,7 @@ func (p *PackageValue) String() string {
 	}
 	name := p.Name
 	if p.Namespace != "" {
-		name = fmt.Sprintf("%s/%s", p.Namespace, p.Name)
+		name = fmt.Sprintf("%s:%s", p.Namespace, p.Name)
 	}
 	if p.Version == "" {
 		return name
@@ -151,13 +153,18 @@ func (p *PackageValue) Set(s string) error {
 		p.Version = strings.TrimSpace(v[1])
 		s = v[0]
 	}
-	if !strings.Contains(s, "/") {
+	switch {
+	case strings.Contains(s, ":"):
+		v := strings.Split(s, ":")
+		p.Namespace = strings.TrimSpace(strings.Join(v[0:len(v)-1], ":"))
+		p.Name = strings.TrimSpace(v[len(v)-1])
+	case strings.Contains(s, "/"):
+		v := strings.Split(s, "/")
+		p.Namespace = strings.TrimSpace(strings.Join(v[0:len(v)-1], "/"))
+		p.Name = strings.TrimSpace(v[len(v)-1])
+	default:
 		p.Name = strings.TrimSpace(s)
-		return nil
 	}
-	v := strings.Split(s, "/")
-	p.Namespace = strings.TrimSpace(strings.Join(v[0:len(v)-1], "/"))
-	p.Name = strings.TrimSpace(v[len(v)-1])
 	return nil
 }
 

--- a/internal/captain/values_test.go
+++ b/internal/captain/values_test.go
@@ -53,12 +53,30 @@ func TestPackageValue_Set(t *testing.T) {
 	}{
 		{
 			"namespace, name and version",
-			"namespace/path/name@1.0.0",
+			"namespace/path:name@1.0.0",
 			false,
 			&PackageValue{Namespace: "namespace/path", Name: "name", Version: "1.0.0"},
 		},
 		{
 			"namespace and name",
+			"namespace/path:name",
+			false,
+			&PackageValue{Namespace: "namespace/path", Name: "name"},
+		},
+		{
+			"namespace, name with slashes, and version",
+			"namespace/path:name/with/slashes@1.0.0",
+			false,
+			&PackageValue{Namespace: "namespace/path", Name: "name/with/slashes", Version: "1.0.0"},
+		},
+		{
+			"legacy namespace, name and version",
+			"namespace/path/name@1.0.0",
+			false,
+			&PackageValue{Namespace: "namespace/path", Name: "name", Version: "1.0.0"},
+		},
+		{
+			"legacy namespace and name",
 			"namespace/path/name",
 			false,
 			&PackageValue{Namespace: "namespace/path", Name: "name"},
@@ -99,12 +117,30 @@ func TestPackageFlagNSRequired_Set(t *testing.T) {
 	}{
 		{
 			"namespace, name and version",
-			"namespace/path/name@1.0.0",
+			"namespace/path:name@1.0.0",
 			false,
 			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name", Version: "1.0.0"}},
 		},
 		{
 			"namespace and name",
+			"namespace/path:name",
+			false,
+			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name"}},
+		},
+		{
+			"namespace and name with slashes",
+			"namespace/path:name/with/slashes",
+			false,
+			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name/with/slashes"}},
+		},
+		{
+			"legacy namespace, name and version",
+			"namespace/path/name@1.0.0",
+			false,
+			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name", Version: "1.0.0"}},
+		},
+		{
+			"legacy namespace and name",
 			"namespace/path/name",
 			false,
 			&PackageValueNSRequired{PackageValue{Namespace: "namespace/path", Name: "name"}},

--- a/internal/locale/locales/en-us.yaml
+++ b/internal/locale/locales/en-us.yaml
@@ -1427,7 +1427,7 @@ uploadingredient_success:
     Revision: [ACTIONABLE]{{.V3}}[/RESET]
     Timestamp: [ACTIONABLE]{{.V4}}[/RESET]
 
-    You can install this package by running `[ACTIONABLE]state install {{.V1}}/{{.V0}} --ts now`[/RESET].
+    You can install this package by running `[ACTIONABLE]state install {{.V1}}:{{.V0}} --ts now`[/RESET].
 err_runtime_cache_invalid:
   other: Your runtime needs to be updated. Please run '[ACTIONABLE]state refresh[/RESET]'.
 err_buildscript_not_exist:

--- a/test/integration/package_int_test.go
+++ b/test/integration/package_int_test.go
@@ -304,10 +304,10 @@ func (suite *PackageIntegrationTestSuite) TestPackage_Duplicate() {
 
 	ts.PrepareEmptyProject()
 
-	cp := ts.Spawn("install", "shared/zlib") // install
+	cp := ts.Spawn("install", "shared:zlib") // install
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("install", "shared/zlib") // install again
+	cp = ts.Spawn("install", "shared:zlib") // install again
 	cp.Expect(" no changes")
 	cp.ExpectNotExitCode(0)
 	ts.IgnoreLogErrors()
@@ -663,7 +663,7 @@ func (suite *PackageIntegrationTestSuite) TestCVE_Indirect() {
 	cp = ts.Spawn("config", "set", constants.SecurityPromptConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("install", "private/ActiveState-CLI-Testing/language/python/django_dep", "--ts=2024-09-10T16:36:34.393Z")
+	cp = ts.Spawn("install", "private/ActiveState-CLI-Testing/language/python:django_dep", "--ts=2024-09-10T16:36:34.393Z")
 	cp.ExpectRe(`Warning: Found \d+ indirect known vulnerabilities`, e2e.RuntimeSolvingTimeoutOpt)
 	cp.Expect("Do you want to continue")
 	cp.SendLine("n")

--- a/test/integration/pull_int_test.go
+++ b/test/integration/pull_int_test.go
@@ -89,7 +89,7 @@ func (suite *PullIntegrationTestSuite) TestMergeBuildScript() {
 	cp.Expect("Checked out")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("install", "shared/zlib")
+	cp = ts.Spawn("install", "shared:zlib")
 	cp.Expect("Added", e2e.RuntimeSourcingTimeoutOpt)
 	cp.ExpectExitCode(0)
 

--- a/test/integration/reset_int_test.go
+++ b/test/integration/reset_int_test.go
@@ -29,7 +29,7 @@ func (suite *ResetIntegrationTestSuite) TestReset() {
 	cp := ts.Spawn("config", "set", constants.AsyncRuntimeConfig, "true")
 	cp.ExpectExitCode(0)
 
-	cp = ts.Spawn("install", "shared/zlib")
+	cp = ts.Spawn("install", "shared:zlib")
 	cp.Expect("Added")
 	cp.ExpectExitCode(0)
 
@@ -84,7 +84,7 @@ func (suite *ResetIntegrationTestSuite) TestRevertInvalidURL() {
 	err = fileutils.WriteFile(filepath.Join(ts.Dirs.Work, constants.ConfigFileName), contents)
 	suite.Require().NoError(err)
 
-	cp := ts.Spawn("install", "language/python/requests")
+	cp := ts.Spawn("install", "language/python:requests")
 	cp.Expect("invalid commit ID")
 	cp.Expect("Please run 'state reset' to fix it.")
 	cp.ExpectNotExitCode(0)

--- a/test/integration/runtime_int_test.go
+++ b/test/integration/runtime_int_test.go
@@ -169,7 +169,7 @@ func (suite *RuntimeIntegrationTestSuite) TestBuildInProgress() {
 
 	ts.PrepareEmptyProject()
 
-	cp = ts.Spawn("install", "private/"+e2e.PersistentUsername+"/hello-world", "--ts", "now")
+	cp = ts.Spawn("install", "private/"+e2e.PersistentUsername+":hello-world", "--ts", "now")
 	cp.Expect("Build Log:")
 	cp.Expect("Detailed Progress:")
 	cp.Expect("Building")
@@ -217,7 +217,7 @@ func (suite *RuntimeIntegrationTestSuite) TestRuntimeCache() {
 
 	ts.PrepareEmptyProject()
 
-	cp := ts.Spawn("install", "shared/zlib")
+	cp := ts.Spawn("install", "shared:zlib")
 	cp.Expect("Downloading")
 	cp.ExpectExitCode(0)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-972" title="CP-972" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />CP-972</a>  State tool splits namespace and package name by colon
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This will be needed for languages like Go that have slashes in package names.

Keep the legacy namespace/name syntax around for backward-compatibility.