### PR TITLE
fix: CP-1086 Specify latest timestamp (vs nil) when retrieving latest ingredient revision

### DIFF
--- a/internal/runners/mcp/projecterrors/projecterrors.go
+++ b/internal/runners/mcp/projecterrors/projecterrors.go
@@ -109,11 +109,11 @@ func (runner *ProjectErrorsRunner) Run(params *Params) error {
 // If found, assume the issue is resolved so that a new build could be retried.
 func CheckDependencyFixes(auth *authentication.Auth, failedArtifacts []*buildplan.Artifact) (map[strfmt.UUID]bool, error) {
 	fixed := make(map[strfmt.UUID]bool)
+	latest, err := model.FetchLatestRevisionTimeStamp(auth)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch latest timestamp: %w", err)
+	}
 	for _, artifact := range failedArtifacts {
-		latest, err := model.FetchLatestRevisionTimeStamp(auth)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to fetch latest timestamp: %w", err)
-		}
 		// TODO: Query multiple artifacts at once to reduce API calls, improving performance.
 		latestRevision, err := model.GetIngredientByNameAndVersion(
 			artifact.Ingredients[0].Namespace, artifact.Name(), artifact.Version(), &latest, auth)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1086" title="CP-1086" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-1086</a>  Error when retrieving some ingredients from project failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
