### PR TITLE
fix: CP-1074 MCP tool get_ingredient_details should always return the latest revision

### DIFF
--- a/internal/runners/mcp/ingredientdetails/ingredientdetails.go
+++ b/internal/runners/mcp/ingredientdetails/ingredientdetails.go
@@ -37,8 +37,13 @@ func NewParams(name string, version string, namespace string) *Params {
 }
 
 func (runner *GetIngredientDetailsRunner) Run(params *Params) error {
+	latest, err := model.FetchLatestRevisionTimeStamp(runner.auth)
+	if err != nil {
+		return fmt.Errorf("failed to fetch latest timestamp: %w", err)
+	}
+
 	ingredient, err := model.GetIngredientByNameAndVersion(
-		params.namespace, params.name, params.version, nil, runner.auth)
+		params.namespace, params.name, params.version, &latest, runner.auth)
 
 	if err != nil {
 		return fmt.Errorf("error fetching ingredient: %w", err)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1074" title="CP-1074" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-1074</a>  MCP tool get_ingredient_details should always return the latest revision
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

