### PR TITLE
Fixed panic when tracking artifacts from camel builds.

### DIFF
--- a/pkg/runtime/depot.go
+++ b/pkg/runtime/depot.go
@@ -316,7 +316,7 @@ func (d *depot) Track(artifact *buildplan.Artifact, deploy *deployment) error {
 	d.config.Cache[id].LastAccessTime = time.Now().Unix()
 
 	// For dynamically imported artifacts, also include artifact metadata.
-	if artifact != nil {
+	if len(artifact.Ingredients) > 0 {
 		d.config.Cache[id].Namespace = artifact.Ingredients[0].Namespace
 		d.config.Cache[id].Name = artifact.Name()
 		d.config.Cache[id].Version = artifact.Version()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1088" title="CP-1088" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-1088</a>  State Tool Nightly Failure: lots of things
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
