### PR TITLE
ENG-1984: Fetch the organization key lazily, only when an encrypted artifact is present

### DIFF
--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -309,9 +309,15 @@ func Update(
 	}
 
 	if len(skipped.names) > 0 {
+		// The fetch is memoized, so this returns the error that caused the skip
+		// without contacting the key service again.
+		reason := ""
+		if _, _, err := orgKeyProvider.Key(context.Background()); err != nil {
+			reason = ": " + errs.JoinMessage(err)
+		}
 		prime.Output().Notice(locale.Tl("warn_private_artifacts_skipped",
-			"[WARNING]Warning:[/RESET] These private packages were skipped because the organization key was unavailable: {{.V0}}. Ensure the key is available and run '[ACTIONABLE]state refresh[/RESET]' to try installing them again.",
-			strings.Join(skipped.names, ", ")))
+			"[WARNING]Warning:[/RESET] These private packages were skipped because the organization key was unavailable{{.V1}}. Private packages: {{.V0}}. Ensure the key is available and run '[ACTIONABLE]state refresh[/RESET]' to try installing them again.",
+			strings.Join(skipped.names, ", "), reason))
 	}
 
 	return rt, nil

--- a/internal/runbits/runtime/runtime.go
+++ b/internal/runbits/runtime/runtime.go
@@ -289,18 +289,15 @@ func Update(
 	}
 	rtOpts = append(rtOpts, runtime.WithCacheSize(prime.Config().GetInt(constants.RuntimeCacheSizeConfigKey)))
 
-	// Fetch the organization key for private ingredients, if a key service is configured.
+	// If a key service is configured, provide a lazy fetch of the organization key upon encountering
+	// an encrypted private artifact.
 	orgKeyProvider := orgkey.New(prime.Config(), proj.Owner())
 	if orgKeyProvider.Configured() {
 		defer orgKeyProvider.Close()
-		key, keyID, err := orgKeyProvider.Key(context.Background())
-		if err != nil {
-			prime.Output().Notice(locale.Tl("warn_orgkey_unavailable",
-				"[WARNING]Warning:[/RESET] Could not fetch the organization key: {{.V0}}. Encrypted private artifacts will be skipped. Ensure the key is available and run '[ACTIONABLE]state refresh[/RESET]' to try installing them again.",
-				errs.JoinMessage(err)))
-		} else {
-			rtOpts = append(rtOpts, runtime.WithDecryptionKey(key, keyID))
-		}
+		rtOpts = append(rtOpts, runtime.WithDecryptionKey(func() ([]byte, error) {
+			key, _, err := orgKeyProvider.Key(context.Background())
+			return key, err
+		}))
 	}
 
 	if isArmPlatform(buildPlan) {

--- a/pkg/runtime/decrypt_test.go
+++ b/pkg/runtime/decrypt_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ActiveState/cli/internal/artifactcrypto"
+	"github.com/ActiveState/cli/internal/errs"
 	"github.com/go-openapi/strfmt"
 )
 
@@ -157,7 +158,7 @@ func TestDecryptPayload(t *testing.T) {
 		writeFile(t, filepath.Join(dir, "runtime.json"), []byte(`{"installDir":"."}`))
 		writeFile(t, filepath.Join(dir, artifactcrypto.PayloadFilename), encryptToBytes(t, payload, key))
 
-		s := &setup{opts: &Opts{OrgKey: key}}
+		s := &setup{opts: &Opts{OrgKey: func() ([]byte, error) { return key, nil }}}
 		outcome, err := s.decryptPayload("pkg", dir)
 		if err != nil {
 			t.Fatalf("decryptPayload: %v", err)
@@ -207,12 +208,26 @@ func TestDecryptPayload(t *testing.T) {
 		}
 	})
 
+	t.Run("key fetch error skips", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, artifactcrypto.PayloadFilename), encryptToBytes(t, payload, key))
+
+		s := &setup{opts: &Opts{OrgKey: func() ([]byte, error) { return nil, errs.New("key service unreachable") }}}
+		outcome, err := s.decryptPayload("pkg", dir)
+		if err != nil {
+			t.Fatalf("decryptPayload: %v", err)
+		}
+		if outcome != decryptSkipped {
+			t.Fatalf("outcome = %v, want decryptSkipped", outcome)
+		}
+	})
+
 	t.Run("wrong key fails closed", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, filepath.Join(dir, artifactcrypto.PayloadFilename), encryptToBytes(t, payload, key))
 
 		wrong := make([]byte, artifactcrypto.KeySize) // all zeros
-		s := &setup{opts: &Opts{OrgKey: wrong}}
+		s := &setup{opts: &Opts{OrgKey: func() ([]byte, error) { return wrong, nil }}}
 		_, err := s.decryptPayload("pkg", dir)
 		if err == nil {
 			t.Fatal("expected a wrong-key error, got nil")
@@ -222,7 +237,7 @@ func TestDecryptPayload(t *testing.T) {
 	t.Run("plaintext artifact is untouched", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, filepath.Join(dir, "runtime.json"), []byte(`{"installDir":"."}`))
-		s := &setup{opts: &Opts{OrgKey: key}}
+		s := &setup{opts: &Opts{OrgKey: func() ([]byte, error) { return key, nil }}}
 		outcome, err := s.decryptPayload("pkg", dir)
 		if err != nil {
 			t.Fatal(err)
@@ -238,7 +253,7 @@ func TestDecryptPayload(t *testing.T) {
 		writeFile(t, filepath.Join(dir, "runtime.json"), []byte(`{"installDir":"installdir"}`))
 		writeFile(t, filepath.Join(dir, "installdir", artifactcrypto.PayloadFilename), encryptToBytes(t, payload, key))
 
-		s := &setup{opts: &Opts{OrgKey: key}}
+		s := &setup{opts: &Opts{OrgKey: func() ([]byte, error) { return key, nil }}}
 		outcome, err := s.decryptPayload("pkg", dir)
 		if err != nil {
 			t.Fatalf("decryptPayload: %v", err)

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -15,12 +15,11 @@ func WithAuthToken(token string) SetOpt {
 	return func(opts *Opts) { opts.AuthToken = token }
 }
 
-// WithDecryptionKey supplies the organization AES-256 key (and its id) used to
-// decrypt private artifacts during install.
-func WithDecryptionKey(key []byte, keyID string) SetOpt {
+// WithDecryptionKey supplies a function that lazily fetches the organization
+// AES-256 key used to decrypt private artifacts during install.
+func WithDecryptionKey(fetch func() ([]byte, error)) SetOpt {
 	return func(opts *Opts) {
-		opts.OrgKey = key
-		opts.OrgKeyID = keyID
+		opts.OrgKey = fetch
 	}
 }
 

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -61,11 +61,9 @@ type Opts struct {
 	// the server can authorize the stream. Empty for unauthenticated callers.
 	AuthToken string
 
-	// OrgKey is the organization AES-256 key used to decrypt private artifacts
-	// during install, with OrgKeyID identifying which key it is. Both are empty
-	// when the runtime has no private ingredients.
-	OrgKey   []byte
-	OrgKeyID string
+	// OrgKey lazily fetches the organization AES-256 key used to decrypt private
+	// artifacts during install. It is nil when no key service is configured.
+	OrgKey func() ([]byte, error)
 
 	FromArchive *fromArchive
 
@@ -566,7 +564,15 @@ func (s *setup) decryptPayload(artifactName, unpackPath string) (outcome decrypt
 	}
 	logging.Debug("Detected encrypted payload in artifact %s", artifactName)
 
-	if len(s.opts.OrgKey) == 0 {
+	if s.opts.OrgKey == nil {
+		return decryptSkipped, nil
+	}
+	key, err := s.opts.OrgKey()
+	if err != nil {
+		logging.Debug("Could not obtain org key for artifact %s; skipping: %v", artifactName, errs.JoinMessage(err))
+		return decryptSkipped, nil
+	}
+	if len(key) == 0 {
 		return decryptSkipped, nil
 	}
 
@@ -575,7 +581,7 @@ func (s *setup) decryptPayload(artifactName, unpackPath string) (outcome decrypt
 	if err != nil {
 		return decryptNotEncrypted, errs.Wrap(err, "could not read encrypted payload header")
 	}
-	if err := header.CheckKey(s.opts.OrgKey); err != nil {
+	if err := header.CheckKey(key); err != nil {
 		return decryptNotEncrypted, errs.Wrap(err, "org key does not match encrypted artifact %s", artifactName)
 	}
 
@@ -595,7 +601,7 @@ func (s *setup) decryptPayload(artifactName, unpackPath string) (outcome decrypt
 	if err != nil {
 		return decryptNotEncrypted, errs.Wrap(err, "could not open encrypted payload")
 	}
-	err = artifactcrypto.Decrypt(src, archivePath, s.opts.OrgKey)
+	err = artifactcrypto.Decrypt(src, archivePath, key)
 	if cerr := src.Close(); cerr != nil {
 		err = errs.Pack(err, errs.Wrap(cerr, "could not close encrypted payload"))
 	}


### PR DESCRIPTION
[ENG-1984: Fetch the organization key lazily, only when an encrypted artifact is present](https://activestatef.atlassian.net/browse/ENG-1984)

Part of the private ingredient work ([ENG-1563](https://activestatef.atlassian.net/browse/ENG-1563)). Checking out a project with no encrypted ingredients still printed a spurious "Could not fetch the organization key" warning whenever a key service was configured.

The key is now fetched only when the runtime actually hits an encrypted artifact, rather than up front — so projects with no private ingredients never contact the key service (no warning, no delay). The existing end-of-run notice still reports anything skipped because the key was unavailable.

**Base branch:** targets `version/0-48-1-RC3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-1563]: https://activestatef.atlassian.net/browse/ENG-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ