### PR TITLE
Don't default to arm64 yet; still testing

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -104,8 +104,9 @@ Linux)
 Darwin)
   OS="darwin"
   ARCH="amd64"
-  arch="`uname -m`"
-  if [ $arch = "arm64" ]; then ARCH="arm64"; fi
+  if [ -n "$OVERRIDE_ARCH" ]; then
+    ARCH="$OVERRIDE_ARCH"
+  fi
   DOWNLOADEXT=".tar.gz"
   SHA256SUM="shasum -a 256"
   ;;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1103" title="CP-1103" target="_blank"><img alt="Story" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10308?size=medium" />CP-1103</a>  Don't include Mac ARM64 when targeting beta / release
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


I just changed the default and allowed an override. That way we can still ship and test arm64 without significant risk.
