### PR TITLE
ENG-1979: Fail cleanly when the state publish --build directory is missing

### DIFF
--- a/internal/runners/publish/build.go
+++ b/internal/runners/publish/build.go
@@ -28,6 +28,9 @@ func (r *Runner) generateEncryptedArtifact(params *Params) (cleanup func(), rerr
 	if r.project == nil {
 		return nil, locale.NewInputError("err_publish_build_no_project", "The '[ACTIONABLE]--build[/RESET]' flag requires a project so the organization can be determined.")
 	}
+	if !fileutils.DirExists(params.Build) {
+		return nil, locale.NewInputError("err_publish_build_dir_not_found", "The '[ACTIONABLE]--build[/RESET]' source directory does not exist: [ACTIONABLE]{{.V0}}[/RESET]", params.Build)
+	}
 
 	meta, err := wheel.ResolveMetadata(params.Build, wheel.Metadata{Name: params.Name, Version: params.Version})
 	if err != nil {
@@ -95,12 +98,13 @@ func buildWrappedArtifact(srcDir string, meta wheel.Metadata, key []byte, keyID 
 	if err != nil {
 		return "", nil, errs.Wrap(err, "Could not create temp dir")
 	}
-	cleanup = func() { _ = os.RemoveAll(tmpDir) }
+	removeTmpDir := func() { _ = os.RemoveAll(tmpDir) }
 	defer func() {
 		if rerr != nil {
-			cleanup()
+			removeTmpDir()
 		}
 	}()
+	cleanup = removeTmpDir
 
 	wheelPath, err := wheel.Pack(srcDir, meta, tmpDir)
 	if err != nil {


### PR DESCRIPTION
[ENG-1979: Fail cleanly when the state publish --build directory is missing](https://activestatef.atlassian.net/browse/ENG-1979)

Part of the private ingredient work ([ENG-1563](https://activestatef.atlassian.net/browse/ENG-1563)). A beta tester ran `state publish --build` against a directory that didn't exist and hit a nil-pointer panic instead of a clear error. This makes that case fail cleanly and fixes the underlying crash.

**Base branch:** targets `version/0-48-1-RC3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-1563]: https://activestatef.atlassian.net/browse/ENG-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ