### PR TITLE
Recognize planning errors when evaluating a build expression.

### DIFF
--- a/pkg/platform/api/buildplanner/response/commit.go
+++ b/pkg/platform/api/buildplanner/response/commit.go
@@ -13,7 +13,7 @@ import (
 func ProcessBuildError(build *BuildResponse, fallbackMessage string) error {
 	logging.Debug("ProcessBuildError: build.Type=%s", build.Type)
 	if build.Type == types.PlanningErrorType {
-		return processPlanningError(build.Message, build.SubErrors)
+		return ProcessPlanningError(build.Message, build.SubErrors)
 	} else if build.Error == nil {
 		return errs.New(fallbackMessage)
 	}
@@ -21,7 +21,7 @@ func ProcessBuildError(build *BuildResponse, fallbackMessage string) error {
 	return locale.NewInputError("err_buildplanner_build", "Encountered error processing build response")
 }
 
-func processPlanningError(message string, subErrors []*BuildExprError) error {
+func ProcessPlanningError(message string, subErrors []*BuildExprError) error {
 	var errs []string
 	var isTransient bool
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1148" title="CP-1148" target="_blank"><img alt="Task" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />CP-1148</a>  State tool isn't handling errors from Evaluate queries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
```
% ~/cli/build/state install language/golang:github.com/docker/cli --ts dynamic
█ Installing Package

Operating on project org/project, located at /path/to/project.

• Searching for packages in the ActiveState Catalog ✔ Found
• Resolving Dependencies x Failed
 x Could not plan build. Platform responded with:
  Failed to create build plan due to solve errors
  Request is invalid
  let.sources.dynamic_solve
  dynamic imports: get versions of language/golang:github.com/docker/cli: get versions: '<' not 
supported between instances of 'int' and 'str'.
```