### PR TITLE
Remove partially-unpacked directory if the unpack failed.

### DIFF
--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -406,7 +406,11 @@ func (s *setup) unpack(artifact *buildplan.Artifact, b []byte) (rerr error) {
 			return nil
 		},
 	}, bytes.NewReader(b))
-	if err := ua.Unarchive(proxy, s.depot.Path(artifact.ArtifactID)); err != nil {
+	unpackPath := s.depot.Path(artifact.ArtifactID)
+	if err := ua.Unarchive(proxy, unpackPath); err != nil {
+		if err2 := os.RemoveAll(unpackPath); err2 != nil {
+			return errs.Pack(err, errs.Wrap(err2, "unable to remove partially-unpacked directory"))
+		}
 		return errs.Wrap(err, "unpack failed")
 	}
 


### PR DESCRIPTION
If the directory exists, the depot thinks it's a full artifact, but a failed unpack does not create a runtime.json file, which raises a different error. This masks the original unpacking error.