### PR TITLE
Fixed failing publish integration test.

### DIFF
--- a/test/integration/publish_int_test.go
+++ b/test/integration/publish_int_test.go
@@ -136,7 +136,7 @@ func (suite *PublishIntegrationTestSuite) TestPublish() {
 			},
 				expect{
 					[]string{},
-					"Expected file extension to be either",
+					"Expected file extension:",
 					true,
 					1,
 					true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1128" title="CP-1128" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-1128</a>  State Tool nightly failure: TestPublishIntegrationTestSuite/TestPublish/New_ingredient_with_invalid_filename/New_ingredient_with_invalid_filename_invocation_1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The error message recently changed to accommodate a new extension.