### PR TITLE
ENG-1924: Promote staging files without adding a release/ prefix

### DIFF
--- a/scripts/ci/s3-promoter/main.go
+++ b/scripts/ci/s3-promoter/main.go
@@ -75,8 +75,7 @@ func run() {
 	// Copy each staging object to production location and delete the staging version
 	for _, obj := range stagingObjects {
 		stagingKey := *obj.Key
-		relativeKey := strings.TrimPrefix(stagingKey, basePrefix+"staging/")
-		destinationKey := basePrefix + "release/" + relativeKey
+		destinationKey := productionKey(stagingKey, basePrefix)
 
 		fmt.Printf("Promoting %s -> %s\n", stagingKey, destinationKey)
 
@@ -92,6 +91,14 @@ func run() {
 	}
 
 	fmt.Printf("Successfully promoted %d files from staging to production.\n", len(stagingObjects))
+}
+
+// productionKey maps a staging object key to its production location. The
+// channel (beta, release, ...) is already encoded in the key, so promotion only
+// drops the staging/ segment and adds no prefix of its own.
+func productionKey(stagingKey, basePrefix string) string {
+	relativeKey := strings.TrimPrefix(stagingKey, basePrefix+"staging/")
+	return basePrefix + relativeKey
 }
 
 func createClient() {


### PR DESCRIPTION
[ENG-1924: Promote staging files without adding a release/ prefix](https://activestatef.atlassian.net/browse/ENG-1924)

The promote-staging-to-production step was moving beta release files to release/update/state/beta/ instead of update/state/beta/, which forced a manual copy in the S3 console after every promotion. The promoter stripped the staging/ prefix and then prepended release/, so files landed one directory too deep. Because the updater only ever fetches from update/state/<channel>/, this actually misplaced files for every channel, not just beta.

The fix drops the release/ prefix so promotion maps staging/<key> straight to <key>; the channel (beta, release, ...) is already part of the path. Beta files now land in update/state/beta/ and release-channel files in update/state/release/, matching what the updater serves.

Base branch: targets version/0-48-1-RC3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)