### PR TITLE
After dynamically evaluating a build plan, staging a commit needs to use the latest timestamp.

### DIFF
--- a/internal/runbits/reqop_runbit/update.go
+++ b/internal/runbits/reqop_runbit/update.go
@@ -75,6 +75,12 @@ func UpdateAndReload(prime primeable, script *buildscript.BuildScript, oldCommit
 		if err := script.SetDynamic(false); err != nil {
 			return errs.Wrap(err, "Setting dynamic failed")
 		}
+		// StageCommitAndPoll needs to be called with atTime=now, not the previous script's atTime.
+		latest, err := model.FetchLatestRevisionTimeStamp(prime.Auth())
+		if err != nil {
+			return errs.Wrap(err, "Failed to fetch latest timestamp")
+		}
+		script.SetAtTime(latest, true)
 	}
 
 	commitParams := buildplanner.StageCommitParams{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://activestatef.atlassian.net/browse/CP-1077" title="CP-1077" target="_blank"><img alt="Bug" src="https://activestatef.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />CP-1077</a>  Dynamic Solve fails with PlanningError, but ingredient is imported
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
