### PR TITLE
Update config to override correct URL

### DIFF
--- a/cmd/state-remote-installer/main.go
+++ b/cmd/state-remote-installer/main.go
@@ -208,7 +208,7 @@ func execute(out output.Outputer, prompt prompt.Prompter, cfg *config.Instance, 
 		version = fmt.Sprintf("%s (%s)", version, channel)
 	}
 
-	update := updater.NewUpdateInstaller(an, availableUpdate)
+	update := updater.NewUpdateInstaller(cfg, an, availableUpdate)
 	out.Fprint(os.Stdout, locale.Tl("remote_install_downloading", "• Downloading State Tool version [NOTICE]{{.V0}}[/RESET]... ", version))
 	tmpDir, err := update.DownloadAndUnpack()
 	if err != nil {

--- a/cmd/state/autoupdate.go
+++ b/cmd/state/autoupdate.go
@@ -53,7 +53,7 @@ func autoUpdate(svc *model.SvcModel, args []string, childCmd *captain.Command, c
 	}
 
 	avUpdate := updater.NewAvailableUpdate(upd.Channel, upd.Version, upd.Platform, upd.Path, upd.Sha256, "")
-	up := updater.NewUpdateInstaller(an, avUpdate)
+	up := updater.NewUpdateInstaller(cfg, an, avUpdate)
 	if !up.ShouldInstall() {
 		logging.Debug("Update is not needed")
 		return false, nil

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -418,6 +418,9 @@ const AnalyticsPixelOverrideConfig = "report.analytics.endpoint"
 // UpdateEndpointConfig is the config key used to determine the update endpoint to use
 const UpdateEndpointConfig = "update.endpoint"
 
+// UpdateInfoEndpointConfig is the config key used to determine the update info endpoint to use
+const UpdateInfoEndpointConfig = "update.info.endpoint"
+
 // NotificationsURLConfig is the config key used to determine the notifications url to use
 const NotificationsURLConfig = "notifications.endpoint"
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -133,6 +133,12 @@ const OverwriteDefaultSystemPathEnvVarName = "ACTIVESTATE_TEST_SYSTEM_PATH"
 // TestAutoUpdateEnvVarName is used to test auto updates, when set to true will always attempt to auto update
 const TestAutoUpdateEnvVarName = "ACTIVESTATE_TEST_AUTO_UPDATE"
 
+// TestUpdateInfoURLEnvVarName is used to test update info urls, when set to a url will override the default update info url
+const TestUpdateInfoURLEnvVarName = "ACTIVESTATE_TEST_UPDATE_INFO_URL"
+
+// TestUpdateURLEnvVarName is used to test update urls, when set to a url will override the default update url
+const TestUpdateURLEnvVarName = "ACTIVESTATE_TEST_UPDATE_URL"
+
 // ForceUpdateEnvVarName is used to force state tool to update, regardless of whether the update is equal to the current version
 const ForceUpdateEnvVarName = "ACTIVESTATE_FORCE_UPDATE"
 

--- a/internal/runners/update/update.go
+++ b/internal/runners/update/update.go
@@ -65,7 +65,7 @@ func (u *Update) Run(params *Params) error {
 		))
 	}
 
-	update := updater.NewUpdateInstaller(u.an, upd)
+	update := updater.NewUpdateInstaller(u.cfg, u.an, upd)
 	if !update.ShouldInstall() {
 		logging.Debug("No update found")
 		u.out.Print(output.Prepare(

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -35,7 +35,7 @@ var (
 )
 
 func init() {
-	configMediator.RegisterOption(constants.UpdateEndpointConfig, configMediator.String, "")
+	configMediator.RegisterOption(constants.UpdateInfoEndpointConfig, configMediator.String, "")
 }
 
 type Checker struct {
@@ -87,7 +87,7 @@ func (u *Checker) infoURL(tag, desiredVersion, branchName, platform, arch string
 		infoURL string
 
 		envUrl = os.Getenv("_TEST_UPDATE_INFO_URL")
-		cfgUrl = u.cfg.GetString(constants.UpdateEndpointConfig)
+		cfgUrl = u.cfg.GetString(constants.UpdateInfoEndpointConfig)
 	)
 	switch {
 	case envUrl != "":

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -86,7 +86,7 @@ func (u *Checker) infoURL(tag, desiredVersion, branchName, platform, arch string
 	var (
 		infoURL string
 
-		envUrl = os.Getenv("_TEST_UPDATE_INFO_URL")
+		envUrl = os.Getenv(constants.TestUpdateInfoURLEnvVarName)
 		cfgUrl = u.cfg.GetString(constants.UpdateInfoEndpointConfig)
 	)
 	switch {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -128,7 +128,7 @@ func NewUpdateInstaller(cfg Configurable, an analytics.Dispatcher, avUpdate *Ava
 func getAPIUpdateURL(cfg Configurable, path string) string {
 	var apiUpdateURL string
 
-	envUrl := os.Getenv("_TEST_UPDATE_URL")
+	envUrl := os.Getenv(constants.TestUpdateURLEnvVarName)
 	cfgUrl := cfg.GetString(constants.UpdateEndpointConfig)
 	switch {
 	case envUrl != "":

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type mockConfig struct{}
+
+func (m *mockConfig) GetString(key string) string {
+	return ""
+}
+
+func (m *mockConfig) Set(key string, value interface{}) error {
+	return nil
+}
+
 func newAvailableUpdate(channel, version string) *AvailableUpdate {
 	return NewAvailableUpdate(channel, version, "platform", "path/to/zipfile.zip", "123456", "")
 }
@@ -45,7 +55,7 @@ func TestUpdateNotNeeded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			upd := NewUpdateInstallerByOrigin(nil, tt.Origin, tt.AvailableUpdate)
+			upd := NewUpdateInstallerByOrigin(&mockConfig{}, nil, tt.Origin, tt.AvailableUpdate)
 			assert.Equal(t, tt.IsUseful, upd.ShouldInstall())
 		})
 	}

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -320,9 +320,8 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateInfoHost() {
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("update"),
+		e2e.OptArgs("update", "-v"),
 		e2e.OptAppendEnv(suite.env(false, false)...),
-		e2e.OptAppendEnv("VERBOSE=true"),
 	)
 	cp.ExpectExitCode(0)
 
@@ -340,11 +339,11 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateHost_SetBeforeInvocation() {
 	suite.Assert().Equal(ts.GetConfig(constants.UpdateInfoEndpointConfig), "https://test.example.com/update")
 
 	cp := ts.SpawnWithOpts(
-		e2e.OptArgs("update"),
+		e2e.OptArgs("update", "-v"),
 		e2e.OptAppendEnv(suite.env(false, false)...),
-		e2e.OptAppendEnv("VERBOSE=true"),
 	)
 	cp.ExpectExitCode(11) // Expect failure due to DNS resolution of fake host
+	ts.IgnoreLogErrors()
 
 	correctHostCount := 0
 	incorrectHostCount := 0
@@ -372,14 +371,13 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateHost() {
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	cp := ts.Spawn("config", "set", constants.UpdateEndpointConfig, "https://example.com/update")
+	cp := ts.Spawn("config", "set", constants.UpdateEndpointConfig, "https://test.example.com/update")
 	cp.Expect("Successfully set config key")
 	cp.ExpectExitCode(0)
 
 	cp = ts.SpawnWithOpts(
-		e2e.OptArgs("update"),
+		e2e.OptArgs("update", "-v"),
 		e2e.OptAppendEnv(suite.env(false, false)...),
-		e2e.OptAppendEnv("VERBOSE=true"),
 	)
 	cp.ExpectExitCode(0)
 
@@ -387,7 +385,7 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateHost() {
 	incorrectHostCount := 0
 	for _, path := range ts.LogFiles() {
 		contents := string(fileutils.ReadFileUnsafe(path))
-		if strings.Contains(contents, "https://example.com/update") {
+		if strings.Contains(contents, "https://test.example.com/update") {
 			correctHostCount++
 		}
 		if strings.Contains(contents, "https://state-tool.activestate.com/update") {

--- a/test/integration/update_int_test.go
+++ b/test/integration/update_int_test.go
@@ -275,14 +275,14 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateTags() {
 	}
 }
 
-func (suite *UpdateIntegrationTestSuite) TestUpdateHost_SetBeforeInvocation() {
+func (suite *UpdateIntegrationTestSuite) TestUpdateInfoHost_SetBeforeInvocation() {
 	suite.OnlyRunForTags(tagsuite.Update)
 
 	ts := e2e.New(suite.T(), false)
 	defer ts.Close()
 
-	ts.SetConfig(constants.UpdateEndpointConfig, "https://test.example.com/update")
-	suite.Assert().Equal(ts.GetConfig(constants.UpdateEndpointConfig), "https://test.example.com/update")
+	ts.SetConfig(constants.UpdateInfoEndpointConfig, "https://test.example.com/update")
+	suite.Assert().Equal(ts.GetConfig(constants.UpdateInfoEndpointConfig), "https://test.example.com/update")
 
 	cp := ts.SpawnWithOpts(
 		e2e.OptArgs("--version"),
@@ -302,6 +302,63 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateHost_SetBeforeInvocation() {
 	}
 	suite.Assert().Greater(correctHostCount, 0, "Log file should contain the configured API host 'test.example.com'")
 	suite.Assert().Equal(incorrectHostCount, 0, "Log file should not contain the default API host 'platform.activestate.com'")
+
+	// Clean up - remove the config setting
+	cp = ts.Spawn("config", "set", constants.UpdateInfoEndpointConfig, "")
+	cp.Expect("Successfully")
+	cp.ExpectExitCode(0)
+}
+
+func (suite *UpdateIntegrationTestSuite) TestUpdateInfoHost() {
+	suite.OnlyRunForTags(tagsuite.Update)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	cp := ts.Spawn("config", "set", constants.UpdateInfoEndpointConfig, "https://example.com/update-info")
+	cp.Expect("Successfully set config key")
+	cp.ExpectExitCode(0)
+
+	cp = ts.SpawnWithOpts(
+		e2e.OptArgs("update"),
+		e2e.OptAppendEnv(suite.env(false, false)...),
+		e2e.OptAppendEnv("VERBOSE=true"),
+	)
+	cp.ExpectExitCode(0)
+
+	output := cp.Snapshot()
+	suite.Assert().Contains(output, "Getting update info: https://example.com/update-info/")
+}
+
+func (suite *UpdateIntegrationTestSuite) TestUpdateHost_SetBeforeInvocation() {
+	suite.OnlyRunForTags(tagsuite.Update)
+
+	ts := e2e.New(suite.T(), false)
+	defer ts.Close()
+
+	ts.SetConfig(constants.UpdateInfoEndpointConfig, "https://test.example.com/update")
+	suite.Assert().Equal(ts.GetConfig(constants.UpdateInfoEndpointConfig), "https://test.example.com/update")
+
+	cp := ts.SpawnWithOpts(
+		e2e.OptArgs("update"),
+		e2e.OptAppendEnv(suite.env(false, false)...),
+		e2e.OptAppendEnv("VERBOSE=true"),
+	)
+	cp.ExpectExitCode(11) // Expect failure due to DNS resolution of fake host
+
+	correctHostCount := 0
+	incorrectHostCount := 0
+	for _, path := range ts.LogFiles() {
+		contents := string(fileutils.ReadFileUnsafe(path))
+		if strings.Contains(contents, "https://test.example.com/update") {
+			correctHostCount++
+		}
+		if strings.Contains(contents, "https://state-tool.activestate.com/update") {
+			incorrectHostCount++
+		}
+	}
+	suite.Assert().Greater(correctHostCount, 0, "Log file should contain the configured update endpoint 'test.example.com'")
+	suite.Assert().Equal(incorrectHostCount, 0, "Log file should not contain the default update endpoint 'state-tool.activestate.com'")
 
 	// Clean up - remove the config setting
 	cp = ts.Spawn("config", "set", constants.UpdateEndpointConfig, "")
@@ -326,8 +383,19 @@ func (suite *UpdateIntegrationTestSuite) TestUpdateHost() {
 	)
 	cp.ExpectExitCode(0)
 
-	output := cp.Snapshot()
-	suite.Assert().Contains(output, "Getting update info: https://example.com/update/")
+	correctHostCount := 0
+	incorrectHostCount := 0
+	for _, path := range ts.LogFiles() {
+		contents := string(fileutils.ReadFileUnsafe(path))
+		if strings.Contains(contents, "https://example.com/update") {
+			correctHostCount++
+		}
+		if strings.Contains(contents, "https://state-tool.activestate.com/update") {
+			incorrectHostCount++
+		}
+	}
+	suite.Assert().Greater(correctHostCount, 0, "Log file should contain the configured update endpoint 'example.com'")
+	suite.Assert().Equal(incorrectHostCount, 0, "Log file should not contain the default update endpoint 'state-tool.activestate.com'")
 }
 
 func TestUpdateIntegrationTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1054" title="CP-1054" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />CP-1054</a>  The update url can be configured with `state config`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


In the previous PR I mistakenly used the config value to override the update info endpoint. I still think we need that, however the story calls for this config value to override the update endpoint. I've added another config value specifically for the update info endpoint and repurposed the original one for the indented use case.

Integration test failures appear to be unrelated to this PR as the same failures are happening on the nightly tests.