### PR TITLE
Don't include state-mcp in public releases

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -225,6 +225,9 @@ const BetaChannel = "beta"
 // ExperimentalChannel is the channel used for experimental builds
 const ExperimentalChannel = "master"
 
+// PublicChannels are the channels intended for public consumption -- comma separated because Go doesn't allow slice constants
+const PublicChannels = ReleaseChannel + "," + BetaChannel
+
 // MonoAPIPath is the api path used for the platform api
 const MonoAPIPath = "/api/v1"
 

--- a/scripts/ci/payload-generator/main.go
+++ b/scripts/ci/payload-generator/main.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ActiveState/cli/internal/constants"
 	"github.com/ActiveState/cli/internal/environment"
 	"github.com/ActiveState/cli/internal/fileutils"
 	"github.com/ActiveState/cli/internal/installation"
 	"github.com/ActiveState/cli/internal/osutils"
+	"github.com/ActiveState/cli/internal/sliceutils"
 )
 
 var (
@@ -71,8 +73,11 @@ func generatePayload(inDir, outDir, binDir, channel, version string) error {
 		filepath.Join(inDir, constants.StateCmd+osutils.ExeExtension):          binDir,
 		filepath.Join(inDir, constants.StateSvcCmd+osutils.ExeExtension):       binDir,
 		filepath.Join(inDir, constants.StateExecutorCmd+osutils.ExeExtension):  binDir,
-		filepath.Join(inDir, constants.StateMCPCmd+osutils.ExeExtension):       binDir,
 	}
+	if !sliceutils.Contains(strings.Split(constants.PublicChannels, ","), channel) {
+		files[filepath.Join(inDir, constants.StateMCPCmd+osutils.ExeExtension)] = binDir
+	}
+
 	if err := copyFiles(files); err != nil {
 		return fmt.Errorf(emsg, err)
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1101" title="CP-1101" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />CP-1101</a>  Don't include state-mcp when targeting beta or release
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
