### PR TITLE
ENG-1372: State Tool forwards platform JWT (+ versioned User-Agent) on build-log-streamer WS

### DIFF
--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -257,6 +257,7 @@ func Update(
 		runtime.WithAnnotations(proj.Owner(), proj.Name(), commitID),
 		runtime.WithEventHandlers(pg.Handle, ah.handle),
 		runtime.WithPreferredLibcVersion(prime.Config().GetString(constants.PreferredGlibcVersionConfig)),
+		runtime.WithAuthToken(prime.Auth().BearerToken()),
 	}
 	if opts.Archive != nil {
 		rtOpts = append(rtOpts, runtime.WithArchive(opts.Archive.Dir, opts.Archive.PlatformID, checkout.ArtifactExt))

--- a/pkg/platform/api/api.go
+++ b/pkg/platform/api/api.go
@@ -62,6 +62,12 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // UserAgent returns the user agent used by the State Tool
 func (r *RoundTripper) UserAgent() string {
+	return UserAgent()
+}
+
+// UserAgent returns the user agent used by the State Tool, including the
+// version (so the server can monitor State Tool versions) plus OS/arch.
+func UserAgent() string {
 	var osVersionStr string
 	osVersion, err := sysinfo.OSVersion()
 	if err != nil {

--- a/pkg/platform/api/buildlogstream/streamer.go
+++ b/pkg/platform/api/buildlogstream/streamer.go
@@ -11,13 +11,31 @@ import (
 	"github.com/ActiveState/cli/pkg/platform/api"
 )
 
-func Connect(ctx context.Context) (*websocket.Conn, error) {
+// wsSubprotocol is the "real" subprotocol the build-log-streamer echoes back.
+// The server's upgrader allow-list contains only this value, so the
+// bearer.<jwt> entry we also offer never appears in the upgrade response,
+// keeping the token out of proxy/browser response logs.
+const wsSubprotocol = "build-log-streamer.activestate.com.v1"
+
+// Connect opens the build-log-streamer WebSocket. When jwt is non-empty it is
+// offered via Sec-WebSocket-Protocol as `bearer.<jwt>` (alongside
+// wsSubprotocol, which the server echoes back) so the server can authorize the
+// stream. The browser WebSocket API can't set custom request headers, so the
+// dashboard carries the JWT the same way; using the subprotocol here keeps
+// both clients symmetric. See ENG-1372 / ENG-1374.
+func Connect(ctx context.Context, jwt string) (*websocket.Conn, error) {
 	url := api.GetServiceURL(api.BuildLogStreamer)
 	header := make(http.Header)
 	header.Add("Origin", "https://"+url.Host)
 
+	dialer := *websocket.DefaultDialer // copy so we don't mutate the package global
+	dialer.Subprotocols = []string{wsSubprotocol}
+	if jwt != "" {
+		dialer.Subprotocols = []string{"bearer." + jwt, wsSubprotocol}
+	}
+
 	logging.Debug("Creating websocket for %s (origin: %s)", url.String(), header.Get("Origin"))
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, url.String(), header)
+	conn, _, err := dialer.DialContext(ctx, url.String(), header)
 	if err != nil {
 		return nil, errs.Wrap(err, "Could not create websocket dialer")
 	}

--- a/pkg/platform/api/buildlogstream/streamer.go
+++ b/pkg/platform/api/buildlogstream/streamer.go
@@ -27,6 +27,10 @@ func Connect(ctx context.Context, jwt string) (*websocket.Conn, error) {
 	url := api.GetServiceURL(api.BuildLogStreamer)
 	header := make(http.Header)
 	header.Add("Origin", "https://"+url.Host)
+	// Send the versioned State Tool User-Agent so the server can monitor which
+	// State Tool versions are connecting (e.g. to size the unauthenticated tail
+	// before tightening the gate). See ENG-1372.
+	header.Set("User-Agent", api.UserAgent())
 
 	dialer := *websocket.DefaultDialer // copy so we don't mutate the package global
 	dialer.Subprotocols = []string{wsSubprotocol}

--- a/pkg/platform/api/buildlogstream/streamer_test.go
+++ b/pkg/platform/api/buildlogstream/streamer_test.go
@@ -13,14 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// startMockBLS stands up a real WebSocket server that records the
-// Sec-WebSocket-Protocol values offered on the Upgrade, and redirects
-// Connect's resolved service URL at it via the per-service override env var
-// honored by api.GetServiceURL. Returns a pointer that holds the offered
-// subprotocols after Connect runs.
-func startMockBLS(t *testing.T) *[]string {
+// upgradeRequest captures the headers the build-log-streamer server saw on the
+// WS Upgrade.
+type upgradeRequest struct {
+	protocols []string
+	userAgent string
+}
+
+// startMockBLS stands up a real WebSocket server that records the Upgrade
+// request headers, and redirects Connect's resolved service URL at it via the
+// per-service override env var honored by api.GetServiceURL. Returns a pointer
+// populated after Connect runs.
+func startMockBLS(t *testing.T) *upgradeRequest {
 	t.Helper()
-	offered := &[]string{}
+	got := &upgradeRequest{}
 
 	upgrader := websocket.Upgrader{
 		CheckOrigin: func(*http.Request) bool { return true },
@@ -29,7 +35,8 @@ func startMockBLS(t *testing.T) *[]string {
 		Subprotocols: []string{wsSubprotocol},
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		*offered = r.Header.Values("Sec-WebSocket-Protocol")
+		got.protocols = r.Header.Values("Sec-WebSocket-Protocol")
+		got.userAgent = r.Header.Get("User-Agent")
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
@@ -42,33 +49,37 @@ func startMockBLS(t *testing.T) *[]string {
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 	t.Setenv(constants.APIServiceOverrideEnvVarName+"BUILDLOG_STREAMER", wsURL)
 
-	return offered
+	return got
 }
 
 func TestConnect_ForwardsJWTViaSubprotocol(t *testing.T) {
-	offered := startMockBLS(t)
+	got := startMockBLS(t)
 
 	conn, err := Connect(context.Background(), "header.payload.signature")
 	require.NoError(t, err)
 	_ = conn.Close()
 
-	joined := strings.Join(*offered, ",")
+	joined := strings.Join(got.protocols, ",")
 	assert.Contains(t, joined, "bearer.header.payload.signature",
 		"client must offer the JWT as a bearer.<jwt> subprotocol")
 	assert.Contains(t, joined, wsSubprotocol,
 		"client must still offer the real subprotocol the server echoes back")
+	assert.Contains(t, got.userAgent, "state/",
+		"client must send the versioned State Tool User-Agent so the server can monitor versions")
 }
 
 func TestConnect_AnonymousOffersNoBearer(t *testing.T) {
-	offered := startMockBLS(t)
+	got := startMockBLS(t)
 
 	conn, err := Connect(context.Background(), "")
 	require.NoError(t, err)
 	_ = conn.Close()
 
-	joined := strings.Join(*offered, ",")
+	joined := strings.Join(got.protocols, ",")
 	assert.NotContains(t, joined, "bearer.",
 		"anonymous Connect must not offer a bearer subprotocol")
 	assert.Contains(t, joined, wsSubprotocol,
 		"anonymous Connect must still offer the real subprotocol")
+	assert.Contains(t, got.userAgent, "state/",
+		"client must send the versioned State Tool User-Agent even when anonymous")
 }

--- a/pkg/platform/api/buildlogstream/streamer_test.go
+++ b/pkg/platform/api/buildlogstream/streamer_test.go
@@ -1,0 +1,74 @@
+package buildlogstream
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ActiveState/cli/internal/constants"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startMockBLS stands up a real WebSocket server that records the
+// Sec-WebSocket-Protocol values offered on the Upgrade, and redirects
+// Connect's resolved service URL at it via the per-service override env var
+// honored by api.GetServiceURL. Returns a pointer that holds the offered
+// subprotocols after Connect runs.
+func startMockBLS(t *testing.T) *[]string {
+	t.Helper()
+	offered := &[]string{}
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(*http.Request) bool { return true },
+		// Echo back only the "real" subprotocol; the bearer.<jwt> entry must
+		// not be selected (mirrors the build-log-streamer's allow-list).
+		Subprotocols: []string{wsSubprotocol},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*offered = r.Header.Values("Sec-WebSocket-Protocol")
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	t.Cleanup(srv.Close)
+
+	// http://127.0.0.1:port -> ws://127.0.0.1:port
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	t.Setenv(constants.APIServiceOverrideEnvVarName+"BUILDLOG_STREAMER", wsURL)
+
+	return offered
+}
+
+func TestConnect_ForwardsJWTViaSubprotocol(t *testing.T) {
+	offered := startMockBLS(t)
+
+	conn, err := Connect(context.Background(), "header.payload.signature")
+	require.NoError(t, err)
+	_ = conn.Close()
+
+	joined := strings.Join(*offered, ",")
+	assert.Contains(t, joined, "bearer.header.payload.signature",
+		"client must offer the JWT as a bearer.<jwt> subprotocol")
+	assert.Contains(t, joined, wsSubprotocol,
+		"client must still offer the real subprotocol the server echoes back")
+}
+
+func TestConnect_AnonymousOffersNoBearer(t *testing.T) {
+	offered := startMockBLS(t)
+
+	conn, err := Connect(context.Background(), "")
+	require.NoError(t, err)
+	_ = conn.Close()
+
+	joined := strings.Join(*offered, ",")
+	assert.NotContains(t, joined, "bearer.",
+		"anonymous Connect must not offer a bearer subprotocol")
+	assert.Contains(t, joined, wsSubprotocol,
+		"anonymous Connect must still offer the real subprotocol")
+}

--- a/pkg/runtime/internal/buildlog/buildlog.go
+++ b/pkg/runtime/internal/buildlog/buildlog.go
@@ -59,16 +59,21 @@ type BuildLog struct {
 	eventHandlers        []events.HandlerFunc
 	logFilePath          string
 	onArtifactReadyFuncs map[strfmt.UUID][]func()
+	// authToken is the platform JWT forwarded to the build-log-streamer WS so
+	// the server can authorize the stream. Empty for unauthenticated callers.
+	authToken string
 }
 
 // New creates a new BuildLog instance that allows us to wait for incoming build log information
 // artifactMap comprises all artifacts (from the runtime closure) that are in the recipe, alreadyBuilt is set of artifact IDs that have already been built in the past
-func New(recipeID strfmt.UUID, artifactMap buildplan.ArtifactIDMap) *BuildLog {
+// authToken is the platform JWT forwarded to the build-log-streamer WS (empty if unauthenticated).
+func New(recipeID strfmt.UUID, artifactMap buildplan.ArtifactIDMap, authToken string) *BuildLog {
 	return &BuildLog{
 		recipeID:             recipeID,
 		artifactMap:          artifactMap,
 		eventHandlers:        []events.HandlerFunc{},
 		onArtifactReadyFuncs: map[strfmt.UUID][]func(){},
+		authToken:            authToken,
 	}
 }
 
@@ -94,7 +99,7 @@ func (b *BuildLog) OnArtifactReady(id strfmt.UUID, cb func()) {
 
 // NewWithCustomConnections creates a new BuildLog instance with all physical connections managed by the caller
 func (b *BuildLog) Wait(ctx context.Context) error {
-	conn, err := buildlogstream.Connect(ctx)
+	conn, err := buildlogstream.Connect(ctx, b.authToken)
 	if err != nil {
 		return errs.Wrap(err, "Could not connect to build-log streamer build updates")
 	}

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -9,6 +9,12 @@ func WithEventHandlers(handlers ...events.HandlerFunc) SetOpt {
 	return func(opts *Opts) { opts.EventHandlers = handlers }
 }
 
+// WithAuthToken forwards the platform JWT to the build-log-streamer WebSocket
+// so the server can authorize the stream (ENG-1372). Empty token = anonymous.
+func WithAuthToken(token string) SetOpt {
+	return func(opts *Opts) { opts.AuthToken = token }
+}
+
 func WithBuildlogFilePath(path string) SetOpt {
 	return func(opts *Opts) { opts.BuildlogFilePath = path }
 }

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -50,6 +50,10 @@ type Opts struct {
 	Portable             bool
 	CacheSize            int
 
+	// AuthToken is the platform JWT forwarded to the build-log-streamer WS so
+	// the server can authorize the stream. Empty for unauthenticated callers.
+	AuthToken string
+
 	FromArchive *fromArchive
 
 	// Annotations are used strictly to pass information for the purposes of analytics
@@ -238,7 +242,7 @@ func (s *setup) update() error {
 		return errs.Wrap(err, "Could not create runtime config dir")
 	}
 
-	blog := buildlog.New(s.buildplan.LegacyRecipeID(), s.toBuild).
+	blog := buildlog.New(s.buildplan.LegacyRecipeID(), s.toBuild, s.opts.AuthToken).
 		WithEventHandler(s.opts.EventHandlers...).
 		WithLogFile(filepath.Join(s.path, configDir, buildLogFile))
 


### PR DESCRIPTION
## Summary

Makes newer State Tool versions identify themselves on the build-log-streamer WebSocket Upgrade, so the server (ENG-1246 / ENG-1367) can authorize the stream and monitor client versions. Two things now ride on the Upgrade:

1. **Platform JWT via `Sec-WebSocket-Protocol`.** When authenticated, the client offers `bearer.<jwt>` alongside the real subprotocol `build-log-streamer.activestate.com.v1` (which the server echoes back; its allow-list contains only the real one, so the token never appears in the upgrade *response*). This mirrors the dashboard (ENG-1374), which can't set custom WS request headers — both clients stay symmetric.
2. **Versioned `User-Agent`.** The standard `state/<version>-SHA...; <channel> (<os>; <ver>; <arch>)` agent is now sent on the Upgrade so the server can size/monitor State Tool versions (e.g. the unauthenticated tail) before tightening the gate.

### Scope
The goal here is just that **newer** State Tool versions start sending the token + UA. Forcing *old* shipped versions to stop connecting anonymously (min-version / deprecation strategy) is a separate follow-up — see the ticket's "Long-term" section.

## Design note
The token is threaded as a plain **string** (`prime.Auth().BearerToken()` → `runtime.WithAuthToken` → `Opts.AuthToken` → `buildlog` → `Connect`), so `pkg/runtime` gains no dependency on the `authentication` package. Empty token = anonymous (unchanged behavior). `api.UserAgent()` was extracted as a package-level function (the `*RoundTripper` method delegates) so the WS dialer reuses the exact agent string the HTTP clients use.

## Files
- `pkg/platform/api/buildlogstream/streamer.go` — `Connect(ctx, jwt)` sets subprotocols + User-Agent.
- `pkg/platform/api/api.go` — extract package-level `UserAgent()`.
- `pkg/runtime/{options.go,setup.go,internal/buildlog/buildlog.go}` — thread `AuthToken` through.
- `internal/runbits/runtime/runtime.go` — `WithAuthToken(prime.Auth().BearerToken())`.
- `pkg/platform/api/buildlogstream/streamer_test.go` — **new**; real WS handshake against an httptest server.

## Test plan
- [x] `go build` + gofmt clean across touched packages.
- [x] New `TestConnect_*` tests do a real WS handshake against a mock server and assert the server received: `Sec-WebSocket-Protocol: bearer.<jwt>, build-log-streamer.activestate.com.v1` when authenticated, only the real subprotocol when anonymous, and a `state/` User-Agent in both cases.
- [ ] End-to-end JWT *validation* requires the server-side `Sec-WebSocket-Protocol` reader (TheHomeRepot, currently in the deferred ENG-1367 PR); testable against a PR deploy once that lands.

🔒 ENG-1372
