### PR TITLE
Skip uninstall integration test on Windows.

### DIFF
--- a/test/integration/uninstall_int_test.go
+++ b/test/integration/uninstall_int_test.go
@@ -21,6 +21,9 @@ type UninstallIntegrationTestSuite struct {
 }
 
 func (suite *UninstallIntegrationTestSuite) TestUninstall() {
+	if runtime.GOOS == "windows" {
+		suite.T().Skip("uninstall test on Windows fails too often") // TODO: re-enable in CP-1296
+	}
 	suite.OnlyRunForTags(tagsuite.Uninstall, tagsuite.Critical)
 	suite.T().Run("Partial uninstall", func(t *testing.T) { suite.testUninstall(false) })
 	suite.T().Run("Full uninstall", func(t *testing.T) { suite.testUninstall(true) })


### PR DESCRIPTION
It fails too often.